### PR TITLE
Allow weird hostnames like the Mac default with an apostrophe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,11 +92,11 @@ build-go:
 
 .PHONY: build-ccloud
 build-ccloud:
-	@GO111MODULE=on VERSION=$(VERSION) HOSTNAME=$(HOSTNAME) goreleaser release --snapshot --rm-dist -f .goreleaser-ccloud$(GORELEASER_SUFFIX)
+	@GO111MODULE=on VERSION=$(VERSION) HOSTNAME="$(HOSTNAME)" goreleaser release --snapshot --rm-dist -f .goreleaser-ccloud$(GORELEASER_SUFFIX)
 
 .PHONY: build-confluent
 build-confluent:
-	@GO111MODULE=on VERSION=$(VERSION) HOSTNAME=$(HOSTNAME) goreleaser release --snapshot --rm-dist -f .goreleaser-confluent$(GORELEASER_SUFFIX)
+	@GO111MODULE=on VERSION=$(VERSION) HOSTNAME="$(HOSTNAME)" goreleaser release --snapshot --rm-dist -f .goreleaser-confluent$(GORELEASER_SUFFIX)
 
 .PHONY: build-integ
 build-integ:
@@ -160,8 +160,8 @@ release: get-release-image commit-release tag-release
 .PHONY: gorelease
 gorelease:
 	@GO111MODULE=off go get -u github.com/inconshreveable/mousetrap # dep from cobra -- incompatible with go mod
-	@GO111MODULE=on VERSION=$(VERSION) HOSTNAME=$(HOSTNAME) goreleaser release --rm-dist -f .goreleaser-ccloud.yml
-	@GO111MODULE=on VERSION=$(VERSION) HOSTNAME=$(HOSTNAME) goreleaser release --rm-dist -f .goreleaser-confluent.yml
+	@GO111MODULE=on VERSION=$(VERSION) HOSTNAME="$(HOSTNAME)" goreleaser release --rm-dist -f .goreleaser-ccloud.yml
+	@GO111MODULE=on VERSION=$(VERSION) HOSTNAME="$(HOSTNAME)" goreleaser release --rm-dist -f .goreleaser-confluent.yml
 
 .PHONY: download-licenses
 download-licenses:


### PR DESCRIPTION
Checklist
---
1. Did you add/update any commands that accept secrets as args/flags?
   * no: ok

What
----
Report about the build not working for some devs with hostnames like `dmisca@Dragos-Misca's-MBP15`. So let's just wrap quotes around the `hostname` where needed.

I tried just wrapping the `HOSTNAME` variable with quotes where its set, but that breaks the `build-integ-{ccloud,confluent}-{race,nonrace}` targets, because you're already inside a double quote (for `ldflags`) where that's called, so it inadvertently ends it.

References
----------
https://confluent.slack.com/archives/CG6BW233L/p1580777969027100

Test&Review
------------

I just manually updated my "hostname" in the Makefile for testing, like so:
```
HOSTNAME := $(shell id -u -n)@$(shell hostname)foo'bar
```

But with this fix, running `make build-ccloud` now works:

```
Cody-Rays-MBP15:cli cody$ make build-ccloud

   • releasing using goreleaser dev...
   ...
   • release succeeded after 6.22s
```

You can even see the apostrophe in the `version`
```
$ ./dist/ccloud/darwin_amd64/ccloud version
Your token has expired. You are now logged out.
ccloud - Confluent Cloud CLI

Version:     v0.221.0-7-g5f280fd3-dirty-cody
Git Ref:     5f280fd3
Build Date:  2020-02-04T19:57:00Z
Build Host:  cody@Cody-Rays-MBP15.attlocal.netfoo'bar
Go Version:  go1.12.5 (darwin/amd64)
Development: true
```

You can build the integration tests, which also touch `HOSTNAME`:

```
$ make build-integ-ccloud-nonrace
binary="ccloud_test" ; \
	[ "${OS}" = "Windows_NT" ] && binexe=${binary}.exe || binexe=${binary} ; \
	GO111MODULE=on go test ./cmd/confluent -ldflags="-s -w -X github.com/confluentinc/cli/cmd/confluent.cliName=ccloud \
	-X github.com/confluentinc/cli/cmd/confluent.commit=5f280fd3 -X github.com/confluentinc/cli/cmd/confluent.host=cody@Cody-Rays-MBP15.attlocal.netfoo'bar -X github.com/confluentinc/cli/cmd/confluent.date=2020-02-04T20:21:35Z \
	-X github.com/confluentinc/cli/cmd/confluent.version=v0.221.0-7-g5f280fd3-dirty-cody -X github.com/confluentinc/cli/cmd/confluent.isTest=true" -tags testrunmain -coverpkg=./... -c -o ${binexe}
```

And running them also works, showing the apostrophe in the `version` here too:
```
$ ./ccloud_test version
ccloud - Confluent Cloud CLI

Version:     v0.221.0-7-g5f280fd3-dirty-cody
Git Ref:     5f280fd3
Build Date:  2020-02-04T20:21:35Z
Build Host:  cody@Cody-Rays-MBP15.attlocal.netfoo'bar
Go Version:  go1.12.5 (darwin/amd64)
Development: true

START_OF_METADATA
{"cover_mode":"set","exit_code":0}
END_OF_METADATA
PASS
coverage: 18.2% of statements in ./...
```

<!--
Open questions / Follow ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
