### PR TITLE
[CLI-296] Fix confluent local to work with deb and rpm based installs by default

### DIFF
--- a/internal/cmd/local/local.go
+++ b/internal/cmd/local/local.go
@@ -32,7 +32,7 @@ DO NOT use these commands to setup or manage Confluent Platform in production.
 
 var (
 	commonInstallDirs = []string{
-		"./confluent*",
+		".",
 		"/usr/",
 		"/opt/confluent*",
 		"/usr/local/confluent*",

--- a/internal/cmd/local/local_test.go
+++ b/internal/cmd/local/local_test.go
@@ -176,8 +176,8 @@ func TestDetermineConfluentInstallDir(t *testing.T) {
 		},
 		{
 			name:      "unversioned directory found in ./ and versioned directory found in /opt",
-			dirExists: map[string][]string{"./confluent*": {"./confluent"}, "/opt/confluent*": {"/opt/confluent-5.2.2"}},
-			wantDir:   "./confluent",
+			dirExists: map[string][]string{".": {"."}, "/opt/confluent*": {"/opt/confluent-5.2.2"}},
+			wantDir:   ".",
 			wantFound: true,
 			wantErr:   false,
 		},


### PR DESCRIPTION
What
----
Fixing `confluent local` to auto-detect deb (and should also be rpm) based installs.

Also fix the bug so that if you `cd` into a Confluent install, it uses it by default. (Previously this was actually assuming you were one directory above the Confluent install. BACKWARD INCOMPATIBLE but restoring the actual intention)

References
----------
https://confluentinc.atlassian.net/browse/CLI-296

Test&Review
------------

updated units.

manually tested in an ubuntu docker container

1. setup a test ubuntu container and manually install confluent via deb and the CLI
```
aws s3 ls s3://jenkins-confluent-packages/5.3.x/330/deb/5.3/pool/main/c/confluent-common/

kubectl run my-shell --rm -i --tty --image ubuntu -- bash

apt-get update && apt-get install wget
wget https://s3-us-west-2.amazonaws.com/jenkins-confluent-packages/5.3.x/330/deb/5.3/pool/main/c/confluent-kafka/confluent-kafka-2.12_5.3.1-1_all.deb
wget https://s3-us-west-2.amazonaws.com/jenkins-confluent-packages/5.3.x/330/deb/5.3/pool/main/c/confluent-schema-registry/confluent-schema-registry_5.3.1-1_all.deb
wget https://s3-us-west-2.amazonaws.com/jenkins-confluent-packages/5.3.x/330/deb/5.3/pool/main/c/confluent-kafka-rest/confluent-kafka-rest_5.3.1-1_all.deb
wget https://s3-us-west-2.amazonaws.com/jenkins-confluent-packages/5.3.x/330/deb/5.3/pool/main/c/confluent-ksql/confluent-ksql_5.3.1-1_all.deb
wget https://s3-us-west-2.amazonaws.com/jenkins-confluent-packages/5.3.x/330/deb/5.3/pool/main/c/confluent-kafka-connect-jdbc/confluent-kafka-connect-jdbc_5.3.1-1_all.deb
wget https://s3-us-west-2.amazonaws.com/jenkins-confluent-packages/5.3.x/330/deb/5.3/pool/main/c/confluent-kafka-connect-elasticsearch/confluent-kafka-connect-elasticsearch_5.3.1-1_all.deb
wget https://s3-us-west-2.amazonaws.com/jenkins-confluent-packages/5.3.x/330/deb/5.3/pool/main/c/confluent-kafka-connect-s3/confluent-kafka-connect-s3_5.3.1-1_all.deb
wget https://s3-us-west-2.amazonaws.com/jenkins-confluent-packages/5.3.x/330/deb/5.3/pool/main/c/confluent-common/confluent-common_5.3.1-1_all.deb
wget https://s3-us-west-2.amazonaws.com/jenkins-confluent-packages/5.3.x/330/deb/5.3/pool/main/c/confluent-kafka-connect-storage-common/confluent-kafka-connect-storage-common_5.3.1-1_all.deb
wget https://s3-us-west-2.amazonaws.com/jenkins-confluent-packages/5.3.x/330/deb/5.3/pool/main/c/confluent-rest-utils/confluent-rest-utils_5.3.1-1_all.deb

apt-get install ./*.deb

wget https://cnfl.io/cli
cat cli | sh

# ./bin/confluent local --path /usr/ version
    The local commands are intended for a single-node development environment
    only, NOT for production usage. https://docs.confluent.io/current/cli/index.html

'confluent local' requires 'curl'.

apt-get install curl

# ./bin/confluent local version
Error: Pass --path /path/to/confluent flag or set environment variable CONFLUENT_HOME

# ./bin/confluent local --path /usr/ version
    The local commands are intended for a single-node development environment
    only, NOT for production usage. https://docs.confluent.io/current/cli/index.html

Confluent Community Software: 5.3.1
```

Made the changes in this PR, built a new image for linux, and copied it over:
```
GORELEASER_SUFFIX=-linux.yml make build-confluent
kubectl cp dist/confluent/linux_amd64/confluent my-shell-95cb5df57-5677v:/tmp/confluent

root@my-shell-95cb5df57-5677v:/# /tmp/confluent local --path /usr/ version
    The local commands are intended for a single-node development environment
    only, NOT for production usage. https://docs.confluent.io/current/cli/index.html

Confluent Community Software: 5.3.1

root@my-shell-95cb5df57-5677v:/# /tmp/confluent local version
    The local commands are intended for a single-node development environment
    only, NOT for production usage. https://docs.confluent.io/current/cli/index.html

Confluent Community Software: 5.3.1
```

Now let's update to 5.4 and re-test, for our sanity:

```
wget https://s3-us-west-2.amazonaws.com/jenkins-confluent-packages/5.4.x/74/deb/5.4/pool/main/c/confluent-kafka/confluent-kafka-2.12_5.4.0~SNAPSHOT-1_all.deb
wget https://s3-us-west-2.amazonaws.com/jenkins-confluent-packages/5.4.x/74/deb/5.4/pool/main/c/confluent-schema-registry/confluent-schema-registry_5.4.0~SNAPSHOT-1_all.deb
wget https://s3-us-west-2.amazonaws.com/jenkins-confluent-packages/5.4.x/74/deb/5.4/pool/main/c/confluent-kafka-rest/confluent-kafka-rest_5.4.0~SNAPSHOT-1_all.deb
wget https://s3-us-west-2.amazonaws.com/jenkins-confluent-packages/5.4.x/74/deb/5.4/pool/main/c/confluent-ksql/confluent-ksql_5.4.0~SNAPSHOT-1_all.deb
wget https://s3-us-west-2.amazonaws.com/jenkins-confluent-packages/5.4.x/74/deb/5.4/pool/main/c/confluent-kafka-connect-jdbc/confluent-kafka-connect-jdbc_5.4.0~SNAPSHOT-1_all.deb
wget https://s3-us-west-2.amazonaws.com/jenkins-confluent-packages/5.4.x/74/deb/5.4/pool/main/c/confluent-kafka-connect-elasticsearch/confluent-kafka-connect-elasticsearch_5.4.0~SNAPSHOT-1_all.deb
wget https://s3-us-west-2.amazonaws.com/jenkins-confluent-packages/5.4.x/74/deb/5.4/pool/main/c/confluent-kafka-connect-s3/confluent-kafka-connect-s3_5.4.0~SNAPSHOT-1_all.deb
wget https://s3-us-west-2.amazonaws.com/jenkins-confluent-packages/5.4.x/74/deb/5.4/pool/main/c/confluent-common/confluent-common_5.4.0~SNAPSHOT-1_all.deb
wget https://s3-us-west-2.amazonaws.com/jenkins-confluent-packages/5.4.x/74/deb/5.4/pool/main/c/confluent-kafka-connect-storage-common/confluent-kafka-connect-storage-common_5.4.0~SNAPSHOT-1_all.deb
wget https://s3-us-west-2.amazonaws.com/jenkins-confluent-packages/5.4.x/74/deb/5.4/pool/main/c/confluent-rest-utils/confluent-rest-utils_5.4.0~SNAPSHOT-1_all.deb

apt-get install ./*.deb

# ./bin/confluent local version
Error: Pass --path /path/to/confluent flag or set environment variable CONFLUENT_HOME

# ./bin/confluent local --path /usr/ version
    The local commands are intended for a single-node development environment
    only, NOT for production usage. https://docs.confluent.io/current/cli/index.html

Confluent Community Software: 5.4.0-SNAPSHOT

# /tmp/confluent local version
    The local commands are intended for a single-node development environment
    only, NOT for production usage. https://docs.confluent.io/current/cli/index.html

Confluent Community Software: 5.4.0~SNAPSHOT
```

Also confirmed that this still worked with a basic tarball-based installation in a clean shell. And I fixed the bug to check that you're IN the current confluent install dir (as intended), not that you're one-up from it (as implemented).

```
kubectl run my-shell2 --rm -i --tty --image ubuntu -- bash

kubectl cp dist/confluent/linux_amd64/confluent my-shell2-6d4b4f7f8c-wz52p:/tmp/confluent

apt-get update && apt-get install curl

wget https://s3-us-west-2.amazonaws.com/jenkins-confluent-packages/5.4.x/74/archive/5.4/confluent-community-5.4.0-SNAPSHOT-2.12.tar.gz

tar -xvzf confluent-community-5.4.0-SNAPSHOT-2.12.tar.gz

root@my-shell2-6d4b4f7f8c-wz52p:/# /tmp/confluent local version
Error: Pass --path /path/to/confluent flag or set environment variable CONFLUENT_HOME

# copy over new binary with bugfix for local dir CP installs
GORELEASER_SUFFIX=-linux.yml make build-confluent
kubectl cp dist/confluent/linux_amd64/confluent my-shell2-6d4b4f7f8c-wz52p:/tmp/confluent

root@my-shell2-6d4b4f7f8c-wz52p:/# cd confluent-5.4.0-SNAPSHOT/
root@my-shell2-6d4b4f7f8c-wz52p:/confluent-5.4.0-SNAPSHOT# /tmp/confluent local version
    The local commands are intended for a single-node development environment
    only, NOT for production usage. https://docs.confluent.io/current/cli/index.html

Confluent Community Software: 5.4.0-SNAPSHOT
```


Open questions / Follow ups
--------------------------
* Confirm breaking change is OK, as it was an unintended bug. This should use the current CP install if you're _in_ the CP install dir, not if the dir you're in _contains_ (one or more) CP install dirs. @ybyzek @rjain-confluent thoughts?

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
