### PR TITLE
CIAM-276: Remove RBAC feature flag for GA

### DIFF
--- a/test/cli_test.go
+++ b/test/cli_test.go
@@ -130,8 +130,6 @@ func (s *CLITestSuite) SetupSuite() {
 	// dumb but effective
 	err = os.Chdir("..")
 	req.NoError(err)
-	err = os.Setenv("XX_CCLOUD_RBAC", "yes")
-	req.NoError(err)
 	for _, binary := range []string{ccloudTestBin, confluentTestBin} {
 		if _, err = os.Stat(binaryPath(s.T(), binary)); os.IsNotExist(err) || !*noRebuild {
 			var makeArgs string
@@ -152,7 +150,6 @@ func (s *CLITestSuite) SetupSuite() {
 
 func (s *CLITestSuite) TearDownSuite() {
 	// Merge coverage profiles.
-	_ = os.Unsetenv("XX_CCLOUD_RBAC")
 	_ = covCollector.TearDown()
 	s.TestBackend.Close()
 }


### PR DESCRIPTION
<!--
Is there any breaking changes?  If so this is a major release, make sure '#major' is in at least one
commit message to get CI to bump the major.  This will prevent automatic down stream dependency
bumping / consuming.  For more information about semantic versioning see: https://semver.org/


Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
Checklist
---
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok
   
2. Did you add/update any commands that accept secrets as args/flags?
   * no: ok

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->

Removed the `CC_CCLOUD_RBAC` feature flag now that cloud RBAC is ready for GA.

References
----------
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

https://confluentinc.atlassian.net/browse/CIAM-276

Test&Review
------------

<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

Verified that all existing tests continue to pass.

