### PR TITLE
[CLI-187] Fix api-key use command error to guide you to api-key store

### DIFF
--- a/internal/pkg/cmd/config.go
+++ b/internal/pkg/cmd/config.go
@@ -86,7 +86,7 @@ func (c *ConfigHelper) UseAPIKey(apiKey, clusterID string) error {
 	_, found = cluster.APIKeys[apiKey]
 	if !found {
 		// check if this is API key exists server-side
-		key, err := c.Client.APIKey.Get(context.Background(), &authv1.ApiKey{Key: apiKey})
+		key, err := c.Client.APIKey.Get(context.Background(), &authv1.ApiKey{AccountId: c.Config.Auth.Account.Id, Key: apiKey})
 		if err != nil {
 			return err
 		}

--- a/test/cli_test.go
+++ b/test/cli_test.go
@@ -527,6 +527,7 @@ func serve(t *testing.T, kafkaAPIURL string) *httptest.Server {
 			req := &authv1.CreateApiKeyRequest{}
 			err = json.Unmarshal(b, req)
 			require.NoError(t, err)
+			require.NotEmpty(t, req.ApiKey.AccountId)
 			apiKey := req.ApiKey
 			apiKey.Id = int32(KEY_INDEX)
 			apiKey.Key = fmt.Sprintf("MYKEY%d", KEY_INDEX)
@@ -539,6 +540,7 @@ func serve(t *testing.T, kafkaAPIURL string) *httptest.Server {
 			_, err = io.WriteString(w, string(b))
 			require.NoError(t, err)
 		} else if r.Method == "GET" {
+			require.NotEmpty(t, r.URL.Query().Get("account_id"))
 			var apiKeys []*authv1.ApiKey
 			for _, a := range KEY_STORE {
 				apiKeys = append(apiKeys, a)
@@ -552,6 +554,7 @@ func serve(t *testing.T, kafkaAPIURL string) *httptest.Server {
 		}
 	})
 	mux.HandleFunc("/api/clusters/", func(w http.ResponseWriter, r *http.Request) {
+		require.NotEmpty(t, r.URL.Query().Get("account_id"))
 		parts := strings.Split(r.URL.Path, "/")
 		id := parts[len(parts)-1]
 		if id == "lkc-unknown" {


### PR DESCRIPTION
Small bug prevented this from working. Here's what you see now:
```
    Error: please add API secret with 'api-key store BA4B6YCFUHC4E4K7 --cluster lkc-o39vj'
```