### PR TITLE
Fix cloud provider output field name for kafka cluster list and describe

### DIFF
--- a/command/kafka/command_cluster.go
+++ b/command/kafka/command_cluster.go
@@ -20,9 +20,9 @@ import (
 
 var (
 	listFields      = []string{"Id", "Name", "ServiceProvider", "Region", "Durability", "Status"}
-	listLabels      = []string{"Id", "Name", "GRPCPlugin", "Region", "Durability", "Status"}
+	listLabels      = []string{"Id", "Name", "Provider", "Region", "Durability", "Status"}
 	describeFields  = []string{"Id", "Name", "NetworkIngress", "NetworkEgress", "Storage", "ServiceProvider", "Region", "Status", "Endpoint", "ApiEndpoint", "PricePerHour"}
-	describeRenames = map[string]string{"NetworkIngress": "Ingress", "NetworkEgress": "Egress", "ServiceProvider": "GRPCPlugin"}
+	describeRenames = map[string]string{"NetworkIngress": "Ingress", "NetworkEgress": "Egress", "ServiceProvider": "Provider"}
 )
 
 type clusterCommand struct {


### PR DESCRIPTION
Looks like this was inadvertently renamed during a refactor.