### PR TITLE
Fix auto bump to bump minor version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 ALL_SRC         := $(shell find . -name "*.go" | grep -v -e vendor)
 GIT_REMOTE_NAME ?= origin
+MASTER_BRANCH   ?= master
 RELEASE_BRANCH  ?= master
 
 include ./semver.mk


### PR DESCRIPTION
CI committed a `chore: patch version bump v0.25.2`

Why the patch bump? Turns out that we decide that by checking whether we're on the master branch (minor) or a release branch (patch). 
```
ifeq ($(RELEASE_BRANCH),$(MASTER_BRANCH))
```

https://github.com/confluentinc/cli/blob/master/semver.mk#L10

Since the `MASTER_BRANCH` env wasn't set, it went to the other condition and did a patch bump.

