### PR TITLE
Clean up error

### DIFF
--- a/cmd/confluent/main.go
+++ b/cmd/confluent/main.go
@@ -59,8 +59,7 @@ func main() {
 	if err != nil {
 		stubCmd := &cobra.Command{}
 		err = errors.HandleCommon(err, stubCmd)
-		logger.Debug(errors.ConfigUnableToLoadError, err)
-		fmt.Fprintf(os.Stderr, errors.ConfigUnableToLoadError, err)
+		logger.Errorf(errors.ConfigUnableToLoadError, err)
 		if isTest {
 			bincover.ExitCode = 1
 			return

--- a/internal/pkg/config/v3/config.go
+++ b/internal/pkg/config/v3/config.go
@@ -60,7 +60,7 @@ func New(params *config.Params) *Config {
 // Save a default version if none exists yet.
 func (c *Config) Load() error {
 	currentVersion := Version
-	filename, err := c.GetFilename()
+	filename, err := c.getFilename()
 	if err != nil {
 		return err
 	}
@@ -122,7 +122,7 @@ func (c *Config) Save() error {
 	if err != nil {
 		return errors.Wrapf(err, "unable to marshal config")
 	}
-	filename, err := c.GetFilename()
+	filename, err := c.getFilename()
 	if err != nil {
 		return err
 	}

--- a/test/cli_test.go
+++ b/test/cli_test.go
@@ -442,7 +442,7 @@ func fixturePath(t *testing.T, fixture string) string {
 		t.Fatalf("problems recovering caller information")
 	}
 
-	return filepath.Join(filepath.Dir(filename), "fixtures", fixture)
+	return filepath.Join(filepath.Dir(filename), "fixtures", "output", fixture)
 }
 
 func binaryPath(t *testing.T, binaryName string) string {

--- a/test/utils.go
+++ b/test/utils.go
@@ -1,8 +1,6 @@
 package test
 
-import (
-	"bytes"
-)
+import "bytes"
 
 // NormalizeNewLines replaces \r\n and \r newline sequences with \n
 func NormalizeNewLines(raw string) string {


### PR DESCRIPTION
<!--
Is there any breaking changes?  If so this is a major release, make sure '#major' is in at least one
commit message to get CI to bump the major.  This will prevent automatic down stream dependency
bumping / consuming.  For more information about semantic versioning see: https://semver.org/


Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
Checklist
---
1. Did you add/update any commands that accept secrets as args/flags?
   * no: ok

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->

Removed unused error.

Remove HandleString struct.

to simplify code, and remove non reused struct
improve UX for ccloud init: when the user uses ccloud init and have not provided bootstrap url, api key and api secret, they will be prompted for those one by one. HandleString suppresses the error such that if user inputs an invalid value for the first prompt (bootstrap url), they are still prompted for the second and third value just to have the error indicating the first prompt is invalid in the end. And so directly catching and throwing the error will throw the error right away if the user puts an invalid value.

References
----------
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test&Review
------------

<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

<!--
Open questions / Follow ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
