### PR TITLE
Reset log levels/verbosity to ERROR by default

### DIFF
--- a/command/common/logging.go
+++ b/command/common/logging.go
@@ -13,15 +13,17 @@ func SetLoggingVerbosity(cmd *cobra.Command, logger *log.Logger) error {
 	}
 	switch verbosity {
 	case 0:
-		logger.SetLevel(log.WARN)
+		logger.SetLevel(log.ERROR)
 	case 1:
-		logger.SetLevel(log.INFO)
+		logger.SetLevel(log.WARN)
 	case 2:
-		logger.SetLevel(log.DEBUG)
+		logger.SetLevel(log.INFO)
 	case 3:
+		logger.SetLevel(log.DEBUG)
+	case 4:
 		logger.SetLevel(log.TRACE)
 	default:
-		// requested more than 3 -v's, so let's give them the max verbosity we support
+		// requested more than 4 -v's, so let's give them the max verbosity we support
 		logger.SetLevel(log.TRACE)
 	}
 	return nil

--- a/go.sum
+++ b/go.sum
@@ -84,6 +84,7 @@ github.com/confluentinc/ccloudapis v0.0.0-20190223013552-64fe4ec0c600 h1:VPORV8Z
 github.com/confluentinc/ccloudapis v0.0.0-20190223013552-64fe4ec0c600/go.mod h1:RGupQo6tb6J+1BnSqqueADkoC8b/F60+Ci3FMB3wDFo=
 github.com/confluentinc/ccloudapis v0.0.0-20190227054330-86f4a19ce258 h1:PG+A0yGB6m7AMAknluVChLBhdgKNLRilsKR7BjHuhhM=
 github.com/confluentinc/ccloudapis v0.0.0-20190227054330-86f4a19ce258/go.mod h1:RGupQo6tb6J+1BnSqqueADkoC8b/F60+Ci3FMB3wDFo=
+github.com/confluentinc/ccloudapis v0.0.0-20190227065628-cf9b2483670a h1:XAtQEdDNhladJViSs4irZAYKYNb8S8a+Hn3gfHLgosw=
 github.com/confluentinc/ccloudapis v0.0.0-20190227065628-cf9b2483670a/go.mod h1:RGupQo6tb6J+1BnSqqueADkoC8b/F60+Ci3FMB3wDFo=
 github.com/confluentinc/proto-go-setter v0.0.0-20180912191759-fb17e76fc076 h1:tJszovtvIkdc+Sq0TBZK2d8ExqQ6Y2jjUbBERqivSMk=
 github.com/confluentinc/proto-go-setter v0.0.0-20180912191759-fb17e76fc076/go.mod h1:WD/4qYOPFMs2ozq2z2VJFtHljgptKHWtOMb9ochncfA=

--- a/main.go
+++ b/main.go
@@ -12,8 +12,8 @@ import (
 	"github.com/confluentinc/cli/command/kafka"
 	"github.com/confluentinc/cli/command/ksql"
 	"github.com/confluentinc/cli/command/service-account"
-
 	"github.com/hashicorp/go-plugin"
+
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
@@ -53,11 +53,13 @@ func main() {
 	version := cliVersion.NewVersion(version, commit, date, host)
 	factory := &common.GRPCPluginFactoryImpl{}
 
-	cli := BuildCommand(cfg, version, factory, logger)
-	check(cli.Execute())
+	defer plugin.CleanupClients()
 
-	plugin.CleanupClients()
-	os.Exit(0)
+	cli := BuildCommand(cfg, version, factory, logger)
+	err := cli.Execute()
+	if err != nil {
+		os.Exit(1)
+	}
 }
 
 func BuildCommand(cfg *shared.Config, version *cliVersion.Version, factory common.GRPCPluginFactory, logger *log.Logger) *cobra.Command {
@@ -122,11 +124,4 @@ func BuildCommand(cfg *shared.Config, version *cliVersion.Version, factory commo
 	}
 
 	return cli
-}
-
-func check(err error) {
-	if err != nil {
-		plugin.CleanupClients()
-		os.Exit(1)
-	}
 }


### PR DESCRIPTION
This is a workaround.

I'd prefer to show WARN by default, but I can't figure out how to fix an issue that our `go-plugin` library is showing as WARN on every command. 

The issue is logged as "WARN: plugin failed to exit gracefully" on all commands

The workaround is log at ERROR by default and let each verbosity level increase from there.
```
default: ERROR
-v: WARN
-vv: INFO
-vvv: DEBUG
-vvvv: TRACE
```

BEFORE: (notice, WARN in output by default)
```
$ ccloud kafka cluster list
      ID      |  NAME   | PROVIDER |   REGION    | DURABILITY | STATUS  
+-------------+---------+----------+-------------+------------+--------+
  * lkc-o39vj | prestag | aws      | us-west-2   | LOW        | UP      
    lkc-4ypk4 | gcpsr   | gcp      | us-central1 | LOW        | UP      
2019-02-27T02:49:23.636-0600 [WARN ] ccloud-kafka-plugin: plugin failed to exit gracefully
```

AFTER: (clean output by default, logging level increases slower)
```
$ ccloud kafka cluster list
      ID      |  NAME   | PROVIDER |   REGION    | DURABILITY | STATUS  
+-------------+---------+----------+-------------+------------+--------+
  * lkc-o39vj | prestag | aws      | us-west-2   | LOW        | UP      
    lkc-4ypk4 | gcpsr   | gcp      | us-central1 | LOW        | UP      

$ ccloud kafka cluster list -v
      ID      |  NAME   | PROVIDER |   REGION    | DURABILITY | STATUS  
+-------------+---------+----------+-------------+------------+--------+
  * lkc-o39vj | prestag | aws      | us-west-2   | LOW        | UP      
    lkc-4ypk4 | gcpsr   | gcp      | us-central1 | LOW        | UP      
2019-02-27T02:49:23.636-0600 [WARN ] ccloud-kafka-plugin: plugin failed to exit gracefully
Cody-Rays-MBP15:cli cody$ PATH=dist/$(go env GOOS)_$(go env GOARCH):$PATH dist/$(go env GOOS)_$(go env GOARCH)/ccloud kafka cluster list -vv
      ID      |  NAME   | PROVIDER |   REGION    | DURABILITY | STATUS  
+-------------+---------+----------+-------------+------------+--------+
  * lkc-o39vj | prestag | aws      | us-west-2   | LOW        | UP      
    lkc-4ypk4 | gcpsr   | gcp      | us-central1 | LOW        | UP      
2019-02-27T02:49:26.915-0600 [WARN ] ccloud-kafka-plugin: plugin failed to exit gracefully

$ ccloud kafka cluster list -vvv
2019-02-27T02:49:29.900-0600 [DEBUG] ccloud-kafka-plugin: starting plugin: path=/bin/sh args="[sh -c dist/darwin_amd64/ccloud-kafka-plugin]"
2019-02-27T02:49:29.902-0600 [DEBUG] ccloud-kafka-plugin: plugin started: path=/bin/sh pid=89195
2019-02-27T02:49:29.902-0600 [DEBUG] ccloud-kafka-plugin: waiting for RPC address: path=/bin/sh
2019-02-27T02:49:29.933-0600 [DEBUG] ccloud-kafka-plugin: using plugin: version=1
2019-02-27T02:49:29.933-0600 [DEBUG] ccloud-kafka-plugin.sh: plugin address: address=/var/folders/81/kbvhd83n2sj12dy2xnxjc0140000gp/T/plugin148037630 network=unix timestamp=2019-02-27T02:49:29.933-0600
2019-02-27T02:49:29.934-0600 [DEBUG] ccloud-kafka-plugin.sh: request: account=t710 cluster= method=list resource=cluster timestamp=2019-02-27T02:49:29.934-0600
      ID      |  NAME   | PROVIDER |   REGION    | DURABILITY | STATUS  
+-------------+---------+----------+-------------+------------+--------+
  * lkc-o39vj | prestag | aws      | us-west-2   | LOW        | UP      
    lkc-4ypk4 | gcpsr   | gcp      | us-central1 | LOW        | UP      
2019-02-27T02:49:30.652-0600 [WARN ] ccloud-kafka-plugin: plugin failed to exit gracefully
2019-02-27T02:49:30.658-0600 [DEBUG] ccloud-kafka-plugin: plugin process exited: path=/bin/sh pid=89195 error="signal: killed"

$ ccloud kafka cluster list -vvvv
2019-02-27T02:49:32.162-0600 [DEBUG] ccloud-kafka-plugin: starting plugin: path=/bin/sh args="[sh -c dist/darwin_amd64/ccloud-kafka-plugin]"
2019-02-27T02:49:32.163-0600 [DEBUG] ccloud-kafka-plugin: plugin started: path=/bin/sh pid=89203
2019-02-27T02:49:32.163-0600 [DEBUG] ccloud-kafka-plugin: waiting for RPC address: path=/bin/sh
2019-02-27T02:49:32.190-0600 [DEBUG] ccloud-kafka-plugin: using plugin: version=1
2019-02-27T02:49:32.190-0600 [DEBUG] ccloud-kafka-plugin.sh: plugin address: address=/var/folders/81/kbvhd83n2sj12dy2xnxjc0140000gp/T/plugin194273838 network=unix timestamp=2019-02-27T02:49:32.190-0600
2019-02-27T02:49:32.191-0600 [DEBUG] ccloud-kafka-plugin.sh: request: account=t710 cluster= method=list resource=cluster timestamp=2019-02-27T02:49:32.191-0600
      ID      |  NAME   | PROVIDER |   REGION    | DURABILITY | STATUS  
+-------------+---------+----------+-------------+------------+--------+
  * lkc-o39vj | prestag | aws      | us-west-2   | LOW        | UP      
    lkc-4ypk4 | gcpsr   | gcp      | us-central1 | LOW        | UP      
2019-02-27T02:49:32.928-0600 [WARN ] ccloud-kafka-plugin: plugin failed to exit gracefully
2019-02-27T02:49:32.935-0600 [DEBUG] ccloud-kafka-plugin: plugin process exited: path=/bin/sh pid=89203 error="signal: killed"
```

Note looks like the "token expired" message works ok but could be better (like, "hey you , relogin")
```
$ PATH=dist/$(go env GOOS)_$(go env GOARCH):$PATH dist/$(go env GOOS)_$(go env GOARCH)/ccloud kafka cluster list
error retrieving kafka clusters: token is expired
```