### PR TITLE
updating mockgen version to resolve conflicts with cc-structs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ deps:
         go get github.com/goreleaser/goreleaser@v0.106.0 && \
 	go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.21.0 && \
 	go get github.com/mitchellh/golicense@v0.1.1 && \
-	go get github.com/golang/mock/mockgen@v1.2.0 && \
+	go get github.com/golang/mock/mockgen@v1.3.1 && \
 	go get github.com/kevinburke/go-bindata/...@v3.13.0
 
 build: bindata build-go

--- a/go.mod
+++ b/go.mod
@@ -19,13 +19,13 @@ require (
 	github.com/confluentinc/bincover v0.0.0-20191217221125-80a7bb37ae5e
 	github.com/confluentinc/cc-structs/kafka/core v0.419.0
 	github.com/confluentinc/cc-structs/kafka/metrics v0.419.0
-	github.com/confluentinc/cc-structs/kafka/org v0.424.0
+	github.com/confluentinc/cc-structs/kafka/org v0.419.0
 	github.com/confluentinc/cc-structs/kafka/product/core v0.419.0
-	github.com/confluentinc/cc-structs/kafka/scheduler v0.424.0
+	github.com/confluentinc/cc-structs/kafka/scheduler v0.419.0
 	github.com/confluentinc/cc-structs/kafka/util v0.419.0
 	github.com/confluentinc/cc-structs/operator v0.419.0
 	github.com/confluentinc/cc-utils-public v0.1.0
-	github.com/confluentinc/ccloud-sdk-go v0.0.0-00010101000000-000000000000
+	github.com/confluentinc/ccloud-sdk-go v0.0.23
 	github.com/confluentinc/go-editor v0.4.0
 	github.com/confluentinc/go-printer v0.13.0
 	github.com/confluentinc/mds-sdk-go v0.0.0-20200330220448-02620efc8d62
@@ -101,7 +101,6 @@ require (
 )
 
 replace (
-	github.com/confluentinc/ccloud-sdk-go => github.com/confluentinc/ccloud-sdk-go v0.0.23
 	github.com/mutagen-io/gopass => github.com/mutagen-io/gopass v0.0.0-20161007065903-6331a34a3f3b
 	github.com/shurcooL/sanitized_anchor_name => github.com/shurcooL/sanitized_anchor_name v1.0.0
 	github.com/ugorji/go v1.1.4 => github.com/ugorji/go v0.0.0-20190316192920-e2bddce071ad


### PR DESCRIPTION
<!--
Is there any breaking changes?  If so this is a major release, make sure '#major' is in at least one
commit message to get CI to bump the major.  This will prevent automatic down stream dependency
bumping / consuming.  For more information about semantic versioning see: https://semver.org/


Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
Checklist
---
1. Did you add/update any commands that accept secrets as args/flags?
   * no: ok

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->
`make deps` previously pinned the mockgen version to `v1.2.0` which was causing dependency conflicts with newer cc-structs, and subsequently build errors. Bumping the version up seems to fix the problem with no side-effects!

References
----------
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test&Review
------------

<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->
```
PASS
ok  	github.com/confluentinc/cli/test	46.694s
Running packaging/installer tests
All tests passed!
```

<!--
Open questions / Follow ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
