### PR TITLE
Bump cc-structs

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -64,16 +64,18 @@
   revision = "4f3c7e6dfbe2e5f711a618ef9113794d5fd442fa"
 
 [[projects]]
-  digest = "1:02615aaec0c7801447c2493a254fba817cd947dfa182507a4b5e1b5cad5231d8"
+  digest = "1:117f02c19ffa3d8928bb18609b2303674a09d9cff57382d1f55be54c022c77fb"
   name = "github.com/confluentinc/cc-structs"
   packages = [
     "kafka/core/v1",
     "kafka/org/v1",
     "kafka/scheduler/v1",
     "operator/v1",
+    "scheduler_plugins/common/v1",
+    "scheduler_plugins/connect/v1",
   ]
   pruneopts = "UT"
-  revision = "8bf61f9b1ef035bc211c63ff6ffdd0febaae3e26"
+  revision = "9e4088a50c2c43c232f8a35462869f891ea4fdd0"
 
 [[projects]]
   digest = "1:38724ee117eaeb604001a7922bdb48f794ac6ebc423bdfbd7a9a75a410667a42"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -64,7 +64,7 @@
 
 [[constraint]]
   name = "github.com/confluentinc/cc-structs"
-  revision = "8bf61f9b1ef035bc211c63ff6ffdd0febaae3e26"
+  revision = "9e4088a50c2c43c232f8a35462869f891ea4fdd0"
 
 [[constraint]]
   name = "github.com/codyaray/go-printer"

--- a/http/interfaces.go
+++ b/http/interfaces.go
@@ -29,7 +29,7 @@ type User interface {
 // APIKey service allows managing API Keys in Confluent Cloud
 type APIKey interface {
 	Create(key *schedv1.ApiKey) (*schedv1.ApiKey, *http.Response, error)
-    Delete(key *schedv1.ApiKey) (*http.Response, error)
+	Delete(key *schedv1.ApiKey) (*http.Response, error)
 }
 
 // Kafka service allows managing Kafka clusters in Confluent Cloud


### PR DESCRIPTION
@confluentinc/ccloud 

We need to break the http lib out into its own repo. When using it as a library, the cc-structs version needs to be loose (like, anything greater than x version). But when using it as an app (like for the cli), you want a fixed version.

This is why everytime I change the version of cc-structs for cc-integration-tests, i have to bump the structs version in the CLI codebase