### PR TITLE
fix typo

### DIFF
--- a/internal/cmd/ksql/command_cluster.go
+++ b/internal/cmd/ksql/command_cluster.go
@@ -141,7 +141,7 @@ func (c *clusterCommand) create(cmd *cobra.Command, args []string) error {
 		count += 1
 	}
 	if cluster.Endpoint == "" {
-		pcmd.ErrPrint(cmd, "Endpoint not yet populated. To obtain the endpoint please use `ccloud ksql app describe`.")
+		pcmd.ErrPrint(cmd, "Endpoint not yet populated. To obtain the endpoint please use `ccloud ksql app describe`.\n")
 	}
 	return output.DescribeObject(cmd, cluster, describeFields, describeHumanRenames, describeStructuredRenames)
 }


### PR DESCRIPTION
As it stands, this message was getting printed on the same line as the top border of the table, which messed up table output.  Now it will break properly.