### PR TITLE
[CLI-360] Ensure .confluent directory exists before attempting to write to it

### DIFF
--- a/packaging/confluent.sh
+++ b/packaging/confluent.sh
@@ -52,6 +52,7 @@ check_executable() {
   fi
 }
 init_config() {
+  mkdir -p ${HOME}/.confluent
   if [[ ! -f "${HOME}/.confluent/config.json" ]] ; then
     echo '{"disable_updates": true}' > "${HOME}/.confluent/config.json"
   fi


### PR DESCRIPTION

Checklist
---
1. Did you add/update any commands that accept secrets as args/flags?

   * no: ok

What
----

The wrapper script `bin/confluent{.sh}` in CP attempts to write to a config file if it doesn't exist, but the dir in which it wants to write it may not exist either.  `mkdir -p` creates if it doesn't exist.  Good to always have this in there so if user e.g. deleted their folder later it'd get recreated.

References
----------

https://confluentinc.atlassian.net/browse/CLI-360

Test&Review
------------

Manual validation on Mac...