### PR TITLE
[FF-2849] Service account names can be up to 64 characters long

### DIFF
--- a/internal/cmd/service-account/command.go
+++ b/internal/cmd/service-account/command.go
@@ -27,7 +27,7 @@ var (
 	describeStructuredRenames = map[string]string{"ServiceName": "name", "ServiceDescription": "description"}
 )
 
-const nameLength = 32
+const nameLength = 64
 const descriptionLength = 128
 
 // New returns the Cobra command for service accounts.
@@ -106,7 +106,7 @@ func (c *command) init() {
 
 func requireLen(val string, maxLen int, field string) error {
 	if len(val) > maxLen {
-		return fmt.Errorf(field+" length should be less then %d characters.", maxLen)
+		return fmt.Errorf(field+" length should not exceed %d characters.", maxLen)
 	}
 
 	return nil


### PR DESCRIPTION
Checklist
---
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok
   
2. Did you add/update any commands that accept secrets as args/flags?
   * no: ok

What
----
[FF ticket](https://confluentinc.atlassian.net/browse/FF-2849) to raise this limit. Looks like it already supports 64 characters the backend:

References
----------
* https://confluentinc.atlassian.net/browse/FF-2849
* https://github.com/confluentinc/cc-mk-include/blob/master/seed-db/mothership-seed.sql#L743
* https://github.com/confluentinc/cc-org-service/blob/e9fe5f608bc50b29667620c3a9efdd284df6f6ab/pg/user_service.go#L985

I'm not sure why the CLI enforces limits separately, ideally it'd just pass the error from the backend, right?

Anyway, just a quick win to make it support longer service account names...  for customer love. <3 

Test&Review
------------

<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

```
$ ./dist/ccloud/darwin_amd64/ccloud -vvvv service-account create Cz0r53D6nwojt9fjAxh730jhx9xaWO5W4 --description "testing 33 character string"
2020-07-24T22:26:48.705-0500 [DEBUG] UserService.CreateServiceAccount request: POST https://confluent.cloud/api/service_accounts Body:{"user":{"organizationId":15649,"serviceName":"Cz0r53D6nwojt9fjAxh730jhx9xaWO5W4","serviceDescription":"testing 33 character string","serviceAccount":true}}
2020-07-24T22:26:49.307-0500 [DEBUG] UserService.CreateServiceAccount response: 200 OK Body: {"error":null,"user":{"id":92299,"email":"15649-Cz0r53D6nwojt9fjAxh730jhx9xaWO5W4@serviceaccounts.confluent.cloud","first_name":"","last_name":"","organization_id":15649,"deactivated":false,"verified":"1970-01-01T00:00:00Z","created":"2020-07-25T03:26:49.198206256Z","modified":"2020-07-25T03:26:49.198206256Z","password_changed":"2020-07-25T03:26:49.198206256Z","service_name":"Cz0r53D6nwojt9fjAxh730jhx9xaWO5W4","service_description":"testing 33 character string","service_account":true,"sso":null,"preferences":{},"internal":false,"resource_id":"sa-4kkvng"}} request: POST https://confluent.cloud/api/service_accounts Body:{"user":{"organizationId":15649,"serviceName":"Cz0r53D6nwojt9fjAxh730jhx9xaWO5W4","serviceDescription":"testing 33 character string","serviceAccount":true}}
+-------------+-----------------------------------+
| Id          |                             92299 |
| Name        | Cz0r53D6nwojt9fjAxh730jhx9xaWO5W4 |
| Description | testing 33 character string       |
+-------------+-----------------------------------+
```

```
Cody-Rays-MBP15:cli cody$ ./dist/ccloud/darwin_amd64/ccloud -vvvv service-account create QW1cf7UAlkXjLgPaCxpCRiQCFgeZX8PnpaV99vsyWQdEh9Ih6RzOvB1JXNjNlTgY --description "testing 64 character string"
2020-07-24T22:28:05.171-0500 [DEBUG] UserService.CreateServiceAccount request: POST https://confluent.cloud/api/service_accounts Body:{"user":{"organizationId":15649,"serviceName":"QW1cf7UAlkXjLgPaCxpCRiQCFgeZX8PnpaV99vsyWQdEh9Ih6RzOvB1JXNjNlTgY","serviceDescription":"testing 64 character string","serviceAccount":true}}
2020-07-24T22:28:05.809-0500 [DEBUG] UserService.CreateServiceAccount response: 200 OK Body: {"error":null,"user":{"id":92300,"email":"15649-QW1cf7UAlkXjLgPaCxpCRiQCFgeZX8PnpaV99vsyWQdEh9Ih6RzOvB1JXNjNlTgY@serviceaccounts.confluent.cloud","first_name":"","last_name":"","organization_id":15649,"deactivated":false,"verified":"1970-01-01T00:00:00Z","created":"2020-07-25T03:28:05.853637276Z","modified":"2020-07-25T03:28:05.853637276Z","password_changed":"2020-07-25T03:28:05.853637276Z","service_name":"QW1cf7UAlkXjLgPaCxpCRiQCFgeZX8PnpaV99vsyWQdEh9Ih6RzOvB1JXNjNlTgY","service_description":"testing 64 character string","service_account":true,"sso":null,"preferences":{},"internal":false,"resource_id":"sa-l5qjwq"}} request: POST https://confluent.cloud/api/service_accounts Body:{"user":{"organizationId":15649,"serviceName":"QW1cf7UAlkXjLgPaCxpCRiQCFgeZX8PnpaV99vsyWQdEh9Ih6RzOvB1JXNjNlTgY","serviceDescription":"testing 64 character string","serviceAccount":true}}
+-------------+------------------------------------------------------------------+
| Id          |                                                            92300 |
| Name        | QW1cf7UAlkXjLgPaCxpCRiQCFgeZX8PnpaV99vsyWQdEh9Ih6RzOvB1JXNjNlTgY |
| Description | testing 64 character string                                      |
+-------------+------------------------------------------------------------------+
Cody-Rays-MBP15:cli cody$
Cody-Rays-MBP15:cli cody$
Cody-Rays-MBP15:cli cody$ ./dist/ccloud/darwin_amd64/ccloud -vvvv service-account create zQW1cf7UAlkXjLgPaCxpCRiQCFgeZX8PnpaV99vsyWQdEh9Ih6RzOvB1JXNjNlTgY --description "testing 64 character string"
Error: service name length should not exceed 64 characters.
```

<!--
Open questions / Follow ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
