### PR TITLE
CLI Unification: kafka

### DIFF
--- a/internal/cmd/command.go
+++ b/internal/cmd/command.go
@@ -131,7 +131,7 @@ func NewConfluentCommand(cfg *v3.Config, isTest bool, ver *pversion.Version) *co
 	// No-login commands
 	cli.AddCommand(completion.New(cli, cliName))
 	cli.AddCommand(config.New(cfg.IsCloud(), prerunner, analyticsClient))
-	cli.AddCommand(kafka.New(isAPIKeyLogin, cliName, prerunner, logger.Named("kafka"), ver.ClientID, serverCompleter, analyticsClient))
+	cli.AddCommand(kafka.New(cfg, isAPIKeyLogin, prerunner, logger.Named("kafka"), ver.ClientID, serverCompleter, analyticsClient))
 	cli.AddCommand(local.New(prerunner))
 	cli.AddCommand(login.New(prerunner, logger, ccloudClientFactory, mdsClientManager, analyticsClient, netrcHandler, loginCredentialsManager, authTokenHandler, isTest).Command)
 	cli.AddCommand(logout.New(cliName, prerunner, analyticsClient, netrcHandler).Command)

--- a/internal/cmd/kafka/command_acl_onprem.go
+++ b/internal/cmd/kafka/command_acl_onprem.go
@@ -1,12 +1,13 @@
 package kafka
 
 import (
+	"github.com/confluentinc/kafka-rest-sdk-go/kafkarestv3"
+	"github.com/spf13/cobra"
+
 	aclutil "github.com/confluentinc/cli/internal/pkg/acl"
 	pcmd "github.com/confluentinc/cli/internal/pkg/cmd"
 	"github.com/confluentinc/cli/internal/pkg/examples"
 	"github.com/confluentinc/cli/internal/pkg/output"
-	"github.com/confluentinc/kafka-rest-sdk-go/kafkarestv3"
-	"github.com/spf13/cobra"
 )
 
 var (

--- a/internal/cmd/kafka/command_test.go
+++ b/internal/cmd/kafka/command_test.go
@@ -659,7 +659,7 @@ func Test_HandleError_NotLoggedIn(t *testing.T) {
 		},
 	}
 	client := &ccloud.Client{Kafka: kafka}
-	cmd := New(false, conf.CLIName, cliMock.NewPreRunnerMock(client, nil, nil, conf),
+	cmd := New(conf, false, cliMock.NewPreRunnerMock(client, nil, nil, conf),
 		log.New(), "test-client", &cliMock.ServerSideCompleter{}, cliMock.NewDummyAnalyticsMock())
 	cmd.PersistentFlags().CountP("verbose", "v", "Increase output verbosity")
 	cmd.SetArgs([]string{"cluster", "list"})
@@ -1172,7 +1172,7 @@ func newMockCmd(kafkaExpect chan interface{}, kafkaRestExpect chan interface{}, 
 		}
 		return nil, nil
 	})
-	cmd := New(false, conf.CLIName, cliMock.NewPreRunnerMock(client, nil, &provider, conf),
+	cmd := New(conf, false, cliMock.NewPreRunnerMock(client, nil, &provider, conf),
 		log.New(), "test-client", &cliMock.ServerSideCompleter{}, cliMock.NewDummyAnalyticsMock())
 	cmd.PersistentFlags().CountP("verbose", "v", "Increase output verbosity")
 	return cmd

--- a/internal/pkg/config/v3/mock.go
+++ b/internal/pkg/config/v3/mock.go
@@ -10,6 +10,7 @@ import (
 	v1 "github.com/confluentinc/cli/internal/pkg/config/v1"
 	v2 "github.com/confluentinc/cli/internal/pkg/config/v2"
 	"github.com/confluentinc/cli/internal/pkg/log"
+	testserver "github.com/confluentinc/cli/test/test-server"
 )
 
 var (
@@ -53,7 +54,7 @@ func AuthenticatedCloudConfigMock() *Config {
 		userId:         mockUserId,
 		userResourceId: MockUserResourceId,
 		username:       mockEmail,
-		url:            MockUserResourceId,
+		url:            testserver.TestCloudURL.String(),
 		envId:          MockEnvironmentId,
 		orgId:          mockOrganizationId,
 		orgResourceId:  MockOrgResourceId,
@@ -164,6 +165,7 @@ func AuthenticatedConfigMock(params mockConfigParams) *Config {
 		MetricSink: nil,
 		Logger:     log.New(),
 	})
+	conf.IsTest = true
 
 	ctx, err := newContext(params.contextName, platform, credential, kafkaClusters, kafkaCluster.ID, srClusters, contextState, conf)
 	if err != nil {


### PR DESCRIPTION
Checklist
---
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok
   
2. Did you add/update any commands that accept secrets as args/flags?
   * no: ok

What
----
Unified the `kafka` command. Notably, the on-prem `kafka acl` and `kafka topic` commands are "stateless" (they have a `--url` flag, so they can be used without logging in). We show the on-prem version of those command when the user is not logged in, or logged in on-prem. Otherwise, we show the cloud version of those commands.

Test & Review
------------
Make sure integration tests can infer a cloud or on-prem context. All existing tests pass.