### PR TITLE
Add gometalinter and cleanup issues

### DIFF
--- a/.gometalinter.json
+++ b/.gometalinter.json
@@ -1,0 +1,17 @@
+{
+    "Exclude": [
+        "command/.*/grpc.go:.* exported (method|type) .* should have comment or be unexported.*golint.*",
+        "command/.*/interface.go:.* exported (method|type) .* should have comment or be unexported.*golint.*",
+        "shared/errors.go:.* exported var Err.* should have comment or be unexported.*golint.*",
+        "plugin/.*/main.go:.* exported (method|type) .* should have comment or be unexported.*golint.*",
+        ".*Errors unhandled.*logger.Log.*gas.*",
+        ".*Errors unhandled.*fmt.Fprintf.*gas.*"
+    ],
+    "Linters": {
+        "gas": {
+            "Command": "gas -fmt=csv",
+            "Pattern": "^(?P<path>.*?\\.go),(?P<line>\\d+),(?P<message>[^,]+,[^,]+,[^,]+,\".*\")"
+        }
+    },
+    "Deadline": "200s"
+}

--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,28 @@
-CCSTRUCTS = $(GOPATH)/src/github.com/confluentinc/cc-structs
+CCSTRUCTS := $(GOPATH)/src/github.com/confluentinc/cc-structs
 
+.PHONY: deps
+deps:
+	which dep 2>/dev/null || go get -u github.com/golang/dep/cmd/dep
+	which gometalinter 2>/dev/null || ( go get -u github.com/alecthomas/gometalinter && gometalinter --install &> /dev/null )
+	dep ensure $(ARGS)
+
+.PHONY: compile-proto
 compile-proto:
 	protoc -I shared/connect -I $(CCSTRUCTS) -I $(CCSTRUCTS)/vendor shared/connect/*.proto --gogo_out=plugins=grpc:shared/connect
 	protoc -I shared/kafka -I $(CCSTRUCTS) -I $(CCSTRUCTS)/vendor shared/kafka/*.proto --gogo_out=plugins=grpc:shared/kafka
 
+.PHONY: install-plugins
 install-plugins:
 	go install ./plugin/...
 
-deps:
-	which dep 2>/dev/null || go get -u github.com/golang/dep/cmd/dep
-	dep ensure $(ARGS)
+.PHONY: lint
+lint:
+	gometalinter ./... --vendor
 
-test:
+.PHONY: test
+test: lint
 	go test -v -cover $(TEST_ARGS) ./...
 
+.PHONY: clean
 clean:
 	rm $(PROTO)/*.pb.go

--- a/command/auth/auth.go
+++ b/command/auth/auth.go
@@ -16,18 +16,19 @@ import (
 	"github.com/confluentinc/cli/shared"
 )
 
-type Authentication struct {
+type commands struct {
 	Commands  []*cobra.Command
 	config    *shared.Config
 }
 
+// New returns a list of auth-related Cobra commands.
 func New(config *shared.Config) []*cobra.Command {
-	cmd := &Authentication{config: config}
+	cmd := &commands{config: config}
 	cmd.init()
 	return cmd.Commands
 }
 
-func (a *Authentication) init() {
+func (a *commands) init() {
 	loginCmd := &cobra.Command{
 		Use:   "login",
 		Short: "Login to a Confluent Control Plane.",
@@ -42,7 +43,7 @@ func (a *Authentication) init() {
 	a.Commands = []*cobra.Command{loginCmd, logoutCmd}
 }
 
-func (a *Authentication) login(cmd *cobra.Command, args []string) error {
+func (a *commands) login(cmd *cobra.Command, args []string) error {
 	email, password, err := credentials()
 	if err != nil {
 		return err
@@ -51,7 +52,7 @@ func (a *Authentication) login(cmd *cobra.Command, args []string) error {
 	client := chttp.NewClient(chttp.BaseClient, a.config.AuthURL, a.config.Logger)
 	token, err := client.Auth.Login(email, password)
 	if err != nil {
-		err := shared.ConvertAPIError(err)
+		err = shared.ConvertAPIError(err)
 		if err == shared.ErrUnauthorized { // special case for login failure
 			err = shared.ErrIncorrectAuth
 		}
@@ -74,7 +75,7 @@ func (a *Authentication) login(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func (a *Authentication) logout(cmd *cobra.Command, args []string) error {
+func (a *commands) logout(cmd *cobra.Command, args []string) error {
 	a.config.AuthToken = ""
 	a.config.Auth = nil
 	err := a.config.Save()

--- a/command/common/cli.go
+++ b/command/common/cli.go
@@ -6,6 +6,7 @@ import (
 	"github.com/confluentinc/cli/shared"
 )
 
+// HandleError provides standard error messaging for common errors.
 func HandleError(err error) error {
 	switch err {
 	case shared.ErrUnauthorized:

--- a/command/common/output.go
+++ b/command/common/output.go
@@ -49,6 +49,7 @@ import (
 	"github.com/olekukonko/tablewriter"
 )
 
+// ToRow formats a single row for inclusion in RenderTable output.
 func ToRow(obj interface{}, fields []string) []string {
 	c := reflect.ValueOf(obj).Elem()
 	var data []string
@@ -58,6 +59,7 @@ func ToRow(obj interface{}, fields []string) []string {
 	return data
 }
 
+// RenderTable outputs data in a tabular format.
 func RenderTable(data [][]string, labels []string) {
 	table := tablewriter.NewWriter(os.Stdout)
 	table.SetHeader(labels)
@@ -66,6 +68,7 @@ func RenderTable(data [][]string, labels []string) {
 	table.Render()
 }
 
+// RenderDetail outputs a subset of fields of an object, with fields renamed by labels.
 func RenderDetail(obj interface{}, fields []string, labels []string) {
 	c := reflect.ValueOf(obj).Elem()
 	var data [][]string

--- a/command/connect/grpc.go
+++ b/command/connect/grpc.go
@@ -61,7 +61,7 @@ func (c *GRPCClient) Delete(ctx context.Context, cluster *schedv1.ConnectCluster
 	return nil
 }
 
-// The gRPC server the GPRClient talks to. Plugin authors implement this if they're using Go.
+// GRPCServer the GPRClient talks to. Plugin authors implement this if they're using Go.
 type GRPCServer struct {
 	Impl Connect
 }

--- a/command/kafka/grpc.go
+++ b/command/kafka/grpc.go
@@ -29,7 +29,7 @@ func (c *GRPCClient) Describe(ctx context.Context, cluster *schedv1.KafkaCluster
 	return resp.Cluster, nil
 }
 
-// The gRPC server the GPRClient talks to. Plugin authors implement this if they're using Go.
+// GRPCServer the GPRClient talks to. Plugin authors implement this if they're using Go.
 type GRPCServer struct {
 	Impl Kafka
 }

--- a/http/auth.go
+++ b/http/auth.go
@@ -38,6 +38,7 @@ func NewAuthService(client *Client) *AuthService {
 	}
 }
 
+// Login attempts to login a user by username and password, returning either a token or an error.
 func (a *AuthService) Login(username, password string) (string, error) {
 	payload := map[string]string{"email": username, "password": password}
 	req, err := a.sling.New().Post(loginPath).BodyJSON(payload).Request()
@@ -68,6 +69,7 @@ func (a *AuthService) Login(username, password string) (string, error) {
 	return "", errUnauthorized
 }
 
+// User returns the AuthConfig for the authenticated user.
 func (a *AuthService) User() (*shared.AuthConfig, error) {
 	me := &orgv1.GetUserReply{}
 	_, err := a.sling.New().Get(mePath).Receive(me, me)

--- a/http/client.go
+++ b/http/client.go
@@ -17,10 +17,12 @@ const (
 )
 
 var (
+	// BaseClient represents a raw golang http client with the SDK http defaults.
 	BaseClient  = &http.Client{Timeout: timeout}
 	errNotFound = &corev1.Error{Code: http.StatusNotFound, Message: "cluster not found"} // matches gateway response
 )
 
+// Client represents the Confluent SDK client.
 type Client struct {
 	httpClient *http.Client
 	baseURL    string
@@ -31,6 +33,7 @@ type Client struct {
 	Connect    *ConnectService
 }
 
+// NewClient creates a Confluent SDK client.
 func NewClient(httpClient *http.Client, baseURL string, logger *log.Logger) *Client {
 	client := &Client{
 		httpClient: httpClient,
@@ -44,6 +47,7 @@ func NewClient(httpClient *http.Client, baseURL string, logger *log.Logger) *Cli
 	return client
 }
 
+// NewClientWithJWT creates a Confluent SDK client which authenticates with the given JSON Web Token (JWT).
 func NewClientWithJWT(ctx context.Context, jwt, baseURL string, logger *log.Logger) *Client {
 	ctx = context.WithValue(ctx, oauth2.HTTPClient, BaseClient)
 	ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: jwt})

--- a/log/logger.go
+++ b/log/logger.go
@@ -4,11 +4,21 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+// Logger is the standard logger for the Confluent SDK.
 type Logger struct {
 	*logrus.Logger
 }
 
-func (l *Logger) Log(args ...interface{}) error {
+// New create and configures a new Logger.
+func New() *Logger {
+	logger := &Logger{Logger: logrus.New()}
+	logger.Formatter = &logrus.TextFormatter{FullTimestamp: true, DisableLevelTruncation: true}
+	return logger
+}
+
+// Log logs a "msg" and key-value pairs.
+// Example: Log("msg", "hello", "key1", "val1", "key2", "val2")
+func (l *Logger) Log(args ...interface{}) {
 	var msg interface{}
 	m := make(map[string]interface{})
 	for i := 0; i < len(args); i += 2 {
@@ -21,11 +31,4 @@ func (l *Logger) Log(args ...interface{}) error {
 		}
 	}
 	l.WithFields(logrus.Fields(m)).Debug(msg)
-	return nil
-}
-
-func New() *Logger {
-	logger := &Logger{Logger: logrus.New()}
-	logger.Formatter = &logrus.TextFormatter{FullTimestamp: true, DisableLevelTruncation: true}
-	return logger
 }

--- a/metric/sink.go
+++ b/metric/sink.go
@@ -6,10 +6,12 @@ import (
 	s "github.com/armon/go-metrics"
 )
 
+// Sink is used to transmit metrics information to an external system.
 type Sink struct {
 	s.MetricSink
 }
 
+// NewSink returns a new in-memory metrics sink.
 func NewSink() *Sink {
 	return &Sink{
 		MetricSink: s.NewInmemSink(time.Second, 15*time.Second),

--- a/plugin/confluent-connect-plugin/main.go
+++ b/plugin/confluent-connect-plugin/main.go
@@ -23,7 +23,7 @@ func main() {
 		logger.Log("msg", "hello")
 		defer logger.Log("msg", "goodbye")
 
-		f, err := os.OpenFile("/tmp/confluent-connect-plugin.log", os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0666)
+		f, err := os.OpenFile("/tmp/confluent-connect-plugin.log", os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0600)
 		check(err)
 		logger.SetLevel(logrus.DebugLevel)
 		logger.Logger.Out = f

--- a/plugin/confluent-kafka-plugin/main.go
+++ b/plugin/confluent-kafka-plugin/main.go
@@ -23,7 +23,7 @@ func main() {
 		logger.Log("msg", "hello")
 		defer logger.Log("msg", "goodbye")
 
-		f, err := os.OpenFile("/tmp/confluent-kafka-plugin.log", os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0666)
+		f, err := os.OpenFile("/tmp/confluent-kafka-plugin.log", os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0600)
 		check(err)
 		logger.SetLevel(logrus.DebugLevel)
 		logger.Logger.Out = f

--- a/shared/cli.go
+++ b/shared/cli.go
@@ -7,13 +7,16 @@ import (
 	orgv1 "github.com/confluentinc/cc-structs/kafka/org/v1"
 )
 
+// AuthConfig represents an authenticated user.
 type AuthConfig struct {
 	User      *orgv1.User    `json:"user" hcl:"user"`
 	Account   *orgv1.Account `json:"account" hcl:"account"`
 }
 
+// Label represents a key-value pair for a metric.
 type Label = metrics.Label
 
+// The MetricSink interface is used to transmit metrics information to an external system.
 type MetricSink interface {
 	// A Gauge should retain the last value it is set to
 	SetGauge(key []string, val float32)
@@ -31,6 +34,7 @@ type MetricSink interface {
 	AddSampleWithLabels(key []string, val float32, labels []Label)
 }
 
+// Handshake is a configuration for CLI to communicate with SDK components.
 var Handshake = plugin.HandshakeConfig{
 	ProtocolVersion:  1,
 	MagicCookieKey:   "CLI_PLUGIN",

--- a/shared/config.go
+++ b/shared/config.go
@@ -20,8 +20,10 @@ const (
 	defaultConfigFile = "~/.confluent/config.hcl"
 )
 
+// ErrNoConfig means that no configuration exists.
 var ErrNoConfig = fmt.Errorf("no config file exists")
 
+// Config represents the CLI configuration.
 type Config struct {
 	MetricSink MetricSink  `json:"-" hcl:"-"`
 	Logger     *log.Logger `json:"-" hcl:"-"`
@@ -31,6 +33,7 @@ type Config struct {
 	Auth       *AuthConfig `json:"auth" hcl:"auth"`
 }
 
+// Load reads the CLI config from disk.
 func (c *Config) Load() error {
 	filename, err := c.getFilename()
 	if err != nil {
@@ -50,6 +53,7 @@ func (c *Config) Load() error {
 	return nil
 }
 
+// Save writes the CLI config to disk.
 func (c *Config) Save() error {
 	cfg, err := json.Marshal(c)
 	if err != nil {
@@ -71,7 +75,7 @@ func (c *Config) Save() error {
 	if err != nil {
 		return errors.Wrapf(err, "unable to create config file: %s", filename)
 	}
-	defer f.Close()
+	defer func(){_ = f.Close()}()
 	err = printer.Fprint(f, ast)
 	if err != nil {
 		return errors.Wrapf(err, "unable to write config to file: %s", filename)
@@ -79,6 +83,7 @@ func (c *Config) Save() error {
 	return nil
 }
 
+// CheckLogin returns an error if the user is not logged in.
 func (c *Config) CheckLogin() error {
 	if c.Auth == nil || c.Auth.Account == nil || c.Auth.Account.Id == "" {
 		return ErrUnauthorized

--- a/shared/errors.go
+++ b/shared/errors.go
@@ -31,6 +31,7 @@ var (
 	ErrNotFound       = fmt.Errorf("not found")
 )
 
+// ConvertAPIError transforms a corev1.Error into one of the standard errors if it matches.
 func ConvertAPIError(err error) error {
 	if e, ok := errors.Cause(err).(*corev1.Error); ok {
 		switch e.Message {
@@ -51,6 +52,7 @@ func ConvertAPIError(err error) error {
 	return err
 }
 
+// ConvertGRPCError unboxes and returns the underlying standard error sent over gRPC if it matches.
 func ConvertGRPCError(err error) error {
 	if s, ok := status.FromError(err); ok {
 		switch s.Message() {


### PR DESCRIPTION
@confluentinc/caas 

This runs a bunch of linters, two of which catch the issue from #18.

```
http/auth.go:48:8:warning: ineffectual assignment to err (ineffassign)
http/auth.go:48:8:warning: this value of err is never used (SA4006) (megacheck)
```

Created a linter config file to ignore the stuff we don't care about and cleaned up the rest.