### PR TITLE
Add short-term hack to fix CI is addressed

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,6 +5,8 @@ before:
     # to avoid goreleaser error due to `make deps` on CI: git is currently in a dirty state
     # we should never see go.mod be dirty because we `go build -mod=readonly`, but we can't well control go.sum updates
     - git checkout go.sum
+    # TODO: [CLI-92] we delete the semaphore cache during release to workaround an issue with semaphore and goreleaser
+    - rm -rf $GOPATH/pkg/mod
 
 builds:
   -


### PR DESCRIPTION
I created a JIRA to fix this without breaking the cache: https://confluentinc.atlassian.net/browse/CLI-92

But we need to stabilize CI in the meantime. 