### PR TITLE
Revert "CLI-967 Maybe: ‘kafka cluster describe` should not reveal the Kafka API endpoint"

### DIFF
--- a/internal/cmd/kafka/command_cluster_cloud.go
+++ b/internal/cmd/kafka/command_cluster_cloud.go
@@ -28,7 +28,7 @@ var (
 	listFields           = []string{"Id", "Name", "Type", "ServiceProvider", "Region", "Availability", "Status"}
 	listHumanLabels      = []string{"Id", "Name", "Type", "Provider", "Region", "Availability", "Status"}
 	listStructuredLabels = []string{"id", "name", "type", "provider", "region", "availability", "status"}
-	basicDescribeFields  = []string{"Id", "Name", "Type", "NetworkIngress", "NetworkEgress", "Storage", "ServiceProvider", "Availability", "Region", "Status", "Endpoint", "RestEndpoint"}
+	basicDescribeFields  = []string{"Id", "Name", "Type", "NetworkIngress", "NetworkEgress", "Storage", "ServiceProvider", "Availability", "Region", "Status", "Endpoint", "ApiEndpoint", "RestEndpoint"}
 	describeHumanRenames = map[string]string{
 		"NetworkIngress":  "Ingress",
 		"NetworkEgress":   "Egress",
@@ -48,6 +48,7 @@ var (
 		"Availability":       "availability",
 		"Status":             "status",
 		"Endpoint":           "endpoint",
+		"ApiEndpoint":        "api_endpoint",
 		"EncryptionKeyId":    "encryption_key_id",
 		"RestEndpoint":       "rest_endpoint",
 	}
@@ -86,6 +87,7 @@ type describeStruct struct {
 	Availability       string
 	Status             string
 	Endpoint           string
+	ApiEndpoint        string
 	EncryptionKeyId    string
 	RestEndpoint       string
 }
@@ -589,6 +591,7 @@ func convertClusterToDescribeStruct(cluster *schedv1.KafkaCluster) *describeStru
 		Availability:       durabilityToAvaiablityNameMap[cluster.Durability.String()],
 		Status:             cluster.Status.String(),
 		Endpoint:           cluster.Endpoint,
+		ApiEndpoint:        cluster.ApiEndpoint,
 		EncryptionKeyId:    cluster.EncryptionKeyId,
 		RestEndpoint:       cluster.RestEndpoint,
 	}

--- a/internal/cmd/kafka/command_cluster_cloud_test.go
+++ b/internal/cmd/kafka/command_cluster_cloud_test.go
@@ -213,6 +213,7 @@ Please confirm you've authorized the key for this identity: id-xyz (y/n): It may
 | Region       | us-central1   |
 | Status       | PROVISIONING  |
 | Endpoint     |               |
+| ApiEndpoint  |               |
 | RestEndpoint |               |
 | ClusterSize  |             0 |
 +--------------+---------------+

--- a/test/fixtures/output/kafka/17.golden
+++ b/test/fixtures/output/kafka/17.golden
@@ -10,5 +10,6 @@
 | Region       | us-west-2                 |
 | Status       | PROVISIONING              |
 | Endpoint     | SASL_SSL://kafka-endpoint |
+| ApiEndpoint  | http://kafka-api-url      |
 | RestEndpoint | http://kafka-rest-url     |
 +--------------+---------------------------+

--- a/test/fixtures/output/kafka/18.golden
+++ b/test/fixtures/output/kafka/18.golden
@@ -10,5 +10,6 @@
   "availability": "single-zone",
   "status": "PROVISIONING",
   "endpoint": "SASL_SSL://kafka-endpoint",
+  "api_endpoint": "http://kafka-api-url",
   "rest_endpoint": "http://kafka-rest-url"
 }

--- a/test/fixtures/output/kafka/19.golden
+++ b/test/fixtures/output/kafka/19.golden
@@ -1,3 +1,4 @@
+api_endpoint: http://kafka-api-url
 availability: single-zone
 egress: 100
 endpoint: SASL_SSL://kafka-endpoint

--- a/test/fixtures/output/kafka/2.golden
+++ b/test/fixtures/output/kafka/2.golden
@@ -11,5 +11,6 @@ It may take up to 5 minutes for the Kafka cluster to be ready.
 | Region       | us-east-1                 |
 | Status       | PROVISIONING              |
 | Endpoint     | SASL_SSL://kafka-endpoint |
+| ApiEndpoint  | http://127.0.0.1:12345    |
 | RestEndpoint |                           |
 +--------------+---------------------------+

--- a/test/fixtures/output/kafka/22.golden
+++ b/test/fixtures/output/kafka/22.golden
@@ -11,6 +11,7 @@ It may take up to 5 minutes for the Kafka cluster to be ready.
 | Region       | us-east-1                 |
 | Status       | PROVISIONING              |
 | Endpoint     | SASL_SSL://kafka-endpoint |
+| ApiEndpoint  | http://127.0.0.1:12345    |
 | RestEndpoint |                           |
 | ClusterSize  |                         1 |
 +--------------+---------------------------+

--- a/test/fixtures/output/kafka/23.golden
+++ b/test/fixtures/output/kafka/23.golden
@@ -10,5 +10,6 @@
   "availability": "single-zone",
   "status": "PROVISIONING",
   "endpoint": "SASL_SSL://kafka-endpoint",
+  "api_endpoint": "http://127.0.0.1:12345",
   "rest_endpoint": ""
 }

--- a/test/fixtures/output/kafka/24.golden
+++ b/test/fixtures/output/kafka/24.golden
@@ -1,3 +1,4 @@
+api_endpoint: http://127.0.0.1:12345
 availability: single-zone
 egress: 100
 endpoint: SASL_SSL://kafka-endpoint

--- a/test/fixtures/output/kafka/26.golden
+++ b/test/fixtures/output/kafka/26.golden
@@ -10,5 +10,6 @@
 | Region       | us-west-2                 |
 | Status       | UP                        |
 | Endpoint     | SASL_SSL://kafka-endpoint |
+| ApiEndpoint  | http://kafka-api-url      |
 | RestEndpoint | http://kafka-rest-url     |
 +--------------+---------------------------+

--- a/test/fixtures/output/kafka/27.golden
+++ b/test/fixtures/output/kafka/27.golden
@@ -10,6 +10,7 @@
 | Region             | us-west-2                   |
 | Status             | EXPANDING                   |
 | Endpoint           | SASL_SSL://kafka-endpoint   |
+| ApiEndpoint        | http://kafka-api-url        |
 | RestEndpoint       |                             |
 | ClusterSize        |                           1 |
 | PendingClusterSize |                           2 |

--- a/test/fixtures/output/kafka/28.golden
+++ b/test/fixtures/output/kafka/28.golden
@@ -10,5 +10,6 @@
   "availability": "single-zone",
   "status": "UP",
   "endpoint": "SASL_SSL://kafka-endpoint",
+  "api_endpoint": "http://kafka-api-url",
   "rest_endpoint": "http://kafka-rest-url"
 }

--- a/test/fixtures/output/kafka/29.golden
+++ b/test/fixtures/output/kafka/29.golden
@@ -1,3 +1,4 @@
+api_endpoint: http://kafka-api-url
 availability: single-zone
 egress: 100
 endpoint: SASL_SSL://kafka-endpoint

--- a/test/fixtures/output/kafka/30.golden
+++ b/test/fixtures/output/kafka/30.golden
@@ -10,6 +10,7 @@
 | Region       | us-west-2                 |
 | Status       | PROVISIONING              |
 | Endpoint     | SASL_SSL://kafka-endpoint |
+| ApiEndpoint  | http://kafka-api-url      |
 | RestEndpoint | http://kafka-rest-url     |
 | ClusterSize  |                         1 |
 +--------------+---------------------------+

--- a/test/fixtures/output/kafka/31.golden
+++ b/test/fixtures/output/kafka/31.golden
@@ -11,5 +11,6 @@
   "availability": "single-zone",
   "status": "PROVISIONING",
   "endpoint": "SASL_SSL://kafka-endpoint",
+  "api_endpoint": "http://kafka-api-url",
   "rest_endpoint": "http://kafka-rest-url"
 }

--- a/test/fixtures/output/kafka/32.golden
+++ b/test/fixtures/output/kafka/32.golden
@@ -1,3 +1,4 @@
+api_endpoint: http://kafka-api-url
 availability: single-zone
 cluster_size: 1
 egress: 100

--- a/test/fixtures/output/kafka/33.golden
+++ b/test/fixtures/output/kafka/33.golden
@@ -10,6 +10,7 @@
 | Region             | us-west-2                      |
 | Status             | PROVISIONING                   |
 | Endpoint           | SASL_SSL://kafka-endpoint      |
+| ApiEndpoint        | http://kafka-api-url           |
 | RestEndpoint       | http://kafka-rest-url          |
 | ClusterSize        |                              1 |
 | PendingClusterSize |                              2 |

--- a/test/fixtures/output/kafka/34.golden
+++ b/test/fixtures/output/kafka/34.golden
@@ -12,5 +12,6 @@
   "availability": "single-zone",
   "status": "PROVISIONING",
   "endpoint": "SASL_SSL://kafka-endpoint",
+  "api_endpoint": "http://kafka-api-url",
   "rest_endpoint": "http://kafka-rest-url"
 }

--- a/test/fixtures/output/kafka/35.golden
+++ b/test/fixtures/output/kafka/35.golden
@@ -1,3 +1,4 @@
+api_endpoint: http://kafka-api-url
 availability: single-zone
 cluster_size: 1
 egress: 100

--- a/test/fixtures/output/kafka/36.golden
+++ b/test/fixtures/output/kafka/36.golden
@@ -10,6 +10,7 @@
 | Region            | us-west-2                              |
 | Status            | PROVISIONING                           |
 | Endpoint          | SASL_SSL://kafka-endpoint              |
+| ApiEndpoint       | http://kafka-api-url                   |
 | RestEndpoint      | http://kafka-rest-url                  |
 | ClusterSize       |                                      1 |
 | Encryption Key ID | abc123                                 |

--- a/test/fixtures/output/kafka/37.golden
+++ b/test/fixtures/output/kafka/37.golden
@@ -11,6 +11,7 @@
   "availability": "single-zone",
   "status": "PROVISIONING",
   "endpoint": "SASL_SSL://kafka-endpoint",
+  "api_endpoint": "http://kafka-api-url",
   "encryption_key_id": "abc123",
   "rest_endpoint": "http://kafka-rest-url"
 }

--- a/test/fixtures/output/kafka/38.golden
+++ b/test/fixtures/output/kafka/38.golden
@@ -1,3 +1,4 @@
+api_endpoint: http://kafka-api-url
 availability: single-zone
 cluster_size: 1
 egress: 100

--- a/test/fixtures/output/kafka/39.golden
+++ b/test/fixtures/output/kafka/39.golden
@@ -10,6 +10,7 @@
 | Region             | us-west-2                   |
 | Status             | EXPANDING                   |
 | Endpoint           | SASL_SSL://kafka-endpoint   |
+| ApiEndpoint        | http://kafka-api-url        |
 | RestEndpoint       |                             |
 | ClusterSize        |                           1 |
 | PendingClusterSize |                           2 |

--- a/test/fixtures/output/kafka/41.golden
+++ b/test/fixtures/output/kafka/41.golden
@@ -10,5 +10,6 @@
 | Region       | us-west-2                 |
 | Status       | PROVISIONING              |
 | Endpoint     | SASL_SSL://kafka-endpoint |
+| ApiEndpoint  | http://kafka-api-url      |
 | RestEndpoint | http://kafka-rest-url     |
 +--------------+---------------------------+

--- a/test/fixtures/output/kafka/42.golden
+++ b/test/fixtures/output/kafka/42.golden
@@ -10,5 +10,6 @@
   "availability": "single-zone",
   "status": "PROVISIONING",
   "endpoint": "SASL_SSL://kafka-endpoint",
+  "api_endpoint": "http://kafka-api-url",
   "rest_endpoint": "http://kafka-rest-url"
 }

--- a/test/fixtures/output/kafka/43.golden
+++ b/test/fixtures/output/kafka/43.golden
@@ -1,3 +1,4 @@
+api_endpoint: http://kafka-api-url
 availability: single-zone
 egress: 100
 endpoint: SASL_SSL://kafka-endpoint

--- a/test/fixtures/output/kafka/44.golden
+++ b/test/fixtures/output/kafka/44.golden
@@ -10,6 +10,7 @@
 | Region             | us-west-2                   |
 | Status             | SHRINKING                   |
 | Endpoint           | SASL_SSL://kafka-endpoint   |
+| ApiEndpoint        | http://kafka-api-url        |
 | RestEndpoint       |                             |
 | ClusterSize        |                           2 |
 | PendingClusterSize |                           1 |

--- a/test/fixtures/output/kafka/45.golden
+++ b/test/fixtures/output/kafka/45.golden
@@ -10,6 +10,7 @@
 | Region             | us-west-2                   |
 | Status             | SHRINKING                   |
 | Endpoint           | SASL_SSL://kafka-endpoint   |
+| ApiEndpoint        | http://kafka-api-url        |
 | RestEndpoint       |                             |
 | ClusterSize        |                           2 |
 | PendingClusterSize |                           1 |


### PR DESCRIPTION
Reverts confluentinc/cli#932

REST will not reach Kafka API feature parity in 2021. So we should keep the ApiEndpoint around for the time being because the VPC Peering docs reference this endpoint and need it for setting up UI, we can’t remove it.