### PR TITLE
[CLI-989] Fix typo in Docker script that is supposed to delete old CLI image versions from build cache

### DIFF
--- a/mk-files/dockerhub.mk
+++ b/mk-files/dockerhub.mk
@@ -1,11 +1,11 @@
 .PHONY: publish-dockerhub
 publish-dockerhub:
 	# Dockerfile must be in same or subdirectory of this file
-	docker images | grep "confluentinc/ccloud-cli" | awk '{system("docker rmi -f " "'"confluentinc/ccloud-cli"'" $2)}'
+	docker images | grep "confluentinc/ccloud-cli" | awk '{system("docker rmi -f " "'"confluentinc/ccloud-cli:"'" $2)}'
 	docker build -f ./mk-files/Dockerfile_ccloud -t confluentinc/ccloud-cli:$(CLEAN_VERSION) -t confluentinc/ccloud-cli:latest ./mk-files/
 	docker push confluentinc/ccloud-cli:$(CLEAN_VERSION)
 	docker push confluentinc/ccloud-cli:latest
-	docker images | grep "confluentinc/confluent-cli" | awk '{system("docker rmi -f " "'"confluentinc/confluent-cli"'" $2)}'
+	docker images | grep "confluentinc/confluent-cli" | awk '{system("docker rmi -f " "'"confluentinc/confluent-cli:"'" $2)}'
 	docker build -f ./mk-files/Dockerfile_confluent -t confluentinc/confluent-cli:$(CLEAN_VERSION) -t confluentinc/confluent-cli:latest ./mk-files/
 	docker push confluentinc/confluent-cli:$(CLEAN_VERSION)
 	docker push confluentinc/confluent-cli:latest


### PR DESCRIPTION

Before:
```
docker images | grep "confluentinc/ccloud-cli" | awk '{system("docker rmi -f " "'"confluentinc/ccloud-cli"'" $2)}'
Error: No such image: confluentinc/ccloud-cli1.25.0
Error: No such image: confluentinc/ccloud-cli1.27.0
Error: No such image: confluentinc/ccloud-cli1.29.0
Error: No such image: confluentinc/ccloud-cli1.30.0
Error: No such image: confluentinc/ccloud-cli1.31.0
Error: No such image: confluentinc/ccloud-cli1.33.0
Error: No such image: confluentinc/ccloud-clilatest
Error: No such image: confluentinc/ccloud-cli1.21.1
Error: No such image: confluentinc/ccloud-cli1.22.1
Error: No such image: confluentinc/ccloud-cli1.23.0
Error: No such image: confluentinc/ccloud-cli1.24.0
```
After:
```
DavidHydesMBP15:cli david.hyde$ docker images | grep "confluentinc/ccloud-cli" | awk '{system("docker rmi -f " "'"confluentinc/ccloud-cli:"'" $2)}'
Untagged: confluentinc/ccloud-cli:1.25.0
Untagged: confluentinc/ccloud-cli:1.27.0
Untagged: confluentinc/ccloud-cli:1.29.0
Untagged: confluentinc/ccloud-cli:1.30.0
Untagged: confluentinc/ccloud-cli:1.31.0
Untagged: confluentinc/ccloud-cli:1.33.0
Untagged: confluentinc/ccloud-cli:latest
Untagged: confluentinc/ccloud-cli@sha256:9e89f1ae62d1f60ce1c4a85b080000f87eb25775752b6ecb03530364fbd7fbe8
Deleted: sha256:0889556444f94ad04b788b52451b57b7b254d36fcbd0eed22b86acb0169cf33d
Untagged: confluentinc/ccloud-cli:1.21.1
Untagged: confluentinc/ccloud-cli:1.22.1
Untagged: confluentinc/ccloud-cli:1.23.0
Untagged: confluentinc/ccloud-cli:1.24.0
Untagged: confluentinc/ccloud-cli@sha256:2606711e607f2c59f2e7c365fcdfafe6397eda58ba8c7718c9143e0841dff396
```