### PR TITLE
Add a KSQL command for configuring acls

### DIFF
--- a/internal/cmd/command.go
+++ b/internal/cmd/command.go
@@ -77,7 +77,7 @@ func NewConfluentCommand(cliName string, cfg *configs.Config, ver *versions.Vers
 		cli.AddCommand(apikey.New(prerunner, cfg, apikeys.New(client, logger)))
 		cli.AddCommand(kafka.New(prerunner, cfg, kafkas.New(client, logger)))
 
-		conn = ksql.New(prerunner, cfg, ksqls.New(client, logger))
+		conn = ksql.New(prerunner, cfg, ksqls.New(client, logger), kafkas.New(client, logger), users.New(client, logger))
 		conn.Hidden = true // The ksql feature isn't finished yet, so let's hide it
 		cli.AddCommand(conn)
 

--- a/internal/cmd/kafka/command_acl.go
+++ b/internal/cmd/kafka/command_acl.go
@@ -3,14 +3,15 @@ package kafka
 import (
 	"context"
 	"fmt"
+	"os"
 
-	"github.com/codyaray/go-printer"
 	"github.com/hashicorp/go-multierror"
 	"github.com/spf13/cobra"
 
 	"github.com/confluentinc/ccloud-sdk-go"
 	kafkav1 "github.com/confluentinc/ccloudapis/kafka/v1"
 
+	acl_util "github.com/confluentinc/cli/internal/pkg/acl"
 	"github.com/confluentinc/cli/internal/pkg/config"
 	"github.com/confluentinc/cli/internal/pkg/errors"
 )
@@ -86,30 +87,7 @@ func (c *aclCommand) list(cmd *cobra.Command, args []string) error {
 		return errors.HandleCommon(err, cmd)
 	}
 
-	var bindings [][]string
-	for _, binding := range resp {
-
-		record := &struct {
-			ServiceAccountId string
-			Permission       string
-			Operation        string
-			Resource         string
-			Name             string
-			Type             string
-		}{
-			binding.Entry.Principal,
-			binding.Entry.PermissionType.String(),
-			binding.Entry.Operation.String(),
-			binding.Pattern.ResourceType.String(),
-			binding.Pattern.Name,
-			binding.Pattern.PatternType.String(),
-		}
-		bindings = append(bindings, printer.ToRow(record,
-			[]string{"ServiceAccountId", "Permission", "Operation", "Resource", "Name", "Type"}))
-	}
-
-	printer.RenderCollectionTable(bindings, []string{"ServiceAccountId", "Permission", "Operation", "Resource", "Name", "Type"})
-
+	acl_util.PrintAcls(resp, os.Stdout)
 	return nil
 }
 

--- a/internal/cmd/ksql/comand_test.go
+++ b/internal/cmd/ksql/comand_test.go
@@ -1,0 +1,199 @@
+package ksql
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"github.com/confluentinc/ccloudapis/ksql/v1"
+	"github.com/confluentinc/cli/internal/pkg/acl"
+	"github.com/stretchr/testify/require"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/confluentinc/ccloud-sdk-go/mock"
+	kafkav1 "github.com/confluentinc/ccloudapis/kafka/v1"
+	orgv1 "github.com/confluentinc/ccloudapis/org/v1"
+	"github.com/confluentinc/cli/internal/pkg/config"
+	"github.com/confluentinc/cli/internal/pkg/log"
+	cliMock "github.com/confluentinc/cli/mock"
+)
+
+const (
+	kafkaClusterID = "lkc-12345"
+	ksqlClusterID = "lksqlc-12345"
+	outputTopicPrefix = "pksqlc-abcde"
+	serviceAcctID = int32(123)
+	expectedACLs = `  ServiceAccountId | Permission |    Operation     | Resource |             Name             |   Type    
++------------------+------------+------------------+----------+------------------------------+----------+
+  User:123         | ALLOW      | DESCRIBE         | CLUSTER  | kafka-cluster                | LITERAL   
+  User:123         | ALLOW      | DESCRIBE_CONFIGS | CLUSTER  | kafka-cluster                | LITERAL   
+  User:123         | ALLOW      | CREATE           | TOPIC    | pksqlc-abcde                 | PREFIXED  
+  User:123         | ALLOW      | CREATE           | TOPIC    | _confluent-ksql-pksqlc-abcde | PREFIXED  
+  User:123         | ALLOW      | CREATE           | GROUP    | _confluent-ksql-pksqlc-abcde | PREFIXED  
+  User:123         | ALLOW      | DESCRIBE         | TOPIC    | pksqlc-abcde                 | PREFIXED  
+  User:123         | ALLOW      | DESCRIBE         | TOPIC    | _confluent-ksql-pksqlc-abcde | PREFIXED  
+  User:123         | ALLOW      | DESCRIBE         | GROUP    | _confluent-ksql-pksqlc-abcde | PREFIXED  
+  User:123         | ALLOW      | ALTER            | TOPIC    | pksqlc-abcde                 | PREFIXED  
+  User:123         | ALLOW      | ALTER            | TOPIC    | _confluent-ksql-pksqlc-abcde | PREFIXED  
+  User:123         | ALLOW      | ALTER            | GROUP    | _confluent-ksql-pksqlc-abcde | PREFIXED  
+  User:123         | ALLOW      | DESCRIBE_CONFIGS | TOPIC    | pksqlc-abcde                 | PREFIXED  
+  User:123         | ALLOW      | DESCRIBE_CONFIGS | TOPIC    | _confluent-ksql-pksqlc-abcde | PREFIXED  
+  User:123         | ALLOW      | DESCRIBE_CONFIGS | GROUP    | _confluent-ksql-pksqlc-abcde | PREFIXED  
+  User:123         | ALLOW      | ALTER_CONFIGS    | TOPIC    | pksqlc-abcde                 | PREFIXED  
+  User:123         | ALLOW      | ALTER_CONFIGS    | TOPIC    | _confluent-ksql-pksqlc-abcde | PREFIXED  
+  User:123         | ALLOW      | ALTER_CONFIGS    | GROUP    | _confluent-ksql-pksqlc-abcde | PREFIXED  
+  User:123         | ALLOW      | READ             | TOPIC    | pksqlc-abcde                 | PREFIXED  
+  User:123         | ALLOW      | READ             | TOPIC    | _confluent-ksql-pksqlc-abcde | PREFIXED  
+  User:123         | ALLOW      | READ             | GROUP    | _confluent-ksql-pksqlc-abcde | PREFIXED  
+  User:123         | ALLOW      | WRITE            | TOPIC    | pksqlc-abcde                 | PREFIXED  
+  User:123         | ALLOW      | WRITE            | TOPIC    | _confluent-ksql-pksqlc-abcde | PREFIXED  
+  User:123         | ALLOW      | WRITE            | GROUP    | _confluent-ksql-pksqlc-abcde | PREFIXED  
+  User:123         | ALLOW      | DELETE           | TOPIC    | pksqlc-abcde                 | PREFIXED  
+  User:123         | ALLOW      | DELETE           | TOPIC    | _confluent-ksql-pksqlc-abcde | PREFIXED  
+  User:123         | ALLOW      | DELETE           | GROUP    | _confluent-ksql-pksqlc-abcde | PREFIXED  
+  User:123         | ALLOW      | DESCRIBE         | TOPIC    | *                            | LITERAL   
+  User:123         | ALLOW      | DESCRIBE         | GROUP    | *                            | LITERAL   
+  User:123         | ALLOW      | DESCRIBE_CONFIGS | TOPIC    | *                            | LITERAL   
+  User:123         | ALLOW      | DESCRIBE_CONFIGS | GROUP    | *                            | LITERAL   
+`
+)
+
+type KSQLTestSuite struct {
+	suite.Suite
+	conf         *config.Config
+	kafkaCluster *kafkav1.KafkaCluster
+	ksqlCluster  *v1.KSQLCluster
+	serviceAcct  *orgv1.User
+	ksqlc        *mock.MockKSQL
+	kafkac       *mock.Kafka
+	userc        *mock.User
+}
+
+func (suite *KSQLTestSuite) SetupSuite() {
+	suite.initConf()
+}
+
+func (suite *KSQLTestSuite) initConf() {
+	suite.conf = config.New()
+	suite.conf.Logger = log.New()
+	suite.conf.AuthURL = "http://test"
+	suite.conf.Auth = &config.AuthConfig{
+		User:    new(orgv1.User),
+		Account: &orgv1.Account{Id: "testAccount"},
+	}
+	user := suite.conf.Auth
+	name := fmt.Sprintf("login-%s-%s", user.User.Email, suite.conf.AuthURL)
+
+	suite.conf.Platforms[name] = &config.Platform{
+		Server:        suite.conf.AuthURL,
+		KafkaClusters: map[string]config.KafkaClusterConfig{kafkaClusterID: {}},
+	}
+
+	suite.conf.Credentials[name] = &config.Credential{
+		Username: user.User.Email,
+	}
+
+	suite.conf.Contexts[name] = &config.Context{
+		Platform:   name,
+		Credential: name,
+		Kafka:      kafkaClusterID,
+	}
+
+	suite.conf.CurrentContext = name
+
+	suite.kafkaCluster = &kafkav1.KafkaCluster{
+		Id: kafkaClusterID,
+		Enterprise: true,
+	}
+
+	suite.ksqlCluster = &v1.KSQLCluster{
+		Id: ksqlClusterID,
+		KafkaClusterId: kafkaClusterID,
+		OutputTopicPrefix: outputTopicPrefix,
+	}
+
+	suite.serviceAcct = &orgv1.User{
+		ServiceAccount: true,
+		ServiceName: "KSQL." + ksqlClusterID,
+		Id: serviceAcctID,
+	}
+}
+
+func (suite *KSQLTestSuite) SetupTest() {
+	suite.kafkac = &mock.Kafka{
+		DescribeFunc: func(ctx context.Context, cluster *kafkav1.KafkaCluster) (*kafkav1.KafkaCluster, error) {
+			return suite.kafkaCluster, nil
+		},
+		CreateACLFunc: func(ctx context.Context, cluster *kafkav1.KafkaCluster, binding []*kafkav1.ACLBinding) error {
+			return nil
+		},
+	}
+	suite.ksqlc = &mock.MockKSQL{
+		DescribeFunc: func(arg0 context.Context, arg1 *v1.KSQLCluster) (*v1.KSQLCluster, error) {
+			return suite.ksqlCluster, nil
+		},
+	}
+	suite.userc = &mock.User{
+		GetServiceAccountsFunc: func(arg0 context.Context) (users []*orgv1.User, e error) {
+			return []*orgv1.User{suite.serviceAcct,}, nil
+		},
+	}
+}
+
+func (suite *KSQLTestSuite) newCMD() *cobra.Command {
+	cmd := New(&cliMock.Commander{}, suite.conf, suite.ksqlc, suite.kafkac, suite.userc)
+	cmd.PersistentFlags().CountP("verbose", "v", "increase output verbosity")
+	return cmd
+}
+
+func (suite *KSQLTestSuite) TestShouldConfigureACLs() {
+	cmd := suite.newCMD()
+	cmd.SetArgs(append([]string{"app", "configure-acls", ksqlClusterID}))
+
+	err := cmd.Execute()
+
+	req := require.New(suite.T())
+	req.Nil(err)
+	req.Equal(1, len(suite.kafkac.CreateACLCalls()))
+	bindings := suite.kafkac.CreateACLCalls()[0].Binding
+	buf := new(bytes.Buffer)
+	acl.PrintAcls(bindings, buf)
+	req.Equal(expectedACLs, buf.String())
+}
+
+func (suite *KSQLTestSuite) TestShouldNotConfigureForPro() {
+	cmd := suite.newCMD()
+	cmd.SetArgs(append([]string{"app", "configure-acls", ksqlClusterID}))
+	suite.kafkac.DescribeFunc = func(ctx context.Context, cluster *kafkav1.KafkaCluster) (cluster2 *kafkav1.KafkaCluster, e error) {
+		return &kafkav1.KafkaCluster{Id: kafkaClusterID, Enterprise: false}, nil
+	}
+	buf := new(bytes.Buffer)
+	cmd.SetOutput(buf)
+
+	err := cmd.Execute()
+
+	req := require.New(suite.T())
+	req.Nil(err)
+	req.False(suite.kafkac.CreateACLCalled());
+	req.Equal("Cluster is not an enterprise cluster. No ACLS need to be set", buf.String())
+}
+
+func (suite *KSQLTestSuite) TestShouldNotConfigureOnDryRun() {
+	cmd := suite.newCMD()
+	cmd.SetArgs(append([]string{"app", "configure-acls", "--dry-run", ksqlClusterID}))
+	buf := new(bytes.Buffer)
+	cmd.SetOutput(buf)
+
+	err := cmd.Execute()
+
+	req := require.New(suite.T())
+	req.Nil(err)
+	req.False(suite.kafkac.CreateACLCalled());
+	req.Equal(expectedACLs, buf.String())
+}
+
+func TestKsqlTestSuite(t *testing.T) {
+	suite.Run(t, new(KSQLTestSuite))
+}

--- a/internal/cmd/ksql/command.go
+++ b/internal/cmd/ksql/command.go
@@ -11,12 +11,14 @@ import (
 
 type command struct {
 	*cobra.Command
-	config *config.Config
-	client ccloud.KSQL
+	config      *config.Config
+	client      ccloud.KSQL
+	kafkaClient ccloud.Kafka
+	userClient  ccloud.User
 }
 
 // New returns the default command object for interacting with KSQL.
-func New(prerunner pcmd.PreRunner, config *config.Config, client ccloud.KSQL) *cobra.Command {
+func New(prerunner pcmd.PreRunner, config *config.Config, client ccloud.KSQL, kafkaClient ccloud.Kafka, userClient ccloud.User) *cobra.Command {
 	cmd := &command{
 		Command: &cobra.Command{
 			Use:               "ksql",
@@ -25,11 +27,13 @@ func New(prerunner pcmd.PreRunner, config *config.Config, client ccloud.KSQL) *c
 		},
 		config: config,
 		client: client,
+		kafkaClient: kafkaClient,
+		userClient: userClient,
 	}
 	cmd.init()
 	return cmd.Command
 }
 
 func (c *command) init() {
-	c.AddCommand(NewClusterCommand(c.config, c.client))
+	c.AddCommand(NewClusterCommand(c.config, c.client, c.kafkaClient, c.userClient))
 }

--- a/internal/cmd/ksql/command_cluster.go
+++ b/internal/cmd/ksql/command_cluster.go
@@ -2,11 +2,15 @@ package ksql
 
 import (
 	"context"
+	"fmt"
+	"github.com/confluentinc/cli/internal/pkg/acl"
 	"os"
+	"strconv"
 
 	"github.com/spf13/cobra"
 
 	"github.com/confluentinc/ccloud-sdk-go"
+	kafkav1 "github.com/confluentinc/ccloudapis/kafka/v1"
 	ksqlv1 "github.com/confluentinc/ccloudapis/ksql/v1"
 	"github.com/confluentinc/go-printer"
 
@@ -20,16 +24,19 @@ var (
 	listLabels      = []string{"Id", "Name", "Topic Prefix", "Kafka", "Storage", "Endpoint", "Status"}
 	describeFields  = []string{"Id", "Name", "OutputTopicPrefix", "KafkaClusterId", "Storage", "Endpoint", "Status"}
 	describeRenames = map[string]string{"KafkaClusterId": "Kafka", "OutputTopicPrefix": "Topic Prefix"}
+	aclsDryRun      = false
 )
 
 type clusterCommand struct {
 	*cobra.Command
-	config *config.Config
-	client ccloud.KSQL
+	config      *config.Config
+	client      ccloud.KSQL
+	kafkaClient ccloud.Kafka
+	userClient  ccloud.User
 }
 
 // NewClusterCommand returns the Cobra clusterCommand for Ksql Cluster.
-func NewClusterCommand(config *config.Config, client ccloud.KSQL) *cobra.Command {
+func NewClusterCommand(config *config.Config, client ccloud.KSQL, kafkaClient ccloud.Kafka, userClient ccloud.User) *cobra.Command {
 	cmd := &clusterCommand{
 		Command: &cobra.Command{
 			Use:   "app",
@@ -37,6 +44,8 @@ func NewClusterCommand(config *config.Config, client ccloud.KSQL) *cobra.Command
 		},
 		config: config,
 		client: client,
+		kafkaClient: kafkaClient,
+		userClient: userClient,
 	}
 	cmd.init()
 	return cmd.Command
@@ -77,6 +86,14 @@ func (c *clusterCommand) init() {
 		RunE:  c.delete,
 		Args:  cobra.ExactArgs(1),
 	})
+	aclsCmd := &cobra.Command{
+		Use: "configure-acls ID TOPICS...",
+		Short: "Configure acls for a KSQL cluster",
+		RunE: c.configureACLs,
+		Args: cobra.MinimumNArgs(1),
+	}
+	aclsCmd.Flags().BoolVar(&aclsDryRun, "dry-run", false, "If specified, print the acls that will be set and exit")
+	c.AddCommand(aclsCmd)
 }
 
 func (c *clusterCommand) list(cmd *cobra.Command, args []string) error {
@@ -136,6 +153,140 @@ func (c *clusterCommand) delete(cmd *cobra.Command, args []string) error {
 		return errors.HandleCommon(err, cmd)
 	}
 	pcmd.Printf(cmd, "The ksql app %s has been deleted.\n", args[0])
+	return nil
+}
+
+func (c *clusterCommand) createAcl(prefix string, patternType kafkav1.PatternTypes_PatternType, operation kafkav1.ACLOperations_ACLOperation, resource kafkav1.ResourceTypes_ResourceType, serviceAccountId string) *kafkav1.ACLBinding {
+	binding := &kafkav1.ACLBinding{
+		Entry: &kafkav1.AccessControlEntryConfig{
+			Host: "*",
+		},
+		Pattern: &kafkav1.ResourcePatternConfig{},
+	}
+	binding.Entry.PermissionType = kafkav1.ACLPermissionTypes_ALLOW
+	binding.Entry.Operation = operation
+	binding.Entry.Principal = "User:" + serviceAccountId
+	binding.Pattern.PatternType = patternType
+	binding.Pattern.ResourceType = resource
+	binding.Pattern.Name = prefix
+	return binding
+}
+
+func (c *clusterCommand) createClusterAcl(operation kafkav1.ACLOperations_ACLOperation, serviceAccountId string) *kafkav1.ACLBinding {
+	binding := &kafkav1.ACLBinding{
+		Entry: &kafkav1.AccessControlEntryConfig{
+			Host: "*",
+		},
+		Pattern: &kafkav1.ResourcePatternConfig{},
+	}
+	binding.Entry.PermissionType = kafkav1.ACLPermissionTypes_ALLOW
+	binding.Entry.Operation = operation
+	binding.Entry.Principal = "User:" + serviceAccountId
+	binding.Pattern.PatternType = kafkav1.PatternTypes_LITERAL
+	binding.Pattern.ResourceType = kafkav1.ResourceTypes_CLUSTER
+	binding.Pattern.Name = "kafka-cluster"
+	return binding
+}
+
+func (c *clusterCommand) buildACLBindings(serviceAccountId string, cluster *ksqlv1.KSQLCluster, topics []string) []*kafkav1.ACLBinding {
+	bindings := []*kafkav1.ACLBinding{}
+	for _, op := range []kafkav1.ACLOperations_ACLOperation{
+		kafkav1.ACLOperations_DESCRIBE,
+		kafkav1.ACLOperations_DESCRIBE_CONFIGS,
+	} {
+		bindings = append(bindings, c.createClusterAcl(op, serviceAccountId))
+	}
+	for _ ,op := range []kafkav1.ACLOperations_ACLOperation{
+		kafkav1.ACLOperations_CREATE,
+		kafkav1.ACLOperations_DESCRIBE,
+		kafkav1.ACLOperations_ALTER,
+		kafkav1.ACLOperations_DESCRIBE_CONFIGS,
+		kafkav1.ACLOperations_ALTER_CONFIGS,
+		kafkav1.ACLOperations_READ,
+		kafkav1.ACLOperations_WRITE,
+		kafkav1.ACLOperations_DELETE,
+	} {
+		bindings = append(bindings, c.createAcl(cluster.OutputTopicPrefix, kafkav1.PatternTypes_PREFIXED, op, kafkav1.ResourceTypes_TOPIC, serviceAccountId))
+		bindings = append(bindings, c.createAcl("_confluent-ksql-" + cluster.OutputTopicPrefix, kafkav1.PatternTypes_PREFIXED, op, kafkav1.ResourceTypes_TOPIC, serviceAccountId))
+		bindings = append(bindings, c.createAcl("_confluent-ksql-" + cluster.OutputTopicPrefix, kafkav1.PatternTypes_PREFIXED, op, kafkav1.ResourceTypes_GROUP, serviceAccountId))
+	}
+	for _, op := range[]kafkav1.ACLOperations_ACLOperation{
+		kafkav1.ACLOperations_DESCRIBE,
+		kafkav1.ACLOperations_DESCRIBE_CONFIGS,
+	} {
+		bindings = append(bindings, c.createAcl("*", kafkav1.PatternTypes_LITERAL, op, kafkav1.ResourceTypes_TOPIC, serviceAccountId))
+		bindings = append(bindings, c.createAcl("*", kafkav1.PatternTypes_LITERAL, op, kafkav1.ResourceTypes_GROUP, serviceAccountId))
+	}
+	for _ ,op := range []kafkav1.ACLOperations_ACLOperation{
+		kafkav1.ACLOperations_DESCRIBE,
+		kafkav1.ACLOperations_DESCRIBE_CONFIGS,
+		kafkav1.ACLOperations_READ,
+	} {
+		for _, t := range topics {
+			bindings = append(bindings, c.createAcl(t, kafkav1.PatternTypes_LITERAL, op, kafkav1.ResourceTypes_TOPIC, serviceAccountId))
+		}
+	}
+	return bindings
+}
+
+func (c *clusterCommand) getServiceAccount(cluster *ksqlv1.KSQLCluster) (string, error) {
+	users, err := c.userClient.GetServiceAccounts(context.Background())
+	if err != nil {
+		return "", err
+	}
+	for _, user := range users {
+		if user.ServiceName == fmt.Sprintf("KSQL.%s", cluster.Id) {
+			return strconv.Itoa(int(user.Id)), nil
+		}
+	}
+	return "", errors.New(fmt.Sprintf("No service account found for %s", cluster.Id))
+}
+
+func (c *clusterCommand) configureACLs(cmd *cobra.Command, args[]string) error {
+	ctx := context.Background()
+
+	// Get the Kafka Cluster
+	// Ensure the Kafka Cluster is an Enterprise cluster
+	kafkaCluster, err := c.config.KafkaCluster()
+	if err != nil {
+		return errors.HandleCommon(err, cmd)
+	}
+	kafkaCluster, err = c.kafkaClient.Describe(ctx, kafkaCluster)
+	if err != nil {
+		return errors.HandleCommon(err, cmd)
+	}
+
+	// Ensure the KSQL cluster talks to the current Kafka Cluster
+	req := &ksqlv1.KSQLCluster{AccountId: c.config.Auth.Account.Id, Id: args[0]}
+	cluster, err := c.client.Describe(context.Background(), req)
+	if err != nil {
+		return errors.HandleCommon(err, cmd)
+	}
+	if cluster.KafkaClusterId != kafkaCluster.Id {
+		pcmd.Printf(cmd, "This KSQL cluster is not backed by the current Kafka cluster.")
+	}
+
+	// Ensure the Kafka Cluster is an Enterprise cluster
+	if !kafkaCluster.Enterprise {
+		pcmd.Printf(cmd, "Cluster is not an enterprise cluster. No ACLS need to be set")
+		return nil
+	}
+
+	serviceAccountId, err := c.getServiceAccount(cluster)
+	if err != nil {
+		return errors.HandleCommon(err, cmd)
+	}
+
+	// Setup ACLs
+	bindings := c.buildACLBindings(serviceAccountId, cluster, args[1:])
+	if aclsDryRun {
+		acl.PrintAcls(bindings, cmd.OutOrStderr())
+		return nil
+	}
+	err = c.kafkaClient.CreateACL(ctx, kafkaCluster, bindings)
+	if err != nil {
+		return errors.HandleCommon(err, cmd)
+	}
 	return nil
 }
 

--- a/internal/cmd/ksql/fake_test.go
+++ b/internal/cmd/ksql/fake_test.go
@@ -1,1 +1,0 @@
-package ksql

--- a/internal/pkg/acl/acl.go
+++ b/internal/pkg/acl/acl.go
@@ -1,0 +1,33 @@
+package acl
+
+import (
+	"io"
+
+	"github.com/codyaray/go-printer"
+	kafkav1 "github.com/confluentinc/ccloudapis/kafka/v1"
+)
+
+func PrintAcls(bindingsObj []*kafkav1.ACLBinding, writer io.Writer) {
+	var bindings [][]string
+	for _, binding := range bindingsObj {
+
+		record := &struct {
+			ServiceAccountId string
+			Permission       string
+			Operation        string
+			Resource         string
+			Name             string
+			Type             string
+		}{
+			binding.Entry.Principal,
+			binding.Entry.PermissionType.String(),
+			binding.Entry.Operation.String(),
+			binding.Pattern.ResourceType.String(),
+			binding.Pattern.Name,
+			binding.Pattern.PatternType.String(),
+		}
+		bindings = append(bindings, printer.ToRow(record,
+			[]string{"ServiceAccountId", "Permission", "Operation", "Resource", "Name", "Type"}))
+	}
+	printer.RenderCollectionTableOut(bindings, []string{"ServiceAccountId", "Permission", "Operation", "Resource", "Name", "Type"}, writer)
+}


### PR DESCRIPTION
This patch adds a command for configuring a basic set of ACLs for a KSQL running
on top of an enterprise Kafka cluster. Also includes a dry-run option for printing
out the acls.