### PR TITLE
[CLI-953] call parse flags into context from api key prerunner

### DIFF
--- a/internal/pkg/cmd/prerunner.go
+++ b/internal/pkg/cmd/prerunner.go
@@ -746,6 +746,10 @@ func (r *PreRun) HasAPIKey(command *HasAPIKeyCLICommand) func(cmd *cobra.Command
 			}
 			ctx.client = client
 			command.Config.Client = client
+			err = ctx.ParseFlagsIntoContext(cmd, command.Config.Client)
+			if err != nil {
+				return err
+			}
 			cluster, err := ctx.GetKafkaClusterForCommand(cmd)
 			if err != nil {
 				return err


### PR DESCRIPTION
<!--
Is there any breaking changes?  If so this is a major release, make sure '#major' is in at least one
commit message to get CI to bump the major.  This will prevent automatic down stream dependency
bumping / consuming.  For more information about semantic versioning see: https://semver.org/


Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
Checklist
---
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok
   
2. Did you add/update any commands that accept secrets as args/flags?
   * no: ok

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->

After the changes to how the --environment and --cluster flags were parsed, the produce/consume commands were no longer calling ParseFlagsIntoContext, so I added that call.

References
----------
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->
https://confluentinc.atlassian.net/browse/CLI-953

Test&Review
------------

<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

<!--
Open questions / Follow ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
