### PR TITLE
CLI-32: Add zsh completion

### DIFF
--- a/internal/cmd/completion/completion.go
+++ b/internal/cmd/completion/completion.go
@@ -9,7 +9,7 @@ import (
 )
 
 const longDescriptionTemplate = `Use this command to print the output shell completion
-code for the specified shell (Bash only). The shell code must be evaluated to provide
+code for the specified shell (Bash/Zsh only). The shell code must be evaluated to provide
 interactive completion of {{.CLIName}} commands.
 
 Install Bash completions on macOS:
@@ -31,7 +31,22 @@ Install Bash completions on Linux:
   # Load the {{.CLIName}} completion code for Bash into the current shell
   source /etc/bash_completion.d/{{.CLIName}}
 
-To update your completion scripts after updating the CLI, run "{{.CLIName}} completion bash"
+Add the source command above to your ~/.bashrc or ~/.profile to enable completions for new
+terminals.
+
+Install Zsh completions:
+
+::
+
+  # Set the {{.CLIName}} completion code for zsh to a file in the fpath
+  {{.CLIName}} completion zsh > ${fpath[1]}/_{{.CLIName}}
+
+  # Enable zsh completions
+  autoload -U compinit && compinit
+
+Add the autoload command in your ~/.zshrc to enable completions for new terminals
+
+To update your completion scripts after updating the CLI, run "{{.CLIName}} completion <bash|zsh>"
 again and overwrite the file initially created above.
 `
 
@@ -63,6 +78,8 @@ func (c *completionCommand) completion(cmd *cobra.Command, args []string) error 
 	var err error
 	if args[0] == "bash" {
 		err = c.rootCmd.GenBashCompletion(cmd.OutOrStdout())
+	} else	if args[0] == "zsh" {
+		err = c.rootCmd.GenZshCompletion(cmd.OutOrStdout())
 	} else {
 		err = fmt.Errorf(`unsupported shell type "%s"`, args[0])
 	}

--- a/internal/cmd/completion/completion_test.go
+++ b/internal/cmd/completion/completion_test.go
@@ -28,8 +28,8 @@ func TestCompletionZsh(t *testing.T) {
 	root.AddCommand(cmd)
 
 	output, err := pcmd.ExecuteCommand(root, "completion", "zsh")
-	req.Error(err)
-	req.Contains(output, "Error: unsupported shell type \"zsh\"")
+	req.NoError(err)
+	req.Contains(output, "compdef _")
 }
 
 func TestCompletionUnknown(t *testing.T) {


### PR DESCRIPTION
Verified on the following OS's and zsh versions:
* zsh 5.3 (x86_64-apple-darwin18.0)
* zsh 5.0.2 (x86_64-redhat-linux-gnu)
* zsh 5.4.2 (x86_64-ubuntu-linux-gnu)