### PR TITLE
Producer ignoring empty messages

### DIFF
--- a/internal/cmd/kafka/command_topic.go
+++ b/internal/cmd/kafka/command_topic.go
@@ -377,9 +377,6 @@ func (c *topicCommand) produce(cmd *cobra.Command, args []string) error {
 	var key sarama.Encoder
 	for data := range input {
 		data = strings.TrimSpace(data)
-		if data == "" {
-			continue
-		}
 
 		record := strings.SplitN(data, delim, 2)
 


### PR DESCRIPTION
I was creating a Kafka consumer in Golang and make it read from a Kafka producer created via `ccloud CLI` on a particular topic on an lkc. I could successfully consume the messages. However, once the producer was live, upon hitting some random enters and publish some empty messages, the consumer was not able to consume anymore. I tested and observed the same behavior via a CLI consumer and on the UI (under messages tab). So far the only way for me to make consumer consume again is to restart the producer. Please look at the image to interpret the behavior. Image: https://confluent.slack.com/files/UFQEPRGT1/FMC1W2TEJ/image.png
