### PR TITLE
CLI-545: Update Golden Files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -470,7 +470,7 @@ coverage:
 	@# Run unit tests.
 	@GO111MODULE=on GOPRIVATE=github.com/confluentinc go test -race -coverpkg=./... $$(go list ./... | grep -v vendor | grep -v test) $(TEST_ARGS)
 	@# Run integration tests.
-	@GO111MODULE=on GOPRIVATE=github.com/confluentinc go test -v -race $$(go list ./... | grep cli/test) $(TEST_ARGS)
+	@GO111MODULE=on GOPRIVATE=github.com/confluentinc go test -v -race $$(go list ./... | grep cli/test) $(TEST_ARGS) $(INT_TEST_ARGS)
       endif
 
 .PHONY: mocks

--- a/README.md
+++ b/README.md
@@ -297,32 +297,28 @@ binary and invoke commands on it. These CLI integration tests roughly follow thi
 Read the [CLITest](./test/cli_test.go) configuration to get a better idea
 about how to write and configure your own integration tests.
 
-You can run just the integration tests with
-
-    make test TEST_ARGS="-v"
-
 You can update the golden files from the current output with
 
-    make test TEST_ARGS="-update"
+    make test INT_TEST_ARGS="-update"
 
 You can skip rebuilding the CLI if it already exists in `dist` with
 
-    make test TEST_ARGS="-no-rebuild"
+    make test INT_TEST_ARGS="-no-rebuild"
 
 You can mix and match these flags. To update the golden files without rebuilding, and log verbosely
 
-    make test TEST_ARGS="-update -no-rebuild -v"
+    make test INT_TEST_ARGS="-update -no-rebuild -v"
 
 To run a single test case (or all test cases with a prefix)
 
     # all integration tests
-    make test TEST_ARGS="-run TestCLI"
+    make test INT_TEST_ARGS="-run TestCLI"
 
     # all subtests of this `Test_Confluent_Iam_Rolebinding_List` integration tests
-    make test TEST_ARGS="-run TestCLI/Test_Confluent_Iam_Rolebinding_List"
+    make test INT_TEST_ARGS="-run TestCLI/Test_Confluent_Iam_Rolebinding_List"
 
     # a very specific subset of tests
-    make test TEST_ARGS="-run TestCLI/Test_Confluent_Iam_Rolebinding_List/iam_rolebinding_list_--kafka-cluster-id_CID_--principal_User:frodo"
+    make test INT_TEST_ARGS="-run TestCLI/Test_Confluent_Iam_Rolebinding_List/iam_rolebinding_list_--kafka-cluster-id_CID_--principal_User:frodo"
 
 ## Adding a New Command to the CLI
 
@@ -451,9 +447,9 @@ func (s *CLITestSuite) TestFileCommands() {
 We'll also need to add the new golden file, `file1.golden`, to `test/fixtures/output`. After running the command manually to ensure the output is correct, the content for the golden file can either be:
 
 1. Copied directly from the shell
-2. Generated automatically by running `make test TEST_ARGS="./test/... -update"`, which runs all integration tests and updates all golden files to match their output. This is a risky command to run, as it essentially passes all integration tests, but is convenient to use if you can't get tests to pass from manual copying due to some hidden spaces. In addition to auto-filling the `file` golden file, this command will update the `help` command test outputs to reflect the added command.
+2. Generated automatically by running `make test INT_TEST_ARGS="-update"`, which runs all integration tests and updates all golden files to match their output. This is a risky command to run, as it essentially passes all integration tests, but is convenient to use if you can't get tests to pass from manual copying due to some hidden spaces. In addition to auto-filling the `file` golden file, this command will update the `help` command test outputs to reflect the added command.
 
-To run this integration test, run `make test TEST_ARGS="-run TestCLI/TestFileCommands"`.
+To run this integration test, run `make test INT_TEST_ARGS="-run TestCLI/TestFileCommands"`.
 
 ### Opening a PR!
 


### PR DESCRIPTION
Checklist
---
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok
   
2. Did you add/update any commands that accept secrets as args/flags?
   * no: ok

What
----
Fix for #519, which broke the `make test TEST_ARGS="-update"` command.

References
----------
CLI-545