### PR TITLE
Add output for make deps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ include ./semver.mk
 
 .PHONY: deps
 deps:
-	@GO111MODULE=on go mod download >/dev/null 2>&1
+	@GO111MODULE=on go mod download
 	@GO111MODULE=on go get github.com/goreleaser/goreleaser@v0.101.0
 	@GO111MODULE=on go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.12.2
 


### PR DESCRIPTION
The build failed on master saying it couldn't find any deps, but we nuked all output to see what deps actually installed... not sure why we did that.