### PR TITLE
[CLI-21] Add first integration tests to test exit code

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,3 +71,36 @@ Things under `internal/cmd` are commands, things under `internal/pkg` are packag
 When you add a new command or resource, assuming its already in the SDK, you generally just need to create
 * `internal/cmd/<command>/<command>.go` (and test)
 * `internal/pkg/sdk/<resource>/<resource>.go` (and test)
+
+## Testing
+
+The CLI is tested with a combination of unit tests and integration tests
+(backed by mocks). These are both contained within this repo.
+
+We also have end-to-end system tests for
+* ccloud-only functionality - [cc-system-tests](https://github.com/confluentinc/cc-system-tests/blob/master/test/cli_test.go)
+* on-prem-only functionality - [muckrake](https://github.com/confluentinc/muckrake) (TODO: fix link to CLI tests)
+
+Unit tests exist in `_test.go` files alongside the main source code files.
+
+### Integration Tests
+
+The [./test](./test) directory contains the integration tests. These build a CLI
+binary and invoke commands on it. These CLI integration tests roughly follow this
+[pattern](http://lucapette.me/writing-integration-tests-for-a-go-cli-application):
+
+1. table tests for quickly testing a variety of CLI commands
+1. golden files are expected output fixtures for spec compliance testing
+1. http test server for stubbing the Confluent Platform Control Plane API
+
+You can run just the integration tests with
+
+    make test TEST_ARGS="./test/... -v"
+
+You can update the golden files from the current output with
+
+    make test TEST_ARGS="./test/... -update"
+
+You can force rebuilding the CLI even if it already exists in `dist` with
+
+    make test TEST_ARGS="./test/... -update -rebuild -v"

--- a/internal/cmd/auth/auth.go
+++ b/internal/cmd/auth/auth.go
@@ -184,6 +184,7 @@ func (a *commands) createOrUpdateContext(user *config.AuthConfig) {
 	if _, ok := a.config.Platforms[name]; !ok {
 		a.config.Platforms[name] = &config.Platform{
 			Server: a.config.AuthURL,
+			KafkaClusters: map[string]config.KafkaClusterConfig{},
 		}
 	}
 	if _, ok := a.config.Credentials[name]; !ok {

--- a/test/delete-unknown-key.golden
+++ b/test/delete-unknown-key.golden
@@ -1,0 +1,1 @@
+Error:  Invalid Key

--- a/test/err-no-kafka-auth.golden
+++ b/test/err-no-kafka-auth.golden
@@ -1,0 +1,1 @@
+Error: no auth found for Kafka lkc-abc123, please run `ccloud kafka cluster auth` first

--- a/test/err-no-kafka.golden
+++ b/test/err-no-kafka.golden
@@ -1,0 +1,1 @@
+Error: no auth found for Kafka , please run `ccloud kafka cluster auth` first

--- a/test/err-not-authenticated.golden
+++ b/test/err-not-authenticated.golden
@@ -1,0 +1,1 @@
+Error: You must login to access Confluent Cloud.

--- a/test/error_test.go
+++ b/test/error_test.go
@@ -1,0 +1,241 @@
+package test
+
+import (
+	"encoding/json"
+	"flag"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+
+	authv1 "github.com/confluentinc/ccloudapis/auth/v1"
+	orgv1 "github.com/confluentinc/ccloudapis/org/v1"
+
+	"github.com/confluentinc/cli/internal/pkg/config"
+)
+
+var (
+	binaryName = "ccloud"
+	rebuild    = flag.Bool("rebuild", false, "rebuild CLI even if it already exists")
+	update     = flag.Bool("update", false, "update golden files")
+)
+
+type ErrorTestSuite struct {
+	suite.Suite
+}
+
+func TestErrors(t *testing.T) {
+	suite.Run(t, new(ErrorTestSuite))
+}
+
+// SetupSuite builds the CLI binary to test
+func (s *ErrorTestSuite) SetupSuite() {
+	req := require.New(s.T())
+
+	// dumb but effective
+	err := os.Chdir("..")
+	req.NoError(err)
+
+	if _, err = os.Stat(binaryPath(s.T())); os.IsNotExist(err) || *rebuild {
+		makeCmd := exec.Command("make", "build")
+		output, err := makeCmd.CombinedOutput()
+		if err != nil {
+			s.T().Log(string(output))
+			req.NoError(err)
+		}
+	}
+}
+
+func (s *ErrorTestSuite) TestExitCode() {
+	tests := []struct {
+		name        string
+		args        string
+		login       string
+		useKafka    string
+		authKafka   string
+		fixture     string
+		wantErrCode int
+	}{
+		{"no args", "", "", "", "", "help-flag.golden", 0},
+		{"", "help", "", "", "", "help.golden", 0},
+		{"", "--help", "", "", "", "help-flag.golden", 0},
+		{"", "version", "", "", "", "version.golden", 0},
+		{"", "kafka cluster --help", "", "", "", "kafka-cluster-help.golden", 0},
+		{"error if not authenticated", "kafka topic create integ", "", "", "", "err-not-authenticated.golden", 1},
+		{"error if no active kafka", "kafka topic create integ", "default", "", "", "err-no-kafka.golden", 1},
+		{"error if no kafka auth", "kafka topic create integ", "default", "lkc-abc123", "", "err-no-kafka-auth.golden", 1},
+		{"error if topic already exists", "kafka topic create integ", "default", "lkc-abc123", "true", "topic-exists.golden", 1},
+		{"error if deleting non-existent api-key", "api-key delete --api-key UNKNOWN", "default", "lkc-abc123", "true", "delete-unknown-key.golden", 1},
+	}
+	for _, tt := range tests {
+		if tt.name == "" {
+			tt.name = tt.args
+		}
+		s.T().Run(tt.name, func(t *testing.T) {
+			req := require.New(s.T())
+
+			// HACK: delete your current config to isolate tests cases...
+			// probably don't really want to do this or devs will get mad
+			cfg := config.New(&config.Config{CLIName: binaryName})
+			err := cfg.Save()
+			req.NoError(err)
+
+			if tt.login == "default" {
+				env := []string{"XX_CCLOUD_EMAIL=fake@user.com", "XX_CCLOUD_PASSWORD=pass1"}
+				runCommand(t, env, "login --url "+serve(t).URL, 0)
+			}
+
+			if tt.useKafka != "" {
+				runCommand(t, []string{}, "kafka cluster use "+tt.useKafka, 0)
+			}
+
+			if tt.authKafka != "" {
+				runCommand(t, []string{}, "api-key create --cluster "+tt.useKafka, 0)
+			}
+
+			// HACK: there's no non-interactive way to save an API key locally yet (just kafka cluster auth)
+			if tt.name == "error if topic already exists" {
+				err = cfg.Load()
+				req.NoError(err)
+				ctx, err := cfg.Context()
+				req.NoError(err)
+				cfg.Platforms[ctx.Platform].KafkaClusters[ctx.Kafka] = config.KafkaClusterConfig{
+					APIKey: "MYKEY",
+					APISecret: "MYSECRET",
+					APIEndpoint: serveKafkaAPI(t).URL,
+				}
+				err = cfg.Save()
+				req.NoError(err)
+			}
+
+			output := runCommand(t, []string{}, tt.args, tt.wantErrCode)
+
+			if *update && tt.args != "version" {
+				writeFixture(t, tt.fixture, output)
+			}
+
+			actual := string(output)
+			expected := loadFixture(t, tt.fixture)
+
+			if tt.args == "version" {
+				require.Regexp(t, expected, actual)
+				return
+			}
+
+			if !reflect.DeepEqual(actual, expected) {
+				t.Fatalf("actual = %s, expected = %s", actual, expected)
+			}
+		})
+	}
+}
+
+func runCommand(t *testing.T, env []string, args string, wantErrCode int) string {
+	cmd := exec.Command(binaryPath(t), strings.Split(args, " ")...)
+	cmd.Env = append(os.Environ(), env...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		// This exit code testing requires 1.12 - https://stackoverflow.com/a/55055100/337735
+		if exitError, ok := err.(*exec.ExitError); ok {
+			if wantErrCode == 0 {
+				require.Failf(t, "unexpected error",
+					"exit %d: %s", exitError.ExitCode(), string(output))
+			} else {
+				require.Equal(t, wantErrCode, exitError.ExitCode())
+			}
+		} else {
+			require.Failf(t, "unexpected error", "command returned err: %s", err)
+		}
+	}
+	return string(output)
+}
+
+func writeFixture(t *testing.T, fixture string, content string) {
+	err := ioutil.WriteFile(fixturePath(t, fixture), []byte(content), 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func loadFixture(t *testing.T, fixture string) string {
+	content, err := ioutil.ReadFile(fixturePath(t, fixture))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return string(content)
+}
+
+func fixturePath(t *testing.T, fixture string) string {
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatalf("problems recovering caller information")
+	}
+
+	return filepath.Join(filepath.Dir(filename), fixture)
+}
+
+func binaryPath(t *testing.T) string {
+	dir, err := os.Getwd()
+	require.NoError(t, err)
+
+	return path.Join(dir, "dist", binaryName, runtime.GOOS+"_"+runtime.GOARCH, binaryName)
+}
+
+func serve(t *testing.T) *httptest.Server {
+	req := require.New(t)
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/sessions", func(w http.ResponseWriter, r *http.Request) {
+		http.SetCookie(w, &http.Cookie{Name: "auth_token", Value: "my.fav.jwt"})
+	})
+	mux.HandleFunc("/api/me", func(w http.ResponseWriter, r *http.Request) {
+		b, err := json.Marshal(&orgv1.GetUserReply{
+			User: &orgv1.User{
+				Id:        23,
+				Email:     "cody@confluent.io",
+				FirstName: "Cody",
+			},
+			Accounts: []*orgv1.Account{{Id: "a-595", Name: "default"}},
+		})
+		req.NoError(err)
+		_, err = io.WriteString(w, string(b))
+		req.NoError(err)
+	})
+	mux.HandleFunc("/api/api_keys", func(w http.ResponseWriter, r *http.Request) {
+		b, err := json.Marshal(&authv1.CreateApiKeyReply{
+			ApiKey: &authv1.ApiKey{
+				Key: "MYKEY",
+				Secret: "MYSECRET",
+			},
+		})
+		require.NoError(t, err)
+		_, err = io.WriteString(w, string(b))
+		require.NoError(t, err)
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		_, err := io.WriteString(w, `{"error": "unexpected call to ` + r.URL.Path + `"}`)
+		require.NoError(t, err)
+	})
+	return httptest.NewServer(mux)
+}
+
+func serveKafkaAPI(t *testing.T) *httptest.Server {
+	mux := http.NewServeMux()
+	// TODO: no idea how this "topic already exists" API request or response actually looks
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(400)
+		_, err := io.WriteString(w, `{}`)
+		require.NoError(t, err)
+	})
+	return httptest.NewServer(mux)
+}

--- a/test/help-flag.golden
+++ b/test/help-flag.golden
@@ -1,0 +1,23 @@
+Welcome to the Confluent Cloud CLI
+
+Usage:
+  ccloud [command]
+
+Available Commands:
+  api-key         Manage API keys
+  completion      Output shell completion code
+  environment     Manage and select ccloud environments
+  help            Help about any command
+  kafka           Manage Kafka
+  login           Login to Confluent Cloud
+  logout          Logout of Confluent Cloud
+  service-account Manage service accounts
+  update          Update ccloud
+  version         Print the ccloud version
+
+Flags:
+  -h, --help            help for ccloud
+  -v, --verbose count   increase output verbosity
+      --version         version for ccloud
+
+Use "ccloud [command] --help" for more information about a command.

--- a/test/help.golden
+++ b/test/help.golden
@@ -1,0 +1,22 @@
+Welcome to the Confluent Cloud CLI
+
+Usage:
+  ccloud [command]
+
+Available Commands:
+  api-key         Manage API keys
+  completion      Output shell completion code
+  environment     Manage and select ccloud environments
+  help            Help about any command
+  kafka           Manage Kafka
+  login           Login to Confluent Cloud
+  logout          Logout of Confluent Cloud
+  service-account Manage service accounts
+  update          Update ccloud
+  version         Print the ccloud version
+
+Flags:
+  -h, --help            help for ccloud
+  -v, --verbose count   increase output verbosity
+
+Use "ccloud [command] --help" for more information about a command.

--- a/test/kafka-cluster-help.golden
+++ b/test/kafka-cluster-help.golden
@@ -1,0 +1,21 @@
+Manage Kafka clusters
+
+Usage:
+  ccloud kafka cluster [command]
+
+Available Commands:
+  auth        Configure authorization for a Kafka cluster
+  create      Create a Kafka cluster
+  delete      Delete a Kafka cluster
+  describe    Describe a Kafka cluster
+  list        List Kafka clusters
+  use         Make the Kafka cluster active for use in other commands
+
+Flags:
+      --environment string   ID of the environment in which to run the command
+  -h, --help                 help for cluster
+
+Global Flags:
+  -v, --verbose count   increase output verbosity
+
+Use "ccloud kafka cluster [command] --help" for more information about a command.

--- a/test/topic-exists.golden
+++ b/test/topic-exists.golden
@@ -1,0 +1,1 @@
+Error: error creating topic integ: 

--- a/test/version.golden
+++ b/test/version.golden
@@ -1,0 +1,9 @@
+ccloud - Confluent Cloud CLI
+
+Version:     v.*
+Git Ref:     [0-9a-f]{40}
+Build Date:  20[0-9]{2}-(0[1-9]|1[0-2])-([0-2][1-9]|3[0-1])T([0-1][0-9]|2[0-4]):[0-5][0-9]:[0-5][0-9]Z
+Build Host:  [a-zA-Z0-9]*@.*
+Go Version:  go.*
+Development: .*
+


### PR DESCRIPTION
https://confluentinc.atlassian.net/browse/CLI-21 reported incorrect exit codes on some commands. Looks like it was already fixed but wanted to put some regression/ tests in place. This first set of integration tests verifies the exit code and output text for a small set of commands.

Probably some smarter stuff we can do here, but it gets us started in the right direction. I'd really like to get to the point that I have an explicit "CLI spec" and a full suite of compliance tests/linters in place. This will be very important as we move toward a scriptable CLI.

Note: this also shows the current state of the world, which includes some sub-awesome error messages.
1. if you haven't `use`d a kafka cluster yet, your error is `no auth found for Kafka , please run...`
2. if you're managing topics, you don't need an API key locally but you get an error anyway: `no auth found for Kafka lkc-abc123, please run...`
3. if you call `ccloud` with no args, or `ccloud --help`, you see `ccloud --version`. But if you call `ccloud help`, you won't.