### PR TITLE
Abscract away KafkaClusterContext

### DIFF
--- a/internal/cmd/apikey/apikey_test.go
+++ b/internal/cmd/apikey/apikey_test.go
@@ -61,7 +61,7 @@ func (suite *APITestSuite) SetupTest() {
 	ctx := suite.conf.Context()
 	srCluster := ctx.SchemaRegistryClusters[ctx.State.Auth.Account.Id]
 	srCluster.SrCredentials = &v0.APIKeyPair{Key: apiKeyVal, Secret: apiSecretVal}
-	cluster := ctx.KafkaClusterContext.GetActiveKafkaClusterConfig()
+	cluster := ctx.GetActiveKafkaClusterConfig()
 	suite.kafkaCluster = &kafkav1.KafkaCluster{
 		Id:         cluster.ID,
 		Name:       cluster.Name,

--- a/internal/cmd/connector-catalog/command_test.go
+++ b/internal/cmd/connector-catalog/command_test.go
@@ -37,7 +37,7 @@ func (suite *CatalogTestSuite) SetupSuite() {
 	suite.conf = v3.AuthenticatedCloudConfigMock()
 	ctx := suite.conf.Context()
 	suite.kafkaCluster = &kafkav1.KafkaCluster{
-		Id:         ctx.KafkaClusterContext.GetActiveKafkaClusterId(),
+		Id:         ctx.GetActiveKafkaClusterId(),
 		Name:       "KafkaMock",
 		AccountId:  "testAccount",
 		Enterprise: true,

--- a/internal/cmd/connector/command_test.go
+++ b/internal/cmd/connector/command_test.go
@@ -37,7 +37,7 @@ func (suite *ConnectTestSuite) SetupSuite() {
 	suite.conf = v3.AuthenticatedCloudConfigMock()
 	ctx := suite.conf.Context()
 	suite.kafkaCluster = &kafkav1.KafkaCluster{
-		Id:         ctx.KafkaClusterContext.GetActiveKafkaClusterId(),
+		Id:         ctx.GetActiveKafkaClusterId(),
 		Name:       "KafkaMock",
 		AccountId:  "testAccount",
 		Enterprise: true,

--- a/internal/cmd/kafka/command_cluster.go
+++ b/internal/cmd/kafka/command_cluster.go
@@ -117,7 +117,7 @@ func (c *clusterCommand) list(cmd *cobra.Command, args []string) error {
 	for _, cluster := range clusters {
 		// Add '*' only in the case where we are printing out tables
 		if outputWriter.GetOutputFormat() == output.Human {
-			if cluster.Id == c.Context.KafkaClusterContext.GetActiveKafkaClusterId() {
+			if cluster.Id == c.Context.GetActiveKafkaClusterId() {
 				cluster.Id = fmt.Sprintf("* %s", cluster.Id)
 			} else {
 				cluster.Id = fmt.Sprintf("  %s", cluster.Id)

--- a/internal/cmd/ksql/command_test.go
+++ b/internal/cmd/ksql/command_test.go
@@ -77,7 +77,7 @@ func (suite *KSQLTestSuite) SetupSuite() {
 	suite.conf = v3.AuthenticatedCloudConfigMock()
 	suite.ksqlCluster = &ksqlv1.KSQLCluster{
 		Id:                ksqlClusterID,
-		KafkaClusterId:    suite.conf.Context().KafkaClusterContext.GetActiveKafkaClusterId(),
+		KafkaClusterId:    suite.conf.Context().GetActiveKafkaClusterId(),
 		PhysicalClusterId: physicalClusterID,
 		OutputTopicPrefix: outputTopicPrefix,
 	}
@@ -148,7 +148,7 @@ func (suite *KSQLTestSuite) TestShouldAlsoConfigureForPro() {
 	cmd := suite.newCMD()
 	cmd.SetArgs(append([]string{"app", "configure-acls", ksqlClusterID}))
 	suite.kafkac.DescribeFunc = func(ctx context.Context, cluster *kafkav1.KafkaCluster) (cluster2 *kafkav1.KafkaCluster, e error) {
-		return &kafkav1.KafkaCluster{Id: suite.conf.Context().KafkaClusterContext.GetActiveKafkaClusterId(), Enterprise: false}, nil
+		return &kafkav1.KafkaCluster{Id: suite.conf.Context().GetActiveKafkaClusterId(), Enterprise: false}, nil
 	}
 
 	err := cmd.Execute()

--- a/internal/cmd/schema-registry/command_cluster_test.go
+++ b/internal/cmd/schema-registry/command_cluster_test.go
@@ -41,7 +41,7 @@ type ClusterTestSuite struct {
 func (suite *ClusterTestSuite) SetupSuite() {
 	suite.conf = v3.AuthenticatedCloudConfigMock()
 	ctx := suite.conf.Context()
-	cluster := ctx.KafkaClusterContext.GetActiveKafkaClusterConfig()
+	cluster := ctx.GetActiveKafkaClusterConfig()
 	suite.kafkaCluster = &kafkav1.KafkaCluster{
 		Id:         cluster.ID,
 		Name:       cluster.Name,

--- a/internal/cmd/schema-registry/command_schema_test.go
+++ b/internal/cmd/schema-registry/command_schema_test.go
@@ -48,7 +48,7 @@ func (suite *SchemaTestSuite) SetupSuite() {
 	ctx := suite.conf.Context()
 	srCluster := ctx.SchemaRegistryClusters[ctx.State.Auth.Account.Id]
 	srCluster.SrCredentials = &v0.APIKeyPair{Key: "key", Secret: "secret"}
-	cluster := ctx.KafkaClusterContext.GetActiveKafkaClusterConfig()
+	cluster := ctx.GetActiveKafkaClusterConfig()
 	suite.kafkaCluster = &kafkav1.KafkaCluster{
 		Id:         cluster.ID,
 		Name:       cluster.Name,

--- a/internal/cmd/schema-registry/command_subject_test.go
+++ b/internal/cmd/schema-registry/command_subject_test.go
@@ -39,7 +39,7 @@ func (suite *SubjectTestSuite) SetupSuite() {
 	ctx := suite.conf.Context()
 	srCluster := ctx.SchemaRegistryClusters[ctx.State.Auth.Account.Id]
 	srCluster.SrCredentials = &v0.APIKeyPair{Key: "key", Secret: "secret"}
-	cluster := ctx.KafkaClusterContext.GetActiveKafkaClusterConfig()
+	cluster := ctx.GetActiveKafkaClusterConfig()
 	suite.kafkaCluster = &kafkav1.KafkaCluster{
 		Id:         cluster.ID,
 		Name:       cluster.Name,

--- a/internal/pkg/cmd/dynamic_context.go
+++ b/internal/pkg/cmd/dynamic_context.go
@@ -48,7 +48,7 @@ func (d *DynamicContext) ActiveKafkaCluster(cmd *cobra.Command) (*v1.KafkaCluste
 		}
 		if clusterId == "" {
 			// No flags provided, just retrieve the current one specified in the config.
-			clusterId = d.KafkaClusterContext.GetActiveKafkaClusterId()
+			clusterId = d.GetActiveKafkaClusterId()
 		}
 	}
 	cluster, err := d.FindKafkaCluster(cmd, clusterId)
@@ -59,7 +59,7 @@ func (d *DynamicContext) ActiveKafkaCluster(cmd *cobra.Command) (*v1.KafkaCluste
 }
 
 func (d *DynamicContext) FindKafkaCluster(cmd *cobra.Command, clusterId string) (*v1.KafkaClusterConfig, error) {
-	if cluster := d.KafkaClusterContext.GetKafkaClusterConfig(clusterId); cluster != nil {
+	if cluster := d.GetKafkaClusterConfig(clusterId); cluster != nil {
 		return cluster, nil
 	}
 	if d.client == nil {
@@ -78,7 +78,7 @@ func (d *DynamicContext) FindKafkaCluster(cmd *cobra.Command, clusterId string) 
 		APIEndpoint: kcc.ApiEndpoint,
 		APIKeys:     make(map[string]*v0.APIKeyPair),
 	}
-	d.KafkaClusterContext.AddKafkaClusterConfig(cluster)
+	d.AddKafkaClusterConfig(cluster)
 	err = d.Save()
 	if err != nil {
 		return nil, err
@@ -90,7 +90,7 @@ func (d *DynamicContext) SetActiveKafkaCluster(cmd *cobra.Command, clusterId str
 	if _, err := d.FindKafkaCluster(cmd, clusterId); err != nil {
 		return err
 	}
-	d.KafkaClusterContext.SetActiveKafkaCluster(clusterId)
+	d.Context.SetActiveKafkaCluster(clusterId)
 	return d.Save()
 }
 

--- a/internal/pkg/config/v3/config_test.go
+++ b/internal/pkg/config/v3/config_test.go
@@ -637,22 +637,22 @@ func TestKafkaClusterContext_SetAndGetActiveKafkaCluster_Env(t *testing.T) {
 	ctx.State.Auth.Accounts = append(ctx.State.Auth.Accounts, otherAccount)
 	var activeKafka string
 
-	activeKafka = ctx.KafkaClusterContext.GetActiveKafkaClusterId()
+	activeKafka = ctx.GetActiveKafkaClusterId()
 	if activeKafka != testInputs.activeKafka {
 		t.Errorf("GetActiveKafkaClusterId() got %s, want %s.", activeKafka, testInputs.activeKafka)
 	}
 
 	// switch environment
 	ctx.State.Auth.Account = otherAccount
-	ctx.KafkaClusterContext.SetActiveKafkaCluster(otherKafkaClusterId)
-	activeKafka = ctx.KafkaClusterContext.GetActiveKafkaClusterId()
+	ctx.SetActiveKafkaCluster(otherKafkaClusterId)
+	activeKafka = ctx.GetActiveKafkaClusterId()
 	if activeKafka != otherKafkaClusterId {
 		t.Errorf("After settting active kafka in new environment, GetActiveKafkaClusterId() got %s, want %s.", activeKafka, testInputs.activeKafka)
 	}
 
 	// switch environment back
 	ctx.State.Auth.Account = testInputs.account
-	activeKafka = ctx.KafkaClusterContext.GetActiveKafkaClusterId()
+	activeKafka = ctx.GetActiveKafkaClusterId()
 	if activeKafka != testInputs.activeKafka {
 		t.Errorf("After switching to back to first environment, GetActiveKafkaClusterId() got %s, want %s.", activeKafka, testInputs.activeKafka)
 	}
@@ -667,14 +667,14 @@ func TestKafkaClusterContext_SetAndGetActiveKafkaCluster_NonEnv(t *testing.T) {
 	ctx.Config.Filename = configFile.Name()
 	var activeKafka string
 
-	activeKafka = ctx.KafkaClusterContext.GetActiveKafkaClusterId()
+	activeKafka = ctx.GetActiveKafkaClusterId()
 	if activeKafka != testInputs.activeKafka {
 		t.Errorf("GetActiveKafkaClusterId() got %s, want %s.", activeKafka, testInputs.activeKafka)
 	}
 
 	otherKafkaClusterId := "other-kafka"
-	ctx.KafkaClusterContext.SetActiveKafkaCluster(otherKafkaClusterId)
-	activeKafka = ctx.KafkaClusterContext.GetActiveKafkaClusterId()
+	ctx.SetActiveKafkaCluster(otherKafkaClusterId)
+	activeKafka = ctx.GetActiveKafkaClusterId()
 	if activeKafka != otherKafkaClusterId {
 		t.Errorf("After settting active kafka, GetActiveKafkaClusterId() got %s, want %s.", activeKafka, testInputs.activeKafka)
 	}

--- a/internal/pkg/config/v3/context.go
+++ b/internal/pkg/config/v3/context.go
@@ -182,3 +182,31 @@ func (c *Context) GetCurrentEnvironmentId() string {
 	}
 	return c.State.Auth.Account.Id
 }
+
+func (c *Context) GetActiveKafkaClusterId() string {
+	return c.KafkaClusterContext.getActiveKafkaClusterId()
+}
+
+func (c *Context) GetActiveKafkaClusterConfig() *v1.KafkaClusterConfig {
+	return c.KafkaClusterContext.getActiveKafkaClusterConfig()
+}
+
+func (c *Context) SetActiveKafkaCluster(clusterId string) {
+	c.KafkaClusterContext.setActiveKafkaCluster(clusterId)
+}
+
+func (c *Context) GetKafkaClusterConfig(clusterId string) *v1.KafkaClusterConfig {
+	return c.KafkaClusterContext.getKafkaClusterConfig(clusterId)
+}
+
+func (c *Context) AddKafkaClusterConfig(kcc *v1.KafkaClusterConfig) {
+	c.KafkaClusterContext.addKafkaClusterConfig(kcc)
+}
+
+func (c *Context) DeleteAPIKey(apiKey string) {
+	c.KafkaClusterContext.deleteAPIKey(apiKey)
+}
+
+func (c *Context) GetCurrentKafkaEnvContext() *KafkaEnvContext {
+	return c.KafkaClusterContext.getCurrentKafkaEnvContext()
+}

--- a/internal/pkg/config/v3/kafka_cluster_context.go
+++ b/internal/pkg/config/v3/kafka_cluster_context.go
@@ -59,53 +59,53 @@ func newKafkaClusterNonEnvironmentContext(activeKafka string, kafkaClusters map[
 	return kafkaClusterContext
 }
 
-func (k *KafkaClusterContext) GetActiveKafkaClusterId() string {
+func (k *KafkaClusterContext) getActiveKafkaClusterId() string {
 	if !k.EnvContext {
 		return k.ActiveKafkaCluster
 	}
-	kafkaEnvContext := k.GetCurrentKafkaEnvContext()
+	kafkaEnvContext := k.getCurrentKafkaEnvContext()
 	return kafkaEnvContext.ActiveKafkaCluster
 }
 
-func (k *KafkaClusterContext) GetActiveKafkaClusterConfig() *v1.KafkaClusterConfig {
+func (k *KafkaClusterContext) getActiveKafkaClusterConfig() *v1.KafkaClusterConfig {
 	if !k.EnvContext {
 		return k.KafkaClusterConfigs[k.ActiveKafkaCluster]
 	}
-	kafkaEnvContext := k.GetCurrentKafkaEnvContext()
+	kafkaEnvContext := k.getCurrentKafkaEnvContext()
 	return kafkaEnvContext.KafkaClusterConfigs[kafkaEnvContext.ActiveKafkaCluster]
 }
 
-func (k *KafkaClusterContext) SetActiveKafkaCluster(clusterId string) {
+func (k *KafkaClusterContext) setActiveKafkaCluster(clusterId string) {
 	if !k.EnvContext {
 		k.ActiveKafkaCluster = clusterId
 		return
 	}
-	kafkaEnvContext := k.GetCurrentKafkaEnvContext()
+	kafkaEnvContext := k.getCurrentKafkaEnvContext()
 	kafkaEnvContext.ActiveKafkaCluster = clusterId
 }
 
-func (k *KafkaClusterContext) GetKafkaClusterConfig(clusterId string) *v1.KafkaClusterConfig {
+func (k *KafkaClusterContext) getKafkaClusterConfig(clusterId string) *v1.KafkaClusterConfig {
 	if !k.EnvContext {
 		return k.KafkaClusterConfigs[clusterId]
 	}
-	kafkaEnvContext := k.GetCurrentKafkaEnvContext()
+	kafkaEnvContext := k.getCurrentKafkaEnvContext()
 	return kafkaEnvContext.KafkaClusterConfigs[clusterId]
 }
 
-func (k *KafkaClusterContext) AddKafkaClusterConfig(kcc *v1.KafkaClusterConfig) {
+func (k *KafkaClusterContext) addKafkaClusterConfig(kcc *v1.KafkaClusterConfig) {
 	if !k.EnvContext {
 		k.KafkaClusterConfigs[kcc.ID] = kcc
 	}
-	kafkaEnvContext := k.GetCurrentKafkaEnvContext()
+	kafkaEnvContext := k.getCurrentKafkaEnvContext()
 	kafkaEnvContext.KafkaClusterConfigs[kcc.ID] = kcc
 }
 
-func (k *KafkaClusterContext) DeleteAPIKey(apiKey string) {
+func (k *KafkaClusterContext) deleteAPIKey(apiKey string) {
 	var clusterConfigs map[string]*v1.KafkaClusterConfig
 	if !k.EnvContext {
 		clusterConfigs = k.KafkaClusterConfigs
 	} else {
-		clusterConfigs = k.GetCurrentKafkaEnvContext().KafkaClusterConfigs
+		clusterConfigs = k.getCurrentKafkaEnvContext().KafkaClusterConfigs
 	}
 	for _, kcc := range clusterConfigs {
 		for clusterApiKey := range kcc.APIKeys {
@@ -116,7 +116,7 @@ func (k *KafkaClusterContext) DeleteAPIKey(apiKey string) {
 	}
 }
 
-func (k *KafkaClusterContext) GetCurrentKafkaEnvContext() *KafkaEnvContext {
+func (k *KafkaClusterContext) getCurrentKafkaEnvContext() *KafkaEnvContext {
 	curEnv := k.Context.GetCurrentEnvironmentId()
 	if k.KafkaEnvContexts[curEnv] == nil {
 		k.KafkaEnvContexts[curEnv] = &KafkaEnvContext{

--- a/internal/pkg/keystore/keystore.go
+++ b/internal/pkg/keystore/keystore.go
@@ -64,6 +64,6 @@ func (c *ConfigKeyStore) DeleteAPIKey(key string, cmd *cobra.Command) error {
 	if context == nil {
 		return errors.ErrNoContext
 	}
-	context.KafkaClusterContext.DeleteAPIKey(key)
+	context.DeleteAPIKey(key)
 	return c.Config.Save()
 }

--- a/internal/pkg/ps1/ps1.go
+++ b/internal/pkg/ps1/ps1.go
@@ -50,7 +50,7 @@ var (
 			if context == nil {
 				return "(none)", nil
 			}
-			kcc := context.KafkaClusterContext.GetActiveKafkaClusterConfig()
+			kcc := context.GetActiveKafkaClusterConfig()
 			if kcc == nil {
 				return "(none)", nil
 			} else {
@@ -62,7 +62,7 @@ var (
 			if context == nil {
 				return "(none)", nil
 			}
-			kcc := context.KafkaClusterContext.GetActiveKafkaClusterConfig()
+			kcc := context.GetActiveKafkaClusterConfig()
 			if kcc == nil || kcc.Name == "" {
 				return "(none)", nil
 			} else {
@@ -74,7 +74,7 @@ var (
 			if context == nil {
 				return "(none)", nil
 			}
-			kcc := context.KafkaClusterContext.GetActiveKafkaClusterConfig()
+			kcc := context.GetActiveKafkaClusterConfig()
 			if kcc == nil || kcc.APIKey == "" {
 				return "(none)", nil
 			} else {
@@ -100,7 +100,7 @@ var (
 		context := cfg.Context()
 		var kcc *v1.KafkaClusterConfig
 		if context != nil {
-			kcc = context.KafkaClusterContext.GetActiveKafkaClusterConfig()
+			kcc = context.GetActiveKafkaClusterConfig()
 		}
 		kafkaClusterID := "(none)"
 		kafkaClusterName := "(none)"

--- a/test/apikey_test.go
+++ b/test/apikey_test.go
@@ -101,7 +101,7 @@ func (s *CLITestSuite) TestAPIKeyCommands() {
 				require.NoError(t, err)
 				ctx := cfg.Context()
 				require.NotNil(t, ctx)
-				kcc := ctx.KafkaClusterContext.GetKafkaClusterConfig("lkc-cool1")
+				kcc := ctx.GetKafkaClusterConfig("lkc-cool1")
 				pair := kcc.APIKeys["UIAPIKEY100"]
 				require.NotNil(t, pair)
 				require.Equal(t, "NEWSECRET", pair.Secret)


### PR DESCRIPTION
<!--
Is there any breaking changes?  If so this is a major release, make sure '#major' is in at least one
commit message to get CI to bump the major.  This will prevent automatic down stream dependency
bumping / consuming.  For more information about semantic versioning see: https://semver.org/


Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
Checklist
---
1. Did you add/update any commands that accept secrets as args/flags?
   * no: ok

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->
Create methods in Context struct to abstract away all the methods in KafkaClusterContext
The abstraction of KafkaClusterContext maybe better because
- the adjustments of states made by these methods are on the state of the Context itself so it would make sense for the Context to have this method
- allows editing context state without knowing the internal of Context structure, specifically the KafkaClusterContext
References
----------
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test&Review
------------

<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

<!--
Open questions / Follow ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
