### PR TITLE
fix lint-cli to know api-key update doesn't need a --cluster flag

### DIFF
--- a/cmd/lint/main.go
+++ b/cmd/lint/main.go
@@ -152,6 +152,7 @@ func linters(cmd *cobra.Command) *multierror.Error {
 				// these all require explicit cluster as id/name args
 				!strings.Contains(fullCommand(cmd), "kafka cluster") &&
 				// this doesn't need a --cluster override since you provide the api key itself to identify it
+				!strings.Contains(fullCommand(cmd), "api-key update") &&
 				!strings.Contains(fullCommand(cmd), "api-key delete") {
 				f := cmd.Flag("cluster")
 				if f == nil {


### PR DESCRIPTION
Looks like @DABH and my PRs crossed each other. I added `--cluster` flag on everything, and a linter to fail where it was missing. He added the new `api-key update` command which doesn't need the flag, but wasn't excluded in the linter. So CI master is red. This should fix that.