### PR TITLE
Don't regenerate bindata when running make test.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -148,9 +148,6 @@ build-integ-confluent-race:
 .PHONY: bindata
 bindata: internal/cmd/local/bindata.go
 
-.PHONY: cp_cli/
-.PHONY: assets/
-.PHONY:
 internal/cmd/local/bindata.go: cp_cli/ assets/
 	@go-bindata -pkg local -o internal/cmd/local/bindata.go cp_cli/ assets/
 


### PR DESCRIPTION
<!--
Is there any breaking changes?  If so this is a major release, make sure '#major' is in at least one
commit message to get CI to bump the major.  This will prevent automatic down stream dependency
bumping / consuming.  For more information about semantic versioning see: https://semver.org/


Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->
It looks like this was causing `make test` to always regenerate `bindata.go`, which in turn caused `make release` to fail due to modified files in the workspace.

Removed the `.PHONY` labels for the requirements for the `bindata.go` file. It's not super clear to me though if this might have any impact elsewhere.

References
----------
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

This was introduced as part of 0bd50043cfde53cd666c2656fcb42ba08fae2f90

Test&Review
------------

<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->
Ran `make deps && make build && make test` and it passed.
<!--
Open questions / Follow ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
