### PR TITLE
Fix inability to include spaces at begin/end of your password

### DIFF
--- a/command/auth/auth.go
+++ b/command/auth/auth.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -141,7 +142,7 @@ func (a *commands) credentials() (string, string, error) {
 	}
 	password := string(bytePassword)
 
-	return email, password, nil
+	return strings.TrimSpace(email), password, nil
 }
 
 func (a *commands) createOrUpdateContext(user *shared.AuthConfig) {

--- a/command/auth/auth_test.go
+++ b/command/auth/auth_test.go
@@ -93,10 +93,10 @@ func TestLogout(t *testing.T) {
 	req.Empty(config.Auth)
 }
 
-func Test_credentials_ShouldSupportSpacesAtBeginOrEnd(t *testing.T) {
+func Test_credentials_NoSpacesAroundEmail_ShouldSupportSpacesAtBeginOrEnd(t *testing.T) {
 	req := require.New(t)
 
-	prompt := prompt("cody@confluent.io", " iamrobin ")
+	prompt := prompt(" cody@confluent.io ", " iamrobin ")
 	prompt.Out = os.Stdout
 	auth := &sdkMock.Auth{}
 	cmds, _ := newAuthCommand(prompt, auth, req)


### PR DESCRIPTION
Apparently some people put spaces at the end of their passwords. Who knew.