### PR TITLE
KC-1133: modify link creation response message in cli when `dry-run` is passed in

### DIFF
--- a/internal/cmd/kafka/command_link.go
+++ b/internal/cmd/kafka/command_link.go
@@ -230,7 +230,11 @@ func (c *linkCommand) create(cmd *cobra.Command, args []string) error {
 	err = c.Client.Kafka.CreateLink(context.Background(), cluster, sourceLink, createOptions)
 
 	if err == nil {
-		pcmd.Printf(cmd, errors.CreatedLinkMsg, linkName)
+		msg := errors.CreatedLinkMsg
+		if validateOnly {
+			msg = errors.DryRunPrefix + msg
+		}
+		pcmd.Printf(cmd, msg, linkName)
 	}
 
 	return err

--- a/internal/pkg/errors/strings.go
+++ b/internal/pkg/errors/strings.go
@@ -52,6 +52,7 @@ const (
 	StoppedTopicMirrorMsg  = "Stopped mirroring for topic \"%s\".\n"
 
 	// kafka link commands
+	DryRunPrefix   = "[DRY RUN] "
 	DeletedLinkMsg = "Deleted cluster link \"%s\".\n"
 	CreatedLinkMsg = "Created cluster link \"%s\".\n"
 	UpdatedLinkMsg = "Updated cluster link \"%s\".\n"


### PR DESCRIPTION
Checklist
---
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * **yes**: ok
   * ~no: DO NOT MERGE until the required functionalites are live in prod~  
   
2. Did you add/update any commands that accept secrets as args/flags?
   * ~yes: did you update `secretCommandFlags` and/or `secretCommandArgs` in [internal/pkg/analytics/analytics.go](https://github.com/confluentinc/cli/pull/325/files#diff-2d0a5a6a592890b6dff2d6f891316b82R28)~
   * **no**: ok

What
----
KC-1133: modify link creation response message in cli when `dry-run` is passed in

References
----------
KC-1133

<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test&Review
------------

<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

<!--
Open questions / Follow ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
