### PR TITLE
[CLI-400] Update context if it already exists rather than doing nothing; fixes issue where logging in did nothing after logging out

### DIFF
--- a/internal/pkg/config/v2/config.go
+++ b/internal/pkg/config/v2/config.go
@@ -197,25 +197,8 @@ func (c *Config) AddContext(name string, platformName string, credentialName str
 	kafkaClusters map[string]*v1.KafkaClusterConfig, kafka string,
 	schemaRegistryClusters map[string]*SchemaRegistryCluster, state *ContextState) error {
 	if _, ok := c.Contexts[name]; ok {
-		return fmt.Errorf("cannot create context \"%s\" because a context with this name already exists", name)
+		return fmt.Errorf("context \"%s\" already exists", name)
 	}
-
-	return c.BuildAndSaveContext(name, platformName, credentialName, kafkaClusters, kafka, schemaRegistryClusters, state)
-}
-
-func (c *Config) UpdateContext(name string, platformName string, credentialName string,
-	kafkaClusters map[string]*v1.KafkaClusterConfig, kafka string,
-	schemaRegistryClusters map[string]*SchemaRegistryCluster, state *ContextState) error {
-	if _, ok := c.Contexts[name]; !ok {
-		return fmt.Errorf("context \"%s\" does not exist and so cannot be updated", name)
-	}
-
-	return c.BuildAndSaveContext(name, platformName, credentialName, kafkaClusters, kafka, schemaRegistryClusters, state)
-}
-
-func (c *Config) BuildAndSaveContext(name string, platformName string, credentialName string,
-	kafkaClusters map[string]*v1.KafkaClusterConfig, kafka string,
-	schemaRegistryClusters map[string]*SchemaRegistryCluster, state *ContextState) error {
 	credential, ok := c.Credentials[credentialName]
 	if !ok {
 		return fmt.Errorf("credential \"%s\" not found", credentialName)

--- a/internal/pkg/config/v3/config.go
+++ b/internal/pkg/config/v3/config.go
@@ -208,8 +208,24 @@ func (c *Config) AddContext(name string, platformName string, credentialName str
 	kafkaClusters map[string]*v1.KafkaClusterConfig, kafka string,
 	schemaRegistryClusters map[string]*v2.SchemaRegistryCluster, state *v2.ContextState) error {
 	if _, ok := c.Contexts[name]; ok {
-		return fmt.Errorf("context \"%s\" already exists", name)
+		return fmt.Errorf("cannot create context \"%s\" because a context with this name already exists", name)
 	}
+	return c.BuildAndSaveContext(name, platformName, credentialName, kafkaClusters, kafka, schemaRegistryClusters, state)
+}
+
+func (c *Config) UpdateContext(name string, platformName string, credentialName string,
+	kafkaClusters map[string]*v1.KafkaClusterConfig, kafka string,
+	schemaRegistryClusters map[string]*v2.SchemaRegistryCluster, state *v2.ContextState) error {
+	if _, ok := c.Contexts[name]; !ok {
+		return fmt.Errorf("context \"%s\" does not exist and so cannot be updated", name)
+	}
+	return c.BuildAndSaveContext(name, platformName, credentialName, kafkaClusters, kafka, schemaRegistryClusters, state)
+}
+
+func (c *Config) BuildAndSaveContext(name string, platformName string, credentialName string,
+	kafkaClusters map[string]*v1.KafkaClusterConfig, kafka string,
+	schemaRegistryClusters map[string]*v2.SchemaRegistryCluster, state *v2.ContextState) error {
+
 	credential, ok := c.Credentials[credentialName]
 	if !ok {
 		return fmt.Errorf("credential \"%s\" not found", credentialName)


### PR DESCRIPTION
When login was run, either a new context was added, or, if a ctx with that name already existed, nothing was done.  But when you run logout it mutates the ctx (deletes the auth token) and so then logging in did nothing but you couldn't run any commands.

Now logging in adds _or updates_ (replaces) a context if it doesn't/already exist(s).  Verified the workflow mentioned here works now https://confluent.slack.com/archives/C9Y6NAM6X/p1582524032000100?thread_ts=1581978751.125000&cid=C9Y6NAM6X

Also ran `make fmt`
