### PR TITLE
Update kafka cluster auth to include AccountId in create api key request

### DIFF
--- a/command/kafka/command_cluster.go
+++ b/command/kafka/command_cluster.go
@@ -295,6 +295,7 @@ func (c *clusterCommand) createKafkaCreds(ctx context.Context, kafkaClusterID st
 		LogicalClusters: []*authv1.ApiKey_Cluster{
 			{Id: kafkaClusterID},
 		},
+		AccountId:c.config.Auth.Account.Id,
 	})
 
 	if err != nil {


### PR DESCRIPTION
Looks like we missed a spot when updating the gateway api to make keys account scoped. 