### PR TITLE
Install scripts fix: args were not being passed to parse_args

### DIFF
--- a/install-ccloud.sh
+++ b/install-ccloud.sh
@@ -406,5 +406,5 @@ main() {
 }
 
 if [ "${TEST}" != "true" ]; then
-  main
+  main "$@"
 fi

--- a/install-confluent.sh
+++ b/install-confluent.sh
@@ -406,5 +406,5 @@ main() {
 }
 
 if [ "${TEST}" != "true" ]; then
-  main
+  main "$@"
 fi


### PR DESCRIPTION
For some reason these scripts have been working on Mac/Linux (?).  But in general with bash, the command line args ("argc and argv" / "$#" and "$@") are only available in the global scope and don't automatically get passed into functions.  So we have to pass around those vars to any functions that need them.  We were already passing them from `main` to `parse_args` but for some reason were not passing them from the global scope to `main`, so in my Windows test environment at least I never saw args getting passed.

Now, with this PR, I see args getting passed correctly, and the install scripts I can make work on Windows (in an appropriate environment where `curl`, `sh`, etc. exist).