### PR TITLE
Remove redundant code that was getting MDS token twice

### DIFF
--- a/internal/cmd/auth/command_login.go
+++ b/internal/cmd/auth/command_login.go
@@ -8,7 +8,6 @@ import (
 
 	orgv1 "github.com/confluentinc/cc-structs/kafka/org/v1"
 	"github.com/confluentinc/ccloud-sdk-go"
-	mds "github.com/confluentinc/mds-sdk-go/mdsv1"
 	"github.com/spf13/cobra"
 
 	"github.com/confluentinc/cli/internal/pkg/analytics"


### PR DESCRIPTION
Credit: https://confluent.slack.com/archives/C9Y6NAM6X/p1598040290009300?thread_ts=1597917596.001000&cid=C9Y6NAM6X

The auth token is obtained from MDS a few lines above this.