### PR TITLE
New CLI CI Milestone 2: Mac Support

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,7 +27,7 @@ steps:
   displayName: 'Install gnu-tar (Darwin)'
 
 - script: |
-    wget "https://storage.googleapis.com/golang/go1.12.5.linux-amd64.tar.gz" --output-document "$(Agent.BuildDirectory)/go1.12.5.tar.gz"
+    wget "https://storage.googleapis.com/golang/go1.12.5.darwin-amd64.tar.gz" --output-document "$(Agent.BuildDirectory)/go1.12.5.tar.gz"
     gtar -C '$(Agent.BuildDirectory)' -xzf "$(Agent.BuildDirectory)/go1.12.5.tar.gz"
   condition: eq( variables['Agent.OS'], 'Darwin' )
   displayName: 'Install Go 1.12.5 (Darwin)'


### PR DESCRIPTION
Now Azure Pipelines runs our tests on Mac in addition to Linux.  Two OSs down, one (or two... Alpine?) to go!