### PR TITLE
CLI Unification: Fix `confluent kafka topic` subcommands

### DIFF
--- a/internal/cmd/command.go
+++ b/internal/cmd/command.go
@@ -38,7 +38,6 @@ import (
 	pcmd "github.com/confluentinc/cli/internal/pkg/cmd"
 	pconfig "github.com/confluentinc/cli/internal/pkg/config"
 	"github.com/confluentinc/cli/internal/pkg/config/load"
-	v2 "github.com/confluentinc/cli/internal/pkg/config/v2"
 	v3 "github.com/confluentinc/cli/internal/pkg/config/v3"
 	"github.com/confluentinc/cli/internal/pkg/errors"
 	"github.com/confluentinc/cli/internal/pkg/form"
@@ -130,7 +129,7 @@ func NewConfluentCommand(cfg *v3.Config, isTest bool, ver *pversion.Version) *co
 	cli.AddCommand(environmentCmd.Command)
 	cli.AddCommand(iam.New(cfg, prerunner))
 	cli.AddCommand(initcontext.New(prerunner, flagResolver, analyticsClient))
-	cli.AddCommand(kafka.New(cfg, isAPIKeyCredential(cfg), prerunner, logger.Named("kafka"), ver.ClientID, serverCompleter, analyticsClient))
+	cli.AddCommand(kafka.New(cfg, prerunner, logger.Named("kafka"), ver.ClientID, serverCompleter, analyticsClient))
 	cli.AddCommand(ksql.New(cfg, prerunner, serverCompleter, analyticsClient))
 	cli.AddCommand(local.New(prerunner))
 	cli.AddCommand(login.New(prerunner, logger, ccloudClientFactory, mdsClientManager, analyticsClient, netrcHandler, loginCredentialsManager, authTokenHandler, isTest).Command)
@@ -164,11 +163,6 @@ func getAnalyticsClient(isTest bool, cliName string, cfg *v3.Config, cliVersion 
 		Logger: analytics.NewLogger(logger),
 	})
 	return analytics.NewAnalyticsClient(cliName, cfg, cliVersion, segmentClient, clockwork.NewRealClock())
-}
-
-func isAPIKeyCredential(cfg *v3.Config) bool {
-	ctx := cfg.Context()
-	return ctx != nil && ctx.Credential != nil && ctx.Credential.CredentialType == v2.APIKey
 }
 
 func (c *command) Execute(args []string) error {

--- a/internal/cmd/kafka/command_test.go
+++ b/internal/cmd/kafka/command_test.go
@@ -659,8 +659,7 @@ func Test_HandleError_NotLoggedIn(t *testing.T) {
 		},
 	}
 	client := &ccloud.Client{Kafka: kafka}
-	cmd := New(conf, false, cliMock.NewPreRunnerMock(client, nil, nil, conf),
-		log.New(), "test-client", &cliMock.ServerSideCompleter{}, cliMock.NewDummyAnalyticsMock())
+	cmd := New(conf, cliMock.NewPreRunnerMock(client, nil, nil, conf), log.New(), "test-client", &cliMock.ServerSideCompleter{}, cliMock.NewDummyAnalyticsMock())
 	cmd.PersistentFlags().CountP("verbose", "v", "Increase output verbosity")
 	cmd.SetArgs([]string{"cluster", "list"})
 	buf := new(bytes.Buffer)
@@ -1172,8 +1171,7 @@ func newMockCmd(kafkaExpect chan interface{}, kafkaRestExpect chan interface{}, 
 		}
 		return nil, nil
 	})
-	cmd := New(conf, false, cliMock.NewPreRunnerMock(client, nil, &provider, conf),
-		log.New(), "test-client", &cliMock.ServerSideCompleter{}, cliMock.NewDummyAnalyticsMock())
+	cmd := New(conf, cliMock.NewPreRunnerMock(client, nil, &provider, conf), log.New(), "test-client", &cliMock.ServerSideCompleter{}, cliMock.NewDummyAnalyticsMock())
 	cmd.PersistentFlags().CountP("verbose", "v", "Increase output verbosity")
 	return cmd
 }

--- a/internal/cmd/kafka/command_topic_onprem_test.go
+++ b/internal/cmd/kafka/command_topic_onprem_test.go
@@ -236,7 +236,7 @@ func (suite *KafkaTopicOnPremTestSuite) createCommand() *cobra.Command {
 	conf = v3.AuthenticatedConfluentConfigMock()
 	provider := suite.getRestProvider()
 	testPrerunner := cliMock.NewPreRunnerMock(nil, nil, &provider, conf)
-	return NewTopicCommand(conf, false, testPrerunner, nil, "").Command
+	return NewTopicCommand(conf, testPrerunner, nil, "").authenticatedTopicCommand.Command
 }
 
 // Executes the given command with the given args, returns the command executed, stdout and error.

--- a/internal/cmd/kafka/command_topic_test.go
+++ b/internal/cmd/kafka/command_topic_test.go
@@ -40,7 +40,7 @@ func (suite *KafkaTopicTestSuite) newCmd(conf *v3.Config) *kafkaTopicCommand {
 		},
 	}
 	prerunner := cliMock.NewPreRunnerMock(client, nil, nil, conf)
-	cmd := NewTopicCommand(conf, false, prerunner, nil, "id")
+	cmd := NewTopicCommand(conf, prerunner, nil, "id")
 	return cmd
 }
 


### PR DESCRIPTION
Checklist
---
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok
   
2. Did you add/update any commands that accept secrets as args/flags?
   * no: ok

What
----
The on-prem version of this command wasn't displaying subcommands correctly after https://github.com/confluentinc/cli/pull/962 (a side effect of unnecessarily confusing logic!) I was able to make a few simplifications in the process.

Test & Review
------------
Test cases still pass and verified that available commands match the current docs.
