### PR TITLE
hiding consumer-group and lag commands

### DIFF
--- a/internal/cmd/kafka/command_consumer-group_cloud.go
+++ b/internal/cmd/kafka/command_consumer-group_cloud.go
@@ -167,6 +167,7 @@ func (g *groupCommand) init() {
 				Code: "ccloud kafka consumer-group list",
 			},
 		),
+		Hidden: true,
 	}
 	listCmd.Flags().StringP(output.FlagName, output.ShortHandFlag, output.DefaultValue, output.Usage)
 	listCmd.Flags().SortFlags = false
@@ -183,6 +184,7 @@ func (g *groupCommand) init() {
 				Code: "ccloud kafka consumer-group describe my_consumer_group",
 			},
 		),
+		Hidden: true,
 	}
 	describeCmd.Flags().StringP(output.FlagName, output.ShortHandFlag, output.DefaultValue, output.Usage)
 	describeCmd.Flags().SortFlags = false
@@ -369,6 +371,7 @@ func (lagCmd *lagCommand) init() {
 				Code: "ccloud kafka consumer-group lag list my_consumer_group",
 			},
 		),
+		Hidden: true,
 	}
 	listLagCmd.Flags().StringP(output.FlagName, output.ShortHandFlag, output.DefaultValue, output.Usage)
 	listLagCmd.Flags().SortFlags = false
@@ -386,6 +389,7 @@ func (lagCmd *lagCommand) init() {
 				Code: "ccloud kafka consumer-group lag get my_consumer_group --topic my_topic --partition 0",
 			},
 		),
+		Hidden: true,
 	}
 	getLagCmd.Flags().StringP(output.FlagName, output.ShortHandFlag, output.DefaultValue, output.Usage)
 	getLagCmd.Flags().String("topic", "", "Topic name.")

--- a/test/fixtures/output/kafka/consumer-group-help.golden
+++ b/test/fixtures/output/kafka/consumer-group-help.golden
@@ -1,14 +1,7 @@
 Manage Kafka consumer groups.
 
 Usage:
-  ccloud kafka consumer-group [command]
-
-Available Commands:
-  describe    Describe a Kafka consumer group.
-  list        List Kafka consumer groups.
 
 Global Flags:
   -h, --help            Show help for this command.
   -v, --verbose count   Increase verbosity (-v for warn, -vv for info, -vvv for debug, -vvvv for trace).
-
-Use "ccloud kafka consumer-group [command] --help" for more information about a command.

--- a/test/fixtures/output/kafka/consumer-group-lag-help.golden
+++ b/test/fixtures/output/kafka/consumer-group-lag-help.golden
@@ -1,11 +1,6 @@
 View consumer lag.
 
 Usage:
-  ccloud kafka consumer-group lag [command]
-
-Available Commands:
-  get         Get consumer lag for a Kafka topic partition.
-  list        List consumer lags for a Kafka consumer group.
 
 Flags:
       --environment string   Environment ID.
@@ -15,5 +10,3 @@ Flags:
 Global Flags:
   -h, --help            Show help for this command.
   -v, --verbose count   Increase verbosity (-v for warn, -vv for info, -vvv for debug, -vvvv for trace).
-
-Use "ccloud kafka consumer-group lag [command] --help" for more information about a command.


### PR DESCRIPTION
<!--
Is there any breaking changes?  If so this is a major release, make sure '#major' is in at least one
commit message to get CI to bump the major.  This will prevent automatic down stream dependency
bumping / consuming.  For more information about semantic versioning see: https://semver.org/


Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
Checklist
---
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok
   * no: DO NOT MERGE until the required functionalites are live in prod  
   
2. Did you add/update any commands that accept secrets as args/flags?
   * yes: did you update `secretCommandFlags` and/or `secretCommandArgs` in [internal/pkg/analytics/analytics.go](https://github.com/confluentinc/cli/pull/325/files#diff-2d0a5a6a592890b6dff2d6f891316b82R28)
   * no: ok

What
----
Hiding consumer-group and lag commands before we can confirm performance of lag proxy calls.

<!--
Open questions / Follow ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
