### PR TITLE
Add support to remove individual encrypted jaas configurations

### DIFF
--- a/internal/pkg/secret/jaas_config_parser.go
+++ b/internal/pkg/secret/jaas_config_parser.go
@@ -44,6 +44,9 @@ func (j *JAASParser) updateJAASConfig(op string, key string, value string, confi
 				return "", fmt.Errorf("The configuration " + config + " not present in JAAS configuration.")
 			}
 			config = pattern.ReplaceAllString(config, delete)
+			if strings.HasSuffix(matched, ";") {
+				config = config + ";"
+			}
 		} else {
 			keyValuePattern := key + PASSWORD_PATTERN // check if value is in Secrets format
 			pattern := regexp.MustCompile(keyValuePattern)
@@ -65,7 +68,7 @@ func (j *JAASParser) updateJAASConfig(op string, key string, value string, confi
 				config = config + ";"
 			}
 		} else {
-			add := NEW_LINE + key + j.WhitespaceKey + "=" + j.WhitespaceKey + value
+			add := SPACE + key + j.WhitespaceKey + "=" + j.WhitespaceKey + value
 			config = strings.TrimSuffix(config, ";") + add + ";"
 		}
 		break

--- a/internal/pkg/secret/password_protection_constants.go
+++ b/internal/pkg/secret/password_protection_constants.go
@@ -67,6 +67,6 @@ const (
 	ADD                     = "add"
 	DELETE                  = "delete"
 	UPDATE                  = "update"
-	NEW_LINE                = "\n "
+	SPACE                   = " "
 	KEY_SEPARATOR           = "/"
 )

--- a/internal/pkg/secret/password_protection_test.go
+++ b/internal/pkg/secret/password_protection_test.go
@@ -1003,7 +1003,7 @@ func TestPasswordProtectionSuite_RemoveConfigFileSecrets(t *testing.T) {
 				config:                 "",
 			},
 			wantErr:    true,
-			wantErrMsg: "Configuration key ssl.keystore.password is not present in the configuration file.",
+			wantErrMsg: "Configuration key ssl.keystore.password is not encrypted.",
 		},
 		{
 			name: "ValidTestCase:Remove existing configs from jaas config file",
@@ -1024,6 +1024,24 @@ func TestPasswordProtectionSuite_RemoveConfigFileSecrets(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "ValidTestCase:Nested Key in jaas config file",
+			args: &args{
+				masterKeyPassphrase: "abc123",
+				contents: `test.config.jaas = com.sun.security.auth.module.Krb5LoginModule required \
+    useKeyTab=false \
+    password=pass234 \
+    useTicketCache=true \
+    doNotPrompt=true;`,
+				configFilePath:         "/tmp/securePass987/remove/embeddedJaas.properties",
+				localSecureConfigPath:  "/tmp/securePass987/remove/secureConfig.properties",
+				secureDir:              "/tmp/securePass987/remove",
+				remoteSecureConfigPath: "/tmp/securePass987/remove/secureConfig.properties",
+				removeConfigs:          "test.config.jaas/com.sun.security.auth.module.Krb5LoginModule/password",
+				config:                 "",
+			},
+			wantErr: false,
+		},
+		{
 			name: "InvalidTestCase:Key not present in jaas config file",
 			args: &args{
 				masterKeyPassphrase: "abc123",
@@ -1040,7 +1058,7 @@ func TestPasswordProtectionSuite_RemoveConfigFileSecrets(t *testing.T) {
 				config:                 "",
 			},
 			wantErr:    true,
-			wantErrMsg: "Configuration key test.config.jaas/com.sun.security.auth.module.Krb5LoginModule/location is not present in the configuration file.",
+			wantErrMsg: "Configuration key test.config.jaas/com.sun.security.auth.module.Krb5LoginModule/location is not encrypted.",
 		},
 		{
 			name: "ValidTestCase:Remove existing configs from json config file",
@@ -1079,7 +1097,7 @@ func TestPasswordProtectionSuite_RemoveConfigFileSecrets(t *testing.T) {
 				config:                 "",
 			},
 			wantErr:    true,
-			wantErrMsg: "Configuration key credentials/location is not present in JSON configuration file.",
+			wantErrMsg: "Configuration key credentials/location is not encrypted.",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
Currently we could only remove a complete jaas configuration. Added support to remove each field in jaas configuration.





<!--
Is there any breaking changes?  If so this is a major release, make sure '#major' is in at least one
commit message to get CI to bump the major.  This will prevent automatic down stream dependency
bumping / consuming.  For more information about semantic versioning see: https://semver.org/


Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
Checklist
---
1. Did you add/update any commands that accept secrets as args/flags?
   * yes: did you update `secretCommandFlags` and/or `secretCommandArgs` in [internal/pkg/analytics/analytics.go](https://github.com/confluentinc/cli/pull/325/files#diff-2d0a5a6a592890b6dff2d6f891316b82R28)
   * no: ok

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->

References
----------
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test&Review
------------

<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

<!--
Open questions / Follow ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
