### PR TITLE
CIAM-884 Bugfix to show MetricsViewer in role list

### DIFF
--- a/internal/cmd/iam/command_rolebinding.go
+++ b/internal/cmd/iam/command_rolebinding.go
@@ -50,7 +50,7 @@ var (
 
 	organizationScopedRoles = map[string]bool{
 		"OrganizationAdmin": true,
-		"MetricsViewer": true,
+		"MetricsViewer":     true,
 	}
 )
 
@@ -147,11 +147,11 @@ func (c *rolebindingCommand) init() {
 	}
 
 	listCmd := &cobra.Command{
-		Use:   "list",
-		Short: "List role bindings.",
-		Long:  "List the role bindings for a particular principal and/or role, and a particular scope.",
-		Args:  cobra.NoArgs,
-		RunE:  cmd.NewCLIRunE(c.list),
+		Use:     "list",
+		Short:   "List role bindings.",
+		Long:    "List the role bindings for a particular principal and/or role, and a particular scope.",
+		Args:    cobra.NoArgs,
+		RunE:    cmd.NewCLIRunE(c.list),
 		Example: example,
 	}
 	listCmd.Flags().String("principal", "", "Principal whose rolebindings should be listed.")

--- a/internal/cmd/iam/command_rolebinding_test.go
+++ b/internal/cmd/iam/command_rolebinding_test.go
@@ -39,7 +39,7 @@ type roleBindingTest struct {
 
 type myRoleBindingTest struct {
 	scopeRoleBindingMapping []mdsv2alpha1.ScopeRoleBindingMapping
-	mockedListUserResult []*v1.User
+	mockedListUserResult    []*v1.User
 	expected                []listDisplay
 }
 
@@ -184,9 +184,9 @@ func (suite *RoleBindingTestSuite) TestRoleBindingsList() {
 }
 
 func (suite *RoleBindingTestSuite) newMockIamListRoleBindingCmd(
-		mockeRoleBindingsResult chan []mdsv2alpha1.ScopeRoleBindingMapping,
-		mockeddListUserResult chan []*v1.User,
-		) *cobra.Command {
+	mockeRoleBindingsResult chan []mdsv2alpha1.ScopeRoleBindingMapping,
+	mockeddListUserResult chan []*v1.User,
+) *cobra.Command {
 	// Mock MDS Client
 	mdsClient := mdsv2alpha1.NewAPIClient(mdsv2alpha1.NewConfiguration())
 	mdsClient.RBACRoleBindingSummariesApi = &mds2mock.RBACRoleBindingSummariesApi{
@@ -258,7 +258,7 @@ var myRoleBindingListTests = []myRoleBindingTest{
 				Principal: "User:u-123",
 				Role:      "MetricsViewer",
 				Name:      "Skynet",
-				Email: "test@email.com",
+				Email:     "test@email.com",
 			},
 		},
 	},


### PR DESCRIPTION
What
----
Fixes bug where MetricsViewer was not listed.

Test&Review
------------
Added unit testing
Also built the cli locally (`make build`) and tested against my stag cluster:
 - Made myself MetricsViewer, then did `X_CCLOUD_RBAC=1 dist/ccloud/linux_amd64/ccloud iam rolebinding list --current-user`, verified the MetricsViewer role was missing
 -  Recompile with my fix, and show that role now appears with the same command
