### PR TITLE
update ksql configure-acls

### DIFF
--- a/internal/cmd/ksql/command_cluster.go
+++ b/internal/cmd/ksql/command_cluster.go
@@ -351,7 +351,7 @@ func (c *clusterCommand) configureACLs(cmd *cobra.Command, args []string) error 
 	}
 
 	if cluster.ServiceAccountId == 0 {
-		return fmt.Errorf(errors.KsqlDBNoServiceAccount)
+		return fmt.Errorf(errors.KsqlDBNoServiceAccount, args[0])
 	}
 
 

--- a/internal/cmd/ksql/command_test.go
+++ b/internal/cmd/ksql/command_test.go
@@ -181,7 +181,7 @@ func (suite *KSQLTestSuite) TestShouldNotConfigureAclsWhenUser() {
 	err := cmd.Execute()
 
 	req := require.New(suite.T())
-	req.EqualError(err, errors.KsqlDBNoServiceAccount)
+	req.EqualError(err, fmt.Sprintf(errors.KsqlDBNoServiceAccount, ksqlClusterID))
 	req.Equal(0, len(suite.kafkac.CreateACLsCalls()))
 }
 

--- a/internal/pkg/errors/strings.go
+++ b/internal/pkg/errors/strings.go
@@ -74,7 +74,7 @@ const (
 	EndPointNotPopulatedMsg   = "Endpoint not yet populated. To obtain the endpoint, use `ccloud ksql app describe`."
 	KsqlDBDeletedMsg          = "ksqlDB app \"%s\" has been deleted.\n"
 	KsqlDBNotBackedByKafkaMsg = "The ksqlDB cluster \"%s\" is backed by \"%s\" which is not the current Kafka cluster \"%s\".\nTo switch to the correct cluster, use `ccloud kafka cluster use %s`.\n"
-	KsqlDBNoServiceAccount    = "ACLs do not need to be set for the ksqlDB cluster, the ksqlDB cluster has the same permissions as the user who provisioned the cluster.\n"
+	KsqlDBNoServiceAccount    = "ACLs do not need to be configured for the ksqlDB app, \"%s\", because it was created with user-level access to the Kafka cluster.\n"
 
 	// local commands
 	AvailableServicesMsg       = "Available Services:\n%s\n"


### PR DESCRIPTION
<!--
Is there any breaking changes?  If so this is a major release, make sure '#major' is in at least one
commit message to get CI to bump the major.  This will prevent automatic down stream dependency
bumping / consuming.  For more information about semantic versioning see: https://semver.org/


Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
Checklist
---
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok
   
2. Did you add/update any commands that accept secrets as args/flags?
   * no: ok

What
----


References
----------
https://confluentinc.atlassian.net/browse/KCI-103

Test&Review
------------

Unit tests
Built the cli and tried it
```
testing:cli stevenz$ ./dist/ccloud/ccloud_darwin_amd64/ccloud ksql app configure-acls lksqlc-1mrr6
Error: ACLs do not need to be configured for the ksqlDB app, "lksqlc-1mrr6", because it was created with user-level access to the Kafka cluster.
```

<!--
Open questions / Follow ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
