### PR TITLE
Fix cc-system-tests CI

### DIFF
--- a/system-tests-pipelines.yml
+++ b/system-tests-pipelines.yml
@@ -112,7 +112,13 @@ jobs:
   - bash: make cpd-priv-testenv || make cpd-debug-and-err
     displayName: Get environment variables for cc-system-tests
 
-  - bash: make system-test-init-env || make cpd-debug-and-err
+  - bash: |
+      export PATH="$(BIN_PATH):$PATH"
+      . $(vaultsecrets.secureFilePath)
+      . mk-include/bin/vault-setup
+      . vault-sem-get-secret azure_credentials
+      . vault-sem-get-secret cc-system-tests
+      make system-test-init-env || make cpd-debug-and-err
     env:
       CREATE_KAFKA_CLUSTERS: "true"
     displayName: Initialize CPD environment
@@ -120,7 +126,13 @@ jobs:
   - bash: make replace-cli-binary
     displayName: Replace CLI binary
 
-  - bash: make run-system-tests
+  - bash: |
+      export PATH="$(BIN_PATH):$PATH"
+      . $(vaultsecrets.secureFilePath)
+      . mk-include/bin/vault-setup
+      . vault-sem-get-secret azure_credentials
+      . vault-sem-get-secret cc-system-tests
+      make run-system-tests
     env:
       GO_TEST_PACKAGE_ARGS: "./test/cli/..."
     displayName: Run system tests


### PR DESCRIPTION
Made several necessary fixes for CI to work, such as injecting Vault credentials into CPD, following these instructions: https://confluentinc.atlassian.net/wiki/spaces/Foundations/pages/1347408263/How+to+Run+CLI+System+Tests

There is also a ~12 min speedup due to changing order of command execution: Provisioning a CPD cluster is the slowest step, so we create one as early as possible, and perform minor steps such as downloading Go dependencies and building the CLI binary while we wait for the cluster to provision. Total running time is now about 1h40m.

Currently, 12 tests fail all with the same error which is being actively debugged in the following Slack channel: https://confluent.slack.com/archives/C028F0JNSA1