### PR TITLE
CLI-668: Fix Kafka consumer message, EOF is not allowed

### DIFF
--- a/internal/pkg/errors/strings.go
+++ b/internal/pkg/errors/strings.go
@@ -55,9 +55,9 @@ const (
 	RestProxyNotAvailable = "Operation not supported: REST proxy is not available.\n"
 
 	// kafka topic commands
-	StartingProducerMsg    = "Starting Kafka Producer. ^C or ^D to exit"
+	StartingProducerMsg    = "Starting Kafka Producer. Use Ctrl-C or Ctrl-D to exit."
 	StoppingConsumer       = "Stopping Consumer."
-	StartingConsumerMsg    = "Starting Kafka Consumer. ^C or ^D to exit"
+	StartingConsumerMsg    = "Starting Kafka Consumer. Use Ctrl-C to exit."
 	CreatedTopicMsg        = "Created topic \"%s\".\n"
 	DeletedTopicMsg        = "Deleted topic \"%s\".\n"
 	UnknownTopicMsg        = "Unknown topic: \"%s\".\n"


### PR DESCRIPTION
<!--
Is there any breaking changes?  If so this is a major release, make sure '#major' is in at least one
commit message to get CI to bump the major.  This will prevent automatic down stream dependency
bumping / consuming.  For more information about semantic versioning see: https://semver.org/


Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
Checklist
---
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok
   
2. Did you add/update any commands that accept secrets as args/flags?
   * no: ok

What
----
A consumer can _output_ text, but can't _input_ text. It shouldn't be able to be stopped with an EOF, since that is considered an input. Changed help messages to reflect this.