### PR TITLE
Remove docs task to update tools-autotasks repo -- apparently no longer used

### DIFF
--- a/mk-files/docs.mk
+++ b/mk-files/docs.mk
@@ -68,7 +68,7 @@ clean-docs:
 # NB2: If a patch release just happened, $(DOCS_BASE_BRANCH) will still be accurate.
 # Warning: BUMP must be set to patch if you are releasing docs for a patch release that was just done
 .PHONY: release-docs
-release-docs: clone-docs-repos cut-docs-branches update-settings-and-conf update-tools-autotasks
+release-docs: clone-docs-repos cut-docs-branches update-settings-and-conf
 
 .PHONY: cut-docs-branches
 cut-docs-branches:
@@ -144,25 +144,3 @@ update-settings-and-conf:
 		cd .. ; \
 	done
 
-.PHONY: update-tools-autotasks
-update-tools-autotasks:
-	$(eval TOOLS_AUTOTASKS_DIR=$(TMP_BASE)/tools-autotasks)
-	git clone git@github.com:confluentinc/tools-autotasks.git $(TOOLS_AUTOTASKS_DIR)
-	if [[ "$(BUMP)" != "patch" ]]; then \
-		cd $(TOOLS_AUTOTASKS_DIR) && \
-		git checkout monitor-docs-pipeline-dev && \
-		sed -i '' "$$(sed -n  '\|docs-ccloud-cli|=' Jenkinsfile) s/.$$/, \"$(MINOR_BRANCH)\"\]/" Jenkinsfile && \
-		sed -i '' "$$(sed -n  '\|docs-confluent-cli|=' Jenkinsfile) s/.$$/, \"$(MINOR_BRANCH)\"\]/" Jenkinsfile && \
-		git checkout -b cli-update-$(MINOR_BRANCH) && \
-		git commit -am "[ci skip] chore: update Jenkinsfile for CLI branch $(MINOR_BRANCH)" && \
-		git push -u origin cli-update-$(MINOR_BRANCH) && \
-		hub pull-request -b monitor-docs-pipeline-dev -m "chore: update Jenkinsfile for CLI branch $(MINOR_BRANCH)" ; \
-	fi
-	cd $(TOOLS_AUTOTASKS_DIR) && \
-	git checkout monitor-docs-pipeline-pre-prod && \
-	sed -i '' "$$(sed -n  '\|docs-ccloud-cli|=' Jenkinsfile) s/.$$/, \"$(CLEAN_VERSION)-post\"\]/" Jenkinsfile && \
-	sed -i '' "$$(sed -n  '\|docs-confluent-cli|=' Jenkinsfile) s/.$$/, \"$(CLEAN_VERSION)-post\"\]/" Jenkinsfile && \
-	git checkout -b cli-update-$(CLEAN_VERSION)-post && \
-	git commit -am "[ci skip] chore: update Jenkinsfile for CLI branch $(CLEAN_VERSION)-post" && \
-	git push -u origin cli-update-$(CLEAN_VERSION)-post && \
-	hub pull-request -b monitor-docs-pipeline-pre-prod -m "chore: update Jenkinsfile for CLI branch $(CLEAN_VERSION)-post"


### PR DESCRIPTION
This caused an error (non-blocking) in the release pipeline for 1.24.0.  Seems like the Jenkinsfiles we were updating are just gone.  And the docs all got updated properly for 1.24.0; so evidently we just no longer need this.