### PR TITLE
Remove unlaunched plugins from main goreleaser config

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -44,44 +44,6 @@ builds:
     ignore:
       - goos: darwin
         goarch: 386
-  -
-    binary: ccloud-connect-plugin
-    main: ./plugin/ccloud-connect-plugin
-    ldflags:
-      - -s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}}  -X main.host={{.Env.HOSTNAME}}
-    gcflags:
-      - -trimpath={{.Env.GOPATH}}
-    asmflags:
-      - -trimpath={{.Env.GOPATH}}
-    goos:
-      - linux
-      - darwin
-      - windows
-    goarch:
-      - amd64
-      - 386
-    ignore:
-      - goos: darwin
-        goarch: 386
-  -
-    binary: ccloud-ksql-plugin
-    main: ./plugin/ccloud-ksql-plugin
-    ldflags:
-      - -s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}}  -X main.host={{.Env.HOSTNAME}}
-    gcflags:
-      - -trimpath={{.Env.GOPATH}}
-    asmflags:
-      - -trimpath={{.Env.GOPATH}}
-    goos:
-      - linux
-      - darwin
-      - windows
-    goarch:
-      - amd64
-      - 386
-    ignore:
-      - goos: darwin
-        goarch: 386
 
 release:
   disable: true

--- a/Makefile
+++ b/Makefile
@@ -50,8 +50,6 @@ release: get-release-image commit-release tag-release
 dist:
 	@# unfortunately goreleaser only supports one archive right now (either tar/zip or binaries): https://github.com/goreleaser/goreleaser/issues/705
 	@# we had goreleaser upload binaries (they're uncompressed, so goreleaser's parallel uploads will save more time with binaries than archives)
-	@rm -f dist/**/ccloud-connect-plugin*
-	@rm -f dist/**/ccloud-ksql-plugin*
 	tar -czf dist/ccloud_$(VERSION)_darwin_amd64.tar.gz -C dist/darwin_amd64 ../../LICENSE ../../INSTALL.md .
 	tar -czf dist/ccloud_$(VERSION)_linux_amd64.tar.gz -C dist/linux_amd64 ../../LICENSE ../../INSTALL.md .
 	tar -czf dist/ccloud_$(VERSION)_linux_386.tar.gz -C dist/linux_386 ../../LICENSE ../../INSTALL.md .


### PR DESCRIPTION
Let's not upload binaries either. Just leave them out of the release altogether til we launch.