### PR TITLE
Update connectors for 6.0.x

### DIFF
--- a/internal/cmd/local/command_service_connect.go
+++ b/internal/cmd/local/command_service_connect.go
@@ -18,13 +18,9 @@ import (
 )
 
 var connectors = []string{
-	"elasticsearch-sink",
 	"file-sink",
 	"file-source",
-	"hdfs-sink",
-	"jdbc-sink",
-	"jdbc-source",
-	"s3-sink",
+	"replicator",
 }
 
 func NewConnectConnectorCommand(prerunner cmd.PreRunner) *cobra.Command {


### PR DESCRIPTION
The bundled connectors have changed for 6.0.x

```
$ confluent local services connect connector list 
The local commands are intended for a single-node development environment only,
NOT for production usage. https://docs.confluent.io/current/cli/index.html

Bundled Connectors:
  file-sink
  file-source
  replicator
```
