### PR TITLE
Add goreleaser for better packaging and distribution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-build/
+dist/
 /confluent
 /confluent-*-plugin
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,116 @@
+project_name: confluent-cli
+
+builds:
+  -
+    binary: confluent
+    main: .
+    ldflags:
+      # remove the date so builds are reproducible (identical SHAs)
+      - -s -w -X main.version={{.Version}} -X main.commit={{.Commit}}
+    gcflags:
+      - -trimpath={{.Env.GOPATH}}
+    asmflags:
+      - -trimpath={{.Env.GOPATH}}
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - 386
+    ignore:
+      - goos: darwin
+        goarch: 386
+  -
+    binary: confluent-kafka-plugin
+    main: ./plugin/confluent-kafka-plugin
+    ldflags:
+      # remove the date so builds are reproducible (identical SHAs)
+      - -s -w -X main.version={{.Version}} -X main.commit={{.Commit}}
+    gcflags:
+      - -trimpath={{.Env.GOPATH}}
+    asmflags:
+      - -trimpath={{.Env.GOPATH}}
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - 386
+    ignore:
+      - goos: darwin
+        goarch: 386
+  -
+    binary: confluent-connect-plugin
+    main: ./plugin/confluent-connect-plugin
+    ldflags:
+      # remove the date so builds are reproducible (identical SHAs)
+      - -s -w -X main.version={{.Version}} -X main.commit={{.Commit}}
+    gcflags:
+      - -trimpath={{.Env.GOPATH}}
+    asmflags:
+      - -trimpath={{.Env.GOPATH}}
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - 386
+    ignore:
+      - goos: darwin
+        goarch: 386
+
+release:
+  github:
+    owner: confluentinc
+    name: cli
+
+  prerelease: true
+
+archive:
+  files:
+  - LICENSE
+  wrap_in_directory: true
+
+  format_overrides:
+    - goos: windows
+      format: zip
+
+  replacements:
+    darwin: Darwin
+    linux: Linux
+    windows: Windows
+    386: i386
+    amd64: x86_64
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+    - '^docs:'
+    - '^test:'
+    - Merge pull request
+    - Merge branch
+    - ci skip
+
+s3:
+  -
+    bucket: cloud-confluent-bin
+    region: us-west-2
+    folder: "cli/{{.Version}}"
+
+brew:
+  github:
+    owner: confluentinc
+    name: homebrew-ccloud
+  folder: Formula
+  download_strategy: GitHubPrivateRepositoryReleaseDownloadStrategy
+
+  homepage: https://confluent.io
+  description: Confluent CLI
+
+  commit_author:
+    name: Cody A. Ray
+    email: cody@confluent.io

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,1 @@
+Copyright 2016 Confluent, Inc.

--- a/README.md
+++ b/README.md
@@ -6,20 +6,36 @@
 
 ## Install
 
-Right now, we're publishing to a private S3 bucket. Make sure you have your AWS
+### Brew
+
+Setup the Confluent Cloud brew tap:
+
+    brew tap confluentinc/ccloud
+
+For now, the CLI is private so you'll need to use your Github token:
+
+    HOMEBREW_GITHUB_API_TOKEN=xxx brew install confluent-cli
+
+### S3
+
+We're publishing pre-built binaries to a private S3 bucket. Make sure you have your AWS
 engineering creds setup in your `[default]` AWS profile locally, like normal.
 
-To install the CLI itself, run:
+To list all available packages for a version:
 
-    VERSION=12ffed3
-    aws s3 cp s3://cloud-confluent-bin/cli/cli-${VERSION}-darwin-amd64 ./cli
+    VERSION=0.6.0
+    aws s3 ls s3://cloud-confluent-bin/cli/${VERSION}/
 
-To install all components, run:
+To download the CLI for your OS and architecture:
 
-    VERSION=12ffed3
-    for COMPONENT in confluent-kafka-plugin confluent-connect-plugin ; do
-        aws s3 cp s3://cloud-confluent-bin/cli/components/${COMPONENT}/${COMPONENT}-${VERSION}-darwin-amd64 ./${COMPONENT}
-    done
+    OS=Darwin
+    ARCH=x86_64
+    aws s3 cp s3://cloud-confluent-bin/cli/${VERSION}/confluent-cli_${VERSION}_${OS}_${ARCH}.tar.gz .
+
+To install the CLI:
+
+    tar -xzvf confluent-cli_${VERSION}_${OS}_${ARCH}.tar.gz
+    sudo mv confluent-cli_${VERSION}_${OS}_${ARCH}/confluent* /usr/local/bin
 
 Note: components must be installed in your `$PATH` for the CLI to pick them up.
 
@@ -42,3 +58,10 @@ Now you can run:
 ```
 $ go run main.go connect list
 ```
+
+# Packaging and Distribution
+
+Either set the `GITHUB_TOKEN` environment variable or create `~/.config/goreleaser/github_token`
+with this value. The token must have `repo` scope to deploy artifacts to Github.
+
+


### PR DESCRIPTION
@confluentinc/caas 

We can use [goreleaser](https://goreleaser.com/) to automate parallel cross-compile builds, archiving to tar.gz/zip, SHA creation, github release & changelog creation, uploads to S3, homebrew, etc.

We'll add deb/rpm packages soon. Unfortunately those have to be compiled on golang 1.10 so I haven't had a chance to test yet.