### PR TITLE
Add delete method to APIKey service interface

### DIFF
--- a/http/interfaces.go
+++ b/http/interfaces.go
@@ -29,6 +29,7 @@ type User interface {
 // APIKey service allows managing API Keys in Confluent Cloud
 type APIKey interface {
 	Create(key *schedv1.ApiKey) (*schedv1.ApiKey, *http.Response, error)
+    Delete(key *schedv1.ApiKey) (*http.Response, error)
 }
 
 // Kafka service allows managing Kafka clusters in Confluent Cloud


### PR DESCRIPTION
@confluentinc/ccloud 

Realized this was missing when trying to use this interface in cc-integration-tests