### PR TITLE
Password protection: Improve CLI help to specify key/value pair

### DIFF
--- a/internal/cmd/secret/command_file.go
+++ b/internal/cmd/secret/command_file.go
@@ -94,7 +94,7 @@ command returns a failure if a master key has not already been set using the "ma
 	addCmd.Flags().String("remote-secrets-file", "", "Path to the remote encrypted configuration properties file.")
 	check(addCmd.MarkFlagRequired("remote-secrets-file"))
 
-	addCmd.Flags().String("config", "", "List of configuration properties.")
+	addCmd.Flags().String("config", "", "List of key/value pairs of configuration properties.")
 	check(addCmd.MarkFlagRequired("config"))
 	addCmd.Flags().SortFlags = false
 	c.AddCommand(addCmd)
@@ -115,7 +115,7 @@ command returns a failure if a master key has not already been set using the "ma
 	updateCmd.Flags().String("remote-secrets-file", "", "Path to the remote encrypted configuration properties file.")
 	check(updateCmd.MarkFlagRequired("remote-secrets-file"))
 
-	updateCmd.Flags().String("config", "", "List of configuration properties.")
+	updateCmd.Flags().String("config", "", "List of key/value pairs of configuration properties.")
 	check(updateCmd.MarkFlagRequired("config"))
 	updateCmd.Flags().SortFlags = false
 	c.AddCommand(updateCmd)


### PR DESCRIPTION
CLI help enhancement to read as following for add and update command

```--config string                List of key/value pairs of configuration properties.```

Fix for issue: https://confluentinc.atlassian.net/browse/SEC-288