### PR TITLE
Bump go-printer version to not autoformat tables

### DIFF
--- a/command/apikey/command.go
+++ b/command/apikey/command.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/codyaray/go-printer"
 	"github.com/spf13/cobra"
 
 	ccloud "github.com/confluentinc/ccloud-sdk-go"
@@ -15,6 +14,7 @@ import (
 	"github.com/confluentinc/cli/command/common"
 	"github.com/confluentinc/cli/shared"
 	"github.com/confluentinc/cli/shared/apikey"
+	"github.com/confluentinc/go-printer"
 )
 
 type command struct {

--- a/command/config/context.go
+++ b/command/config/context.go
@@ -3,11 +3,11 @@ package config
 import (
 	"fmt"
 
-	"github.com/codyaray/go-printer"
 	"github.com/spf13/cobra"
 
 	"github.com/confluentinc/cli/command/common"
 	"github.com/confluentinc/cli/shared"
+	"github.com/confluentinc/go-printer"
 )
 
 type contextCommand struct {

--- a/command/config/context_test.go
+++ b/command/config/context_test.go
@@ -23,7 +23,7 @@ func TestContext(t *testing.T) {
 
 	output, err = run("context", "list")
 	req.NoError(err)
-	req.Equal("  CURRENT | NAME | PLATFORM | CREDENTIAL  \n+---------+------+----------+------------+\n", output)
+	req.Equal("  Current | Name | Platform | Credential  \n+---------+------+----------+------------+\n", output)
 
 	output, err = run("context", "set", "my-context", "--kafka-cluster", "bob")
 	req.NoError(err)
@@ -31,7 +31,7 @@ func TestContext(t *testing.T) {
 
 	output, err = run("context", "list")
 	req.NoError(err)
-	req.Equal("  CURRENT |    NAME    | PLATFORM | CREDENTIAL  \n+---------+------------+----------+------------+\n          | my-context |          |             \n", output)
+	req.Equal("  Current |    Name    | Platform | Credential  \n+---------+------------+----------+------------+\n          | my-context |          |             \n", output)
 
 	output, err = run("context", "get", "my-context")
 	req.NoError(err)

--- a/command/connect/command_sink.go
+++ b/command/connect/command_sink.go
@@ -7,8 +7,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/codyaray/go-printer"
-	"github.com/codyaray/go-printer/editor"
 	"github.com/ghodss/yaml"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -17,6 +15,8 @@ import (
 	connectv1 "github.com/confluentinc/ccloudapis/connect/v1"
 	"github.com/confluentinc/cli/command/common"
 	"github.com/confluentinc/cli/shared"
+	"github.com/confluentinc/go-printer"
+	"github.com/confluentinc/go-printer/editor"
 )
 
 var (

--- a/command/kafka/command_acl.go
+++ b/command/kafka/command_acl.go
@@ -5,13 +5,13 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/codyaray/go-printer"
 	"github.com/spf13/cobra"
 
 	chttp "github.com/confluentinc/ccloud-sdk-go"
 	kafkav1 "github.com/confluentinc/ccloudapis/kafka/v1"
 	"github.com/confluentinc/cli/command/common"
 	"github.com/confluentinc/cli/shared"
+	"github.com/confluentinc/go-printer"
 )
 
 type aclCommand struct {
@@ -104,7 +104,7 @@ func (c *aclCommand) list(cmd *cobra.Command, args []string) error {
 			Operation        string
 			Resource         string
 			Name             string
-			Type 			 string
+			Type             string
 		}{
 			binding.Entry.Principal,
 			binding.Entry.PermissionType.String(),

--- a/command/kafka/command_cluster.go
+++ b/command/kafka/command_cluster.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/codyaray/go-printer"
 	"github.com/spf13/cobra"
 	"golang.org/x/crypto/ssh/terminal"
 
@@ -16,6 +15,7 @@ import (
 	kafkav1 "github.com/confluentinc/ccloudapis/kafka/v1"
 	"github.com/confluentinc/cli/command/common"
 	"github.com/confluentinc/cli/shared"
+	"github.com/confluentinc/go-printer"
 )
 
 var (

--- a/command/kafka/command_topic.go
+++ b/command/kafka/command_topic.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 
 	"github.com/Shopify/sarama"
-	"github.com/codyaray/go-printer"
 	"github.com/google/uuid"
 	"github.com/spf13/cobra"
 
@@ -17,6 +16,7 @@ import (
 	kafkav1 "github.com/confluentinc/ccloudapis/kafka/v1"
 	"github.com/confluentinc/cli/command/common"
 	"github.com/confluentinc/cli/shared"
+	"github.com/confluentinc/go-printer"
 )
 
 type topicCommand struct {

--- a/command/ksql/command_cluster.go
+++ b/command/ksql/command_cluster.go
@@ -5,13 +5,13 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/codyaray/go-printer"
 	"github.com/spf13/cobra"
 
 	chttp "github.com/confluentinc/ccloud-sdk-go"
 	ksqlv1 "github.com/confluentinc/ccloudapis/ksql/v1"
 	"github.com/confluentinc/cli/command/common"
 	"github.com/confluentinc/cli/shared"
+	"github.com/confluentinc/go-printer"
 )
 
 var (

--- a/command/service-account/command.go
+++ b/command/service-account/command.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/codyaray/go-printer"
 	"github.com/spf13/cobra"
 
 	ccloud "github.com/confluentinc/ccloud-sdk-go"
@@ -13,6 +12,7 @@ import (
 	"github.com/confluentinc/cli/command/common"
 	"github.com/confluentinc/cli/shared"
 	"github.com/confluentinc/cli/shared/user"
+	"github.com/confluentinc/go-printer"
 )
 
 type command struct {

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/Shopify/toxiproxy v2.1.3+incompatible // indirect
 	github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da
 	github.com/codyaray/go-editor v0.3.0
+	github.com/codyaray/go-printer v0.9.0 // indirect
 	github.com/codyaray/retag v0.0.0-20180529164156-4f3c7e6dfbe2 // indirect
 	github.com/confluentinc/cc-structs v0.0.0-20190216225128-bc354c6bf010
 	github.com/confluentinc/ccloud-sdk-go v0.0.6-0.20190226163025-48f4ae5f158f

--- a/go.sum
+++ b/go.sum
@@ -56,6 +56,8 @@ github.com/codyaray/go-editor v0.3.0 h1:UR09THBRSPvWSy8stAoIL76Neq0LtiK1KJAuPzrT
 github.com/codyaray/go-editor v0.3.0/go.mod h1:KTJY2oaaxgAcgmJj+NK8/gFXpOePIVDt1/3FUbBBDTY=
 github.com/codyaray/go-printer v0.8.0 h1:yEzJ3F8pZDtwbg0kQXChZhFdfKYVp2JmeqAqN28p4VI=
 github.com/codyaray/go-printer v0.8.0/go.mod h1:D3QhRgp4mumbs4wNyaZmAyztIWjd125AqqSmeD6+U04=
+github.com/codyaray/go-printer v0.9.0 h1:6pBM0Km7O/WQNIxYFHJAzsevgw+RxHfDPHR5Lg9Zrok=
+github.com/codyaray/go-printer v0.9.0/go.mod h1:D3QhRgp4mumbs4wNyaZmAyztIWjd125AqqSmeD6+U04=
 github.com/codyaray/proto-go-setter v0.0.0-20180912191759-fb17e76fc076/go.mod h1:wdKBjHZZ/HCmrfPs1UoD/Xuzat9EKHRsScG03kDM2pU=
 github.com/codyaray/retag v0.0.0-20180529164156-4f3c7e6dfbe2 h1:sIWhdehnHPCWoZeMVBRvb6+/73GxXKCHo9PhhWe9UcY=
 github.com/codyaray/retag v0.0.0-20180529164156-4f3c7e6dfbe2/go.mod h1:HNotNNYHefttEUajcmByCW4bWNBiYd7s5mNZWzB62r0=
@@ -86,6 +88,7 @@ github.com/confluentinc/ccloudapis v0.0.0-20190227054330-86f4a19ce258 h1:PG+A0yG
 github.com/confluentinc/ccloudapis v0.0.0-20190227054330-86f4a19ce258/go.mod h1:RGupQo6tb6J+1BnSqqueADkoC8b/F60+Ci3FMB3wDFo=
 github.com/confluentinc/ccloudapis v0.0.0-20190227065628-cf9b2483670a h1:XAtQEdDNhladJViSs4irZAYKYNb8S8a+Hn3gfHLgosw=
 github.com/confluentinc/ccloudapis v0.0.0-20190227065628-cf9b2483670a/go.mod h1:RGupQo6tb6J+1BnSqqueADkoC8b/F60+Ci3FMB3wDFo=
+github.com/confluentinc/go-printer v0.9.0 h1:AnXGsoRM5bRlQN4xnFYjbKFjl3Kvwpgbq/i3KPi3mHU=
 github.com/confluentinc/go-printer v0.9.0/go.mod h1:bOK/pPNm4ao7bZIcRnGPGca1B64nW+lApFXHZEZ0PcM=
 github.com/confluentinc/proto-go-setter v0.0.0-20180912191759-fb17e76fc076 h1:tJszovtvIkdc+Sq0TBZK2d8ExqQ6Y2jjUbBERqivSMk=
 github.com/confluentinc/proto-go-setter v0.0.0-20180912191759-fb17e76fc076/go.mod h1:WD/4qYOPFMs2ozq2z2VJFtHljgptKHWtOMb9ochncfA=


### PR DESCRIPTION
We don't want the table headers being ALL CAPS. This changes go-printer behavior.