### PR TITLE
[CLI-602] Fix panic when invalid role is specified during resource-scoped rolebinding commands

### DIFF
--- a/internal/cmd/iam/command_rolebinding.go
+++ b/internal/cmd/iam/command_rolebinding.go
@@ -231,9 +231,10 @@ func (c *rolebindingCommand) validateRoleAndResourceType(roleName string, resour
 	role, resp, err := c.MDSClient.RBACRoleDefinitionsApi.RoleDetail(ctx, roleName)
 	if err != nil || resp.StatusCode == 204 {
 		if err == nil {
-			err = errors.New(errors.RoleNotFoundErrorMsg)
+			return errors.NewErrorWithSuggestions(fmt.Sprintf(errors.LookUpRoleErrorMsg, roleName), errors.LookUpRoleSuggestions)
+		} else {
+			return errors.NewWrapErrorWithSuggestions(err, fmt.Sprintf(errors.LookUpRoleErrorMsg, roleName), errors.LookUpRoleSuggestions)
 		}
-		return errors.NewWrapErrorWithSuggestions(err, fmt.Sprintf(errors.LookUpRoleErrorMsg, roleName), errors.LookUpRoleSuggestions)
 	}
 
 	var allResourceTypes []string

--- a/internal/pkg/errors/error_message.go
+++ b/internal/pkg/errors/error_message.go
@@ -65,7 +65,6 @@ const (
 	ResourceFormatErrorMsg          = "incorrect resource format specified"
 	ResourceFormatSuggestions       = "Resource must be specified in this format: `<Resource Type>:<Resource Name>`."
 	LookUpRoleErrorMsg              = "failed to lookup role \"%s\""
-	RoleNotFoundErrorMsg            = "role not found"
 	LookUpRoleSuggestions           = "To check for valid roles, use `confluent role list`."
 	InvalidResourceTypeErrorMsg     = "invalid resource type \"%s\""
 	InvalidResourceTypeSuggestions  = "The available resource types are: %s"


### PR DESCRIPTION
Panics were occurring (see https://confluent.slack.com/archives/CG6BW233L/p1594921975104400?thread_ts=1594869616.102200&cid=CG6BW233L) because, see code in this PR, `err` could be `nil` (when response code was 204) but then we were trying to `Wrap` a `nil` `error` which failed.