### PR TITLE
Fix CLI to use same 5TB default storage as UI

### DIFF
--- a/internal/cmd/kafka/command_cluster.go
+++ b/internal/cmd/kafka/command_cluster.go
@@ -145,7 +145,7 @@ func (c *clusterCommand) create(cmd *cobra.Command, args []string) error {
 		Region:          region,
 		Durability:      kafkav1.Durability_LOW,
 		// TODO: remove this once it's no longer required (MCM-130)
-		Storage:         500,
+		Storage:         5000,
 	}
 	cluster, err := c.client.Create(context.Background(), cfg)
 	if err != nil {

--- a/test/cli_test.go
+++ b/test/cli_test.go
@@ -921,15 +921,19 @@ func handleKafkaClusterGetListDelete(t *testing.T, kafkaAPIURL string) func(w ht
 
 func handleKafkaClusterCreate(t *testing.T, kafkaAPIURL string) func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
+		req := &kafkav1.CreateKafkaClusterRequest{}
+		err := utilv1.UnmarshalJSON(r.Body, req)
+		require.NoError(t, err)
 		b, err := utilv1.MarshalJSONToBytes(&kafkav1.GetKafkaClusterReply{
 			Cluster: &kafkav1.KafkaCluster{
 				Id:              "lkc-def963",
-				Name:            "kafka-cluster",
+				AccountId:       req.Config.AccountId,
+				Name:            req.Config.Name,
 				NetworkIngress:  100,
 				NetworkEgress:   100,
-				Storage:         500,
-				ServiceProvider: "aws",
-				Region:          "us-west-2",
+				Storage:         req.Config.Storage,
+				ServiceProvider: req.Config.ServiceProvider,
+				Region:          req.Config.Region,
 				Endpoint:        "SASL_SSL://kafka-endpoint",
 				ApiEndpoint:     kafkaAPIURL,
 			},

--- a/test/fixtures/output/kafka2.golden
+++ b/test/fixtures/output/kafka2.golden
@@ -1,11 +1,11 @@
 +-------------+---------------------------+
 | Id          | lkc-def963                |
-| Name        | kafka-cluster             |
+| Name        | my-new-cluster            |
 | Ingress     |                       100 |
 | Egress      |                       100 |
-| Storage     |                       500 |
+| Storage     |                      5000 |
 | Provider    | aws                       |
-| Region      | us-west-2                 |
+| Region      | us-east-1                 |
 | Status      | PROVISIONING              |
 | Endpoint    | SASL_SSL://kafka-endpoint |
 | ApiEndpoint | http://127.0.0.1:12345    |


### PR DESCRIPTION
this should be an API default but thats still a jira

What
----
Fix an inconsistency between the UI and CLI.

Ideally this would be enforced by the API. This is marked in-progress in [MCM-130](https://confluentinc.atlassian.net/browse/MCM-130) but I think its forgotten at this point. I don't want to leave this inconsistency so I just updated the CLI for now.

References
----------
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test&Review
------------

<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

<!--
Open questions / Follow ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
