### PR TITLE
change ksql app create to use num csu

### DIFF
--- a/cmd/lint/main.go
+++ b/cmd/lint/main.go
@@ -32,7 +32,7 @@ var (
 		"Enterprise", "KSQL", "Connect",
 	}
 	vocabWords = []string{
-		"ccloud", "kafka", "api", "url", "config", "configs", "multizone", "transactional", "ksql", "KSQL", "stdin",
+		"ccloud", "kafka", "api", "url", "config", "configs", "csu", "multizone", "transactional", "ksql", "KSQL", "stdin",
 		"connect", "connect-catalog", "JSON", "plaintext", "json", "YAML", "yaml",
 		// security
 		"iam", "acl", "acls", "ACL", "rolebinding", "rolebindings", "PEM", "auth", "init", "decrypt", "READWRITE",

--- a/internal/cmd/ksql/command_cluster.go
+++ b/internal/cmd/ksql/command_cluster.go
@@ -63,7 +63,7 @@ func (c *clusterCommand) init() {
 		Args:  cobra.ExactArgs(1),
 	}
 	createCmd.Flags().String("cluster", "", "Kafka cluster ID.")
-	createCmd.Flags().Int32("servers", 1, "Number of servers in the cluster.")
+	createCmd.Flags().Int32("csu", 4, "Number of CSUs to use in the cluster.")
 	createCmd.Flags().Int32("storage", 50, "Amount of data storage available in GB.")
 	createCmd.Flags().StringP(output.FlagName, output.ShortHandFlag, output.DefaultValue, output.Usage)
 	check(createCmd.MarkFlagRequired("storage"))
@@ -124,14 +124,14 @@ func (c *clusterCommand) create(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return errors.HandleCommon(err, cmd)
 	}
-	servers, err := cmd.Flags().GetInt32("servers")
+	csus, err := cmd.Flags().GetInt32("csu")
 	if err != nil {
 		return errors.HandleCommon(err, cmd)
 	}
 	cfg := &ksqlv1.KSQLClusterConfig{
 		AccountId:      c.EnvironmentId(),
 		Name:           args[0],
-		Servers:        servers,
+	    TotalNumCsu:    uint32(csus),
 		Storage:        storage,
 		KafkaClusterId: kafkaCluster.Id,
 	}

--- a/test/fixtures/output/ksql-app-create-help.golden
+++ b/test/fixtures/output/ksql-app-create-help.golden
@@ -5,7 +5,7 @@ Usage:
 
 Flags:
       --cluster string   Kafka cluster ID.
-      --servers int32    Number of servers in the cluster. (default 1)
+      --csu int32        Number of CSUs to use in the cluster. (default 4)
       --storage int32    Amount of data storage available in GB. (default 50)
   -o, --output string    Specify the output format as "human", "json" or "yaml". (default "human")
   -h, --help             help for create


### PR DESCRIPTION
What
----
We don't use the term servers anymore when creating ksql, it should be "csu"
Should we also potentially update the output to display the number of CSU?
Current output
```
+--------------+--------------+
| Id           | lksqlc-100jj |
| Name         | currrr       |
| Topic Prefix | pksqlc-3rk3o |
| Kafka        | lkc-nykg3    |
| Storage      |           40 |
| Endpoint     |              |
| Status       | PROVISIONING |
+--------------+--------------+
```


References
----------
https://confluentinc.atlassian.net/browse/KSQL-4383

Test&Review
------------

<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

<!--
Open questions / Follow ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
