### PR TITLE
CLI-1071 Add back UserId field in API key object passed in API key delete cmd

### DIFF
--- a/internal/cmd/api-key/command.go
+++ b/internal/cmd/api-key/command.go
@@ -439,6 +439,7 @@ func (c *command) delete(cmd *cobra.Command, args []string) error {
 		Id:             userKey.Id,
 		Key:            apiKey,
 		AccountId:      c.EnvironmentId(),
+		UserId:         userKey.UserId,
 		UserResourceId: userKey.UserResourceId,
 	}
 


### PR DESCRIPTION
<!--
Is there any breaking changes?  If so this is a major release, make sure '#major' is in at least one
commit message to get CI to bump the major.  This will prevent automatic down stream dependency
bumping / consuming.  For more information about semantic versioning see: https://semver.org/


Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
Checklist
---
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok
   
2. Did you add/update any commands that accept secrets as args/flags?
   * no: ok

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->
There's been issue deleting API keys because backend services compare the user id of the key passed in and the account id in the org.AuditLog.ServiceAccountId to make sure the key can be deleted, but as a part of deprecating the use of numeric user ID, the delete call in CLI is passing the resource ID instead, making the user ID passed in 0. Right now we need to add the user ID field back to ensure the proper function of auditlog.

References
----------
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test&Review
------------

<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

<!--
Open questions / Follow ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
