### PR TITLE
Password Protection:  Workaround for retaining the last comment in config file

### DIFF
--- a/internal/pkg/secret/password_protection_constants.go
+++ b/internal/pkg/secret/password_protection_constants.go
@@ -10,6 +10,11 @@ const (
 
 	SECURE_CONFIG_PROVIDER_CLASS = "io.confluent.kafka.security.config.provider.SecurePassConfigProvider"
 
+	/* The properties file writer associates comments with the next property, so if the comment is the last line in the config file
+	   the comment is deleted after performing encryption/add/update operation on the file. In order to retain the last comment we add delimiter
+	   SECURE_CONFIG_PROVIDER_DELIMITER at the end of the config file before performing the encryption/add/update operation. This delimiter is removed
+	   after the operations are completed.
+	*/
 	SECURE_CONFIG_PROVIDER_DELIMITER = "\nconfig.providers.securepass.delimiter = delimiter"
 )
 

--- a/internal/pkg/secret/utils.go
+++ b/internal/pkg/secret/utils.go
@@ -88,16 +88,15 @@ func GenerateConfigKey(path string, key string) string {
 }
 
 func AppendDelimiter(path string) error {
-	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0)
 	if err != nil {
 		return err
 	}
 	if _, err := f.Write([]byte(SECURE_CONFIG_PROVIDER_DELIMITER)); err != nil {
 		return err
 	}
-	if err := f.Close(); err != nil {
-		return err
-	}
+
+	defer f.Close()
 
 	return nil
 }


### PR DESCRIPTION
The properties file writer associate comments with the next property, so if there is no next property the comment ie. comment is last line in the config file the comment is lost after performing encryption/add/update operation on the file.

Added a workaround to fix the issue by adding a delimeter key at the end of file before performing the encryption operation and removing it after we perform the encryption so last line is retained. 

