### PR TITLE
Make decrypt command config field optional

### DIFF
--- a/internal/cmd/secret/command_file.go
+++ b/internal/cmd/secret/command_file.go
@@ -74,7 +74,6 @@ if a master key has not already been set using the "master-key generate" command
 	check(decryptCmd.MarkFlagRequired("output-file"))
 
 	decryptCmd.Flags().String("config", "", "List of configuration keys.")
-	check(decryptCmd.MarkFlagRequired("config"))
 	decryptCmd.Flags().SortFlags = false
 	c.AddCommand(decryptCmd)
 


### PR DESCRIPTION
To make the code backward compatible need to make the decrypt command config field optional
<!--
Is there any breaking changes?  If so this is a major release, make sure '#major' is in at least one
commit message to get CI to bump the major.  This will prevent automatic down stream dependency
bumping / consuming.  For more information about semantic versioning see: https://semver.org/


Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
Checklist
---
1. Did you add/update any commands that accept secrets as args/flags?
   * yes: did you update `secretCommandFlags` and/or `secretCommandArgs` in [internal/pkg/analytics/analytics.go](https://github.com/confluentinc/cli/pull/325/files#diff-2d0a5a6a592890b6dff2d6f891316b82R28)
   * no: ok

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->

References
----------
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test&Review
------------

<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

<!--
Open questions / Follow ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
