### PR TITLE
Fix version bumping... CI wasn't pushing commits to master

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 ALL_SRC         := $(shell find . -name "*.go" | grep -v -e vendor)
 GIT_REMOTE_NAME ?= origin
-RELEASE_BRANCH  ?= =master
+RELEASE_BRANCH  ?= master
 
 include ./semver.mk
 


### PR DESCRIPTION
we need RELEASE_BRANCH=master in our makefile

https://github.com/confluentinc/cc-mk-include/blob/master/cc-semver.mk#L82

```
git push $(GIT_REMOTE_NAME) $(RELEASE_BRANCH) --tags
```

note the space in the `git push` in CI `make release-ci` command?
```
git push origin  --tags
```

https://semaphoreci.com/confluent/cli/branches/master/builds/151

here's what `cc-mk-include` set it to:
```
RELEASE_BRANCH := $(shell echo $(BRANCH_NAME) | grep -E '^($(MASTER_BRANCH)|v[0-9]+\.[0-9]+\.x)$$')
```

https://github.com/confluentinc/cc-mk-include/blob/4f3f39503a4e555640ec740f522884f85a5e8a8d/cc-begin.mk#L36

But we don't have `cc-begin.mk` to set this for us. Nor do we have release branches `vN.N.x` like we do there (yet). So let's just hardcode it to master for now.