### PR TITLE
Add plugin lifecycle management

### DIFF
--- a/command/connect/command.go
+++ b/command/connect/command.go
@@ -47,6 +47,7 @@ func (c *Command) init() error {
 		Plugins:          shared.PluginMap,
 		Cmd:              exec.Command("sh", "-c", path),
 		AllowedProtocols: []plugin.Protocol{plugin.ProtocolGRPC},
+		Managed:          true,
 	})
 
 	// Connect via RPC.

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/hashicorp/go-plugin"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -61,6 +62,12 @@ func main() {
 	}
 
 	cli.Version = version
+
+	// Automatically stop plugins when CLI exits
+	cli.PersistentPostRun = func(cmd *cobra.Command, args []string) {
+		plugin.CleanupClients()
+	}
+
 	cli.AddCommand(auth.New(config)...)
 	cli.AddCommand(kafka.New(config))
 


### PR DESCRIPTION
@confluentinc/caas 

Automatically stop plugin processes on exit

Right now, you end up with a separate confluent-connect-plugin process each time you run a new connect cli command.