### PR TITLE
use mds url and ca cert env vars with login command

### DIFF
--- a/internal/pkg/errors/error_message.go
+++ b/internal/pkg/errors/error_message.go
@@ -29,6 +29,8 @@ const (
 	UnableToSaveUserAuthErrorMsg     = "unable to save user authentication"
 	NoEnvironmentFoundErrorMsg       = "no environment found for authenticated user"
 	NotUsernameAuthenticatedErrorMsg = "user not username authenticated has no access to ccloud client"
+	NoURLFlagOrMdsEnvVarErrorMsg	 = "no mds url passed"
+	NoURLFlagOrMdsEnvVarSuggestions	 = "Use the `--url` flag or set the \"CONFLUENT_MDS_URL\" environment variable."
 
 	// confluent cluster commands
 	FetchClusterMetadataErrorMsg     = "unable to fetch cluster metadata: %s - %s"


### PR DESCRIPTION
<!--
Is there any breaking changes?  If so this is a major release, make sure '#major' is in at least one
commit message to get CI to bump the major.  This will prevent automatic down stream dependency
bumping / consuming.  For more information about semantic versioning see: https://semver.org/


Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
Checklist
---
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok
   
2. Did you add/update any commands that accept secrets as args/flags?
   * no: ok

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->
using CONFLUENT_MDS_URL and CONFLUENT_CA_CERT_PATH with login command (before they were only checked for auto-login via prerun). Flag values take precedence.

References
----------
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->
https://confluentinc.atlassian.net/browse/ESCALATION-4812

Test&Review
------------

<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->
manually against cp-demo
unit tests

<!--
Open questions / Follow ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
