### PR TITLE
Update CreateApiKey to include Account_id for new gateway API

### DIFF
--- a/command/kafka/command_cluster.go
+++ b/command/kafka/command_cluster.go
@@ -19,8 +19,8 @@ import (
 )
 
 var (
-	listFields      = []string{"Id", "Name", "ServiceProvider", "Region", "Durability", "Status"}
-	listLabels      = []string{"Id", "Name", "Provider", "Region", "Durability", "Status"}
+	listFields      = []string{"Id", "Name", "ServiceProvider", "Region", "Durability", "Status", "Enterprise"}
+	listLabels      = []string{"Id", "Name", "Provider", "Region", "Durability", "Status", "Enterprise"}
 	describeFields  = []string{"Id", "Name", "NetworkIngress", "NetworkEgress", "Storage", "ServiceProvider", "Region", "Status", "Endpoint", "ApiEndpoint", "PricePerHour"}
 	describeRenames = map[string]string{"NetworkIngress": "Ingress", "NetworkEgress": "Egress", "ServiceProvider": "Provider"}
 )
@@ -295,6 +295,7 @@ func (c *clusterCommand) createKafkaCreds(ctx context.Context, kafkaClusterID st
 		LogicalClusters: []*authv1.ApiKey_Cluster{
 			{Id: kafkaClusterID},
 		},
+		AccountId: c.config.Auth.Account.Id,
 	})
 
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -13,8 +13,8 @@ require (
 	github.com/codyaray/go-printer v0.8.0
 	github.com/codyaray/retag v0.0.0-20180529164156-4f3c7e6dfbe2 // indirect
 	github.com/confluentinc/cc-structs v0.0.0-20181109155559-7cfce9602e5d
-	github.com/confluentinc/ccloud-sdk-go v0.0.5-0.20190205193832-1f6d876cdc3f
-	github.com/confluentinc/ccloudapis v0.0.0-20190205225915-829aeb3a907d
+	github.com/confluentinc/ccloud-sdk-go v0.0.5-0.20190212021901-96b398ba05b0
+	github.com/confluentinc/ccloudapis v0.0.0-20190212005548-af6f7798248f
 	github.com/confluentinc/confluent-kafka-go v0.11.6
 	github.com/confluentinc/proto-go-setter v0.0.0-20180912191759-fb17e76fc076 // indirect
 	github.com/confluentinc/protoc-gen-ccloud v0.0.1 // indirect


### PR DESCRIPTION
- Update ccloudapis and ccloud-sdk-go. 
- Add account_id to ApiKey request per the new gateway API 
- Add enterprise field to list output 