### PR TITLE
SEC-283: Remove extra whitespace after prefix when writing comments

### DIFF
--- a/internal/pkg/secret/utils.go
+++ b/internal/pkg/secret/utils.go
@@ -41,7 +41,7 @@ func findMatchTrim(original string, re *regexp.Regexp, prefix string, suffix str
 func WritePropertiesFile(path string, property *properties.Properties, writeComments bool) error {
 	buf := new(bytes.Buffer)
 	if writeComments {
-		_, err := property.WriteComment(buf, "# ", properties.UTF8)
+		_, err := property.WriteComment(buf, "#", properties.UTF8)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
From SEC-283, it looks like we don't want the extra whitespace added after comment prefixes. If that is the only issue, then this change will fix it. Before this change:
```
#comment1
a=b
# comment2
c=d
```
would change to 
```
# comment1
a=b
# comment2
c=d
```
After this change though, the original file would change to:
```
#comment1
a=b
#comment2
c=d
```
Note that although comment1 has retained its original spacing, the whitespace between comment2 and its prefix gets stripped out. To retain and passthrough all such formatting would require additional changes to the underlying properties parser library.
