### PR TITLE
separate unit tests and integration test targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -461,7 +461,6 @@ coverage-unit:
       ifdef CI
 	@# Run unit tests with coverage.
 	@GO111MODULE=on GOPRIVATE=github.com/confluentinc go test -v -race -coverpkg=$$(go list ./... | grep -v test | grep -v mock | tr '\n' ',' | sed 's/,$$//g') -coverprofile=unit_coverage.txt $$(go list ./... | grep -v vendor | grep -v test) $(UNIT_TEST_ARGS)
-	@echo "mode: atomic" > coverage.txt
 	@grep -h -v "mode: atomic" unit_coverage.txt >> coverage.txt
       else
 	@# Run unit tests.
@@ -473,7 +472,6 @@ coverage-integ:
       ifdef CI
 	@# Run integration tests with coverage.
 	@GO111MODULE=on INTEG_COVER=on go test -v $$(go list ./... | grep cli/test) $(INT_TEST_ARGS)
-	@echo "mode: atomic" > coverage.txt
 	@grep -h -v "mode: atomic" integ_coverage.txt >> coverage.txt
       else
 	@# Run integration tests.
@@ -491,14 +489,20 @@ test-installers:
 	@echo Running packaging/installer tests
 	@bash test-installers.sh
 
+.PHONY: test-prep
+test-prep: bindata mocks lint
+      ifdef CI
+    @echo "mode: atomic" > coverage.txt
+      endif
+
 .PHONY: test
-test: bindata mocks lint coverage-unit coverage-integ test-installers
+test: test-prep coverage-unit coverage-integ test-installers
 
 .PHONY: unit-test
-unit-test: bindata mocks lint coverage-unit
+unit-test: test-prep coverage-unit
 
 .PHONY: int-test
-int-test: bindata mocks lint coverage-integ
+int-test: test-prep coverage-integ
 
 .PHONY: doctoc
 doctoc:

--- a/README.md
+++ b/README.md
@@ -289,7 +289,7 @@ To run all tests
 UNIT_TEST_ARGS environment variable is used to manipulate unit test execution,
 while INT_TEST_ARGS environment variable is for integration tests.
 
-For example you can filter for a subset of unit test and as subset integration tests to be run
+For example you can filter for a subset of unit test and a subset integration tests to be run
 
     make test UNIT_TEST_ARGS="-run TestApiTestSuite" INT_TEST_ARGS="-run TestCLI/Test_Confluent_Iam_Rolebinding_List"
 


### PR DESCRIPTION
<!--
Is there any breaking changes?  If so this is a major release, make sure '#major' is in at least one
commit message to get CI to bump the major.  This will prevent automatic down stream dependency
bumping / consuming.  For more information about semantic versioning see: https://semver.org/


Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
Checklist
---
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok
   
2. Did you add/update any commands that accept secrets as args/flags?
   * no: ok

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->
- Have separate make targets that runs only unit tests, and another that runs only integration tests.
- Separate arguments for unit test and integration test passing. This fixes `-update` and `no-rebuild` flag problem as they only work for integration tests, and also allow filter of unit test and integration test in one `make test` run
Although https://github.com/confluentinc/cli/pull/521 already fixed the `-update` and `-no-rebuild` flag issues
- Update the README about the change and to let developers know that we now support filtering unit tests as well.

References
----------
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test&Review
------------

<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

<!--
Open questions / Follow ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
