### PR TITLE
Add log levels for api-keys and service-accounts

### DIFF
--- a/command/apikey/command.go
+++ b/command/apikey/command.go
@@ -54,6 +54,9 @@ func newCMD(config *shared.Config, provider common.GRPCPlugin) (*cobra.Command, 
 
 func (c *command) init(plugin common.GRPCPlugin) error {
 	c.Command.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
+		if err := common.SetLoggingVerbosity(cmd, c.config.Logger); err != nil {
+			return common.HandleError(err, cmd)
+		}
 		if err := c.config.CheckLogin(); err != nil {
 			return common.HandleError(err, cmd)
 		}

--- a/command/service-account/command.go
+++ b/command/service-account/command.go
@@ -55,6 +55,9 @@ func newCMD(config *shared.Config, provider common.GRPCPlugin) (*cobra.Command, 
 
 func (c *command) init(plugin common.GRPCPlugin) error {
 	c.Command.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
+		if err := common.SetLoggingVerbosity(cmd, c.config.Logger); err != nil {
+			return common.HandleError(err, cmd)
+		}
 		if err := c.config.CheckLogin(); err != nil {
 			return common.HandleError(err, cmd)
 		}

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/Shopify/toxiproxy v2.1.3+incompatible // indirect
 	github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da
 	github.com/codyaray/go-editor v0.3.0
-	github.com/codyaray/go-printer v0.9.0 // indirect
+	github.com/codyaray/go-printer v0.9.0
 	github.com/codyaray/retag v0.0.0-20180529164156-4f3c7e6dfbe2 // indirect
 	github.com/confluentinc/cc-structs v0.0.0-20190216225128-bc354c6bf010
 	github.com/confluentinc/ccloud-sdk-go v0.0.6-0.20190226163025-48f4ae5f158f


### PR DESCRIPTION
I probably started working on these pre-merge so missed them.

Without this change:
```
ccloud api-key list 
        Key        | Owner | Clusters   
+------------------+-------+-----------+
  BA4B6YCFUHC4E4K7 |    87 | lkc-o39vj  
  UDVMGZGU7VTTJNE4 |    87 | lkc-o39vj  
  DTMFUNJCSIAVMJHE |    87 | lkc-o39vj  
  A7GJBRWCLKA5SETV |    87 | lkc-o39vj  
2019-02-27T15:29:10.418-0600 [WARN ] ccloud-apikey-plugin: plugin failed to exit gracefully
```

This will get rid of the warning

