### PR TITLE
fixed context switch on login bug

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -71,8 +71,8 @@ require (
 	github.com/pierrec/lz4 v2.4.1+incompatible // indirect
 	github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4
 	github.com/pkg/errors v0.8.1
-	github.com/rsc/goversion v1.2.0
 	github.com/rcrowley/go-metrics v0.0.0-20190826022208-cac0b30c2563 // indirect
+	github.com/rsc/goversion v1.2.0
 	github.com/segmentio/analytics-go v3.1.0+incompatible
 	github.com/segmentio/backo-go v0.0.0-20160424052352-204274ad699c // indirect
 	github.com/shurcooL/go v0.0.0-20190704215121-7189cc372560 // indirect

--- a/internal/cmd/auth/auth.go
+++ b/internal/cmd/auth/auth.go
@@ -349,6 +349,10 @@ func (a *commands) credentials(cmd *cobra.Command, userField string, cloudClient
 func (a *commands) addContextIfAbsent(username string, url string, state *v2.ContextState, caCertPath string) error {
 	ctxName := generateContextName(username, url)
 	if _, ok := a.config.Contexts[ctxName]; ok {
+		err := a.config.SetContext(ctxName)
+		if err != nil {
+			return err
+		}
 		return nil
 	}
 	credName := generateCredentialName(username)


### PR DESCRIPTION
<!--
Is there any breaking changes?  If so this is a major release, make sure '#major' is in at least one
commit message to get CI to bump the major.  This will prevent automatic down stream dependency
bumping / consuming.  For more information about semantic versioning see: https://semver.org/


Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
Checklist
---
1. Did you add/update any commands that accept secrets as args/flags?
   * no: ok

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->
context did not switch when logging in with an existing context, just added a line to make sure it switches

bug (notice how api-key list doesn't change when logging back in with existing context):
```
chris:darwin_amd64 csreesangkom$ ./ccloud api-key list
         Key         | Owner | Description | Resource Type | Resource ID  
+--------------------+-------+-------------+---------------+-------------+
    DEMIKHUXQP7LQHTY | 10098 |             |               | lkc-lodkp    
    XW4WLJ7H2Y3ME2MC | 10098 |             |               | lkc-lodkp    
    EKTEQTNH34NBH4DR | 10098 |             |               | lkc-lodkp    
    XROXXDTHSNLYO4G3 | 10098 |             | kafka         | lkc-8171m    
    BBZ3JGPBNLZUXHD2 | 10098 |             | kafka         | lkc-yo1m6    
    4AJREGU6JK5JF6TY | 10098 |             | kafka         | lkc-yo1m6    
    3URYFCRAWDVFXCLF | 10098 |             |               | lsrc-nvdzk   
    374DMD52UYEEDULB | 10098 |             |               | lkc-38qyw    
chris:darwin_amd64 csreesangkom$ ccloud_signin 
spawn ./ccloud login --url https://devel.cpdev.cloud
Enter your Confluent credentials:
Email: csreesangkom@confluent.io
Password: 

Logged in as csreesangkom@confluent.io
Using environment a-42651 ("default")
chris:darwin_amd64 csreesangkom$ ./ccloud api-key list
         Key         | Owner | Description | Resource Type | Resource ID   
+--------------------+-------+-------------+---------------+--------------+
    D63464TH5R5J2ZRI | 15372 |             |               | lkc-mkmj7     
    7S6NEX5YG2CHNMH6 | 15372 |             |               | lkc-23g7m     
    VVFQIX5TDW6P3ARH | 15372 |             | kafka         | lkc-mkmj7     
    Y6ISLJRCDU5HI5LN | 19113 |             | kafka         | lkc-mkmj7     
    N5USJTLGK4RPVW6P | 15372 |             |               | lkc-nxmqv     
    VXWDZWSO5BV33ZAS | 15372 |             | kafka         | lkc-23gj1     
    QOPYHMMWT6ICBHIB | 15372 |             | kafka         | lkc-23gj1     
    TVDLULP5K7WWHD6E | 15372 |             | kafka         | lkc-nxmqv     
    56SGEQZJEULROOZE | 15372 | abc         | kafka         | lkc-7qjgp     
    M7K6ZXW23B7ZD3D3 | 15372 |             |               | lkc-7qjgp     
    CEJ7DIVSQ2ANVZUE | 15372 |             |               | lkc-23gj1     
    UMUIAEBJMU2SFODA | 15372 |             | kafka         | lkc-y686j     
    TGAKA2IEELSJZCGS | 15372 |             | kafka         | lkc-23gj1     
    S7L5LSJALUAHMLG4 | 15372 |             | kafka         | lkc-y686j     
    KBP7DQD3TCLPJJ5Y | 15372 |             | kafka         | lkc-1nx75     
    UAE2CT7HPV6IUQGJ | 52935 |             | kafka         | lkc-nxmqv     
    UAE2CT7HPV6IUQGJ | 52935 |             | ksql          | lksqlc-9p1q5  
chris:darwin_amd64 csreesangkom$ ./ccloud login
Enter your Confluent credentials:
Email: csreesangkom@confluent.io
Password: 

Logged in as csreesangkom@confluent.io
Using environment t6315 ("default")
chris:darwin_amd64 csreesangkom$ ./ccloud api-key list
         Key         | Owner | Description | Resource Type | Resource ID   
+--------------------+-------+-------------+---------------+--------------+
    D63464TH5R5J2ZRI | 15372 |             |               | lkc-mkmj7     
    7S6NEX5YG2CHNMH6 | 15372 |             |               | lkc-23g7m     
    VVFQIX5TDW6P3ARH | 15372 |             | kafka         | lkc-mkmj7     
    Y6ISLJRCDU5HI5LN | 19113 |             | kafka         | lkc-mkmj7     
    N5USJTLGK4RPVW6P | 15372 |             |               | lkc-nxmqv     
    VXWDZWSO5BV33ZAS | 15372 |             | kafka         | lkc-23gj1     
    QOPYHMMWT6ICBHIB | 15372 |             | kafka         | lkc-23gj1     
    TVDLULP5K7WWHD6E | 15372 |             | kafka         | lkc-nxmqv     
    56SGEQZJEULROOZE | 15372 | abc         | kafka         | lkc-7qjgp     
    M7K6ZXW23B7ZD3D3 | 15372 |             |               | lkc-7qjgp     
    CEJ7DIVSQ2ANVZUE | 15372 |             |               | lkc-23gj1     
    UMUIAEBJMU2SFODA | 15372 |             | kafka         | lkc-y686j     
    TGAKA2IEELSJZCGS | 15372 |             | kafka         | lkc-23gj1     
    S7L5LSJALUAHMLG4 | 15372 |             | kafka         | lkc-y686j     
    KBP7DQD3TCLPJJ5Y | 15372 |             | kafka         | lkc-1nx75     
    UAE2CT7HPV6IUQGJ | 52935 |             | kafka         | lkc-nxmqv     
    UAE2CT7HPV6IUQGJ | 52935 |             | ksql          | lksqlc-9p1q5  
```

References
----------
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test&Review
------------

<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->
manually tested


<!--
Open questions / Follow ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
