### PR TITLE
Remove cluster from schema registry request

### DIFF
--- a/internal/cmd/schema-registry/command.go
+++ b/internal/cmd/schema-registry/command.go
@@ -44,8 +44,6 @@ func (c *command) init() {
 		RunE:    c.enable,
 		Args:    cobra.NoArgs,
 	}
-	createCmd.Flags().String("cluster", "", "Kafka cluster ID")
-	_ = createCmd.MarkFlagRequired("cluster")
 	createCmd.Flags().String("cloud", "", "Cloud provider (e.g. 'aws', 'azure', or 'gcp')")
 	_ = createCmd.MarkFlagRequired("cloud")
 	createCmd.Flags().String("geo", "", "Either 'us', 'eu', or 'apac' (only applies to Enterprise accounts)")
@@ -77,14 +75,8 @@ func (c *command) enable(cmd *cobra.Command, args []string) error {
 	// Trust the API will handle CCP/CCE and whether geo is required
 	location := srv1.GlobalSchemaRegistryLocation(srv1.GlobalSchemaRegistryLocation_value[strings.ToUpper(locationFlag)])
 
-	kafkaClusterId, err := cmd.Flags().GetString("cluster")
-	if err != nil {
-		return errors.HandleCommon(err, cmd)
-	}
-
 	// Build the SR instance
 	clusterConfig := &srv1.SchemaRegistryClusterConfig{
-		KafkaClusterId:  kafkaClusterId,
 		AccountId:       accountId,
 		Location:        location,
 		ServiceProvider: serviceProvider,

--- a/internal/cmd/schema-registry/command_test.go
+++ b/internal/cmd/schema-registry/command_test.go
@@ -87,7 +87,7 @@ func (suite *SRTestSuite) newCMD() *cobra.Command {
 
 func (suite *SRTestSuite) TestCreateSR() {
 	cmd := suite.newCMD()
-	cmd.SetArgs(append([]string{"enable", "--cloud", "aws", "--cluster", kafkaClusterID}))
+	cmd.SetArgs(append([]string{"enable", "--cloud", "aws"}))
 
 	err := cmd.Execute()
 	req := require.New(suite.T())


### PR DESCRIPTION
This param specifies the backing cluster ID, but user should not be specifying that. Confluent will pick/create a multitenant backing cluster