### PR TITLE
[CLI-221] Use atrox homedir so sudo cli commands work in proper way

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -54,7 +54,6 @@ require (
 	github.com/magiconair/properties v1.8.0
 	github.com/mattn/go-isatty v0.0.4
 	github.com/mattn/go-runewidth v0.0.3 // indirect
-	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/golicense v0.1.1
 	github.com/neurosnap/sentences v1.0.6 // indirect
 	github.com/olekukonko/tablewriter v0.0.0-20180912035003-be2c049b30cc

--- a/go.sum
+++ b/go.sum
@@ -163,6 +163,7 @@ github.com/golangci/dupl v0.0.0-20180902072040-3e9179ac440a h1:w8hkcTqaFpzKqonE9
 github.com/golangci/dupl v0.0.0-20180902072040-3e9179ac440a/go.mod h1:ryS0uhF+x9jgbj/N71xsEqODy9BN81/GonCZiOzirOk=
 github.com/golangci/errcheck v0.0.0-20181003203344-ef45e06d44b6 h1:i2jIkQFb8RG45DuQs+ElyROY848cSJIoIkBM+7XXypA=
 github.com/golangci/errcheck v0.0.0-20181003203344-ef45e06d44b6/go.mod h1:DbHgvLiFKX1Sh2T1w8Q/h4NAI8MHIpzCdnBUDTXU3I0=
+github.com/golangci/go-misc v0.0.0-20180628070357-927a3d87b613 h1:9kfjN3AdxcbsZBf8NjltjWihK2QfBBBZuv91cMFfDHw=
 github.com/golangci/go-misc v0.0.0-20180628070357-927a3d87b613/go.mod h1:SyvUF2NxV+sN8upjjeVYr5W7tyxaT1JVtvhKhOn2ii8=
 github.com/golangci/go-tools v0.0.0-20180109140146-af6baa5dc196/go.mod h1:unzUULGw35sjyOYjUt0jMTXqHlZPpPc6e+xfO4cd6mM=
 github.com/golangci/go-tools v0.0.0-20190124090046-35a9f45a5db0 h1:MRhC9XbUjE6XDOInSJ8pwHuPagqsyO89QDU9IdVhe3o=

--- a/internal/cmd/local/local.go
+++ b/internal/cmd/local/local.go
@@ -7,8 +7,8 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/atrox/homedir"
 	"github.com/hashicorp/go-version"
-	"github.com/mitchellh/go-homedir"
 	"github.com/spf13/cobra"
 
 	pcmd "github.com/confluentinc/cli/internal/pkg/cmd"

--- a/internal/cmd/local/local_test.go
+++ b/internal/cmd/local/local_test.go
@@ -6,14 +6,14 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/atrox/homedir"
 	"github.com/golang/mock/gomock"
-	"github.com/mitchellh/go-homedir"
 	"github.com/stretchr/testify/require"
 
 	"github.com/confluentinc/cli/internal/pkg/cmd"
 	"github.com/confluentinc/cli/internal/pkg/mock"
 	cliMock "github.com/confluentinc/cli/mock"
-	"github.com/confluentinc/cli/mock/local"
+	mock_local "github.com/confluentinc/cli/mock/local"
 )
 
 func TestLocal(t *testing.T) {

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/mitchellh/go-homedir"
+	"github.com/atrox/homedir"
 
 	v1 "github.com/confluentinc/ccloudapis/org/v1"
 


### PR DESCRIPTION
Debugged  https://github.com/confluentinc/cli/pull/new/CLI-221 with @sdanduConf .  Turns out go-homedir returns _your_ homedir when running a command as sudo, rather than root's homedir.  atrox's homedir package returns root's homedir while running under sudo, which is the desired behavior.

Now everything in CLI uses atrox's homedir, and we've manually verified that both sudo and non-sudo behavior works correctly / correct homedirs are used.