### PR TITLE
Fix passing cli name for docs generation

### DIFF
--- a/cmd/docs/main.go
+++ b/cmd/docs/main.go
@@ -20,7 +20,7 @@ var (
 func main() {
 	emptyStr := func(filename string) string { return "" }
 	sphinxRef := func(name, ref string) string { return fmt.Sprintf(":ref:`%s`", ref) }
-	confluent, err := cmd.NewConfluentCommand(cliName, &config.Config{}, &version.Version{}, log.New())
+	confluent, err := cmd.NewConfluentCommand(cliName, &config.Config{CLIName: cliName}, &version.Version{}, log.New())
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
The core bug is that some commands use `config.CLIName` while others use the CLIName passed into `NewConfluentCommand()`. Ideally we'll not duplicate this info, but for now just set it appropriately to fix the docs generation.

### Testing

Fixed top-level doc:
```diff
diff --git a/docs/ccloud/ccloud.rst b/docs/ccloud/ccloud.rst
index 814e644..24ad1ce 100644
--- a/docs/ccloud/ccloud.rst
+++ b/docs/ccloud/ccloud.rst
@@ -25,9 +25,9 @@ See Also
 * :ref:`ccloud_completion`      - Print shell completion code.
 * :ref:`ccloud_environment`     - Manage and select ccloud environments.
 * :ref:`ccloud_kafka`   - Manage Apache Kafka.
-* :ref:`ccloud_login`   - Log in to Confluent Platform (required for RBAC).
-* :ref:`ccloud_logout`          - Logout of Confluent Platform.
-* :ref:`ccloud_prompt`          - Print  CLI context for your terminal prompt.
+* :ref:`ccloud_login`   - Log in to Confluent Cloud.
+* :ref:`ccloud_logout`          - Logout of Confluent Cloud.
+* :ref:`ccloud_prompt`          - Print ccloud CLI context for your terminal prompt.
 * :ref:`ccloud_service-account`         - Manage service accounts. This is only available for Confluent Cloud Enterprise users.
 * :ref:`ccloud_update`          - Update the ccloud CLI.
 * :ref:`ccloud_version`         - Print the  CLI version.
```

Fixed ccloud login doc:
```diff
diff --git a/docs/ccloud/ccloud_login.rst b/docs/ccloud/ccloud_login.rst
index 0feaba6..7be4ff4 100644
--- a/docs/ccloud/ccloud_login.rst
+++ b/docs/ccloud/ccloud_login.rst
@@ -6,7 +6,7 @@ ccloud login
 Description
 ~~~~~~~~~~~

-Log in to Confluent Platform (required for RBAC).
+Log in to Confluent Cloud.

 ::

@@ -17,10 +17,10 @@ Flags

 ::

-      --url string   Metadata service URL.
+      --url string   Confluent Cloud service URL. (default "https://confluent.cloud")
   -h, --help         help for login

-Log in to Confluent Platform (required for RBAC).
+Log in to Confluent Cloud.

 Global Flags
 ~~~~~~~~~~~~
```

Fixed ccloud logout doc:
```diff
diff --git a/docs/ccloud/ccloud_logout.rst b/docs/ccloud/ccloud_logout.rst
index 5d15bc7..f451e5d 100644
--- a/docs/ccloud/ccloud_logout.rst
+++ b/docs/ccloud/ccloud_logout.rst
@@ -6,7 +6,7 @@ ccloud logout
 Description
 ~~~~~~~~~~~

-Logout of Confluent Platform.
+Logout of Confluent Cloud.

 ::

@@ -19,7 +19,7 @@ Flags

   -h, --help   help for logout

-Logout of Confluent Platform.
+Logout of Confluent Cloud.

 Global Flags
 ~~~~~~~~~~~~
```

Fixed ccloud prompt doc:
```diff
diff --git a/docs/ccloud/ccloud_prompt.rst b/docs/ccloud/ccloud_prompt.rst
index eaa3df7..c48376c 100644
--- a/docs/ccloud/ccloud_prompt.rst
+++ b/docs/ccloud/ccloud_prompt.rst
@@ -6,7 +6,7 @@ ccloud prompt
 Description
 ~~~~~~~~~~~

-Print  CLI context for your terminal prompt.
+Print ccloud CLI context for your terminal prompt.

 ::

@@ -22,36 +22,36 @@ Flags
   -t, --timeout string   The maximum execution time in milliseconds. (default "200ms")
   -h, --help             help for prompt

-Use this command to add  information in your terminal prompt.
+Use this command to add ccloud information in your terminal prompt.

 For Bash, you'll want to do something like this:

 ::

-  $ export PS1="$( prompt) $PS1"
+  $ export PS1="$(ccloud prompt) $PS1"

 ZSH users should be aware that they will have to set the 'PROMPT_SUBST' option first:

 ::

   $ setopt prompt_subst
-  $ export PS1="$( prompt) $PS1"
+  $ export PS1="$(ccloud prompt) $PS1"

-You can customize the prompt by calling passing a '--format' flag, such as '-f "|%E:%K"'.
+You can customize the prompt by calling passing a '--format' flag, such as '-f "ccloud|%E:%K"'.
 If you want to create a more sophisticated prompt (such as using the built-in color functions),
 it'll be easiest for you if you use an environment variable rather than try to escape the quotes.

 ::

-  $ export _PROMPT_FMT='({{color "blue" ""}}|{{color "red" "%E"}}:{{color "cyan" "%K"}})'
-  $ export PS1="$( prompt -f "$_PROMPT_FMT") $PS1"
+  $ export CCLOUD_PROMPT_FMT='({{color "blue" "ccloud"}}|{{color "red" "%E"}}:{{color "cyan" "%K"}})'
+  $ export PS1="$(ccloud prompt -f "$CCLOUD_PROMPT_FMT") $PS1"

 To make this permanent, you must add it to your bash or zsh profile.

 Formats
 ~~~~~~~

-' prompt' comes with a number of formatting tokens. What follows is a list of all tokens:
+'ccloud prompt' comes with a number of formatting tokens. What follows is a list of all tokens:

 * '%C' or {{.ContextName}}
```

Fixed index doc:
```diff
diff --git a/docs/ccloud/index.rst b/docs/ccloud/index.rst
index 953020a..9578aaf 100644
--- a/docs/ccloud/index.rst
+++ b/docs/ccloud/index.rst
@@ -86,9 +86,9 @@ The available |ccloud| CLI commands are documented here.
  :ref:`ccloud_kafka_topic_list`         List Kafka topics.
  :ref:`ccloud_kafka_topic_produce`      Produce messages to a Kafka topic.
  :ref:`ccloud_kafka_topic_update`       Update a Kafka topic.
- :ref:`ccloud_login`                    Log in to Confluent Platform (required for RBAC).
- :ref:`ccloud_logout`                   Logout of Confluent Platform.
- :ref:`ccloud_prompt`                   Print  CLI context for your terminal prompt.
+ :ref:`ccloud_login`                    Log in to Confluent Cloud.
+ :ref:`ccloud_logout`                   Logout of Confluent Cloud.
+ :ref:`ccloud_prompt`                   Print ccloud CLI context for your terminal prompt.
  :ref:`ccloud_service-account`          Manage service accounts. This is only available for Confluent Cloud Enterprise users.
  :ref:`ccloud_service-account_create`   Create a service account. This is only available for Confluent Cloud Enterprise users.
  :ref:`ccloud_service-account_delete`   Delete a service account. This is only available for Confluent Cloud Enterprise users.
```