### PR TITLE
Improvements and tests for update changes

### DIFF
--- a/test/fixtures/output/confluent-version.golden
+++ b/test/fixtures/output/confluent-version.golden
@@ -3,7 +3,7 @@ confluent - Confluent CLI
 Version:     v.*
 Git Ref:     [0-9a-f]{40}
 Build Date:  20[0-9]{2}-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])T([0-1][0-9]|2[0-4]):[0-5][0-9]:[0-5][0-9]Z
-Build Host:  [a-zA-Z0-9]*@.*
+Build Host:  [a-zA-Z0-9\.]*@.*
 Go Version:  go.*
 Development: .*
 

--- a/test/fixtures/output/version.golden
+++ b/test/fixtures/output/version.golden
@@ -3,7 +3,7 @@ ccloud - Confluent Cloud CLI
 Version:     v.*
 Git Ref:     [0-9a-f]{40}
 Build Date:  20[0-9]{2}-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])T([0-1][0-9]|2[0-4]):[0-5][0-9]:[0-5][0-9]Z
-Build Host:  [a-zA-Z0-9]*@.*
+Build Host:  [a-zA-Z0-9\.]*@.*
 Go Version:  go.*
 Development: .*
 


### PR DESCRIPTION
Per https://confluent.slack.com/archives/CG6BW233L/p1559261366008800 .

This doesn't handle a case where `mv` silently fails.  I am not familiar when that could occur.  (for that matter, cp or others could silently fail too?)

I also changed the version tests to be a bit more relaxed so that tests can all pass on my laptop.