### PR TITLE
minor: fix README.md instructions for building other platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,9 +182,9 @@ When you add a new command or resource, assuming its already in the SDK, you gen
 
 If you have a need to build a binary for a platform that is not the current one, use the following to target a different `.goreleaser-*` file matching the destined platform.
 
-    make build-go GORELEASER_SUFFIX=-linux.yml   # build linux
-    make build-go GORELEASER_SUFFIX=-mac.yml     # build mac
-    make build-go GORELEASER_SUFFIX=-windows.yml # build windows
+    make build GORELEASER_SUFFIX=-linux.yml   # build linux
+    make build GORELEASER_SUFFIX=-mac.yml     # build mac
+    make build GORELEASER_SUFFIX=-windows.yml # build windows
 
 ### URLS
 Use the `login` command with the `--url` option to point to a different development environment


### PR DESCRIPTION
target is 'build' and not 'build-go' (tested that `make build GORELEASER_SUFFIX=-linux.yml` works)