### PR TITLE
CLI-406: Support self-signed certs for confluent cluster describe

### DIFF
--- a/internal/cmd/auth/command_test.go
+++ b/internal/cmd/auth/command_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/confluentinc/cli/internal/pkg/log"
 	pmock "github.com/confluentinc/cli/internal/pkg/mock"
 	"github.com/confluentinc/cli/internal/pkg/netrc"
+	"github.com/confluentinc/cli/internal/pkg/utils"
 	cliMock "github.com/confluentinc/cli/mock"
 )
 
@@ -561,7 +562,7 @@ func getNewLoginCommandForSelfSignedCertTest(req *require.Assertions, cfg *v3.Co
 	}
 	mdsClientManager := &cliMock.MockMDSClientManager{
 		GetMDSClientFunc: func(url string, caCertPath string, logger *log.Logger) (client *mds.APIClient, e error) {
-			mdsClient.GetConfig().HTTPClient, err = pauth.SelfSignedCertClient(certReader, logger)
+			mdsClient.GetConfig().HTTPClient, err = utils.SelfSignedCertClient(certReader, logger)
 			if err != nil {
 				return nil, err
 			}

--- a/internal/cmd/command.go
+++ b/internal/cmd/command.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"net/http"
 	"os"
 
 	"github.com/jonboulle/clockwork"
@@ -168,7 +167,7 @@ func NewConfluentCommand(cliName string, isTest bool, ver *pversion.Version, net
 		}
 	} else if cliName == "confluent" {
 		cli.AddCommand(auditlog.New(prerunner))
-		cli.AddCommand(cluster.New(prerunner, cluster.NewScopedIdService(&http.Client{}, ver.UserAgent, logger)))
+		cli.AddCommand(cluster.New(prerunner, cluster.NewScopedIdService(ver.UserAgent, logger)))
 		cli.AddCommand(connect.New(prerunner))
 		cli.AddCommand(iam.New(cliName, prerunner))
 		// Never uses it under "confluent", so a nil ServerCompleter is fine.

--- a/internal/pkg/auth/auth_token_handler.go
+++ b/internal/pkg/auth/auth_token_handler.go
@@ -86,10 +86,7 @@ func (a *AuthTokenHandlerImpl) refreshCCloudSSOToken(client *ccloud.Client, refr
 }
 
 func (a *AuthTokenHandlerImpl) GetConfluentToken(mdsClient *mds.APIClient, credentials *Credentials) (string, error) {
-	ctx := context.Background()
-	if a.logger.GetLevel() == log.TRACE {
-		ctx = utils.HTTPTracedContext(ctx, a.logger)
-	}
+	ctx := utils.GetContext(a.logger)
 	basicContext := context.WithValue(ctx, mds.ContextBasicAuth, mds.BasicAuth{UserName: credentials.Username, Password: credentials.Password})
 	resp, _, err := mdsClient.TokensAndAuthenticationApi.GetToken(basicContext)
 	if err != nil {

--- a/internal/pkg/auth/mds_client.go
+++ b/internal/pkg/auth/mds_client.go
@@ -2,13 +2,10 @@
 package auth
 
 import (
-	"net/http"
-	"os"
-	"path/filepath"
-
 	mds "github.com/confluentinc/mds-sdk-go/mdsv1"
 
 	log "github.com/confluentinc/cli/internal/pkg/log"
+	"github.com/confluentinc/cli/internal/pkg/utils"
 )
 
 // Made it an interface so that we can inject MDS client for testing through GetMDSClient
@@ -26,37 +23,15 @@ func (m *MDSClientManagerImpl) GetMDSClient(url string, caCertPath string, logge
 	if caCertPath != "" {
 		logger.Debugf("CA certificate path was specified.  Note, the set of supported ciphers for the CLI can be found at https://golang.org/pkg/crypto/tls/#pkg-constants")
 		var err error
-		mdsConfig.HTTPClient, err = getSelfSignedCertClient(caCertPath, logger)
+
+		mdsConfig.HTTPClient, err = utils.SelfSignedCertClientFromPath(caCertPath, logger)
 		if err != nil {
 			return nil, err
 		}
 	} else {
-		mdsConfig.HTTPClient = DefaultClient()
+		mdsConfig.HTTPClient = utils.DefaultClient()
 	}
 	mdsClient := mds.NewAPIClient(mdsConfig)
 	mdsClient.ChangeBasePath(url)
 	return mdsClient, nil
-}
-
-func getSelfSignedCertClient(caCertPath string, logger *log.Logger) (*http.Client, error) {
-	caCertPath, err := filepath.Abs(caCertPath)
-	if err != nil {
-		return nil, err
-	}
-
-	logger.Debugf("Attempting to load certificate from absolute path %s", caCertPath)
-	certReader, err := os.Open(caCertPath)
-	if err != nil {
-		return nil, err
-	}
-	defer certReader.Close()
-	logger.Tracef("Successfully read CA certificate.")
-
-	logger.Tracef("Attempting to initialize HTTP client using certificate")
-	client, err := SelfSignedCertClient(certReader, logger)
-	if err != nil {
-		return nil, err
-	}
-	logger.Tracef("Successfully loaded certificate from %s", caCertPath)
-	return client, nil
 }

--- a/internal/pkg/cmd/prerunner.go
+++ b/internal/pkg/cmd/prerunner.go
@@ -422,6 +422,9 @@ func (r *PreRun) setConfluentClient(cliCmd *AuthenticatedCLICommand) error {
 
 func (r *PreRun) createMDSClient(ctx *DynamicContext, ver *version.Version) *mds.APIClient {
 	mdsConfig := mds.NewConfiguration()
+	if r.Logger.GetLevel() == log.DEBUG || r.Logger.GetLevel() == log.TRACE {
+		mdsConfig.Debug = true
+	}
 	if ctx == nil {
 		return mds.NewAPIClient(mdsConfig)
 	}
@@ -436,14 +439,14 @@ func (r *PreRun) createMDSClient(ctx *DynamicContext, ver *version.Version) *mds
 	caCertFile, err := os.Open(caCertPath)
 	if err == nil {
 		defer caCertFile.Close()
-		mdsConfig.HTTPClient, err = pauth.SelfSignedCertClient(caCertFile, r.Logger)
+		mdsConfig.HTTPClient, err = utils.SelfSignedCertClient(caCertFile, r.Logger)
 		if err != nil {
 			r.Logger.Warnf("Unable to load certificate from %s. %s. Resulting SSL errors will be fixed by logging in with the --ca-cert-path flag.", caCertPath, err.Error())
-			mdsConfig.HTTPClient = pauth.DefaultClient()
+			mdsConfig.HTTPClient = utils.DefaultClient()
 		}
 	} else {
 		r.Logger.Warnf("Unable to load certificate from %s. %s. Resulting SSL errors will be fixed by logging in with the --ca-cert-path flag.", caCertPath, err.Error())
-		mdsConfig.HTTPClient = pauth.DefaultClient()
+		mdsConfig.HTTPClient = utils.DefaultClient()
 
 	}
 	return mds.NewAPIClient(mdsConfig)
@@ -551,6 +554,9 @@ func (r *PreRun) warnIfConfluentLocal(cmd *cobra.Command) {
 
 func (r *PreRun) createMDSv2Client(ctx *DynamicContext, ver *version.Version) *mdsv2alpha1.APIClient {
 	mdsv2Config := mdsv2alpha1.NewConfiguration()
+	if r.Logger.GetLevel() == log.DEBUG || r.Logger.GetLevel() == log.TRACE {
+		mdsv2Config.Debug = true
+	}
 	if ctx == nil {
 		return mdsv2alpha1.NewAPIClient(mdsv2Config)
 	}
@@ -565,14 +571,14 @@ func (r *PreRun) createMDSv2Client(ctx *DynamicContext, ver *version.Version) *m
 	caCertFile, err := os.Open(caCertPath)
 	if err == nil {
 		defer caCertFile.Close()
-		mdsv2Config.HTTPClient, err = pauth.SelfSignedCertClient(caCertFile, r.Logger)
+		mdsv2Config.HTTPClient, err = utils.SelfSignedCertClient(caCertFile, r.Logger)
 		if err != nil {
 			r.Logger.Warnf("Unable to load certificate from %s. %s. Resulting SSL errors will be fixed by logging in with the --ca-cert-path flag.", caCertPath, err.Error())
-			mdsv2Config.HTTPClient = pauth.DefaultClient()
+			mdsv2Config.HTTPClient = utils.DefaultClient()
 		}
 	} else {
 		r.Logger.Warnf("Unable to load certificate from %s. %s. Resulting SSL errors will be fixed by logging in with the --ca-cert-path flag.", caCertPath, err.Error())
-		mdsv2Config.HTTPClient = pauth.DefaultClient()
+		mdsv2Config.HTTPClient = utils.DefaultClient()
 
 	}
 	return mdsv2alpha1.NewAPIClient(mdsv2Config)

--- a/internal/pkg/utils/http_tracer.go
+++ b/internal/pkg/utils/http_tracer.go
@@ -10,8 +10,16 @@ import (
 	"github.com/confluentinc/cli/internal/pkg/log"
 )
 
-// HTTPTracedContext returns a context.Context that verbosely traces many HTTP events that occur during the request
-func HTTPTracedContext(ctx context.Context, logger *log.Logger) context.Context {
+func GetContext(logger *log.Logger) context.Context {
+	ctx := context.Background()
+	if logger.GetLevel() == log.TRACE {
+		ctx = httpTracedContext(ctx, logger)
+	}
+	return ctx
+}
+
+// httpTracedContext returns a context.Context that verbosely traces many HTTP events that occur during the request
+func httpTracedContext(ctx context.Context, logger *log.Logger) context.Context {
 	trace := &httptrace.ClientTrace{
 		DNSStart: func(dnsInfo httptrace.DNSStartInfo) {
 			logger.Tracef("DNS Start; Info: %+v\n", dnsInfo)


### PR DESCRIPTION
<!--
Is there any breaking changes?  If so this is a major release, make sure '#major' is in at least one
commit message to get CI to bump the major.  This will prevent automatic down stream dependency
bumping / consuming.  For more information about semantic versioning see: https://semver.org/


Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
Checklist
---
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok
   * ~~no: DO NOT MERGE until the required functionalites are live in prod~~
   
2. Did you add/update any commands that accept secrets as args/flags?
   * ~~yes: did you update `secretCommandFlags` and/or `secretCommandArgs` in [internal/pkg/analytics/analytics.go](https://github.com/confluentinc/cli/pull/325/files#diff-2d0a5a6a592890b6dff2d6f891316b82R28)~~
   * no: ok

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->
* Adds self-signed cert support for the snowflake `confluent cluster describe` command, which doesn't use any of the existing clients.
* Refactored the self-signed certs reader methods and get traced context methods so I could reuse them in the cluster package.
* Added trace dump for the cluster describe command.

References
----------
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->
https://confluentinc.atlassian.net/browse/CLI-406

Test&Review
------------
<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->
Ran a test env with ssl enabled using https://github.com/confluentinc/cp-test-env-manager with yml file:

```
% cat cp-testenv.yml
version: 2
owner: athirunar@confluent.io
install:
  version: '6.0.0'
  staging: yes
rbac: yes
ssl: yes
ttl: 2
main_cluster:
    services:
      zookeeper: 1
      kafka: zookeeper
```

Verified that `confluent cluster describe` works against it.

```
% dist/confluent/confluent_darwin_amd64/confluent cluster describe --url https://ec2-35-164-150-167.us-west-2.compute.amazonaws.com:8090
Error: Get "https://ec2-35-164-150-167.us-west-2.compute.amazonaws.com:8090/v1/metadata/id": x509: certificate signed by unknown authority

% dist/confluent/confluent_darwin_amd64/confluent cluster describe --url https://ec2-35-164-150-167.us-west-2.compute.amazonaws.com:8090 --ca-cert-path ~/cp-testenv/certs/snakeoil-ca-1.crt
Confluent Resource Name: mdpHPwIlRwO27ikKHedOcw

Scope:
      Type      |           ID
+---------------+------------------------+
  kafka-cluster | mdpHPwIlRwO27ikKHedOcw

% dist/confluent/confluent_darwin_amd64/confluent cluster describe --url https://ec2-35-164-150-167.us-west-2.compute.amazonaws.com:8090 --ca-cert-path ~/junk/cp-testenv/certs/snakeoil-ca-1.crt -vvvv
...
2020-12-04T19:02:43.071-0600 [TRACE] TLSHandshakeStart
2020-12-04T19:02:43.229-0600 [TRACE] TLSHandShakeDone; Info:

(tls.ConnectionState) {
 Version: (uint16) 771,
...
2020-12-04T19:02:43.460-0600 [TRACE] Got Conn; Info: {Conn:0xc000710a80 Reused:false WasIdle:false IdleTime:0s}

Confluent Resource Name: mdpHPwIlRwO27ikKHedOcw

Scope:
      Type      |           ID
+---------------+------------------------+
  kafka-cluster | mdpHPwIlRwO27ikKHedOcw
```

<!--
Open questions / Follow ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
