### PR TITLE
Print topic configuration with describe output

### DIFF
--- a/command/kafka/command_topic.go
+++ b/command/kafka/command_topic.go
@@ -225,7 +225,7 @@ func (c *topicCommand) describe(cmd *cobra.Command, args []string) error {
 	}
 	printer.RenderCollectionTable(partitions, titleRow)
 
-	fmt.Printf("\nTopic: %s Configuration\n ",resp.Name)
+	fmt.Println("\nConfiguration\n ")
 
 	var entries [][]string
 	titleRow = []string{"Name", "Value"}


### PR DESCRIPTION
```
 ccloud kafka topic describe f1
Topic: f1 PartitionCount: 6 ReplicationFactor: 3
  Topic | Partition | Leader | Replicas |   ISR
+-------+-----------+--------+----------+---------+
  f1    |         0 |      0 | [0 1 2]  | [0 1 2]
  f1    |         1 |      1 | [1 2 3]  | [1 2 3]
  f1    |         2 |      2 | [2 3 0]  | [2 3 0]
  f1    |         3 |      3 | [3 0 1]  | [3 0 1]
  f1    |         4 |      0 | [0 2 3]  | [0 2 3]
  f1    |         5 |      1 | [1 3 0]  | [1 3 0]

Topic: f1 Configuration
                    Name                   |        Value
+-----------------------------------------+---------------------+
  compression.type                        | producer
  leader.replication.throttled.replicas   |
  min.insync.replicas                     |                   2
  message.downconversion.enable           | true
  segment.jitter.ms                       |                   0
  cleanup.policy                          | delete
  flush.ms                                | 9223372036854775807
  follower.replication.throttled.replicas |
  segment.bytes                           |          1073741824
  retention.ms                            |           604800000
  flush.messages                          | 9223372036854775807
  message.format.version                  | 2.1-IV2
  file.delete.delay.ms                    |               60000
  max.message.bytes                       |             2097164
  min.compaction.lag.ms                   |                   0
  message.timestamp.type                  | CreateTime
  preallocate                             | false
  index.interval.bytes                    |                4096
  min.cleanable.dirty.ratio               |                 0.5
  unclean.leader.election.enable          | false
  retention.bytes                         |                  -1
  delete.retention.ms                     |            86400000
  tier.enable                             | false
  segment.ms                              |           604800000
  message.timestamp.difference.max.ms     | 9223372036854775807
  segment.index.bytes                     |            10485760
```