### PR TITLE
Specifies goreleaser dependency for building from source

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ To install the CLI:
     sudo mv ccloud/ccloud /usr/local/bin
 
 ### Building From Source
+Requires [goreleaser](https://goreleaser.com/install/)
 
 ```
 $ make deps


### PR DESCRIPTION
When I first tried building from source, I got an error when running `make build` because I didn't have `goreleaser`. Updating the docs so the next person won't run into the same problem 😄 