### PR TITLE
[CLI-483] Trim GOPATH from all packages not just top-level one

### DIFF
--- a/.goreleaser-ccloud-fake.yml
+++ b/.goreleaser-ccloud-fake.yml
@@ -21,9 +21,9 @@ builds:
     ldflags:
       - -s -w -X main.version={{.Env.VERSION}} -X main.commit={{.ShortCommit}} -X main.date={{.Date}} -X main.host={{.Env.HOSTNAME}} -X main.cliName=ccloud
     gcflags:
-      - -trimpath={{.Env.GOPATH}}
+      - all=-trimpath={{.Env.GOPATH}}
     asmflags:
-      - -trimpath={{.Env.GOPATH}}
+      - all=-trimpath={{.Env.GOPATH}}
     goos:
       - linux
       - darwin

--- a/.goreleaser-ccloud-linux.yml
+++ b/.goreleaser-ccloud-linux.yml
@@ -11,9 +11,9 @@ builds:
     ldflags:
       - -s -w -X main.version={{.Env.VERSION}} -X main.commit={{.ShortCommit}} -X main.date={{.Date}}  -X main.host={{.Env.HOSTNAME}} -X main.cliName=ccloud
     gcflags:
-      - -trimpath={{.Env.GOPATH}}
+      - all=-trimpath={{.Env.GOPATH}}
     asmflags:
-      - -trimpath={{.Env.GOPATH}}
+      - all=-trimpath={{.Env.GOPATH}}
     goos:
       - linux
     goarch:

--- a/.goreleaser-ccloud-mac.yml
+++ b/.goreleaser-ccloud-mac.yml
@@ -11,9 +11,9 @@ builds:
     ldflags:
       - -s -w -X main.version={{.Env.VERSION}} -X main.commit={{.ShortCommit}} -X main.date={{.Date}}  -X main.host={{.Env.HOSTNAME}} -X main.cliName=ccloud
     gcflags:
-      - -trimpath={{.Env.GOPATH}}
+      - all=-trimpath={{.Env.GOPATH}}
     asmflags:
-      - -trimpath={{.Env.GOPATH}}
+      - all=-trimpath={{.Env.GOPATH}}
     goos:
       - darwin
     goarch:

--- a/.goreleaser-ccloud-windows.yml
+++ b/.goreleaser-ccloud-windows.yml
@@ -12,9 +12,9 @@ builds:
     ldflags:
       - -s -w -X main.version={{.Env.VERSION}} -X main.commit={{.ShortCommit}} -X main.date={{.Date}}  -X main.host={{.Env.HOSTNAME}} -X main.cliName=ccloud
     gcflags:
-      - -trimpath={{.Env.GOPATH}}
+      - all=-trimpath={{.Env.GOPATH}}
     asmflags:
-      - -trimpath={{.Env.GOPATH}}
+      - all=-trimpath={{.Env.GOPATH}}
     goos:
       - windows
     goarch:

--- a/.goreleaser-ccloud.yml
+++ b/.goreleaser-ccloud.yml
@@ -21,9 +21,9 @@ builds:
     ldflags:
       - -s -w -X main.version={{.Env.VERSION}} -X main.commit={{.ShortCommit}} -X main.date={{.Date}} -X main.host={{.Env.HOSTNAME}} -X main.cliName=ccloud
     gcflags:
-      - -trimpath={{.Env.GOPATH}}
+      - all=-trimpath={{.Env.GOPATH}}
     asmflags:
-      - -trimpath={{.Env.GOPATH}}
+      - all=-trimpath={{.Env.GOPATH}}
     goos:
       - linux
       - darwin

--- a/.goreleaser-confluent-fake.yml
+++ b/.goreleaser-confluent-fake.yml
@@ -21,9 +21,9 @@ builds:
     ldflags:
       - -s -w -X main.version={{.Env.VERSION}} -X main.commit={{.ShortCommit}} -X main.date={{.Date}} -X main.host={{.Env.HOSTNAME}} -X main.cliName=confluent
     gcflags:
-      - -trimpath={{.Env.GOPATH}}
+      - all=-trimpath={{.Env.GOPATH}}
     asmflags:
-      - -trimpath={{.Env.GOPATH}}
+      - all=-trimpath={{.Env.GOPATH}}
     goos:
       - linux
       - darwin

--- a/.goreleaser-confluent-linux.yml
+++ b/.goreleaser-confluent-linux.yml
@@ -11,9 +11,9 @@ builds:
     ldflags:
       - -s -w -X main.version={{.Env.VERSION}} -X main.commit={{.ShortCommit}} -X main.date={{.Date}}  -X main.host={{.Env.HOSTNAME}} -X main.cliName=confluent
     gcflags:
-      - -trimpath={{.Env.GOPATH}}
+      - all=-trimpath={{.Env.GOPATH}}
     asmflags:
-      - -trimpath={{.Env.GOPATH}}
+      - all=-trimpath={{.Env.GOPATH}}
     goos:
       - linux
     goarch:

--- a/.goreleaser-confluent-mac.yml
+++ b/.goreleaser-confluent-mac.yml
@@ -11,9 +11,9 @@ builds:
     ldflags:
       - -s -w -X main.version={{.Env.VERSION}} -X main.commit={{.ShortCommit}} -X main.date={{.Date}}  -X main.host={{.Env.HOSTNAME}} -X main.cliName=confluent
     gcflags:
-      - -trimpath={{.Env.GOPATH}}
+      - all=-trimpath={{.Env.GOPATH}}
     asmflags:
-      - -trimpath={{.Env.GOPATH}}
+      - all=-trimpath={{.Env.GOPATH}}
     goos:
       - darwin
     goarch:

--- a/.goreleaser-confluent-windows.yml
+++ b/.goreleaser-confluent-windows.yml
@@ -11,9 +11,9 @@ builds:
     ldflags:
       - -s -w -X main.version={{.Env.VERSION}} -X main.commit={{.ShortCommit}} -X main.date={{.Date}}  -X main.host={{.Env.HOSTNAME}} -X main.cliName=confluent
     gcflags:
-      - -trimpath={{.Env.GOPATH}}
+      - all=-trimpath={{.Env.GOPATH}}
     asmflags:
-      - -trimpath={{.Env.GOPATH}}
+      - all=-trimpath={{.Env.GOPATH}}
     goos:
       - windows
     goarch:

--- a/.goreleaser-confluent.yml
+++ b/.goreleaser-confluent.yml
@@ -21,9 +21,9 @@ builds:
     ldflags:
       - -s -w -X main.version={{.Env.VERSION}} -X main.commit={{.ShortCommit}} -X main.date={{.Date}} -X main.host={{.Env.HOSTNAME}} -X main.cliName=confluent
     gcflags:
-      - -trimpath={{.Env.GOPATH}}
+      - all=-trimpath={{.Env.GOPATH}}
     asmflags:
-      - -trimpath={{.Env.GOPATH}}
+      - all=-trimpath={{.Env.GOPATH}}
     goos:
       - linux
       - darwin


### PR DESCRIPTION
https://confluent.slack.com/archives/C9Y6NAM6X/p1587395464061100

Now get good looking stack traces like
```
./dist/ccloud/darwin_amd64/ccloud kafka topic produce foo --delimiter :
panic: die

goroutine 1 [running]:
github.com/confluentinc/cli/internal/cmd/kafka.(*hasAPIKeyTopicCommand).produce(0xc0002f0ae0, 0xc000316780, 0xc0003572f0, 0x1, 0x3, 0x0, 0x0)
	src/github.com/confluentinc/cli/internal/cmd/kafka/command_topic.go:325 +0x39
github.com/spf13/cobra.(*Command).execute(0xc000316780, 0xc000357230, 0x3, 0x3, 0xc000316780, 0xc000357230)
	pkg/mod/github.com/spf13/cobra@v0.0.6-0.20190805155617-b80588d523ec/command.go:829 +0x460
github.com/spf13/cobra.(*Command).ExecuteC(0xc000294f00, 0x1000, 0x51345e0, 0xc000010010)
	pkg/mod/github.com/spf13/cobra@v0.0.6-0.20190805155617-b80588d523ec/command.go:917 +0x2fb
github.com/spf13/cobra.(*Command).Execute(...)
	pkg/mod/github.com/spf13/cobra@v0.0.6-0.20190805155617-b80588d523ec/command.go:867
github.com/confluentinc/cli/internal/cmd.(*Command).Execute(0xc0002da4a0, 0xc000032080, 0x6, 0x6, 0xc000166500, 0x515e140)
	src/github.com/confluentinc/cli/internal/cmd/command.go:162 +0x7d
main.main()
	src/github.com/confluentinc/cli/cmd/confluent/main.go:100 +0x56c
```