### PR TITLE
Update invalid role error handling for CP 6.0 MDS change

### DIFF
--- a/internal/cmd/iam/command_rolebinding.go
+++ b/internal/cmd/iam/command_rolebinding.go
@@ -157,8 +157,8 @@ func (c *rolebindingCommand) parseAndValidateResourcePattern(typename string, pr
 
 func (c *rolebindingCommand) validateRoleAndResourceType(roleName string, resourceType string) error {
 	ctx := c.createContext()
-	role, _, err := c.MDSClient.RBACRoleDefinitionsApi.RoleDetail(ctx, roleName)
-	if err != nil {
+	role, resp, err := c.MDSClient.RBACRoleDefinitionsApi.RoleDetail(ctx, roleName)
+	if err != nil || resp.StatusCode == 204 {
 		return errors.Wrapf(err, "Failed to look up role %s. Was an invalid role name specified?", roleName)
 	}
 
@@ -440,7 +440,7 @@ func (c *rolebindingCommand) parseCommon(cmd *cobra.Command) (*rolebindingOption
 			parsedResourcePattern,
 		}
 		resourcesRequest = mds.ResourcesRequest{
-			Scope:         *scope,
+			Scope:            *scope,
 			ResourcePatterns: resourcePatterns,
 		}
 	}


### PR DESCRIPTION
This is backwards compatible with CP 5.x so should be safe to merge -- and is required for the new/breaking change in MDS for CP 6.0 (MDS returns a 204 for invalid roles now instead of a 500 or 502).

This is the CLI side of the fix for SEC-1205 https://confluentinc.atlassian.net/browse/SEC-1205?atlOrigin=eyJpIjoiMjNkNGM2ZjMxYzUwNGFhYjgzYTRlNmQwZDdmMGZmYmEiLCJwIjoiamlyYS1zbGFjay1pbnQifQ