### PR TITLE
Add basic shell completion support for bash and zsh

### DIFF
--- a/command/common/completion.go
+++ b/command/common/completion.go
@@ -1,0 +1,74 @@
+package common
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+const longDescription = `Output shell completion code for the specified shell (bash or zsh).
+The shell code must be evaluated to provide interactive completion of confluent commands.
+
+Install bash completions on macOS:
+
+  # Enable bash completions using homebrew
+  ## If running Bash 3.2 included with macOS
+  brew install bash-completion
+  ## or, if running Bash 4.1+
+  brew install bash-completion@2
+  # Set the confluent completion code for bash to a file that's sourced on login
+  confluent completion bash > $(brew --prefix)/etc/bash_completion.d/confluent
+
+Install bash completions on Linux:
+
+  # Load the confluent completion code for bash into the current shell
+  source <(confluent completion bash)
+
+  # Set the confluent completion code for bash to a file that's sourced on login
+  confluent completion bash > /etc/bash_completion.d/confluent
+
+Install zsh completions:
+
+  # Load the confluent completion code for zsh into the current shell
+  source <(confluent completion zsh)
+
+  # Set the confluent completion code for zsh to autoload on startup
+  confluent completion zsh > "${fpath[1]}/_confluent"
+`
+
+type command struct {
+	*cobra.Command
+	rootCmd *cobra.Command
+}
+
+// NewCompletionCmd returns the Cobra command for shell completion.
+func NewCompletionCmd(rootCmd *cobra.Command) *cobra.Command {
+	cmd := &command{
+		rootCmd: rootCmd,
+	}
+	cmd.init()
+	return cmd.Command
+}
+
+func (c *command) init() {
+	c.Command = &cobra.Command{
+		Use:   "completion SHELL",
+		Short: "Output shell completion code for the specified shell (bash or zsh).",
+		Long:  longDescription,
+		RunE:  c.completion,
+		Args:  cobra.ExactArgs(1),
+	}
+}
+
+func (c *command) completion(cmd *cobra.Command, args []string) error {
+	var err error
+	if args[0] == "bash" {
+		err = c.rootCmd.GenBashCompletion(os.Stdout)
+	} else if args[0] == "zsh" {
+		err = c.rootCmd.GenZshCompletion(os.Stdout)
+	} else {
+		err = fmt.Errorf(`unsupported shell type "%s"`, args[0])
+	}
+	return err
+}

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/confluentinc/cli/command/common"
 	"github.com/hashicorp/go-plugin"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -67,6 +68,8 @@ func main() {
 	cli.PersistentPostRun = func(cmd *cobra.Command, args []string) {
 		plugin.CleanupClients()
 	}
+
+	cli.AddCommand(common.NewCompletionCmd(cli))
 
 	cli.AddCommand(auth.New(config)...)
 


### PR DESCRIPTION
@confluentinc/caas 

```
$ confluent [TAB][TAB]
completion  connect     kafka       login       logout      

$ confluent k[TAB]

$ confluent kafka  [TAB][TAB]
auth      create    delete    describe  list      update    

$ confluent kafka de[TAB]
delete    describe  
```

Doesn't auto-complete resource names/IDs yet or anything fancy. But the basics are here.

```
$ confluent completion --help
Output shell completion code for the specified shell (bash or zsh).
The shell code must be evaluated to provide interactive completion of confluent commands.

Install bash completions on macOS:

  # Enable bash completions using homebrew
  ## If running Bash 3.2 included with macOS
  brew install bash-completion
  ## or, if running Bash 4.1+
  brew install bash-completion@2
  # Set the confluent completion code for bash to a file that's sourced on login
  confluent completion bash > $(brew --prefix)/etc/bash_completion.d/confluent

Install bash completions on Linux:

  # Load the confluent completion code for bash into the current shell
  source <(confluent completion bash)

  # Set the confluent completion code for bash to a file that's sourced on login
  confluent completion bash > /etc/bash_completion.d/confluent

Install zsh completions:

  # Load the confluent completion code for zsh into the current shell
  source <(confluent completion zsh)

  # Set the confluent completion code for zsh to autoload on startup
  confluent completion zsh > "${fpath[1]}/_confluent"

Usage:
  confluent completion SHELL [flags]

Flags:
  -h, --help   help for completion
```