### PR TITLE
Add connect create --type flag

### DIFF
--- a/command/connect/command.go
+++ b/command/connect/command.go
@@ -336,6 +336,7 @@ func check(err error) {
 	}
 }
 
+// Enum is a cobra Args validator that ensures a flag value is one of a set of options.
 func Enum(flag string, options ...string) cobra.PositionalArgs {
 	return func(cmd *cobra.Command, args []string) error {
 		pluginType, err := cmd.Flags().GetString(flag)


### PR DESCRIPTION
@confluentinc/caas 

Getting closer to what's outlined in the Aspirational CLI UX doc. 

    confluent connect sink create --type=s3

But this version doesn't have any subresources yet, so currently just implementing this:

    confluent connect create --type=s3-sink
