### PR TITLE
Update "connect create" to specify kafka cluster by name instead of id

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -28,7 +28,7 @@
     "kafka/scheduler/v1",
     "operator/v1"
   ]
-  revision = "dcaf8a6618cc7f40fc3656486222629f90e54ebe"
+  revision = "5be798cc72a8f445d6197f4aeb0314065abf0968"
 
 [[projects]]
   branch = "jsonpb"

--- a/command/common/cli.go
+++ b/command/common/cli.go
@@ -18,6 +18,8 @@ func HandleError(err error) error {
 		fmt.Println("Your auth token has been corrupted. Please login again.")
 	case shared.ErrNotImplemented:
 		fmt.Println("Sorry, this functionality is not yet available in the CLI.")
+	case shared.ErrNotFound:
+		fmt.Println("Kafka cluster not found.")
 	default:
 		return err
 	}

--- a/command/connect/command.go
+++ b/command/connect/command.go
@@ -21,8 +21,8 @@ import (
 var (
 	listFields     = []string{"Name", "ServiceProvider", "Region", "Durability", "Status"}
 	listLabels     = []string{"Name", "Provider", "Region", "Durability", "Status"}
-	describeFields = []string{"Name", "ServiceProvider", "Region", "Status", "Endpoint", "PricePerHour"}
-	describeLabels = []string{"Name", "Provider", "Region", "Status", "Endpoint", "PricePerHour"}
+	describeFields = []string{"Name", "KafkaClusterId", "ServiceProvider", "Region", "Status", "Endpoint", "PricePerHour"}
+	describeLabels = []string{"Name", "Kafka", "Provider", "Region", "Status", "Endpoint", "PricePerHour"}
 )
 
 type Command struct {
@@ -96,8 +96,8 @@ func (c *Command) init() error {
 	}
 	createCmd.Flags().String("config", "", "Connector configuration file")
 	createCmd.MarkFlagRequired("config")
-	createCmd.Flags().String("kafka-cluster-id", "", "Kafka Cluster ID")
-	createCmd.MarkFlagRequired("kafka-cluster-id")
+	createCmd.Flags().String("kafka-cluster", "", "Kafka Cluster Name")
+	createCmd.MarkFlagRequired("kafka-cluster")
 	c.AddCommand(createCmd)
 
 	c.AddCommand(&cobra.Command{
@@ -153,9 +153,10 @@ func (c *Command) create(cmd *cobra.Command, args []string) error {
 		AccountId: c.config.Auth.Account.Id,
 		Options:   &schedv1.ConnectS3SinkOptions{},
 	}
-	req.KafkaClusterId, err = cmd.Flags().GetString("kafka-cluster-id")
+	// NOTE: KafkaClusterId is actually the Kafka Cluster name. We resolve the ID in the plugin and update this field.
+	req.KafkaClusterId, err = cmd.Flags().GetString("kafka-cluster")
 	if err != nil {
-		return errors.Wrap(err, "error reading --kafka-cluster-id as string")
+		return errors.Wrap(err, "error reading --kafka-cluster as string")
 	}
 
 	// Set s3-sink connector options

--- a/http/client.go
+++ b/http/client.go
@@ -8,6 +8,7 @@ import (
 	"github.com/dghubble/sling"
 	"golang.org/x/oauth2"
 
+	corev1 "github.com/confluentinc/cc-structs/kafka/core/v1"
 	"github.com/confluentinc/cli/log"
 )
 
@@ -15,7 +16,10 @@ const (
 	timeout = time.Second * 10
 )
 
-var BaseClient = &http.Client{Timeout: timeout}
+var (
+	BaseClient  = &http.Client{Timeout: timeout}
+	errNotFound = &corev1.Error{Code: 404, Message: "cluster not found"} // matches gateway response
+)
 
 type Client struct {
 	httpClient *http.Client

--- a/http/connect.go
+++ b/http/connect.go
@@ -49,6 +49,10 @@ func (s *ConnectService) Describe(cluster *schedv1.ConnectCluster) (*schedv1.Con
 	if reply.Error != nil {
 		return nil, resp, errors.Wrap(reply.Error, "error fetching connectors")
 	}
+	// Since we're hitting the get-all endpoint instead of get-one, simulate a NotFound error if no matches return
+	if len(reply.Clusters) == 0 {
+		return nil, resp, errNotFound
+	}
 	return reply.Clusters[0], resp, nil
 }
 

--- a/http/kafka.go
+++ b/http/kafka.go
@@ -49,5 +49,9 @@ func (s *KafkaService) Describe(cluster *schedv1.KafkaCluster) (*schedv1.KafkaCl
 	if reply.Error != nil {
 		return nil, resp, errors.Wrap(reply.Error, "error fetching kafka clusters")
 	}
+	// Since we're hitting the get-all endpoint instead of get-one, simulate a NotFound error if no matches return
+	if len(reply.Clusters) == 0 {
+		return nil, resp, errNotFound
+	}
 	return reply.Clusters[0], resp, nil
 }

--- a/shared/errors.go
+++ b/shared/errors.go
@@ -28,6 +28,7 @@ var (
 	ErrUnauthorized   = fmt.Errorf("unauthorized")
 	ErrExpiredToken   = fmt.Errorf("expired")
 	ErrMalformedToken = fmt.Errorf("malformed")
+	ErrNotFound       = fmt.Errorf("not found")
 )
 
 func ConvertAPIError(err error) error {
@@ -42,6 +43,9 @@ func ConvertAPIError(err error) error {
 		// except this one.. its the special case of errUnauthorized from http/auth.go
 		case "unauthorized":
 			return ErrUnauthorized
+		// except this one.. its the special case of errNotFound from http/client.go
+		case "cluster not found":
+			return ErrNotFound
 		// TODO: assert invariant for default case: we're missing an corev1.Error -> HTTP Error constant mapping
 		}
 	}
@@ -52,12 +56,14 @@ func ConvertGRPCError(err error) error {
 	if s, ok := status.FromError(err); ok {
 		// these messages are from the error constants at the top of this file
 		switch s.Message() {
-		case "expired":
+		case ErrMalformedToken.Error():
 			return ErrExpiredToken
-		case "malformed":
+		case ErrMalformedToken.Error():
 			return ErrMalformedToken
-		case "unauthorized":
+		case ErrUnauthorized.Error():
 			return ErrUnauthorized
+		case ErrNotFound.Error():
+			return ErrNotFound
 		// TODO: assert invariant for default case: we're missing a GRPC -> HTTP Error constant mapping
 		}
 		return fmt.Errorf(s.Message())


### PR DESCRIPTION
@confluentinc/caas 

```
$ go run main.go connect create A --kafka-cluster minikube623 --config examples/s3-sink.options.yaml 
Kafka cluster not found.

$ go run main.go connect create A --kafka-cluster minikube6 --config examples/s3-sink.options.yaml 
Created new connector:
          Name : A          
         Kafka : minikube6  
      Provider : aws        
        Region : us-west-2  
        Status : UP         
      Endpoint :            
  PricePerHour : 0         
```

Still need to add endpoints in the scheduler.