### PR TITLE
CLI-929 Show resource IDs for service accounts in list

### DIFF
--- a/internal/cmd/service-account/command.go
+++ b/internal/cmd/service-account/command.go
@@ -25,12 +25,12 @@ type command struct {
 }
 
 var (
-	listFields                = []string{"Id", "ServiceName", "ServiceDescription"}
-	listHumanLabels           = []string{"Id", "Name", "Description"}
-	listStructuredLabels      = []string{"id", "name", "description"}
-	describeFields            = []string{"Id", "ServiceName", "ServiceDescription"}
-	describeHumanRenames      = map[string]string{"ServiceName": "Name", "ServiceDescription": "Description"}
-	describeStructuredRenames = map[string]string{"ServiceName": "name", "ServiceDescription": "description"}
+	listFields                = []string{"Id", "ResourceId", "ServiceName", "ServiceDescription"}
+	listHumanLabels           = []string{"Id", "Resource ID", "Name", "Description"}
+	listStructuredLabels      = []string{"id", "resource_id", "name", "description"}
+	describeFields            = []string{"Id", "ResourceId", "ServiceName", "ServiceDescription"}
+	describeHumanRenames      = map[string]string{"ServiceName": "Name", "ServiceDescription": "Description", "ResourceId": "Resource ID"}
+	describeStructuredRenames = map[string]string{"ServiceName": "name", "ServiceDescription": "description", "ResourceId": "resource_id"}
 )
 
 const nameLength = 64

--- a/test/fixtures/output/service-account/service-account-create-json.golden
+++ b/test/fixtures/output/service-account/service-account-create-json.golden
@@ -1,5 +1,6 @@
 {
   "id": 55555,
   "name": "json-service",
-  "description": "json-output"
+  "description": "json-output",
+  "resource_id": "sa-55555"
 }

--- a/test/fixtures/output/service-account/service-account-create-yaml.golden
+++ b/test/fixtures/output/service-account/service-account-create-yaml.golden
@@ -1,3 +1,4 @@
 description: yaml-output
 id: 55555
 name: yaml-service
+resource_id: sa-55555

--- a/test/fixtures/output/service-account/service-account-create.golden
+++ b/test/fixtures/output/service-account/service-account-create.golden
@@ -1,5 +1,6 @@
 +-------------+---------------+
 | Id          |         55555 |
+| Resource ID | sa-55555      |
 | Name        | human-service |
 | Description | human-output  |
 +-------------+---------------+

--- a/test/fixtures/output/service-account/service-account-list-json.golden
+++ b/test/fixtures/output/service-account/service-account-list-json.golden
@@ -2,6 +2,7 @@
   {
     "description": "at your service.",
     "id": "12345",
-    "name": "service_account"
+    "name": "service_account",
+    "resource_id": "sa-12345"
   }
 ]

--- a/test/fixtures/output/service-account/service-account-list-yaml.golden
+++ b/test/fixtures/output/service-account/service-account-list-yaml.golden
@@ -1,3 +1,4 @@
 - description: at your service.
   id: "12345"
   name: service_account
+  resource_id: sa-12345

--- a/test/fixtures/output/service-account/service-account-list.golden
+++ b/test/fixtures/output/service-account/service-account-list.golden
@@ -1,3 +1,3 @@
-   Id   |      Name       |   Description     
-+-------+-----------------+------------------+
-  12345 | service_account | at your service.  
+   Id   | Resource ID |      Name       |   Description     
++-------+-------------+-----------------+------------------+
+  12345 | sa-12345    | service_account | at your service.  

--- a/test/test-server/ccloud_handlers.go
+++ b/test/test-server/ccloud_handlers.go
@@ -44,8 +44,9 @@ const (
 	exampleRegion       = "us-east-1"
 	exampleUnit         = "GB"
 
-	serviceAccountID  = int32(12345)
-	deactivatedUserID = int32(6666)
+	serviceAccountID         = int32(12345)
+	serviceAccountResourceID = "sa-12345"
+	deactivatedUserID        = int32(6666)
 )
 
 // Fill API keyStore with default data
@@ -254,6 +255,7 @@ func (c *CloudRouter) HandleServiceAccount(t *testing.T) func(http.ResponseWrite
 		case "GET":
 			serviceAccount := &orgv1.User{
 				Id:                 serviceAccountID,
+				ResourceId:         serviceAccountResourceID,
 				ServiceName:        "service_account",
 				ServiceDescription: "at your service.",
 			}
@@ -269,6 +271,7 @@ func (c *CloudRouter) HandleServiceAccount(t *testing.T) func(http.ResponseWrite
 			require.NoError(t, err)
 			serviceAccount := &orgv1.User{
 				Id:                 55555,
+				ResourceId:         "sa-55555",
 				ServiceName:        req.User.ServiceName,
 				ServiceDescription: req.User.ServiceDescription,
 			}


### PR DESCRIPTION
<!--
Is there any breaking changes?  If so this is a major release, make sure '#major' is in at least one
commit message to get CI to bump the major.  This will prevent automatic down stream dependency
bumping / consuming.  For more information about semantic versioning see: https://semver.org/


Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
Checklist
---
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok
   * no: DO NOT MERGE until the required functionalites are live in prod  

Yes.
   
2. Did you add/update any commands that accept secrets as args/flags?
   * yes: did you update `secretCommandFlags` and/or `secretCommandArgs` in [internal/pkg/analytics/analytics.go](https://github.com/confluentinc/cli/pull/325/files#diff-2d0a5a6a592890b6dff2d6f891316b82R28)
   * no: ok

No.

What
----
In order to perform role bindings on service accounts, users need to be able to discover
the resource IDs. That information is already in cc-structs for the SA, so this is just adding
it to the fields that the `list` command outputs.

References
----------
https://confluentinc.atlassian.net/browse/CLI-929

Test&Review
------------
Unit tests.

Manual test:
```
cli (CLI-929) M > dist/ccloud/ccloud_darwin_amd64/ccloud service-account list
    Id   | Resource ID |                Name                |          Description            
+--------+-------------+------------------------------------+--------------------------------+
  232794 | sa-lgrw81   | roboto                             | mr                              
  441804 | sa-mvz5y7   | sa_org_admin                       | Service Account with Org Admin  
  441806 | sa-w72yx5   | sa_metrics_viewer                  |                                 
  442119 | sa-pgj0rk   | service_account_for_metrics_viewer | Here's a description        
```

<!--
Open questions / Follow ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
