### PR TITLE
Add handling for CTRL-D (EOF) termination of topic produce command.

### DIFF
--- a/internal/cmd/kafka/command_topic.go
+++ b/internal/cmd/kafka/command_topic.go
@@ -358,7 +358,7 @@ func (c *topicCommand) produce(cmd *cobra.Command, args []string) error {
 	scanner := bufio.NewScanner(os.Stdin)
 	input := make(chan string, 1)
 
-	// Avoid blocking in for loop so ^C can exit immediately.
+	// Avoid blocking in for loop so ^C or ^D can exit immediately.
 	scan := func() {
 		hasNext := scanner.Scan()
 		if !hasNext && scanner.Err() == nil {


### PR DESCRIPTION
- Implement CTRL-D handling.
- Closing topic in the sender as recommended [here](https://tour.golang.org/concurrency/4), to avoid panics caused by sending on a closed channel.
- Add "^D" to usage message to reflect change.
- Tested manually on just-started producer, producer with some input, and producer with some newline input, as requested by @DABH. Note that CTRL-D needs to be pressed twice on a non-blank line.