### PR TITLE
CLI-310: Adding replicator monitoring extension for support in quickstart for 5.4

### DIFF
--- a/cp_cli/confluent.sh
+++ b/cp_cli/confluent.sh
@@ -872,9 +872,11 @@ config_service() {
     # Override Connect's config, in case this is an unchanged config from a tar.gz or .zip package
     # installation, to make plugin.path work for any "current working directory (cwd)"
     if [[ "${service}" == "connect" ]]; then
+      export CLASSPATH=${confluent_home}/share/java/kafka-connect-replicator/replicator-rest-extension-5.4.0-SNAPSHOT.jar
         sed "s@^plugin.path=share/java@plugin.path=${confluent_home}/share/java@g" \
             "${service_dir}/${service}.properties" > "${service_dir}/${service}.properties.bak"
         mv -f "${service_dir}/${service}.properties.bak" "${service_dir}/${service}.properties"
+        printf '\n%s\n' 'rest.extension.classes=io.confluent.connect.replicator.monitoring.ReplicatorMonitoringExtension' >> "${service_dir}/${service}.properties"
     fi
 
     # Set ksql-server data dir. TODO: refactor when config_service supports general handling of key-value pairs


### PR DESCRIPTION
What
----
Added two lines to the confluent quick start script so that a user who is testing out the 5.4 confluent quick start is able to see the latest changes to replicator and play around with the new monitoring features.

References
----------
https://confluentinc.atlassian.net/browse/CLI-310

Test&Review
------------
Tested locally with latest passing nightly build
