### PR TITLE
Add version to plugins to aid debugging

### DIFF
--- a/command/common/version.go
+++ b/command/common/version.go
@@ -1,12 +1,10 @@
 package common
 
 import (
-	"runtime"
-	"strconv"
-
 	"github.com/spf13/cobra"
 
 	"github.com/confluentinc/cli/command"
+	"github.com/confluentinc/cli/shared"
 	"github.com/confluentinc/cli/version"
 )
 
@@ -17,22 +15,7 @@ func NewVersionCmd(version *version.Version, prompt command.Prompt) *cobra.Comma
 		Short: "Print the ccloud version",
 		Long:  "Print the ccloud version",
 		Run: func(cmd *cobra.Command, args []string) {
-			_, _ = prompt.Printf(`ccloud - Confluent Cloud CLI
-
-Version:     %s
-Git Ref:     %s
-Build Date:  %s
-Build Host:  %s
-Go Version:  %s (%s/%s)
-Development: %s
-`, version.Version,
-				version.Commit,
-				version.BuildDate,
-				version.BuildHost,
-				runtime.Version(),
-				runtime.GOOS,
-				runtime.GOARCH,
-				strconv.FormatBool(!version.IsReleased()))
+			shared.PrintVersion(version, prompt)
 		},
 		Args: cobra.NoArgs,
 	}

--- a/command/common/version_test.go
+++ b/command/common/version_test.go
@@ -13,7 +13,7 @@ func TestVersion(t *testing.T) {
 	req := require.New(t)
 
 	root, prompt := terminal.BuildRootCommand()
-	v := version.NewVersion("1.2.3", "abc1234", "Fri Feb 22 20:55:53 UTC 2019", "CI", "ccloud/awesome 1.0")
+	v := version.NewVersion("1.2.3", "abc1234", "Fri Feb 22 20:55:53 UTC 2019", "CI")
 	cmd := NewVersionCmd(v, prompt)
 	root.AddCommand(cmd)
 
@@ -30,7 +30,7 @@ func TestDevelopmentVersion_v0(t *testing.T) {
 	req := require.New(t)
 
 	root, prompt := terminal.BuildRootCommand()
-	v := version.NewVersion("0.0.0", "abc1234", "01/23/45", "CI", "ccloud/awesome 1.0")
+	v := version.NewVersion("0.0.0", "abc1234", "01/23/45", "CI")
 	cmd := NewVersionCmd(v, prompt)
 	root.AddCommand(cmd)
 
@@ -45,7 +45,7 @@ func TestDevelopmentVersion_Dirty(t *testing.T) {
 	req := require.New(t)
 
 	root, prompt := terminal.BuildRootCommand()
-	v := version.NewVersion("1.2.3-dirty-timmy", "abc1234", "01/23/45", "CI", "ccloud/awesome 1.0")
+	v := version.NewVersion("1.2.3-dirty-timmy", "abc1234", "01/23/45", "CI")
 	cmd := NewVersionCmd(v, prompt)
 	root.AddCommand(cmd)
 
@@ -60,7 +60,7 @@ func TestDevelopmentVersion_Unmerged(t *testing.T) {
 	req := require.New(t)
 
 	root, prompt := terminal.BuildRootCommand()
-	v := version.NewVersion("1.2.3-g16dd476", "abc1234", "01/23/45", "CI", "ccloud/awesome 1.0")
+	v := version.NewVersion("1.2.3-g16dd476", "abc1234", "01/23/45", "CI")
 	cmd := NewVersionCmd(v, prompt)
 	root.AddCommand(cmd)
 

--- a/main.go
+++ b/main.go
@@ -1,9 +1,7 @@
 package main
 
 import (
-	"fmt"
 	"os"
-	"runtime"
 
 	"github.com/confluentinc/cli/command"
 	"github.com/confluentinc/cli/command/apikey"
@@ -52,8 +50,7 @@ func main() {
 		}
 	}
 
-	userAgent := fmt.Sprintf("Confluent/1.0 ccloud/%s (%s/%s)", version, runtime.GOOS, runtime.GOARCH)
-	version := cliVersion.NewVersion(version, commit, date, host, userAgent)
+	version := cliVersion.NewVersion(version, commit, date, host)
 	factory := &common.GRPCPluginFactoryImpl{}
 
 	cli := BuildCommand(cfg, version, factory, logger)

--- a/main_test.go
+++ b/main_test.go
@@ -24,7 +24,7 @@ func TestAddCommands_MissingPluginsNotShownInHelpUsage(t *testing.T) {
 		Logger: logger,
 	})
 
-	version := cliVersion.NewVersion("1.2.3", "abc1234", "01/23/45", "CI", "ccloud/1.2.3")
+	version := cliVersion.NewVersion("1.2.3", "abc1234", "01/23/45", "CI")
 	factory := &mock.GRPCPluginFactory{
 		CreateFunc: func(name string) common.GRPCPlugin {
 			return &mock.GRPCPlugin{
@@ -56,7 +56,7 @@ func TestAddCommands_AvailablePluginsShownInHelpUsage(t *testing.T) {
 		Logger: logger,
 	})
 
-	version := cliVersion.NewVersion("1.2.3", "abc1234", "01/23/45", "CI", "ccloud/1.2.3")
+	version := cliVersion.NewVersion("1.2.3", "abc1234", "01/23/45", "CI")
 	factory := &mock.GRPCPluginFactory{
 		CreateFunc: func(name string) common.GRPCPlugin {
 			return &mock.GRPCPlugin{

--- a/plugin/ccloud-apikey-plugin/main.go
+++ b/plugin/ccloud-apikey-plugin/main.go
@@ -8,16 +8,30 @@ import (
 
 	chttp "github.com/confluentinc/ccloud-sdk-go"
 	authv1 "github.com/confluentinc/ccloudapis/auth/v1"
+	"github.com/confluentinc/cli/command"
 	log "github.com/confluentinc/cli/log"
 	metric "github.com/confluentinc/cli/metric"
 	"github.com/confluentinc/cli/shared"
 	"github.com/confluentinc/cli/shared/apikey"
+	cliVersion "github.com/confluentinc/cli/version"
+)
+
+var (
+	// Injected from linker flags like `go build -ldflags "-X main.version=$VERSION" -X ...`
+	version = "v0.0.0"
+	commit  = ""
+	date    = ""
+	host    = ""
 )
 
 // Compile-time check for Interface adherence
 var _ chttp.APIKey = (*ApiKey)(nil)
 
 func main() {
+	if os.Args[1] == "version" || os.Args[1] == "--version" {
+		shared.PrintVersion(cliVersion.NewVersion(version, commit, date, host), command.NewTerminalPrompt(os.Stdin))
+	}
+
 	var logger *log.Logger
 	{
 		logger = log.New()

--- a/plugin/ccloud-connect-plugin/main.go
+++ b/plugin/ccloud-connect-plugin/main.go
@@ -9,16 +9,30 @@ import (
 	chttp "github.com/confluentinc/ccloud-sdk-go"
 	connectv1 "github.com/confluentinc/ccloudapis/connect/v1"
 	orgv1 "github.com/confluentinc/ccloudapis/org/v1"
+	"github.com/confluentinc/cli/command"
 	"github.com/confluentinc/cli/log"
 	"github.com/confluentinc/cli/metric"
 	"github.com/confluentinc/cli/shared"
 	"github.com/confluentinc/cli/shared/connect"
+	cliVersion "github.com/confluentinc/cli/version"
+)
+
+var (
+	// Injected from linker flags like `go build -ldflags "-X main.version=$VERSION" -X ...`
+	version = "v0.0.0"
+	commit  = ""
+	date    = ""
+	host    = ""
 )
 
 // Compile-time check for Interface adherence
 var _ chttp.Connect = (*Connect)(nil)
 
 func main() {
+	if os.Args[1] == "version" || os.Args[1] == "--version" {
+		shared.PrintVersion(cliVersion.NewVersion(version, commit, date, host), command.NewTerminalPrompt(os.Stdin))
+	}
+
 	var logger *log.Logger
 	{
 		logger = log.New()

--- a/plugin/ccloud-kafka-plugin/main.go
+++ b/plugin/ccloud-kafka-plugin/main.go
@@ -9,16 +9,30 @@ import (
 	chttp "github.com/confluentinc/ccloud-sdk-go"
 	authv1 "github.com/confluentinc/ccloudapis/auth/v1"
 	kafkav1 "github.com/confluentinc/ccloudapis/kafka/v1"
+	"github.com/confluentinc/cli/command"
 	log "github.com/confluentinc/cli/log"
 	metric "github.com/confluentinc/cli/metric"
 	"github.com/confluentinc/cli/shared"
 	"github.com/confluentinc/cli/shared/kafka"
+	cliVersion "github.com/confluentinc/cli/version"
+)
+
+var (
+	// Injected from linker flags like `go build -ldflags "-X main.version=$VERSION" -X ...`
+	version = "v0.0.0"
+	commit  = ""
+	date    = ""
+	host    = ""
 )
 
 // Compile-time check for Interface adherence
 var _ chttp.Kafka = (*Kafka)(nil)
 
 func main() {
+	if os.Args[1] == "version" || os.Args[1] == "--version" {
+		shared.PrintVersion(cliVersion.NewVersion(version, commit, date, host), command.NewTerminalPrompt(os.Stdin))
+	}
+
 	var logger *log.Logger
 	{
 		logger = log.New()

--- a/plugin/ccloud-ksql-plugin/main.go
+++ b/plugin/ccloud-ksql-plugin/main.go
@@ -8,13 +8,27 @@ import (
 
 	chttp "github.com/confluentinc/ccloud-sdk-go"
 	ksqlv1 "github.com/confluentinc/ccloudapis/ksql/v1"
+	"github.com/confluentinc/cli/command"
 	log "github.com/confluentinc/cli/log"
 	metric "github.com/confluentinc/cli/metric"
 	"github.com/confluentinc/cli/shared"
 	"github.com/confluentinc/cli/shared/ksql"
+	cliVersion "github.com/confluentinc/cli/version"
+)
+
+var (
+	// Injected from linker flags like `go build -ldflags "-X main.version=$VERSION" -X ...`
+	version = "v0.0.0"
+	commit  = ""
+	date    = ""
+	host    = ""
 )
 
 func main() {
+	if os.Args[1] == "version" || os.Args[1] == "--version" {
+		shared.PrintVersion(cliVersion.NewVersion(version, commit, date, host), command.NewTerminalPrompt(os.Stdin))
+	}
+
 	var logger *log.Logger
 	{
 		logger = log.New()

--- a/plugin/ccloud-user-plugin/main.go
+++ b/plugin/ccloud-user-plugin/main.go
@@ -8,16 +8,30 @@ import (
 
 	chttp "github.com/confluentinc/ccloud-sdk-go"
 	orgv1 "github.com/confluentinc/ccloudapis/org/v1"
+	"github.com/confluentinc/cli/command"
 	"github.com/confluentinc/cli/log"
 	"github.com/confluentinc/cli/metric"
 	"github.com/confluentinc/cli/shared"
 	"github.com/confluentinc/cli/shared/user"
+	cliVersion "github.com/confluentinc/cli/version"
+)
+
+var (
+	// Injected from linker flags like `go build -ldflags "-X main.version=$VERSION" -X ...`
+	version = "v0.0.0"
+	commit  = ""
+	date    = ""
+	host    = ""
 )
 
 // Compile-time check for Interface adherence
 var _ chttp.User = (*User)(nil)
 
 func main() {
+	if os.Args[1] == "version" || os.Args[1] == "--version" {
+		shared.PrintVersion(cliVersion.NewVersion(version, commit, date, host), command.NewTerminalPrompt(os.Stdin))
+	}
+
 	var logger *log.Logger
 	{
 		logger = log.New()

--- a/shared/version.go
+++ b/shared/version.go
@@ -1,0 +1,29 @@
+package shared
+
+import (
+	"runtime"
+	"strconv"
+
+	"github.com/confluentinc/cli/command"
+	"github.com/confluentinc/cli/version"
+)
+
+// PrintVersion prints the version to the prompt in a standardized way
+func PrintVersion(version *version.Version, prompt command.Prompt) {
+	_, _ = prompt.Printf(`ccloud - Confluent Cloud CLI
+
+Version:     %s
+Git Ref:     %s
+Build Date:  %s
+Build Host:  %s
+Go Version:  %s (%s/%s)
+Development: %s
+`, version.Version,
+		version.Commit,
+		version.BuildDate,
+		version.BuildHost,
+		runtime.Version(),
+		runtime.GOOS,
+		runtime.GOARCH,
+		strconv.FormatBool(!version.IsReleased()))
+}

--- a/version/version.go
+++ b/version/version.go
@@ -1,6 +1,8 @@
 package version
 
 import (
+	"fmt"
+	"runtime"
 	"strings"
 )
 
@@ -12,13 +14,13 @@ type Version struct {
 	UserAgent string
 }
 
-func NewVersion(version, commit, buildDate, buildHost, userAgent string) *Version {
+func NewVersion(version, commit, buildDate, buildHost string) *Version {
 	return &Version{
 		Version:   version,
 		Commit:    commit,
 		BuildDate: buildDate,
 		BuildHost: buildHost,
-		UserAgent: userAgent,
+		UserAgent: fmt.Sprintf("Confluent/1.0 ccloud/%s (%s/%s)", version, runtime.GOOS, runtime.GOARCH),
 	}
 }
 


### PR DESCRIPTION
It just occurred to me that we don't have versions on the plugins, so its hard to know what version of a plugin they're running. This is definitely going to bite us, for example when someone updates the driver but doesn't update the plugin at the same time; without this we'd have no good way to tell.

BEFORE
```
$ ./dist/darwin_amd64/ccloud-kafka-plugin --version
This binary is a plugin. These are not meant to be executed directly.
Please execute the program that consumes these plugins, which will
load any plugins automatically
```

AFTER

```
$ ./dist/darwin_amd64/ccloud-kafka-plugin --version
ccloud - Confluent Cloud CLI

Version:     v0.25.1-42-gc4e90d2
Git Ref:     c4e90d226853eed15a58403a639ae91b18c6e7b2
Build Date:  2019-02-27T05:56:29Z
Build Host:  cody@Cody-Rays-MBP15
Go Version:  go1.11.1 (darwin/amd64)
Development: true
This binary is a plugin. These are not meant to be executed directly.
Please execute the program that consumes these plugins, which will
load any plugins automatically
```

I can exit before we print the "This binary is a plugin" paragraph at the bottom if folks want. Thought that might be more useful to have, so I left it.