### PR TITLE
Fix panic introduced in consume/produce

### DIFF
--- a/internal/cmd/kafka/sarama.go
+++ b/internal/cmd/kafka/sarama.go
@@ -3,7 +3,6 @@ package kafka
 import (
 	"fmt"
 	"io"
-	"net/url"
 	"strings"
 
 	"github.com/confluentinc/cli/internal/pkg/config"
@@ -67,15 +66,10 @@ func (h *GroupHandler) ConsumeClaim(sess sarama.ConsumerGroupSession, claim sara
 
 // saramaConf converts KafkaClusterConfig to sarama.Config
 func saramaConf(kafka *config.KafkaClusterConfig, clientID string, beginning bool) (*sarama.Config, error) {
-	endpoint, err := url.Parse(kafka.APIEndpoint)
-	if err != nil {
-		return nil, err
-	}
 	saramaConf := sarama.NewConfig()
 	saramaConf.ClientID = clientID
 	saramaConf.Version = sarama.V1_1_0_0
 	saramaConf.Net.TLS.Enable = true
-	saramaConf.Net.TLS.Config.ServerName = endpoint.Hostname()
 	saramaConf.Net.SASL.Enable = true
 	saramaConf.Net.SASL.User = kafka.APIKey
 	saramaConf.Net.SASL.Password = kafka.APIKeys[kafka.APIKey].Secret


### PR DESCRIPTION
What
----
Giuseppe [found a bug](https://confluent.slack.com/archives/C9Y6NAM6X/p1572270098066400) in the newly released CLI version from Friday (which added kafka cluster management). Unfortunately there was a bad change in the merge which results in a nil pointer exception in consume/produce (which is a known missing test case: [CLI-164](https://confluentinc.atlassian.net/browse/CLI-164)).

This removes the bad code. The PR that introduced this wasn't intended to change the consume/produce, so this isn't actually needed. I can't remember how/why it was changed in the first place but I manually tested consume and produce with this fix and it works.

References
----------
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test&Review
------------
Manual for consume/produce
`make test` still works.

<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

<!--
Open questions / Follow ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
