### PR TITLE
CLI-259: Remove centralized acl feature flag to be compatible with 5.4

### DIFF
--- a/internal/cmd/iam/command.go
+++ b/internal/cmd/iam/command.go
@@ -1,13 +1,12 @@
 package iam
 
 import (
-	"os"
-
 	"github.com/spf13/cobra"
+
+	"github.com/confluentinc/mds-sdk-go"
 
 	pcmd "github.com/confluentinc/cli/internal/pkg/cmd"
 	"github.com/confluentinc/cli/internal/pkg/config"
-	"github.com/confluentinc/mds-sdk-go"
 )
 
 type command struct {
@@ -36,8 +35,5 @@ func New(prerunner pcmd.PreRunner, config *config.Config, client *mds.APIClient)
 func (c *command) init() {
 	c.AddCommand(NewRoleCommand(c.config, c.client))
 	c.AddCommand(NewRolebindingCommand(c.config, c.client))
-	if os.Getenv("XX_FLAG_CENTRALIZED_ACL_ENABLE") != "" {
-		// TODO: Remove this feature flag if statement once 5.4 is released
-		c.AddCommand(NewACLCommand(c.config, c.client))
-	}
+	c.AddCommand(NewACLCommand(c.config, c.client))
 }

--- a/internal/cmd/iam/command_acl_test.go
+++ b/internal/cmd/iam/command_acl_test.go
@@ -3,12 +3,14 @@ package iam
 import (
 	"context"
 	net_http "net/http"
-	"os"
 	"testing"
 
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
+
+	"github.com/confluentinc/mds-sdk-go"
+	"github.com/confluentinc/mds-sdk-go/mock"
 
 	pcmd "github.com/confluentinc/cli/internal/pkg/cmd"
 	"github.com/confluentinc/cli/internal/pkg/config"
@@ -16,8 +18,6 @@ import (
 	"github.com/confluentinc/cli/internal/pkg/log"
 	"github.com/confluentinc/cli/internal/pkg/update"
 	cliMock "github.com/confluentinc/cli/mock"
-	"github.com/confluentinc/mds-sdk-go"
-	"github.com/confluentinc/mds-sdk-go/mock"
 )
 
 /*************** TEST command_acl ***************/
@@ -176,16 +176,11 @@ type AclTestSuite struct {
 }
 
 func (suite *AclTestSuite) SetupSuite() {
-	_ = os.Setenv("XX_FLAG_CENTRALIZED_ACL_ENABLE", "true")
 	suite.conf = config.New()
 	suite.conf.CLIName = "confluent"
 	suite.conf.Logger = log.New()
 	suite.conf.AuthURL = "http://test"
 	suite.conf.AuthToken = "T0k3n"
-}
-
-func (suite *AclTestSuite) TearDownSuite() {
-	_ = os.Setenv("XX_FLAG_CENTRALIZED_ACL_ENABLE", "false")
 }
 
 func (suite *AclTestSuite) SetupTest() {


### PR DESCRIPTION
<!--
Is there any breaking changes?  If so this is a major release, make sure '#major' is in at least one
commit message to get CI to bump the major.  This will prevent automatic down stream dependency
bumping / consuming.  For more information about semantic versioning see: https://semver.org/


Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->
Removes the `XX_FLAG_CENTRALIZED_ACL_ENABLE` flag. This will make this and future cli versions forward compatible with CP 5.4.

With this change, the cli will start exposing the 5.4-only centralized acl feature, but its use gracefully degrades when used on a CP 5.3- backend with a helpful error message stating that the functionality is 5.4+ only.

References
----------
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test&Review
------------

<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->
No functionality changes. Tests pass.


Open questions / Follow ups
--------------------------
Putting this PR up now to get an approval, but I'm going to hold off on merging this in until close to the CP 5.4 release. 

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
