### PR TITLE
Add login/logout and store token to config file

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -50,7 +50,6 @@
   revision = "0fb14efe8c47ae851c0034ed7a448854d3d34cf3"
 
 [[projects]]
-  branch = "master"
   name = "github.com/hashicorp/hcl"
   packages = [
     ".",
@@ -86,6 +85,12 @@
 
 [[projects]]
   branch = "master"
+  name = "github.com/mitchellh/go-homedir"
+  packages = ["."]
+  revision = "b8bc1bf767474819792c23f32d8286a45736f1c6"
+
+[[projects]]
+  branch = "master"
   name = "github.com/mitchellh/go-testing-interface"
   packages = ["."]
   revision = "a61a99592b77c9ba629d254a693acffaeb4b7e28"
@@ -109,10 +114,15 @@
   version = "v1.1.0"
 
 [[projects]]
-  name = "github.com/Sirupsen/logrus"
+  name = "github.com/pkg/errors"
   packages = ["."]
-  revision = "c155da19408a8799da419ed3eeb0cb5db0ad5dbc"
-  version = "v1.0.5"
+  revision = "645ef00459ed84a119197bfb8d8205042c6df63d"
+  version = "v0.8.0"
+
+[[projects]]
+  name = "github.com/sirupsen/logrus"
+  packages = ["."]
+  revision = "778f2e774c725116edbc3d039dc0dfc1cc62aae8"
 
 [[projects]]
   name = "github.com/spf13/afero"
@@ -251,6 +261,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "7a12997584137d772504933b883eb8188b9b99752b7c7da8bff4f9737937dba7"
+  inputs-digest = "57f8a4e88a25294829f9fc8b27e3d0993cc0397b6d1865e903104c2a6d51248e"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -38,8 +38,8 @@
   name = "github.com/hashicorp/go-plugin"
 
 [[constraint]]
-  name = "github.com/Sirupsen/logrus"
-  version = "1.0.5"
+  name = "github.com/sirupsen/logrus"
+  revision = "778f2e774c725116edbc3d039dc0dfc1cc62aae8"
 
 [[constraint]]
   name = "github.com/spf13/cobra"
@@ -56,6 +56,10 @@
 [[constraint]]
   name = "google.golang.org/grpc"
   version = "1.11.3"
+
+[[constraint]]
+  name = "github.com/hashicorp/hcl"
+  revision = "ef8a98b0bbce4a65b5aa4c368430a80ddc533168"
 
 [prune]
   go-tests = true

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ $ make compile-proto
 $ go run main.go --help
 ```
 
-The CLI automatically adds commands when their respctive plugins are installed. Enabling the connect
-commands by installing the plugig:
+The CLI automatically adds commands when their respective plugins are installed. Enabling the connect
+commands by installing the plugins:
 
 ```
 $ make install-plugins

--- a/command/auth/auth.go
+++ b/command/auth/auth.go
@@ -1,0 +1,127 @@
+package auth
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"golang.org/x/crypto/ssh/terminal"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+
+	"github.com/confluentinc/cli/shared"
+)
+
+const (
+	loginPath = "/api/sessions"
+)
+
+var (
+	ErrUnauthorized = fmt.Errorf("unauthorized")
+)
+
+type Authentication struct {
+	Commands  []*cobra.Command
+	URL       string
+	config    *shared.Config
+}
+
+func New(config *shared.Config) []*cobra.Command {
+	cmd := &Authentication{config: config}
+	cmd.init()
+	return cmd.Commands
+}
+
+func (a *Authentication) init() {
+	loginCmd := &cobra.Command{
+		Use:   "login",
+		Short: "Login to a Confluent Control Plane.",
+		RunE:  a.login,
+	}
+	loginCmd.Flags().StringVar(&a.URL, "url", "https://confluent.cloud", "Confluent Control Plane URL")
+	logoutCmd := &cobra.Command{
+		Use:   "logout",
+		Short: "Logout of a Confluent Control Plane.",
+		RunE:  a.logout,
+	}
+	a.Commands = []*cobra.Command{loginCmd, logoutCmd}
+}
+
+func (a *Authentication) login(cmd *cobra.Command, args []string) error {
+	username, password, err := credentials()
+	if err != nil {
+		return err
+	}
+	payload, err := json.Marshal(map[string]string{"email": username, "password": password})
+	if err != nil {
+		return err
+	}
+	response, err := a.http().Post(a.URL + loginPath, "application/json", bytes.NewBuffer(payload))
+	if err != nil {
+		return err
+	}
+	switch response.StatusCode {
+	case http.StatusNotFound:
+		return ErrUnauthorized
+	case http.StatusOK:
+		var token string
+		for _, cookie := range response.Cookies() {
+			if cookie.Name == "auth_token" {
+				token = cookie.Value
+				break
+			}
+		}
+		if token == "" {
+			return ErrUnauthorized
+		}
+		a.config.AuthToken = token
+		err := a.config.Save()
+		if err != nil {
+			return errors.Wrap(err, "unable to save auth token")
+		}
+		fmt.Println("Logged in as", username)
+	}
+	return nil
+}
+
+func (a *Authentication) logout(cmd *cobra.Command, args []string) error {
+	a.config.AuthToken = ""
+	err := a.config.Save()
+	if err != nil {
+		return errors.Wrap(err, "unable to delete auth token")
+	}
+	fmt.Println("You are now logged out")
+	return nil
+}
+
+func (a *Authentication) http() *http.Client {
+	return &http.Client{
+		Timeout: time.Second * 10,
+	}
+}
+
+func credentials() (string, string, error) {
+	reader := bufio.NewReader(os.Stdin)
+	fmt.Println("Enter your Confluent Cloud credentials:")
+
+	fmt.Print("Email: ")
+	username, err := reader.ReadString('\n')
+	if err != nil {
+		return "", "", err
+	}
+
+	fmt.Print("Password: ")
+	bytePassword, err := terminal.ReadPassword(0)
+	fmt.Println()
+	if err != nil {
+		return "", "", err
+	}
+	password := string(bytePassword)
+
+	return strings.TrimSpace(username), strings.TrimSpace(password), nil
+}

--- a/command/connect/command.go
+++ b/command/connect/command.go
@@ -3,7 +3,6 @@ package connect
 import (
 	"context"
 	"fmt"
-	"log"
 	"os"
 	"os/exec"
 
@@ -100,7 +99,7 @@ func (c *Command) list(Command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	log.Println(connectors)
+	fmt.Println(connectors)
 	return nil
 }
 

--- a/log/logger.go
+++ b/log/logger.go
@@ -1,7 +1,7 @@
 package log
 
 import (
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 type Logger struct {
@@ -25,5 +25,7 @@ func (l *Logger) Log(args ...interface{}) error {
 }
 
 func New() *Logger {
-	return &Logger{Logger: logrus.New()}
+	logger := &Logger{Logger: logrus.New()}
+	logger.Formatter = &logrus.TextFormatter{FullTimestamp: true, DisableLevelTruncation: true}
+	return logger
 }

--- a/main.go
+++ b/main.go
@@ -4,14 +4,16 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/confluentinc/cli/command/auth"
 	"github.com/confluentinc/cli/command/connect"
 	"github.com/confluentinc/cli/command/kafka"
 	log "github.com/confluentinc/cli/log"
 	"github.com/confluentinc/cli/metric"
 	"github.com/confluentinc/cli/shared"
-	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 var (
@@ -52,9 +54,14 @@ func main() {
 			MetricSink: metricSink,
 			Logger:     logger,
 		}
+		err := config.Load()
+		if err != nil && err != shared.ErrNoConfig {
+			logger.WithError(err).Errorf("unable to load config")
+		}
 	}
 
 	cli.Version = version
+	cli.AddCommand(auth.New(config)...)
 	cli.AddCommand(kafka.New(config))
 
 	conn, err := connect.New(config)

--- a/shared/cli.go
+++ b/shared/cli.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	metrics "github.com/armon/go-metrics"
-	"github.com/confluentinc/cli/log"
 	plugin "github.com/hashicorp/go-plugin"
 )
 
@@ -25,11 +24,6 @@ type MetricSink interface {
 	// Samples are for timing information, where quantiles are used
 	AddSample(key []string, val float32)
 	AddSampleWithLabels(key []string, val float32, labels []Label)
-}
-
-type Config struct {
-	MetricSink MetricSink
-	Logger     *log.Logger
 }
 
 var Handshake = plugin.HandshakeConfig{

--- a/shared/config.go
+++ b/shared/config.go
@@ -1,0 +1,89 @@
+package shared
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	"github.com/hashicorp/hcl"
+	jsonParser "github.com/hashicorp/hcl/json/parser"
+	"github.com/hashicorp/hcl/hcl/printer"
+	homedir "github.com/mitchellh/go-homedir"
+	"github.com/pkg/errors"
+
+	"github.com/confluentinc/cli/log"
+	"path"
+)
+
+const (
+	defaultConfigFile = "~/.confluent/config.hcl"
+)
+
+var ErrNoConfig = fmt.Errorf("no config file exists")
+
+type Config struct {
+	MetricSink MetricSink  `json:"-"`
+	Logger     *log.Logger `json:"-"`
+	Filename   string      `json:"-"`
+	AuthToken  string      `json:"auth_token" hcl:"auth_token"`
+}
+
+func (c *Config) Load() error {
+	filename, err := c.getFilename()
+	if err != nil {
+		return err
+	}
+	input, err := ioutil.ReadFile(filename)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return ErrNoConfig
+		}
+		return errors.Wrapf(err, "unable to read config file: %s", filename)
+	}
+	err = hcl.Unmarshal(input, c)
+	if err != nil {
+		return errors.Wrapf(err, "unable to parse config file: %s", filename)
+	}
+	return nil
+}
+
+func (c *Config) Save() error {
+	cfg, err := json.Marshal(c)
+	if err != nil {
+		return errors.Wrapf(err, "unable to marshal config")
+	}
+	ast, err := jsonParser.Parse(cfg)
+	if err != nil {
+		return errors.Wrapf(err, "unable to parse config")
+	}
+	filename, err := c.getFilename()
+	if err != nil {
+		return err
+	}
+	err = os.MkdirAll(path.Dir(filename), 0700)
+	if err != nil {
+		return errors.Wrapf(err, "unable to create config directory: %s", filename)
+	}
+	f, err := os.OpenFile(filename, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0600)
+	if err != nil {
+		return errors.Wrapf(err, "unable to create config file: %s", filename)
+	}
+	defer f.Close()
+	err = printer.Fprint(f, ast)
+	if err != nil {
+		return errors.Wrapf(err, "unable to write config to file: %s", filename)
+	}
+	return nil
+}
+
+func (c *Config) getFilename() (string, error) {
+	if c.Filename == "" {
+		c.Filename = defaultConfigFile
+	}
+	filename, err := homedir.Expand(c.Filename)
+	if err != nil {
+		return "", err
+	}
+	return filename, nil
+}

--- a/shared/config_test.go
+++ b/shared/config_test.go
@@ -1,0 +1,93 @@
+package shared
+
+import (
+	"io/ioutil"
+	"os"
+	"reflect"
+	"testing"
+)
+
+func TestConfig_Load(t *testing.T) {
+	type args struct {
+		contents string
+	}
+	tests := []struct {
+		name    string
+		args    *args
+		want    *Config
+		wantErr bool
+		file    string
+	}{
+		{
+			name: "should load auth token from file",
+			args: &args{
+				contents: "\"auth_token\" = \"abc123\"",
+			},
+			want: &Config{
+				AuthToken: "abc123",
+			},
+			file: "/tmp/TestConfig_Load.hcl",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Config{Filename: tt.file}
+			ioutil.WriteFile(tt.file, []byte(tt.args.contents), 0644)
+			if err := c.Load(); (err != nil) != tt.wantErr {
+				t.Errorf("Config.Load() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			c.Filename = "" // only for testing
+			if !reflect.DeepEqual(c, tt.want) {
+				t.Errorf("Config.Load() = %v, want %v", c, tt.want)
+			}
+			os.Remove(tt.file)
+		})
+	}
+}
+
+func TestConfig_Save(t *testing.T) {
+	type args struct {
+		token string
+	}
+	tests := []struct {
+		name    string
+		args    *args
+		want    string
+		wantErr bool
+		file    string
+	}{
+		{
+			name: "save auth token to file",
+			args: &args{
+				token: "abc123",
+			},
+			want: "\"auth_token\" = \"abc123\"",
+			file:  "/tmp/TestConfig_Save.hcl",
+		},
+		{
+			name: "create parent config dirs",
+			args: &args{
+				token: "abc123",
+			},
+			want: "\"auth_token\" = \"abc123\"",
+			file:  "/tmp/xyz987/TestConfig_Save.hcl",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Config{Filename: tt.file, AuthToken: tt.args.token}
+			if err := c.Save(); (err != nil) != tt.wantErr {
+				t.Errorf("Config.Save() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			got, _ := ioutil.ReadFile(tt.file)
+			if string(got) != tt.want {
+				t.Errorf("Config.Save() = %v, want %v", got, tt.want)
+			}
+			fd, _ := os.Stat(tt.file)
+			if fd.Mode() != 0600 {
+				t.Errorf("Config.Save() file should only be readable by user")
+			}
+			os.RemoveAll("/tmp/xyz987")
+		})
+	}
+}


### PR DESCRIPTION
@confluentinc/caas 

```
$ go run main.go login --url https://stag.cpdev.cloud
2018-05-02T12:52:48.012-0500 [DEBUG] plugin: starting plugin: path=/bin/sh args="[sh -c /Users/cody/code/go/bin/confluent-connect-plugin]"
2018-05-02T12:52:48.014-0500 [DEBUG] plugin: waiting for RPC address: path=/bin/sh
2018-05-02T12:52:48.028-0500 [DEBUG] plugin.sh: plugin address: address=/var/folders/81/kbvhd83n2sj12dy2xnxjc0140000gp/T/plugin575483489 network=unix timestamp=2018-05-02T12:52:48.028-0500
Enter your Confluent Cloud credentials:
Email: cody@confluent.io
Password: 
Logged in as cody@confluent.io

$ cat ~/.confluent/config.hcl
"auth_token" = "eyJhbGciOiJIUzI1NiIsInR5cCI6Ik..."

$ go run main.go logout
2018-05-02T12:53:06.544-0500 [DEBUG] plugin: starting plugin: path=/bin/sh args="[sh -c /Users/cody/code/go/bin/confluent-connect-plugin]"
2018-05-02T12:53:06.546-0500 [DEBUG] plugin: waiting for RPC address: path=/bin/sh
2018-05-02T12:53:06.557-0500 [DEBUG] plugin.sh: plugin address: address=/var/folders/81/kbvhd83n2sj12dy2xnxjc0140000gp/T/plugin083074154 network=unix timestamp=2018-05-02T12:53:06.557-0500
You are now logged out

$ cat ~/.confluent/config.hcl
"auth_token" = ""
```

Logging still needs some work. Updated logrus to tweak the output a bit. Still need to integrate/silence the go-plugin logging for non-debug usage.