### PR TITLE
[CLI-841] Add new version to all old branches' version picker when a release is done

### DIFF
--- a/mk-files/docs.mk
+++ b/mk-files/docs.mk
@@ -11,6 +11,9 @@ else ifeq ($(BUMP), patch)
 DOCS_BASE_BRANCH=$(BUMPED_MINOR_BRANCH)
 endif
 
+OLDEST_BRANCH_CCLOUD=1.20.1-post
+OLDEST_BRANCH_CONFLUENT=1.16.3-post
+
 NEXT_MINOR_VERSION = $(word 1,$(split_version)).$(shell expr $(word 2,$(split_version)) + 1).0
 SHORT_NEXT_MINOR_VERSION = $(word 1,$(split_version)).$(shell expr $(word 2,$(split_version)) + 1)
 CURRENT_SHORT_MINOR_VERSION = $(word 1,$(split_version)).$(word 2,$(split_version))
@@ -124,6 +127,19 @@ update-settings-and-conf:
 		sed -i '' "s/^release = '.*'/release = \'$(CLEAN_VERSION)\'/g" conf.py && \
 		sed -i '' "s/docVersions = \[/&\n   '$(CLEAN_VERSION)',/" _local-static/js/script.js && \
 		git commit -am "chore: update settings.sh, conf.py, and script.js due to $(CLEAN_VERSION) release" && \
+		git push && \
+		cd .. ; \
+	done
+	for repo in $(CCLOUD_DOCS_DIR) $(CONFLUENT_DOCS_DIR) ; do \
+		oldest_branch=$(OLDEST_BRANCH_CONFLUENT) && \
+		if [[ "$(CCLOUD_DOCS_DIR)" == "$${repo}" ]]; then \
+			oldest_branch=$(OLDEST_BRANCH_CCLOUD); \
+		fi ; \
+		cd $${repo} && \
+		git fetch && \
+		git checkout $${oldest_branch} && \
+		sed -i '' "s/docVersions = \[/&\n   '$(CLEAN_VERSION)',/" _local-static/js/script.js && \
+		git commit -am "chore: add new version $(CLEAN_VERSION) to all old branches' version pickers" && \
 		git push && \
 		cd .. ; \
 	done


### PR DESCRIPTION
The docs tooling was adding the latest version to the version picker on the docs site, but only for the latest version.  I.e. if you switched to an old version of the docs, you couldn't get back to the latest version of the docs without using browser back button or hacking the URL.  This PR fixes that issue; when a new version is released, all old branches' version pickers are updated to have the new version.

The commit this code generates specifically does _not_ use "[ci skip]" unlike those in CLI-842, because we actually _want_ Jenkins to do a pint merge to propagate this change all the way through the branches.

I tested that this won't cause merge conflicts / pint merge issues by manually making this type of commit (without [ci skip]) for v1.23.0, and it looks like Jenkins updated everything successfully (pint merge docs-ccloud-cli and pint merge docs-confluent-cli both returned clean results).

```
DavidHydesMBP15:cli david.hyde$ pint merge docs-ccloud-cli
Checking out docs-ccloud-cli [/var/tmp/tmpnqwrkst4]
Checking for unmerged commits
  from 1.20.1-post to 1.21.1-post
  from 1.21.1-post to 1.22.0-post
  from 1.22.0-post to 1.23.0-post
  from 1.20.1-post to 1.20.x
  from 1.21.1-post to 1.21.x
  from 1.22.0-post to 1.22.x
  from 1.23.0-post to 1.23.x
  from 1.20.x to 1.21.x
  from 1.21.x to 1.22.x
  from 1.22.x to 1.23.x
  from 1.23.x to master
All good -- nothing to merge!
DavidHydesMBP15:cli david.hyde$ pint merge docs-confluent-cli
Checking out docs-confluent-cli [/var/tmp/tmpbao3vnu4]
Checking for unmerged commits
  from 1.16.3-post to 1.20.1-post
  from 1.20.1-post to 1.21.1-post
  from 1.21.1-post to 1.22.0-post
  from 1.22.0-post to 1.23.0-post
  from 1.16.3-post to 1.16.x
  from 1.20.1-post to 1.20.x
  from 1.21.1-post to 1.21.x
  from 1.22.0-post to 1.22.x
  from 1.23.0-post to 1.23.x
  from 1.16.x to 1.20.x
  from 1.20.x to 1.21.x
  from 1.21.x to 1.22.x
  from 1.22.x to 1.23.x
  from 1.23.x to master
All good -- nothing to merge!
DavidHydesMBP15:cli david.hyde$ 
```