### PR TITLE
Fix doc syntax issue

### DIFF
--- a/internal/cmd/schema-registry/command_schema.go
+++ b/internal/cmd/schema-registry/command_schema.go
@@ -44,16 +44,19 @@ Register a new schema
 
 		{{.CLIName}} schema-registry schema create --subject payments --schema schemafilepath
 
-where schemafilepath may include these contents:
-{
-   "type" : "record",
-   "namespace" : "Example",
-   "name" : "Employee",
-   "fields" : [
-      { "name" : "Name" , "type" : "string" },
-      { "name" : "Age" , "type" : "int" }
-   ]
-}
+Where schemafilepath may include these contents:
+
+::
+
+	{
+	   "type" : "record",
+	   "namespace" : "Example",
+	   "name" : "Employee",
+	   "fields" : [
+		  { "name" : "Name" , "type" : "string" },
+		  { "name" : "Age" , "type" : "int" }
+	   ]
+	}
 
 `, c.config.CLIName),
 		RunE: c.create,


### PR DESCRIPTION
Fixes broken syntax in [ccloud schema-registry schema create command](https://docs.confluent.io/current/cloud/cli/command-reference/ccloud_schema-registry_schema_create.html#examples)