### PR TITLE
CLI-1097 Fix table header for `connect plugin list`

### DIFF
--- a/internal/cmd/connect/command_plugin.go
+++ b/internal/cmd/connect/command_plugin.go
@@ -21,12 +21,13 @@ type pluginCommand struct {
 }
 
 type pluginDisplay struct {
-	Name string
-	Type string
+	PluginName string
+	Type       string
 }
 
 var (
-	pluginFields          = []string{"Name", "Type"}
+	pluginFields          = []string{"PluginName", "Type"}
+	pluginHumanFields     = []string{"Plugin Name", "Type"}
 	pluginStructureLabels = []string{"plugin_name", "type"}
 )
 
@@ -78,7 +79,7 @@ func (c *pluginCommand) init(cliName string) {
 }
 
 func (c *pluginCommand) list(cmd *cobra.Command, _ []string) error {
-	outputWriter, err := output.NewListOutputWriter(cmd, pluginFields, pluginFields, pluginStructureLabels)
+	outputWriter, err := output.NewListOutputWriter(cmd, pluginFields, pluginHumanFields, pluginStructureLabels)
 	if err != nil {
 		return err
 	}
@@ -104,8 +105,8 @@ func (c *pluginCommand) getPlugins(cmd *cobra.Command) ([]*pluginDisplay, error)
 	var plugins []*pluginDisplay
 	for _, conn := range connectorInfo {
 		plugins = append(plugins, &pluginDisplay{
-			Name: conn.Class,
-			Type: conn.Type,
+			PluginName: conn.Class,
+			Type:       conn.Type,
 		})
 	}
 	return plugins, nil
@@ -160,7 +161,7 @@ func (c *pluginCommand) ServerComplete() []prompt.Suggest {
 	}
 	for _, conn := range plugins {
 		suggestions = append(suggestions, prompt.Suggest{
-			Text:        conn.Name,
+			Text:        conn.PluginName,
 			Description: conn.Type,
 		})
 	}

--- a/test/fixtures/output/connect/connect-plugin-list.golden
+++ b/test/fixtures/output/connect/connect-plugin-list.golden
@@ -1,4 +1,4 @@
-      Name      | Type  
+   Plugin Name  | Type  
 +---------------+------+
   AzureBlobSink | Sink  
   GcsSink       | Sink  


### PR DESCRIPTION
<!--
Is there any breaking changes?  If so this is a major release, make sure '#major' is in at least one
commit message to get CI to bump the major.  This will prevent automatic down stream dependency
bumping / consuming.  For more information about semantic versioning see: https://semver.org/


Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
Checklist
---
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok
   
2. Did you add/update any commands that accept secrets as args/flags?
   * no: ok

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->
Added PluginHumanFields in connect cmds to fix the output header of `connect plugin list` from "PluginName" to "Plugin Name".

References
----------
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test&Review
------------

<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

<!--
Open questions / Follow ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
