### PR TITLE
Add newline to delete acls message

### DIFF
--- a/internal/pkg/errors/strings.go
+++ b/internal/pkg/errors/strings.go
@@ -53,7 +53,7 @@ const (
 	UpdatedLinkMsg = "Updated cluster link \"%s\".\n"
 
 	// kafka acl commands
-	DeletedACLsMsg = "Deleted ACLs."
+	DeletedACLsMsg = "Deleted ACLs.\n"
 
 	// ksql commands
 	EndPointNotPopulatedMsg   = "Endpoint not yet populated. To obtain the endpoint, use `ccloud ksql app describe`."


### PR DESCRIPTION
Small thing I noticed while playing with ACLs, that we were missing a newline here and so printouts were not rendered well.