### PR TITLE
CLI-1103 Add schema registry api key and secret as inline flags in kafka topic produce and consume

### DIFF
--- a/cmd/lint/main.go
+++ b/cmd/lint/main.go
@@ -30,7 +30,7 @@ var (
 		"Schema Registry", "ZooKeeper", "ZooKeeper™", "cku",
 	}
 	vocabWords = []string{
-		"ack", "acks", "acl", "acls", "apac", "api", "auth", "avro", "aws", "backoff", "ccloud", "cku", "cli", "codec",
+		"ack", "acks", "acl", "acls", "apac", "api", "apikey", "apisecret", "auth", "avro", "aws", "backoff", "ccloud", "cku", "cli", "codec",
 		"config", "configs", "connect", "connect-catalog", "consumer.config", "crn", "csu", "decrypt", "deserializer",
 		"deserializers", "env", "eu", "formatter", "gcp", "geo", "gzip", "hostname", "html", "https", "iam", "init", "io",
 		"json", "jsonschema", "kafka", "ksql", "lifecycle", "lz4", "mds", "multi-zone", "netrc", "pem", "plaintext",

--- a/internal/cmd/kafka/command_topic.go
+++ b/internal/cmd/kafka/command_topic.go
@@ -729,14 +729,14 @@ func (a *authenticatedTopicCommand) delete(cmd *cobra.Command, args []string) er
 	return nil
 }
 
-func (h *hasAPIKeyTopicCommand) registerSchemaWithAPIKey(cmd *cobra.Command, subject string, valueFormat string, schemaPath string, srAPIKey string, srAPISecret string) ([]byte, error) {
+func (h *hasAPIKeyTopicCommand) registerSchemaWithAPIKey(cmd *cobra.Command, subject, valueFormat, schemaPath, srAPIKey, srAPISecret string) ([]byte, error) {
 	schema, err := ioutil.ReadFile(schemaPath)
 	if err != nil {
 		return nil, err
 	}
 	var refs []srsdk.SchemaReference
 
-	srClient, ctx, err := sr.GetApiClientWithAPIKey(cmd, nil, h.Config, h.Version, srAPIKey, srAPISecret)
+	srClient, ctx, err := sr.GetAPIClientWithAPIKey(cmd, nil, h.Config, h.Version, srAPIKey, srAPISecret)
 	if err != nil {
 		if err.Error() == "ccloud" {
 			return nil, &errors.SRNotAuthenticatedError{CLIName: err.Error()}
@@ -979,7 +979,7 @@ func (h *hasAPIKeyTopicCommand) consume(cmd *cobra.Command, args []string) error
 			return err
 		}
 		// Only initialize client and context when schema is specified.
-		srClient, ctx, err = sr.GetApiClientWithAPIKey(cmd, nil, h.Config, h.Version, srAPIKey, srAPISecret)
+		srClient, ctx, err = sr.GetAPIClientWithAPIKey(cmd, nil, h.Config, h.Version, srAPIKey, srAPISecret)
 		if err != nil {
 			if err.Error() == "ccloud" {
 				return &errors.SRNotAuthenticatedError{CLIName: err.Error()}

--- a/internal/cmd/schema-registry/credentials.go
+++ b/internal/cmd/schema-registry/credentials.go
@@ -48,7 +48,7 @@ func getSchemaRegistryAuth(cmd *cobra.Command, srCredentials *v0.APIKeyPair, sho
 	return auth, didPromptUser, nil
 }
 
-func getSchemaRegistryClient(cmd *cobra.Command, cfg *pcmd.DynamicConfig, ver *version.Version, srAPIKey string, srAPISecret string) (*srsdk.APIClient, context.Context, error) {
+func getSchemaRegistryClient(cmd *cobra.Command, cfg *pcmd.DynamicConfig, ver *version.Version, srAPIKey, srAPISecret string) (*srsdk.APIClient, context.Context, error) {
 	srConfig := srsdk.NewConfiguration()
 
 	ctx := cfg.Context()
@@ -88,6 +88,10 @@ func getSchemaRegistryClient(cmd *cobra.Command, cfg *pcmd.DynamicConfig, ver *v
 				Key:    srAPIKey,
 				Secret: srAPISecret,
 			}
+		} else if srAPISecret != "" {
+			utils.ErrPrintln(cmd, "No schema registry API key specified.")
+		} else if srAPIKey != "" {
+			utils.ErrPrintln(cmd, "No schema registry API key secret specified.")
 		}
 		srAuth, didPromptUser, err := getSchemaRegistryAuth(cmd, srCluster.SrCredentials, shouldPrompt)
 		if err != nil {

--- a/internal/cmd/schema-registry/utils.go
+++ b/internal/cmd/schema-registry/utils.go
@@ -25,7 +25,7 @@ func GetApiClient(cmd *cobra.Command, srClient *srsdk.APIClient, cfg *cmd.Dynami
 	return getSchemaRegistryClient(cmd, cfg, ver, "", "")
 }
 
-func GetApiClientWithAPIKey(cmd *cobra.Command, srClient *srsdk.APIClient, cfg *cmd.DynamicConfig, ver *version.Version, srAPIKey string, srAPISecret string) (*srsdk.APIClient, context.Context, error) {
+func GetAPIClientWithAPIKey(cmd *cobra.Command, srClient *srsdk.APIClient, cfg *cmd.DynamicConfig, ver *version.Version, srAPIKey string, srAPISecret string) (*srsdk.APIClient, context.Context, error) {
 	if srClient != nil {
 		// Tests/mocks
 		return srClient, nil, nil


### PR DESCRIPTION
<!--
Is there any breaking changes?  If so this is a major release, make sure '#major' is in at least one
commit message to get CI to bump the major.  This will prevent automatic down stream dependency
bumping / consuming.  For more information about semantic versioning see: https://semver.org/


Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
Checklist
---
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok
   
2. Did you add/update any commands that accept secrets as args/flags?
   * no: ok

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->
Add schema registry api key and secret as inline flags in `ccloud kafka topic produce/consume`. Call `GetApiClientWithAPIKey` with sr credentials in produce and consume, and then call `GetApiClientWithAPIKey`. If sr credentials are specified, `getSchemaRegistryClient` will set key and secret in `srCluster.SrCredentials` and will not prompt for user input. Otherwise `srCluster.SrCredentials` is nil and will prompt.

References
----------
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test&Review
------------

<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

<!--
Open questions / Follow ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
