### PR TITLE
[CLI-1098] installers should use portable [ instead of [[

### DIFF
--- a/install-ccloud.sh
+++ b/install-ccloud.sh
@@ -6,7 +6,7 @@ set -e
 
 S3_URL=https://s3-us-west-2.amazonaws.com/confluent.cloud
 S3_CONTENT_CHECK_URL="${S3_URL}?prefix="
-if [[ ! -z "$OVERRIDE_S3_FOLDER" ]]
+if [ -n "$OVERRIDE_S3_FOLDER" ]
 then
 	S3_CONTENT_CHECK_URL="${S3_URL}?prefix=${OVERRIDE_S3_FOLDER}/"
 	S3_URL=${S3_URL}/${OVERRIDE_S3_FOLDER}

--- a/install-confluent.sh
+++ b/install-confluent.sh
@@ -6,7 +6,7 @@ set -e
 
 S3_URL=https://s3-us-west-2.amazonaws.com/confluent.cloud
 S3_CONTENT_CHECK_URL="${S3_URL}?prefix="
-if [[ ! -z "$OVERRIDE_S3_FOLDER" ]]
+if [ -n "$OVERRIDE_S3_FOLDER" ]
 then
 	S3_CONTENT_CHECK_URL="${S3_URL}?prefix=${OVERRIDE_S3_FOLDER}/"
 	S3_URL=${S3_URL}/${OVERRIDE_S3_FOLDER}


### PR DESCRIPTION
<!--
Is there any breaking changes?  If so this is a major release, make sure '#major' is in at least one
commit message to get CI to bump the major.  This will prevent automatic down stream dependency
bumping / consuming.  For more information about semantic versioning see: https://semver.org/


Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
Checklist
---
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok
   
2. Did you add/update any commands that accept secrets as args/flags?
   * no: ok

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->
Using `[` should be functionally the same as `[[` but is portable. "Keep in mind that it is a bash extension, so if you are writing sh-compatible scripts then you need to stick with [. Make sure you have the #!/bin/bash shebang line for your script if you use double brackets."  https://stackoverflow.com/questions/3427872/whats-the-difference-between-and-in-bash
 
References
----------
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test&Review
------------

<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->
Passing installer tests.
Will publish the installers to prod and test and will be able to quickly revert back if it doesn't work...but it should

<!--
Open questions / Follow ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
