### PR TITLE
[CLI-486] Fix instructions for PS1 prompt

### DIFF
--- a/internal/cmd/prompt/command.go
+++ b/internal/cmd/prompt/command.go
@@ -21,14 +21,14 @@ For Bash, you'll want to do something like this:
 
 ::
 
-  $ export PS1="$({{.CLIName}} prompt) $PS1"
+  $ export PS1="\$({{.CLIName}} prompt) $PS1"
 
 ZSH users should be aware that they will have to set the 'PROMPT_SUBST' option first:
 
 ::
 
   $ setopt prompt_subst
-  $ export PS1="$({{.CLIName}} prompt) $PS1"
+  $ export PS1="\$({{.CLIName}} prompt) $PS1"
 
 You can customize the prompt by calling passing a '--format' flag, such as '-f "{{.CLIName}}|%E:%K"'.
 If you want to create a more sophisticated prompt (such as using the built-in color functions),
@@ -37,7 +37,7 @@ it'll be easiest for you if you use an environment variable rather than try to e
 ::
 
   $ export {{.CLIName | ToUpper}}_PROMPT_FMT='({{"{{"}}color "blue" "{{.CLIName}}"{{"}}"}}|{{"{{"}}color "red" "%E"{{"}}"}}:{{"{{"}}color "cyan" "%K"{{"}}"}})'
-  $ export PS1="$({{.CLIName}} prompt -f "${{.CLIName | ToUpper}}_PROMPT_FMT") $PS1"
+  $ export PS1="\$({{.CLIName}} prompt -f "${{.CLIName | ToUpper}}_PROMPT_FMT") $PS1"
 
 To make this permanent, you must add it to your bash or zsh profile.
 


### PR DESCRIPTION
Checklist
---
1. Did you add/update any commands that accept secrets as args/flags?
   * no: ok

What
----
Fix instructions so that the prompt auto-updates when the value changes

References
----------
https://confluentinc.atlassian.net/browse/CLI-486

Test&Review
------------

here's how the new instructions are printed now. The main thing is the slash before the subshell in `\$(ccloud prompt`

```
$ ./dist/ccloud/darwin_amd64/ccloud prompt -h 2>&1 | head -25
Use this command to add ccloud information in your terminal prompt.

For Bash, you'll want to do something like this:

::

  $ export PS1="\$(ccloud prompt) $PS1"

ZSH users should be aware that they will have to set the 'PROMPT_SUBST' option first:

::

  $ setopt prompt_subst
  $ export PS1="\$(ccloud prompt) $PS1"

You can customize the prompt by calling passing a '--format' flag, such as '-f "ccloud|%E:%K"'.
If you want to create a more sophisticated prompt (such as using the built-in color functions),
it'll be easiest for you if you use an environment variable rather than try to escape the quotes.

::

  $ export CCLOUD_PROMPT_FMT='({{color "blue" "ccloud"}}|{{color "red" "%E"}}:{{color "cyan" "%K"}})'
  $ export PS1="\$(ccloud prompt -f "$CCLOUD_PROMPT_FMT") $PS1"

To make this permanent, you must add it to your bash or zsh profile.
```

Following these instructions for bash, we can see the environment changes from `(none)` -> `default` -> `env2` as I login and switch environments:
```
$ rm ~/.ccloud/config.json
Cody-Rays-MBP15:~ cody$ export PS1="\$(ccloud prompt) $PS1"
(ccloud|(none):(none)) Cody-Rays-MBP15:~ cody$ ccloud login
Enter your Confluent credentials:
Email: cody@confluent.io
Password:

Logged in as cody@confluent.io
Using environment t22416 ("default")
(ccloud|default:(none)) Cody-Rays-MBP15:~ cody$ ccloud environment list
     Id    |  Name
+----------+---------+
  * t22416 | default
    t22417 | env2
(ccloud|default:(none)) Cody-Rays-MBP15:~ cody$ ccloud environment use t22417
Now using t22417 as the default (active) environment.
(ccloud|env2:(none)) Cody-Rays-MBP15:~ cody$
```

<!--
Open questions / Follow ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
