### PR TITLE
CLI-584: Require macOS >= 10.14

### DIFF
--- a/internal/cmd/local/command_service.go
+++ b/internal/cmd/local/command_service.go
@@ -631,7 +631,7 @@ func setServiceEnvs(service string) error {
 }
 
 func checkOSVersion() error {
-	// CLI-84: Require macOS version >= 10.13
+	// CLI-584: Require macOS version >= 10.14
 	if runtime.GOOS == "darwin" {
 		osVersion, err := exec.Command("sw_vers", "-productVersion").Output()
 		if err != nil {
@@ -643,7 +643,7 @@ func checkOSVersion() error {
 			return err
 		}
 
-		required, _ := version.NewSemver("10.13")
+		required, _ := version.NewSemver("10.14")
 		if v.Compare(required) < 0 {
 			return fmt.Errorf(errors.MacVersionErrorMsg, osVersion)
 		}

--- a/internal/pkg/errors/error_message.go
+++ b/internal/pkg/errors/error_message.go
@@ -121,7 +121,7 @@ const (
 		"See https://docs.confluent.io/current/installation/versions-interoperability.html\n" +
 		"If you have multiple versions of Java installed, you may need to set JAVA_HOME to the version you want Confluent to use."
 	NoLogFoundErrorMsg       = "no log found: to run %s, use \"confluent local services %s start\""
-	MacVersionErrorMsg       = "macOS version >= 10.13 is required (detected: %s)"
+	MacVersionErrorMsg       = "macOS version >= 10.14 is required (detected: %s)"
 	JavaExecNotFondErrorMsg  = "could not find java executable, please install java or set JAVA_HOME"
 	NothingToDestroyErrorMsg = "nothing to destroy"
 


### PR DESCRIPTION
Checklist
---
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok
   
2. Did you add/update any commands that accept secrets as args/flags?
   * no: ok

What
----
Bump macOS requirement from `10.13` to `10.14`

References
----------
https://confluentinc.atlassian.net/browse/CLI-584