### PR TITLE
Fix Packaging

### DIFF
--- a/debian/Makefile
+++ b/debian/Makefile
@@ -38,6 +38,7 @@ archive: install
 apply-patches: $(wildcard debian/patches/*)
 ifeq ($(APPLY_PATCHES),yes)
 	git reset --hard HEAD
+	rm -f Makefile # Makefile must be deleted before standard_build_layout.patch is applied
 	cat debian/patches/series | xargs -iPATCH bash -c 'patch -p1 < debian/patches/PATCH'
 endif
 


### PR DESCRIPTION
Fix .DEB packaging: Delete Makefile before applying patch (which creates a new Makefile)