### PR TITLE
[CLI-1110] removed references to local_static.js

### DIFF
--- a/mk-files/docs.mk
+++ b/mk-files/docs.mk
@@ -105,8 +105,7 @@ update-settings-and-conf:
 			sed -i '' 's/export RELEASE_VERSION=.*/export RELEASE_VERSION=$(NEXT_MINOR_VERSION)-SNAPSHOT/g' settings.sh && \
 			sed -i '' "s/^version = '.*'/version = \'$(SHORT_NEXT_MINOR_VERSION)\'/g" conf.py && \
 			sed -i '' "s/^release = '.*'/release = \'$(NEXT_MINOR_VERSION)-SNAPSHOT\'/g" conf.py && \
-			sed -i '' "s/docVersions = \[/&\n   '$(CLEAN_VERSION)',/" _local-static/js/script.js && \
-			git commit -am "[ci skip] chore: update settings.sh, conf.py, and script.js due to $(CLEAN_VERSION) release" && \
+			git commit -am "[ci skip] chore: update settings.sh and conf.py due to $(CLEAN_VERSION) release" && \
 			git push && \
 			cd .. ; \
 		done ; \
@@ -118,29 +117,13 @@ update-settings-and-conf:
 		sed -i '' 's/export RELEASE_VERSION=.*/export RELEASE_VERSION=$(NEXT_PATCH_VERSION)-SNAPSHOT/g' settings.sh && \
 		sed -i '' "s/^version = '.*'/version = \'$(CURRENT_SHORT_MINOR_VERSION)\'/g" conf.py && \
 		sed -i '' "s/^release = '.*'/release = \'$(NEXT_PATCH_VERSION)-SNAPSHOT\'/g" conf.py && \
-		sed -i '' "s/docVersions = \[/&\n   '$(CLEAN_VERSION)',/" _local-static/js/script.js && \
-		git commit -am "[ci skip] chore: update settings.sh, conf.py, and script.js due to $(CLEAN_VERSION) release" && \
+		git commit -am "[ci skip] chore: update settings.sh and conf.py due to $(CLEAN_VERSION) release" && \
 		git push && \
 		git checkout $(CLEAN_VERSION)-post && \
 		sed -i '' 's/export RELEASE_VERSION=.*/export RELEASE_VERSION=$(CLEAN_VERSION)/g' settings.sh && \
 		sed -i '' "s/^version = '.*'/version = \'$(CURRENT_SHORT_MINOR_VERSION)\'/g" conf.py && \
 		sed -i '' "s/^release = '.*'/release = \'$(CLEAN_VERSION)\'/g" conf.py && \
-		sed -i '' "s/docVersions = \[/&\n   '$(CLEAN_VERSION)',/" _local-static/js/script.js && \
-		git commit -am "[ci skip] chore: update settings.sh, conf.py, and script.js due to $(CLEAN_VERSION) release" && \
+		git commit -am "[ci skip] chore: update settings.sh and conf.py due to $(CLEAN_VERSION) release" && \
 		git push && \
 		cd .. ; \
 	done
-	for repo in $(CCLOUD_DOCS_DIR) $(CONFLUENT_DOCS_DIR) ; do \
-		oldest_branch=$(OLDEST_BRANCH_CONFLUENT) && \
-		if [[ "$(CCLOUD_DOCS_DIR)" == "$${repo}" ]]; then \
-			oldest_branch=$(OLDEST_BRANCH_CCLOUD); \
-		fi ; \
-		cd $${repo} && \
-		git fetch && \
-		git checkout $${oldest_branch} && \
-		sed -i '' "s/docVersions = \[/&\n   '$(CLEAN_VERSION)',/" _local-static/js/script.js && \
-		git commit -am "chore: add new version $(CLEAN_VERSION) to all old branches' version pickers" && \
-		git push && \
-		cd .. ; \
-	done
-


### PR DESCRIPTION
<!--
Is there any breaking changes?  If so this is a major release, make sure '#major' is in at least one
commit message to get CI to bump the major.  This will prevent automatic down stream dependency
bumping / consuming.  For more information about semantic versioning see: https://semver.org/


Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
Checklist
---
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok
   
2. Did you add/update any commands that accept secrets as args/flags?
   * no: ok

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->
the static.js file that used to hold the version list to populate the picker has been moved to docs-include repo. So removed all logic referencing that file. For now manual updates to docs-include are required but soon it will be automated.

References
----------
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test&Review
------------

<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

<!--
Open questions / Follow ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
