### PR TITLE
CIAM-340: CLI : Deleting rolebinding without `--role` in CLI gives 404

### DIFF
--- a/internal/cmd/iam/command_rolebinding.go
+++ b/internal/cmd/iam/command_rolebinding.go
@@ -218,6 +218,7 @@ func (c *rolebindingCommand) init() {
 	deleteCmd.Flags().SortFlags = false
 	check(createCmd.MarkFlagRequired("role"))
 	check(deleteCmd.MarkFlagRequired("principal"))
+	check(deleteCmd.MarkFlagRequired("role"))
 	c.AddCommand(deleteCmd)
 }
 

--- a/test/fixtures/output/iam-rolebinding/ccloud-iam-rolebinding-delete-missing-role.golden
+++ b/test/fixtures/output/iam-rolebinding/ccloud-iam-rolebinding-delete-missing-role.golden
@@ -1,0 +1,16 @@
+Error: required flag(s) "role" not set
+Usage:
+  ccloud iam rolebinding delete [flags]
+
+Flags:
+      --role string            REQUIRED: Role name of the existing role binding.
+      --principal string       REQUIRED: Qualified principal name associated with the role binding.
+      --cloud-cluster string   Cloud cluster ID for the role binding.
+      --environment string     Environment ID for scope of rolebinding delete.
+      --current-env            Use current environment ID for scope.
+  -o, --output string          Specify the output format as "human", "json", or "yaml". (default "human")
+
+Global Flags:
+  -h, --help            Show help for this command.
+  -v, --verbose count   Increase verbosity (-v for warn, -vv for info, -vvv for debug, -vvvv for trace).
+

--- a/test/iam_rolebinding_test.go
+++ b/test/iam_rolebinding_test.go
@@ -54,6 +54,13 @@ func (s *CLITestSuite) TestCcloudIAMRoleBindingCRUD() {
 			fixture:     "iam-rolebinding/ccloud-iam-rolebinding-missing-environment.golden",
 			wantErrCode: 1,
 		},
+		{
+			name:        "ccloud iam rolebinding delete cluster-name, invalid use case: missing role",
+			args:        "iam rolebinding delete --principal User:u-11aaa --current-env --cloud-cluster lkc-1111aaa",
+			fixture:     "iam-rolebinding/ccloud-iam-rolebinding-delete-missing-role.golden",
+			wantErrCode: 1,
+
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
- Marked the role field as manadtory for delete command
- Unit Test

<!--
Is there any breaking changes?  If so this is a major release, make sure '#major' is in at least one
commit message to get CI to bump the major.  This will prevent automatic down stream dependency
bumping / consuming.  For more information about semantic versioning see: https://semver.org/


Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
Checklist
---
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok
   * no: DO NOT MERGE until the required functionalites are live in prod  
   
2. Did you add/update any commands that accept secrets as args/flags?
   * yes: did you update `secretCommandFlags` and/or `secretCommandArgs` in [internal/pkg/analytics/analytics.go](https://github.com/confluentinc/cli/pull/325/files#diff-2d0a5a6a592890b6dff2d6f891316b82R28)
   * no: ok

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->

References
----------
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test&Review
------------

<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

<!--
Open questions / Follow ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
