### PR TITLE
CLI-654: Add back precision to ccloud price list

### DIFF
--- a/internal/cmd/price/command.go
+++ b/internal/cmd/price/command.go
@@ -249,7 +249,21 @@ func filterTable(command *cobra.Command, table map[string]*orgv1.UnitPrices) (ma
 }
 
 func formatPrice(price float64, unit string) string {
-	return fmt.Sprintf("$%v USD/%s", price, unit)
+	priceStr := fmt.Sprintf("%v", price)
+
+	// Require >= 2 digits after the decimal
+	if strings.Contains(priceStr, ".") {
+		// Extend the remainder if needed
+		r := strings.Split(priceStr, ".")
+		for len(r[1]) < 2 {
+			r[1] += "0"
+		}
+		priceStr = strings.Join(r, ".")
+	} else {
+		priceStr += ".00"
+	}
+
+	return fmt.Sprintf("$%s USD/%s", priceStr, unit)
 }
 
 func mapToList(m map[string]string) string {

--- a/internal/cmd/price/command_test.go
+++ b/internal/cmd/price/command_test.go
@@ -125,5 +125,8 @@ func mockPriceCommand(prices map[string]float64) *cobra.Command {
 }
 
 func TestFormatPrice(t *testing.T) {
-	require.Equal(t, "$0.123 USD/GB", formatPrice(0.123, "GB"))
+	require.Equal(t, "$1.00 USD/GB", formatPrice(1, "GB"))
+	require.Equal(t, "$1.20 USD/GB", formatPrice(1.2, "GB"))
+	require.Equal(t, "$1.23 USD/GB", formatPrice(1.23, "GB"))
+	require.Equal(t, "$1.234 USD/GB", formatPrice(1.234, "GB"))
 }


### PR DESCRIPTION
Prices were originally rounded to match the website. The full decimal value is now shown (matters at scale)