### PR TITLE
CLI-259 - Ensure host is updated if specified on command line

### DIFF
--- a/internal/cmd/iam/command_acl_test.go
+++ b/internal/cmd/iam/command_acl_test.go
@@ -72,12 +72,12 @@ var mdsAclEntries = []struct {
 			Principal: "User:42", Operation: mds.ACL_OPERATION_READ, Host: "*"},
 	},
 	{
-		args: []string{"--deny", "--principal", "User:42", "--operation", "read"},
+		args: []string{"--deny", "--principal", "User:42", "--host", "testhost", "--operation", "read"},
 		entry: mds.AccessControlEntry{PermissionType: mds.ACL_PERMISSION_TYPE_DENY,
-			Principal: "User:42", Operation: mds.ACL_OPERATION_READ, Host: "*"},
+			Principal: "User:42", Operation: mds.ACL_OPERATION_READ, Host: "testhost"},
 	},
 	{
-		args: []string{"--allow", "--principal", "User:42", "--operation", "write"},
+		args: []string{"--allow", "--principal", "User:42", "--host", "*", "--operation", "write"},
 		entry: mds.AccessControlEntry{PermissionType: mds.ACL_PERMISSION_TYPE_ALLOW,
 			Principal: "User:42", Operation: mds.ACL_OPERATION_WRITE, Host: "*"},
 	},

--- a/internal/cmd/iam/command_acl_utils.go
+++ b/internal/cmd/iam/command_acl_utils.go
@@ -128,6 +128,8 @@ func fromArgs(conf *ACLConfiguration) func(*pflag.Flag) {
 			conf.AclBinding.Pattern.PatternType = mds.PATTERN_TYPE_PREFIXED
 		case "principal":
 			conf.AclBinding.Entry.Principal = v
+		case "host":
+			conf.AclBinding.Entry.Host = v
 		case "operation":
 			v = strings.ToUpper(v)
 			v = strings.Replace(v, "-", "_", -1)


### PR DESCRIPTION
<!--
Is there any breaking changes?  If so this is a major release, make sure '#major' is in at least one
commit message to get CI to bump the major.  This will prevent automatic down stream dependency
bumping / consuming.  For more information about semantic versioning see: https://semver.org/


Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->
Missed actually reading in the host from the cmd line, so it was always set to default. This is now fixed.

References
----------
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->
https://confluentinc.atlassian.net/browse/CLI-259

Test&Review
------------

<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->
Updated existing unit test to cover this scenario.
Test using `confluent iam acl create --kafka-cluster-id testcluster --host testhost ...` followed by `confluent iam list --kafka-cluster-id testcluster`
<!--
Open questions / Follow ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
