### PR TITLE
[CLI-498] Add make unrelease target to run if a release ever fails half-way

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -177,6 +177,10 @@ unrelease: authenticate unrelease-warn
 
 .PHONY: unrelease-warn
 unrelease-warn:
+	@echo "Latest tag:"
+	@git describe --tags `git rev-list --tags --max-count=1`
+	@echo "Latest commits:"
+	@git --no-pager log --decorate=short --pretty=oneline -n10
 	@echo "Warning: Ensure a git version bump (new commit and new tag) has occurred before continuing, else you will remove the prior version.  Continue? [Y/n]"
 	@read line; if [ $$line = "n" ]; then echo aborting; exit 1 ; fi
 


### PR DESCRIPTION
Sometimes issues occur with a release.  For example, Apple's servers might be unavailable and the release fails, even though new git commits, tags, etc. have been pushed (maybe even unsigned binaries etc. pushed to S3).

This PR adds `make unrelease` which rolls back all the artifacts from / evidence of a release, **assuming git tags and commit have already been made for the failed release**.  (Those are the first things that happen and never seem to fail, so shouldn't be an issue -- if they ever did fail you could easily revert manually without this command.)

This should solve the issue of pushing empty versions / having version numbers skip several times between actual releases.

Some related work that needs completing is an actual release doc with instructions for running a (un)release.  We'll probably add that after release notes work is done.