### PR TITLE
[CLI-62] fix(cli): show error when user passes an unexpected arg

### DIFF
--- a/command/apikey/command.go
+++ b/command/apikey/command.go
@@ -68,6 +68,7 @@ func (c *command) init(plugin common.GRPCPlugin) error {
 		Use:   "list",
 		Short: "List API keys",
 		RunE:  c.list,
+		Args:  cobra.NoArgs,
 	})
 
 	createCmd := &cobra.Command{

--- a/command/auth/auth.go
+++ b/command/auth/auth.go
@@ -57,6 +57,7 @@ func (a *commands) init() {
 		Use:   "login",
 		Short: "Login to Confluent Cloud",
 		RunE:  a.login,
+		Args:  cobra.NoArgs,
 	}
 	loginCmd.Flags().String("url", "https://confluent.cloud", "Confluent Control Plane URL")
 	loginCmd.PersistentPreRunE = preRun
@@ -64,6 +65,7 @@ func (a *commands) init() {
 		Use:   "logout",
 		Short: "Logout of Confluent Cloud",
 		RunE:  a.logout,
+		Args:  cobra.NoArgs,
 	}
 	logoutCmd.PersistentPreRunE = preRun
 	a.Commands = []*cobra.Command{loginCmd, logoutCmd}

--- a/command/config/context.go
+++ b/command/config/context.go
@@ -45,6 +45,7 @@ func (c *contextCommand) init() {
 		Use:   "current",
 		Short: "Show the current config context.",
 		RunE:  c.current,
+		Args:  cobra.NoArgs,
 	})
 	c.AddCommand(&cobra.Command{
 		Use:   "get [ID]",

--- a/command/connect/command_sink.go
+++ b/command/connect/command_sink.go
@@ -87,6 +87,7 @@ func (c *sinkCommand) init(plugin common.GRPCPlugin) error {
 		Use:   "list",
 		Short: "List connectors",
 		RunE:  c.list,
+		Args:  cobra.NoArgs,
 	})
 
 	getCmd := &cobra.Command{
@@ -135,6 +136,7 @@ func (c *sinkCommand) init(plugin common.GRPCPlugin) error {
 		Use:   "auth",
 		Short: "Auth a connector",
 		RunE:  c.auth,
+		Args:  cobra.NoArgs,
 	})
 
 	return nil

--- a/command/kafka/command_cluster.go
+++ b/command/kafka/command_cluster.go
@@ -60,6 +60,7 @@ func (c *clusterCommand) init(plugin common.GRPCPlugin) {
 		Use:   "list",
 		Short: "List Kafka clusters",
 		RunE:  c.list,
+		Args:  cobra.NoArgs,
 	})
 
 	createCmd := &cobra.Command{
@@ -105,6 +106,7 @@ func (c *clusterCommand) init(plugin common.GRPCPlugin) {
 		Use:   "auth",
 		Short: "Configure authorization for a Kafka cluster",
 		RunE:  c.auth,
+		Args:  cobra.NoArgs,
 	})
 	c.AddCommand(&cobra.Command{
 		Use:   "use ID",

--- a/command/ksql/command_cluster.go
+++ b/command/ksql/command_cluster.go
@@ -57,6 +57,7 @@ func (c *clusterCommand) init(plugin common.GRPCPlugin) {
 		Use:   "list",
 		Short: "List KSQL apps",
 		RunE:  c.list,
+		Args:  cobra.NoArgs,
 	})
 
 	createCmd := &cobra.Command{


### PR DESCRIPTION
https://confluentinc.atlassian.net/browse/CLI-62

-----

A user was trying to login to their CPD using the new CLI. Here's what they did:
```
ccloud login faithful-flounder.gcp.priv.cpdev.cloud
```

It prompts them for the username/password and looks like its attempting. But this is hitting prod, because the command to specify the url is wrong. The correct way is
```
ccloud login --url https://faithful-flounder.gcp.priv.cpdev.cloud
```

We should've errored when received the unexpected argument earlier. This probably affects a lot of other commands as well.