### PR TITLE
Add "connect get" for general connector info and update "connect describe" for specific connector configs

### DIFF
--- a/command/common/output.go
+++ b/command/common/output.go
@@ -69,8 +69,16 @@ func RenderTable(data [][]string, labels []string) {
 func RenderDetail(obj interface{}, fields []string, labels []string) {
 	c := reflect.ValueOf(obj).Elem()
 	var data [][]string
-	for i, field := range fields {
-		data = append(data, []string{labels[i], fmt.Sprintf("%v", c.FieldByName(field))})
+	if fields == nil {
+		for i := 0; i < c.NumField(); i++ {
+			field := c.Field(i)
+			fieldType := c.Type().Field(i)
+			data = append(data, []string{fieldType.Name, fmt.Sprintf("%v", field)})
+		}
+	} else {
+		for i, field := range fields {
+			data = append(data, []string{labels[i], fmt.Sprintf("%v", c.FieldByName(field))})
+		}
 	}
 	table := tablewriter.NewWriter(os.Stdout)
 	table.AppendBulk(data)


### PR DESCRIPTION
@confluentinc/caas 

Get:

```
Cody-Rays-MBP15:cli cody$ go run main.go connect get I
        Name : I          
        Kind : S3_SINK    
       Kafka : lkc-4rx74  
    Provider : aws        
      Region : us-west-2  
  Durability : LOW        
      Status : UP         
```

Describe:

```
Cody-Rays-MBP15:cli cody$ go run main.go connect describe I
        Name : I          
        Kind : S3_SINK    
       Kafka : lkc-4rx74  
    Provider : aws        
      Region : us-west-2  
  Durability : LOW        
      Status : UP         

S3 Sink Options:
                 SourceTopics : logs.json.kafka,logs.json.zookeeper             
                 BucketRegion : us-west-1                                       
                   BucketName : my-new-bucket                                   
              BucketDirectory :                                                 
           SourceKeyConverter : org.apache.kafka.connect.json.JsonConverter     
         SourceValueConverter : org.apache.kafka.connect.json.JsonConverter     
    KeyConverterSchemasEnable : false                                           
  ValueConverterSchemasEnable : false                                           
            DestinationFormat : io.confluent.connect.s3.format.json.JsonFormat  
                     MaxTasks : 12                                              
                    FlushSize : 0                                               
                     PartSize : 0                                               
```