### PR TITLE
Fixing RPM and Archives packaging bug

### DIFF
--- a/debian/Makefile
+++ b/debian/Makefile
@@ -38,7 +38,6 @@ archive: install
 apply-patches: $(wildcard debian/patches/*)
 ifeq ($(APPLY_PATCHES),yes)
 	git reset --hard HEAD
-	rm -f Makefile # Makefile must be deleted before standard_build_layout.patch is applied
 	cat debian/patches/series | xargs -iPATCH bash -c 'patch -p1 < debian/patches/PATCH'
 endif
 


### PR DESCRIPTION
<!--
Is there any breaking changes?  If so this is a major release, make sure '#major' is in at least one
commit message to get CI to bump the major.  This will prevent automatic down stream dependency
bumping / consuming.  For more information about semantic versioning see: https://semver.org/


Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
Checklist
---
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok
   
2. Did you add/update any commands that accept secrets as args/flags?
   * no: ok

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->
Previous change to `debian` folder successfully released deb files but failed rpm and archives instead.
This could be because the script deletes Makefile when the patch is trying to edit Makefile leading to patch error.
Removing the `rm Makefile` line to fix this.

References
----------
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test&Review
------------

<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

<!--
Open questions / Follow ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
