### PR TITLE
fix missing dist target on publish

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,7 @@ dist: download-licenses
 	done
 
 .PHONY: publish
-publish:
+publish: dist
 	@for binary in ccloud confluent; do \
 		aws s3 cp dist/$${binary}/ s3://confluent.cloud/$${binary}-cli/archives/$(VERSION:v%=%)/ --recursive --exclude "*" --include "*.tar.gz" --include "*.zip" --include "*_checksums.txt" --exclude "*_latest_*" --acl public-read ; \
 		aws s3 cp dist/$${binary}/ s3://confluent.cloud/$${binary}-cli/archives/latest/ --recursive --exclude "*" --include "*.tar.gz" --include "*.zip" --include "*_checksums.txt" --exclude "*_$(VERSION)_*" --acl public-read ; \


### PR DESCRIPTION
This seems like an obvious mistake in the publishing process. 🤕 

https://confluentinc.semaphoreci.com/jobs/f1f66cd1-45b9-42c0-833d-1ad7a2002ae5#L3890

```
make publish
--
  | make[2]: Entering directory '/home/semaphore/go/src/github.com/confluentinc/cli'
  | upload: dist/ccloud/ccloud_0.73.0_checksums.txt to s3://confluent.cloud/ccloud-cli/archives/0.73.0-dirty-semaphore/ccloud_0.73.0_checksums.txt
  | upload: dist/ccloud/ccloud_0.73.0_checksums.txt to s3://confluent.cloud/ccloud-cli/archives/latest/ccloud_0.73.0_checksums.txt
  | upload: dist/confluent/confluent_0.73.0_checksums.txt to s3://confluent.cloud/confluent-cli/archives/0.73.0-dirty-semaphore/confluent_0.73.0_checksums.txt
  | upload: dist/confluent/confluent_0.73.0_checksums.txt to s3://confluent.cloud/confluent-cli/archives/latest/confluent_0.73.0_checksums.txt
  | make[2]: Leaving directory '/home/semaphore/go/src/github.com/confluentinc/cli'
  | make publish-docs
```