### PR TITLE
CLI-716: add server-side completion to 'ccloud schema-registry subjec…

### DIFF
--- a/internal/cmd/command.go
+++ b/internal/cmd/command.go
@@ -149,7 +149,7 @@ func NewConfluentCommand(cliName string, isTest bool, ver *pversion.Version, net
 		cli.AddCommand(ksql.New(cliName, prerunner, serverCompleter))
 		cli.AddCommand(price.New(prerunner))
 		cli.AddCommand(ps1.New(cliName, prerunner, &pps1.Prompt{}, logger))
-		cli.AddCommand(schemaregistry.New(cliName, prerunner, nil, logger)) // Exposed for testing
+		cli.AddCommand(schemaregistry.New(cliName, prerunner, nil, logger, serverCompleter)) // Exposed for testing
 		serviceAccountCmd := serviceaccount.New(prerunner)
 		serverCompleter.AddCommand(serviceAccountCmd)
 		cli.AddCommand(serviceAccountCmd.Command)
@@ -164,9 +164,11 @@ func NewConfluentCommand(cliName string, isTest bool, ver *pversion.Version, net
 		cli.AddCommand(iam.New(cliName, prerunner))
 		// Never uses it under "confluent", so a nil ServerCompleter is fine.
 		cli.AddCommand(kafka.New(isAPIKeyCredential(cfg), cliName, prerunner, logger.Named("kafka"), ver.ClientID, nil))
+		// Never uses it under "confluent", so a nil ServerCompleter is fine.
 		cli.AddCommand(ksql.New(cliName, prerunner, nil))
 		cli.AddCommand(local.New(prerunner))
-		cli.AddCommand(schemaregistry.New(cliName, prerunner, nil, logger))
+		// Never uses it under "confluent", so a nil ServerCompleter is fine.
+		cli.AddCommand(schemaregistry.New(cliName, prerunner, nil, logger, nil))
 		cli.AddCommand(secret.New(resolver, secrets.NewPasswordProtectionPlugin(logger)))
 	}
 	return command, nil

--- a/internal/cmd/schema-registry/command_cluster_test.go
+++ b/internal/cmd/schema-registry/command_cluster_test.go
@@ -91,7 +91,7 @@ func (suite *ClusterTestSuite) newCMD() *cobra.Command {
 		SchemaRegistry: suite.srMock,
 		Metrics:        suite.metrics,
 	}
-	cmd := New("ccloud", cliMock.NewPreRunnerMock(client, nil, suite.conf), suite.srClientMock, suite.logger)
+	cmd := New("ccloud", cliMock.NewPreRunnerMock(client, nil, suite.conf), suite.srClientMock, suite.logger, &cliMock.ServerSideCompleter{})
 	return cmd
 }
 

--- a/internal/cmd/schema-registry/command_schema_test.go
+++ b/internal/cmd/schema-registry/command_schema_test.go
@@ -82,7 +82,7 @@ func (suite *SchemaTestSuite) newCMD() *cobra.Command {
 	client := &ccloud.Client{
 		SchemaRegistry: suite.srMothershipMock,
 	}
-	cmd := New(suite.conf.CLIName, cliMock.NewPreRunnerMock(client, nil, suite.conf), suite.srClientMock, suite.conf.Logger)
+	cmd := New(suite.conf.CLIName, cliMock.NewPreRunnerMock(client, nil, suite.conf), suite.srClientMock, suite.conf.Logger, &cliMock.ServerSideCompleter{})
 	return cmd
 }
 


### PR DESCRIPTION
…t' command

Signed-off-by: Lev Zemlyanov <lev@confluent.io>

<!--
Is there any breaking changes?  If so this is a major release, make sure '#major' is in at least one
commit message to get CI to bump the major.  This will prevent automatic down stream dependency
bumping / consuming.  For more information about semantic versioning see: https://semver.org/


Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
Checklist
---
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok
   * no: DO NOT MERGE until the required functionalites are live in prod  
   
2. Did you add/update any commands that accept secrets as args/flags?
   * yes: did you update `secretCommandFlags` and/or `secretCommandArgs` in [internal/pkg/analytics/analytics.go](https://github.com/confluentinc/cli/pull/325/files#diff-2d0a5a6a592890b6dff2d6f891316b82R28)
   * no: ok

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->

References
----------
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test&Review
------------

<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

<!--
Open questions / Follow ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
