### PR TITLE
Confluent Local: pipeable log output

### DIFF
--- a/internal/cmd/local/command_service.go
+++ b/internal/cmd/local/command_service.go
@@ -67,6 +67,14 @@ func NewServiceLogCommand(service string, prerunner cmd.PreRunner) *cobra.Comman
 func (c *Command) runServiceLogCommand(command *cobra.Command, _ []string) error {
 	service := command.Parent().Name()
 
+	exists, err := c.cc.HasLogFile(service)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		return errors.Errorf(errors.NoLogFoundErrorMsg, writeOfficialServiceName(service), service)
+	}
+
 	log, err := c.cc.GetLogFile(service)
 	if err != nil {
 		return err

--- a/internal/pkg/local/confluent_current.go
+++ b/internal/pkg/local/confluent_current.go
@@ -41,6 +41,7 @@ type ConfluentCurrent interface {
 	WriteConfig(service string, config []byte) error
 
 	GetLogFile(service string) (string, error)
+	HasLogFile(service string) (bool, error)
 
 	GetPidFile(service string) (string, error)
 	HasPidFile(service string) (bool, error)
@@ -143,12 +144,19 @@ func (cc *ConfluentCurrentManager) GetLogFile(service string) (string, error) {
 	return cc.getServiceFile(service, fmt.Sprintf("%s.stdout", service))
 }
 
+func (cc *ConfluentCurrentManager) HasLogFile(service string) (bool, error) {
+	file, err := cc.GetLogFile(service)
+	if err != nil {
+		return false, err
+	}
+	return exists(file), nil
+}
+
 func (cc *ConfluentCurrentManager) HasPidFile(service string) (bool, error) {
 	file, err := cc.GetPidFile(service)
 	if err != nil {
 		return false, err
 	}
-
 	return exists(file), nil
 }
 

--- a/mock/confluent_current.go
+++ b/mock/confluent_current.go
@@ -37,6 +37,9 @@ type MockConfluentCurrent struct {
 	lockGetLogFile sync.Mutex
 	GetLogFileFunc func(service string) (string, error)
 
+	lockHasLogFile sync.Mutex
+	HasLogFileFunc func(service string) (bool, error)
+
 	lockGetPidFile sync.Mutex
 	GetPidFileFunc func(service string) (string, error)
 
@@ -75,6 +78,9 @@ type MockConfluentCurrent struct {
 			Config  []byte
 		}
 		GetLogFile []struct {
+			Service string
+		}
+		HasLogFile []struct {
 			Service string
 		}
 		GetPidFile []struct {
@@ -425,6 +431,44 @@ func (m *MockConfluentCurrent) GetLogFileCalls() []struct {
 	return m.calls.GetLogFile
 }
 
+// HasLogFile mocks base method by wrapping the associated func.
+func (m *MockConfluentCurrent) HasLogFile(service string) (bool, error) {
+	m.lockHasLogFile.Lock()
+	defer m.lockHasLogFile.Unlock()
+
+	if m.HasLogFileFunc == nil {
+		panic("mocker: MockConfluentCurrent.HasLogFileFunc is nil but MockConfluentCurrent.HasLogFile was called.")
+	}
+
+	call := struct {
+		Service string
+	}{
+		Service: service,
+	}
+
+	m.calls.HasLogFile = append(m.calls.HasLogFile, call)
+
+	return m.HasLogFileFunc(service)
+}
+
+// HasLogFileCalled returns true if HasLogFile was called at least once.
+func (m *MockConfluentCurrent) HasLogFileCalled() bool {
+	m.lockHasLogFile.Lock()
+	defer m.lockHasLogFile.Unlock()
+
+	return len(m.calls.HasLogFile) > 0
+}
+
+// HasLogFileCalls returns the calls made to HasLogFile.
+func (m *MockConfluentCurrent) HasLogFileCalls() []struct {
+	Service string
+} {
+	m.lockHasLogFile.Lock()
+	defer m.lockHasLogFile.Unlock()
+
+	return m.calls.HasLogFile
+}
+
 // GetPidFile mocks base method by wrapping the associated func.
 func (m *MockConfluentCurrent) GetPidFile(service string) (string, error) {
 	m.lockGetPidFile.Lock()
@@ -647,6 +691,9 @@ func (m *MockConfluentCurrent) Reset() {
 	m.lockGetLogFile.Lock()
 	m.calls.GetLogFile = nil
 	m.lockGetLogFile.Unlock()
+	m.lockHasLogFile.Lock()
+	m.calls.HasLogFile = nil
+	m.lockHasLogFile.Unlock()
 	m.lockGetPidFile.Lock()
 	m.calls.GetPidFile = nil
 	m.lockGetPidFile.Unlock()


### PR DESCRIPTION
<!--
Is there any breaking changes?  If so this is a major release, make sure '#major' is in at least one
commit message to get CI to bump the major.  This will prevent automatic down stream dependency
bumping / consuming.  For more information about semantic versioning see: https://semver.org/


Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
Checklist
---
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok
   
2. Did you add/update any commands that accept secrets as args/flags?
   * no: ok

What
----
Example usage: `confluent local services kafka log | grep ERROR`

References
----------
https://confluent.slack.com/archives/C010Y0EP5MZ/p1595348894161000