### PR TITLE
Fix stderr -> stdout

### DIFF
--- a/cmd/confluent/main.go
+++ b/cmd/confluent/main.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/confluentinc/cli/internal/cmd"
 	pauth "github.com/confluentinc/cli/internal/pkg/auth"
+	pcmd "github.com/confluentinc/cli/internal/pkg/cmd"
 	pversion "github.com/confluentinc/cli/internal/pkg/version"
 )
 
@@ -37,7 +38,7 @@ func main() {
 		if cli == nil {
 			fmt.Fprintln(os.Stderr, err)
 		} else {
-			cli.Command.PrintErrln(err)
+			pcmd.ErrPrintln(cli.Command, err)
 		}
 		if isTest {
 			bincover.ExitCode = 1

--- a/internal/cmd/local/command_current.go
+++ b/internal/cmd/local/command_current.go
@@ -36,6 +36,6 @@ func (c *Command) runCurrentCommand(command *cobra.Command, _ []string) error {
 		return err
 	}
 
-	command.Println(dir)
+	cmd.Println(command, dir)
 	return nil
 }

--- a/internal/cmd/local/command_destroy.go
+++ b/internal/cmd/local/command_destroy.go
@@ -41,7 +41,7 @@ func (c *Command) runDestroyCommand(command *cobra.Command, _ []string) error {
 		return err
 	}
 
-	command.Printf(errors.DestroyDeletingMsg, dir)
+	cmd.Printf(command, errors.DestroyDeletingMsg, dir)
 	if err := c.cc.RemoveCurrentDir(); err != nil {
 		return err
 	}

--- a/internal/cmd/local/command_service.go
+++ b/internal/cmd/local/command_service.go
@@ -232,7 +232,7 @@ func (c *Command) runServiceVersionCommand(command *cobra.Command, _ []string) e
 		return err
 	}
 
-	command.Println(ver)
+	cmd.Println(command, ver)
 	return nil
 }
 
@@ -253,7 +253,7 @@ func (c *Command) startService(command *cobra.Command, service string, configFil
 		return err
 	}
 
-	command.Printf(errors.StartingServiceMsg, writeServiceName(service))
+	cmd.Printf(command, errors.StartingServiceMsg, writeServiceName(service))
 
 	spin := spinner.New()
 	spin.Start()
@@ -434,7 +434,7 @@ func (c *Command) stopService(command *cobra.Command, service string) error {
 		return c.printStatus(command, service)
 	}
 
-	command.Printf(errors.StoppingServiceMsg, writeServiceName(service))
+	cmd.Printf(command, errors.StoppingServiceMsg, writeServiceName(service))
 
 	spin := spinner.New()
 	spin.Start()
@@ -554,7 +554,7 @@ func (c *Command) printStatus(command *cobra.Command, service string) error {
 		status = color.GreenString("UP")
 	}
 
-	command.Printf(errors.ServiceStatusMsg, writeServiceName(service), status)
+	cmd.Printf(command, errors.ServiceStatusMsg, writeServiceName(service), status)
 	return nil
 }
 

--- a/internal/cmd/local/command_service_connect.go
+++ b/internal/cmd/local/command_service_connect.go
@@ -92,8 +92,8 @@ func (c *Command) runConnectConnectorConfigCommand(command *cobra.Command, args 
 			return err
 		}
 
-		command.Printf("Current configuration of %s:\n", connector)
-		command.Println(out)
+		cmd.Printf(command, "Current configuration of %s:\n", connector)
+		cmd.Println(command, out)
 		return nil
 	}
 
@@ -125,7 +125,7 @@ func (c *Command) runConnectConnectorConfigCommand(command *cobra.Command, args 
 		return err
 	}
 
-	command.Println(out)
+	cmd.Println(command, out)
 	return nil
 }
 
@@ -156,7 +156,7 @@ func (c *Command) runConnectConnectorStatusCommand(command *cobra.Command, args 
 			return err
 		}
 
-		command.Println(out)
+		cmd.Println(command, out)
 		return nil
 	}
 
@@ -166,7 +166,7 @@ func (c *Command) runConnectConnectorStatusCommand(command *cobra.Command, args 
 		return err
 	}
 
-	command.Println(out)
+	cmd.Println(command, out)
 	return nil
 }
 
@@ -184,8 +184,8 @@ func NewConnectConnectorListCommand(prerunner cmd.PreRunner) *cobra.Command {
 }
 
 func (c *Command) runConnectConnectorListCommand(command *cobra.Command, _ []string) {
-	command.Println("Bundled Connectors:")
-	command.Println(local.BuildTabbedList(connectors))
+	cmd.Println(command, "Bundled Connectors:")
+	cmd.Println(command, local.BuildTabbedList(connectors))
 }
 
 func NewConnectConnectorLoadCommand(prerunner cmd.PreRunner) *cobra.Command {
@@ -260,7 +260,7 @@ func (c *Command) runConnectConnectorLoadCommand(command *cobra.Command, args []
 		return err
 	}
 
-	command.Println(out)
+	cmd.Println(command, out)
 	return nil
 }
 
@@ -298,9 +298,9 @@ func (c *Command) runConnectConnectorUnloadCommand(command *cobra.Command, args 
 	}
 
 	if len(out) > 0 {
-		command.Println(out)
+		cmd.Println(command, out)
 	} else {
-		command.Println("Success.")
+		cmd.Println(command, "Success.")
 	}
 	return nil
 }
@@ -346,7 +346,7 @@ func (c *Command) runConnectPluginListCommand(command *cobra.Command, _ []string
 		return err
 	}
 
-	command.Printf(errors.AvailableConnectPluginsMsg, out)
+	cmd.Printf(command, errors.AvailableConnectPluginsMsg, out)
 	return nil
 }
 

--- a/internal/cmd/local/command_service_kafka.go
+++ b/internal/cmd/local/command_service_kafka.go
@@ -304,7 +304,7 @@ func (c *Command) runKafkaCommand(command *cobra.Command, args []string, mode st
 	kafkaCommand.Stderr = os.Stderr
 	if mode == "produce" {
 		kafkaCommand.Stdin = os.Stdin
-		command.Println("Exit with Ctrl+D")
+		cmd.Println(command, "Exit with Ctrl+D")
 	}
 
 	kafkaCommand.Env = []string{

--- a/internal/cmd/local/command_services.go
+++ b/internal/cmd/local/command_services.go
@@ -173,7 +173,8 @@ func (c *Command) runServicesListCommand(command *cobra.Command, _ []string) err
 	for i, service := range services {
 		serviceNames[i] = writeServiceName(service)
 	}
-	command.Printf(errors.AvailableServicesMsg, local.BuildTabbedList(serviceNames))
+
+	cmd.Printf(command, errors.AvailableServicesMsg, local.BuildTabbedList(serviceNames))
 	return nil
 }
 
@@ -470,6 +471,6 @@ func (c *Command) notifyConfluentCurrent(command *cobra.Command) error {
 		return err
 	}
 
-	command.Printf(errors.UsingConfluentCurrentMsg, dir)
+	cmd.Printf(command, errors.UsingConfluentCurrentMsg, dir)
 	return nil
 }

--- a/internal/cmd/local/command_version.go
+++ b/internal/cmd/local/command_version.go
@@ -34,6 +34,6 @@ func (c *Command) runVersionCommand(command *cobra.Command, _ []string) error {
 		return err
 	}
 
-	command.Printf("%s: %s\n", flavor, version)
+	cmd.Printf(command, "%s: %s\n", flavor, version)
 	return nil
 }


### PR DESCRIPTION
`confluent local version` and `confluent local current` were incorrectly printing to stderr instead of stdout. This fixes those commands and others.

```
bstrauch@MacBook-Pro-2 darwin_amd64 % ./confluent local current 2> /dev/null
/var/folders/sf/w83_wg7906x4t8l3z7fz11xm0000gp/T/confluent.544908
bstrauch@MacBook-Pro-2 darwin_amd64 % ./confluent local version 2> /dev/null
Confluent Platform: 5.5.0
```

https://confluent.slack.com/archives/C010Y0EP5MZ/p1596632640186700?thread_ts=1595594591.163100&cid=C010Y0EP5MZ