### PR TITLE
Remove config/context commands and show active kafka cluster

### DIFF
--- a/command/kafka/command_cluster.go
+++ b/command/kafka/command_cluster.go
@@ -116,8 +116,17 @@ func (c *clusterCommand) list(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return common.HandleError(err, cmd)
 	}
+	currCtx, err := c.config.Context()
+	if err != nil && err != shared.ErrNoContext {
+		return err
+	}
 	var data [][]string
 	for _, cluster := range clusters {
+		if cluster.Id == currCtx.Kafka {
+			cluster.Id = fmt.Sprintf("* %s", cluster.Id)
+		} else {
+			cluster.Id = fmt.Sprintf("  %s", cluster.Id)
+		}
 		data = append(data, printer.ToRow(cluster, listFields))
 	}
 	printer.RenderCollectionTable(data, listLabels)

--- a/main.go
+++ b/main.go
@@ -78,7 +78,9 @@ func BuildCommand(cfg *shared.Config, version *cliVersion.Version, factory commo
 	cli.Version = version.Version
 	cli.AddCommand(common.NewVersionCmd(version, prompt))
 
-	cli.AddCommand(config.New(cfg))
+	conn := config.New(cfg)
+	conn.Hidden = true // The config/context feature isn't finished yet, so let's hide it
+	cli.AddCommand(conn)
 
 	cli.AddCommand(common.NewCompletionCmd(cli, prompt))
 

--- a/plugin/ccloud-apikey-plugin/main.go
+++ b/plugin/ccloud-apikey-plugin/main.go
@@ -28,7 +28,7 @@ var (
 var _ chttp.APIKey = (*ApiKey)(nil)
 
 func main() {
-	if os.Args[1] == "version" || os.Args[1] == "--version" {
+	if len(os.Args) > 1 && (os.Args[1] == "version" || os.Args[1] == "--version") {
 		shared.PrintVersion(cliVersion.NewVersion(version, commit, date, host), command.NewTerminalPrompt(os.Stdin))
 	}
 

--- a/plugin/ccloud-connect-plugin/main.go
+++ b/plugin/ccloud-connect-plugin/main.go
@@ -29,7 +29,7 @@ var (
 var _ chttp.Connect = (*Connect)(nil)
 
 func main() {
-	if os.Args[1] == "version" || os.Args[1] == "--version" {
+	if len(os.Args) > 1 && (os.Args[1] == "version" || os.Args[1] == "--version") {
 		shared.PrintVersion(cliVersion.NewVersion(version, commit, date, host), command.NewTerminalPrompt(os.Stdin))
 	}
 

--- a/plugin/ccloud-kafka-plugin/main.go
+++ b/plugin/ccloud-kafka-plugin/main.go
@@ -29,7 +29,7 @@ var (
 var _ chttp.Kafka = (*Kafka)(nil)
 
 func main() {
-	if os.Args[1] == "version" || os.Args[1] == "--version" {
+	if len(os.Args) > 1 && (os.Args[1] == "version" || os.Args[1] == "--version") {
 		shared.PrintVersion(cliVersion.NewVersion(version, commit, date, host), command.NewTerminalPrompt(os.Stdin))
 	}
 

--- a/plugin/ccloud-ksql-plugin/main.go
+++ b/plugin/ccloud-ksql-plugin/main.go
@@ -25,7 +25,7 @@ var (
 )
 
 func main() {
-	if os.Args[1] == "version" || os.Args[1] == "--version" {
+	if len(os.Args) > 1 && (os.Args[1] == "version" || os.Args[1] == "--version") {
 		shared.PrintVersion(cliVersion.NewVersion(version, commit, date, host), command.NewTerminalPrompt(os.Stdin))
 	}
 

--- a/plugin/ccloud-user-plugin/main.go
+++ b/plugin/ccloud-user-plugin/main.go
@@ -28,7 +28,7 @@ var (
 var _ chttp.User = (*User)(nil)
 
 func main() {
-	if os.Args[1] == "version" || os.Args[1] == "--version" {
+	if len(os.Args) > 1 && (os.Args[1] == "version" || os.Args[1] == "--version") {
 		shared.PrintVersion(cliVersion.NewVersion(version, commit, date, host), command.NewTerminalPrompt(os.Stdin))
 	}
 


### PR DESCRIPTION
Notice that the `config` command is gone from the help:

```
$ ccloud help
Welcome to the Confluent Cloud CLI

Usage:
  ccloud [command]

Available Commands:
  api-key         Manage API keys
  completion      Output shell completion code
  connect         Manage Kafka Connect
  help            Help about any command
  kafka           Manage Kafka
  ksql            Manage KSQL
  login           Login to Confluent Cloud
  logout          Logout of Confluent Cloud
  service-account Manage service accounts
  version         Print the ccloud version

Flags:
  -h, --help            help for ccloud
  -v, --verbose count   increase output verbosity

Use "ccloud [command] --help" for more information about a command.
```

NO ACTIVE KAFKA:
```
$ ccloud kafka cluster list 
      ID      |  NAME   | PROVIDER |   REGION    | DURABILITY | STATUS  
+-------------+---------+----------+-------------+------------+--------+
    lkc-o39vj | prestag | aws      | us-west-2   | LOW        | UP      
    lkc-4ypk4 | gcpsr   | gcp      | us-central1 | LOW        | UP      
```

WITH ACTIVE KAFKA

Use a Kafka cluster and you'll see it in the list output

```
$ ccloud kafka cluster use lkc-o39vj

$ ccloud kafka cluster list 
      ID      |  NAME   | PROVIDER |   REGION    | DURABILITY | STATUS  
+-------------+---------+----------+-------------+------------+--------+
  * lkc-o39vj | prestag | aws      | us-west-2   | LOW        | UP      
    lkc-4ypk4 | gcpsr   | gcp      | us-central1 | LOW        | UP      
```