### PR TITLE
parse through flags names for all commands in order to find secret flags

### DIFF
--- a/internal/pkg/analytics/analytics.go
+++ b/internal/pkg/analytics/analytics.go
@@ -440,16 +440,8 @@ func isHelpFlag(flag string) bool {
 }
 
 func apiKeyStoreSecretHandler(args []string) []string {
-	if len(args) < 2 {
-		return args
-	}
-	if !(args[1] == "-" || strings.HasPrefix(args[1], "@")) {
-		argsCopy := make([]string, len(args))
-		copy(argsCopy, args)
-		argsCopy[1] = SecretValueString
-		return argsCopy
-	}
-	return args
+	emptyArgs := []string{"<args>"}
+	return emptyArgs
 }
 
 func SendAnalyticsAndLog(cmd *cobra.Command, args []string, err error, client Client, logger *log.Logger) {

--- a/internal/pkg/analytics/analytics_test.go
+++ b/internal/pkg/analytics/analytics_test.go
@@ -611,13 +611,7 @@ func (suite *AnalyticsTestSuite) TestApiKeyStoreSecretHandler() {
 
 		args, ok := (page.Properties[analytics.ArgsPropertiesKey]).([]string)
 		req.True(ok)
-		req.Equal(2, len(args))
-		req.Equal(apiKey, args[0])
-		if secondArg == apiSecret {
-			req.Equal(analytics.SecretValueString, args[1])
-		} else {
-			req.Equal(secondArg, args[1])
-		}
+		req.Equal([]string{"<args>"}, args)
 		suite.output = make([]segment.Message, 0)
 	}
 }


### PR DESCRIPTION
initially we were just going through the flags of commands included in the list of commands that had secret flags which was not exhaustive. Now we go through the flags for each command (no command list, just a flag list)