### PR TITLE
feat(cli): Add user id to ccloud admin user list (WIP)

### DIFF
--- a/internal/cmd/admin/command_users.go
+++ b/internal/cmd/admin/command_users.go
@@ -17,17 +17,19 @@ import (
 )
 
 var (
-	listFields    = []string{"ResourceId", "Email", "FirstName", "LastName", "Status"}
-	humanLabels   = []string{"Resource ID", "Email", "First Name", "Last Name", "Status"}
+	listFields    = []string{"Id", "ResourceId", "Email", "FirstName", "LastName", "Status"}
+	humanLabels   = []string{"Id", "Resource ID", "Email", "First Name", "Last Name", "Status"}
 	humanLabelMap = map[string]string{
+		"Id":         "Id",
 		"ResourceId": "Resource ID",
 		"Email":      "Email",
 		"FirstName":  "First Name",
 		"LastName":   "Last Name",
 		"Status":     "Status",
 	}
-	structuredLabels   = []string{"resource_id", "email", "first_name", "last_name", "status"}
+	structuredLabels   = []string{"id", "resource_id", "email", "first_name", "last_name", "status"}
 	structuredLabelMap = map[string]string{
+		"Id":         "id",
 		"ResourceId": "resource_id",
 		"Email":      "email",
 		"FirstName":  "first_name",
@@ -47,6 +49,7 @@ type userCommand struct {
 }
 
 type userStruct struct {
+	Id         int32
 	ResourceId string
 	Email      string
 	FirstName  string
@@ -149,6 +152,7 @@ func (c userCommand) list(cmd *cobra.Command, _ []string) error {
 		}
 
 		outputWriter.AddElement(&userStruct{
+			Id:         user.Id,
 			ResourceId: userProfile.ResourceId,
 			Email:      userProfile.Email,
 			FirstName:  userProfile.FirstName,


### PR DESCRIPTION
Checklist
---
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok
   
2. Did you add/update any commands that accept secrets as args/flags?
   * no: ok

What
----
Add additional output to `ccloud admin user list` to include user ID (in addition to current user resource id).

Right now, certain Confluent Cloud components (most notably the audit log) use the older numeric ID rather than the newer resource ID.  We need a way to map numeric IDs to principals.  See https://confluentinc.atlassian.net/browse/FF-5117 for additional details.

References
----------
* https://confluentinc.atlassian.net/browse/FF-5117
* https://confluent.slack.com/archives/C9QRB4HJ7/p1620757432437800
* https://confluent.slack.com/archives/C01D7FRH52N/p1620782528114600

Test&Review
------------

Has been tested manually.  Changes outputs from:
```
% ccloud admin user list
  Resource ID |            Email             |  First Name   |   Last Name   |   Status
+-------------+------------------------------+---------------+---------------+------------+
  u-lgq231    | skpabba+ne@confluent.io      | Sean          | Pabba         | Active
  u-l7y11p    | adomingo+ne@confluent.io     |               |               | Unverified
  u-l97z5v    | chris+ne@confluent.io        | Chris         | Matta         | Active
  u-lo37jx    | earsy+ne@confluent.io        | Paul          | Earsy         | Active
  u-4k82zv    | fotios+ne@confluent.io       | Fotios        | Filacouris    | Active
...
```

to 
```
% ./dist/ccloud/ccloud_darwin_amd64/ccloud admin user list
    Id   | Resource ID |            Email             |  First Name   |   Last Name   |   Status
+--------+-------------+------------------------------+---------------+---------------+------------+
   53584 | u-lgq231    | skpabba+ne@confluent.io      | Sean          | Pabba         | Active
   53585 | u-l7y11p    | adomingo+ne@confluent.io     |               |               | Unverified
   53586 | u-l97z5v    | chris+ne@confluent.io        | Chris         | Matta         | Active
   53588 | u-lo37jx    | earsy+ne@confluent.io        | Paul          | Earsy         | Active
   53589 | u-4k82zv    | fotios+ne@confluent.io       | Fotios        | Filacouris    | Active
...
```

Also works for JSON output:
```
% ./dist/ccloud/ccloud_darwin_amd64/ccloud admin user list -ojson
[
  {
    "email": "skpabba+ne@confluent.io",
    "first_name": "Sean",
    "id": "53584",
    "last_name": "Pabba",
    "resource_id": "u-lgq231",
    "status": "Active"
  },
  {
    "email": "adomingo+ne@confluent.io",
    "first_name": "",
    "id": "53585",
    "last_name": "",
    "resource_id": "u-l7y11p",
    "status": "Unverified"
  },
...
```

Open questions / Follow ups
--------------------------
Need to update tests (hence still WIP).

Review stakeholders
------------------
CC @feocco 