### PR TITLE
Remove Emacs editor config from root directory

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,1 +1,0 @@
-((nil . ((projectile-project-type . go))))

--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,11 @@ git-setup-semaphore.sh
 *.dll
 *.so
 *.dylib
-.idea
+
+# Editor configurations
+*.el
+.idea/
+.vscode/
 
 # Test binary, build with `go test -c`
 *.test
@@ -38,7 +42,6 @@ integ_coverage.txt
 unit_coverage.txt
 /ccloud
 *.sw*
-.vscode
 **/*.DS_Store
 release-notes/prep
 release-notes/ccloud/latest-release.rst


### PR DESCRIPTION
Checklist
---
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok
   
2. Did you add/update any commands that accept secrets as args/flags?
   * no: ok

What
----
I think it's fair to assume that most CLI developers aren't using Emacs. Remove the Emacs editor configuration file and add it to the .gitignore file.

Note: This was added in https://github.com/confluentinc/cli/commit/9b53216e61d0c2be724d9b61ae4b3060b86cec31