### PR TITLE
Fix release version to not be N-1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,8 +47,12 @@ build-go:
 
 .PHONY: release
 release: get-release-image commit-release tag-release
-	@GO111MODULE=on VERSION=$(VERSION) HOSTNAME=$(HOSTNAME) goreleaser release --rm-dist
+	make gorelease
 	make publish
+
+.PHONY: gorelease
+gorelease:
+	@GO111MODULE=on VERSION=$(VERSION) HOSTNAME=$(HOSTNAME) goreleaser release --rm-dist
 
 .PHONY: dist
 dist:


### PR DESCRIPTION
We noticed the the version on the tarballs didn't match the version printed by `ccloud version`.

However, the functionality matched the version on the tarballs. So just the output of `ccloud version` appeared to be wrong. It was always behind by one version.

For example, in the CI build for v0.30.0, the download binary shows version
```
./ccloud version
ccloud - Confluent Cloud CLI

Version:     v0.29.0-1-g9400981
```
https://semaphoreci.com/confluent/cli/branches/master/builds/160

And then when I manually triggered `make release` locally, building v0.31.0 through v0.34.0, it would always show the N-1 version.

What's going on here is that `$(VERSION)` is set on the initial `make` run, then the version is bumped, but the variable isn't updated. We actually need to invoke `make again` before running goreleaser so it gets the most up-to-date version.