### PR TITLE
CLI-340: duplicate kafka cluster id bug

### DIFF
--- a/internal/cmd/cluster/command.go
+++ b/internal/cmd/cluster/command.go
@@ -142,7 +142,7 @@ func (c *command) describe(cmd *cobra.Command, args []string) error {
 	}
 
 	if meta.ID != "" {
-		pcmd.Printf(cmd, "%s\n\n", meta.ID)
+		pcmd.Printf(cmd, "Confluent Resource Name: %s\n\n", meta.ID)
 	}
 	pcmd.Println(cmd, "Scope:")
 	printer.RenderCollectionTable(data, describeLabels)

--- a/test/fixtures/output/scoped_id1.golden
+++ b/test/fixtures/output/scoped_id1.golden
@@ -1,4 +1,4 @@
-crn://md01.example.com/kafka=kafkaCluster1/connect=connectClusterA
+Confluent Resource Name: crn://md01.example.com/kafka=kafkaCluster1/connect=connectClusterA
 
 Scope:
        Type       |       ID         

--- a/test/fixtures/output/scoped_id3.golden
+++ b/test/fixtures/output/scoped_id3.golden
@@ -1,4 +1,4 @@
-crn://md01.example.com/kafka=kafkaCluster1/connect=connectClusterA
+Confluent Resource Name: crn://md01.example.com/kafka=kafkaCluster1/connect=connectClusterA
 
 Scope:
       Type      |      ID        


### PR DESCRIPTION
<!--
Is there any breaking changes?  If so this is a major release, make sure '#major' is in at least one
commit message to get CI to bump the major.  This will prevent automatic down stream dependency
bumping / consuming.  For more information about semantic versioning see: https://semver.org/


Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
Checklist
---
1. Did you add/update any commands that accept secrets as args/flags?
     * no: ok

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->
in 5.5 the MDS API will be fixed to output CRN instead of what it is currently doing right now which is just outputting kafka cluster id in the ID field of its response, and hence once 5.5 is released and the MDS API is fixed that issue should be fixed.
On the other hand for user experience, it may be better to explicitly tell the user what the value being printed is supposed to be so "Confluent Resource Name: " is added in front of the CRN printing.


References
----------
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test&Review
------------

<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->
update integration test golden file to include the field name when printing the CRN

<!--
Open questions / Follow ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
