### PR TITLE
Paths were off by a delimited phrase

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,8 @@ To install the CLI:
 ```
 $ make deps
 $ make build
-$ dist/ccloud/$(go env GOOS)_$(go env GOARCH)/ccloud -h # for cloud CLI
-$ dist/confluent/$(go env GOOS)_$(go env GOARCH)/confluent -h # for on-prem Confluent CLI
+$ dist/ccloud/ccloud_$(go env GOOS)_$(go env GOARCH)/ccloud -h # for cloud CLI
+$ dist/confluent/confluent_$(go env GOOS)_$(go env GOARCH)/confluent -h # for on-prem Confluent CLI
 ```
 
 ## Developing


### PR DESCRIPTION
btw the correct paths follow a redundant naming convention (repeating `ccloud` or `confluent` for no good reason) IMO