### PR TITLE
SEC-1204 - Improve error message handling

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,8 +25,8 @@ require (
 	github.com/confluentinc/ccloud-sdk-go v0.0.37
 	github.com/confluentinc/go-editor v0.4.0
 	github.com/confluentinc/go-printer v0.13.0
-	github.com/confluentinc/mds-sdk-go/mdsv2alpha1 v0.0.11
 	github.com/confluentinc/mds-sdk-go/mdsv1 v0.0.9
+	github.com/confluentinc/mds-sdk-go/mdsv2alpha1 v0.0.11
 	github.com/confluentinc/properties v0.0.0-20190814194548-42c10394a787
 	github.com/confluentinc/schema-registry-sdk-go v0.0.9
 	github.com/dghubble/sling v1.3.0 // indirect

--- a/internal/cmd/auditlog/command_config.go
+++ b/internal/cmd/auditlog/command_config.go
@@ -73,9 +73,9 @@ func (c *configCommand) createContext() context.Context {
 }
 
 func (c *configCommand) describe(cmd *cobra.Command, _ []string) error {
-	spec, _, err := c.MDSClient.AuditLogConfigurationApi.GetConfig(c.createContext())
+	spec, response, err := c.MDSClient.AuditLogConfigurationApi.GetConfig(c.createContext())
 	if err != nil {
-		return err
+		return HandleMdsAuditLogApiError(cmd, err, response)
 	}
 	enc := json.NewEncoder(c.OutOrStdout())
 	enc.SetIndent("", "  ")


### PR DESCRIPTION
Checklist
---
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * no, this is for APIs added in CP 6.0+, but there is already a guard to check for "not found" response and show an error.
   
2. Did you add/update any commands that accept secrets as args/flags?
   * no: ok

What
----
Improved the error message output for the case where an audit log config API error results in a 403 permission denied. The message from the server is a JSON-encoded object, and the message within that object provides helpful information about how to grant the missing permissions. Previously, output looked like:

```
$ confluent audit-log config describe
Error: metadata service backend error: 403 Forbidden: {"error_code":40301,"message":"User:frodo not permitted to DescribeConfigs on one or more clusters. Fix it:\nconfluent iam rolebinding create --role AuditAdmin --principal User:frodo --kafka-cluster-id LrsCUlYdS4iq6St4k9zi5A\n"}
```

With this improvement, it will look like:

```
$ confluent audit-log config describe
Error: 403 Forbidden
User:frodo not permitted to DescribeConfigs on one or more clusters. Fix it:
confluent iam rolebinding create --role AuditAdmin --principal User:frodo --kafka-cluster-id 06uxINEgRkqLz4WGj5bFdg
```

References
----------
https://confluentinc.atlassian.net/browse/SEC-1204