### PR TITLE
CLI-397: Expose connector error messages

### DIFF
--- a/internal/cmd/connector/command.go
+++ b/internal/cmd/connector/command.go
@@ -254,7 +254,7 @@ func (c *command) create(cmd *cobra.Command, args []string) error {
 	if outputFormat == output.Human.String() {
 		pcmd.Printf(cmd, "Created connector %s %s\n", connector.Name, connectorExpansion.Id.Id)
 		if trace != "" {
-			pcmd.Println(cmd, "Error Trace: %s", trace)
+			pcmd.Printf(cmd, "Error Trace: %s\n", trace)
 		}
 	} else {
 		return output.StructuredOutput(outputFormat, &struct {

--- a/test/fixtures/output/connector-describe.golden
+++ b/test/fixtures/output/connector-describe.golden
@@ -4,6 +4,7 @@ Connector Details
 | Name   | az-connector |
 | Status | Running      |
 | Type   | Sink         |
+| Trace  |              |
 +--------+--------------+
 
 

--- a/test/fixtures/output/connector-list-json.golden
+++ b/test/fixtures/output/connector-list-json.golden
@@ -3,6 +3,7 @@
     "id": "lcc-123",
     "name": "lcc-123",
     "status": "Running",
+    "trace": "",
     "type": "Sink"
   }
 ]

--- a/test/fixtures/output/connector-list-yaml.golden
+++ b/test/fixtures/output/connector-list-yaml.golden
@@ -1,4 +1,5 @@
 - id: lcc-123
   name: lcc-123
   status: Running
+  trace: ""
   type: Sink

--- a/test/fixtures/output/connector-list.golden
+++ b/test/fixtures/output/connector-list.golden
@@ -1,3 +1,3 @@
-    ID    |  Name   | Status  | Type  
-+---------+---------+---------+------+
-  lcc-123 | lcc-123 | Running | Sink  
+    ID    |  Name   | Status  | Type | Trace  
++---------+---------+---------+------+-------+
+  lcc-123 | lcc-123 | Running | Sink |        


### PR DESCRIPTION
<!--
Is there any breaking changes?  If so this is a major release, make sure '#major' is in at least one
commit message to get CI to bump the major.  This will prevent automatic down stream dependency
bumping / consuming.  For more information about semantic versioning see: https://semver.org/


Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
Checklist
---
1. Did you add/update any commands that accept secrets as args/flags?
   * yes: did you update `secretCommandFlags` and/or `secretCommandArgs` in [internal/pkg/analytics/analytics.go](https://github.com/confluentinc/cli/pull/325/files#diff-2d0a5a6a592890b6dff2d6f891316b82R28)
   * no: ok

What
----
Expose Trace field:
https://confluentinc.atlassian.net/browse/CLI-397

1. No errors:
<img width="1566" alt="Screen Shot 2020-03-30 at 10 30 33 PM" src="https://user-images.githubusercontent.com/14109893/77990433-2b1b5200-72d6-11ea-8de7-ea492afca46e.png">
2. With Errors
<img width="1605" alt="Screen Shot 2020-03-30 at 10 34 32 PM" src="https://user-images.githubusercontent.com/14109893/77990672-c7ddef80-72d6-11ea-987b-db1d7535480c.png">

<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->

References
----------
https://confluentinc.atlassian.net/wiki/spaces/CONNECT/pages/1073645828/One+Pager+-+Connect+error+messages+in+ccloud

<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test&Review
------------

<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

<!--
Open questions / Follow ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
