### PR TITLE
[ci skip] rm outdated readme info

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ as part of the repo's build process.
   - [File Layout](#file-layout)
   - [Build Other Platforms](#build-other-platforms)
   - [URLS](#urls)
-  - [Releasing a New CLI Version](#releasing-a-new-cli-version)
 - [Installers](#installers)
 - [Documentation](#documentation)
   - [README](#readme)
@@ -187,50 +186,6 @@ If you have a need to build a binary for a platform that is not the current one,
 
 ### URLS
 Use the `login` command with the `--url` option to point to a different development environment
-
-### Releasing a New CLI Version
-
-0. Note: Due to the requirement of signing the macOS binaries, CLI releases
-can currently only be run from a macOS host.  Binaries for all OS will be
-generated and published from the macOS host.
-
-1. To release a new CLI version, first ensure you have an Apple ID with
-permissions for the Confluent organization.  Chris Toney / IT can set you up
-with the appropriate permissions; cc @David Hyde, @srini or CLI or Release team
-manager.  You will also need IT to give you the Developer ID Application cert
-and private key (shared via a LastPass secret).  Chris Toney set that up.
-
-2. Make sure you have `gon` installed and in your PATH.  Get it from
-https://github.com/mitchellh/gon/releases
-
-3. Edit your bash/zsh profile to export your Apple ID and password via the
-`AC_USERNAME` and `AC_PASSWORD` variables.  It is recommended to not write
-your Apple ID password in plaintext in this file; e.g. you can write
-`export AC_PASSWORD=$(echo <your base64-encoded password> | base64 --decode)`.
-
-4. Just in case, e.g. if you did Step 2 for the first time, run
-`source ~/.bash_profile` or the equivalent for your shell/OS.
-
-5. Next run `caasenv prod` (needed to upload files to the CLI S3 buckets).
-
-6. Next make sure your git status is clean: `git status`.  You should also be
-on `master` under normal circumstances.
-
-7. With these steps completed you should be able to run `make release`
-successfully.  If you see any errors during the release process, contact
-a CLI team member.  It is possible to use the AWS CLI to remove any mistakenly-
-uploaded binaries/archives (just remove the corresponding version folders).
-You could also remove an accidentally-published tag on GitHub, but this isn't
-essential.
-
-Note: you can verify whether a macOS binary is signed and notarized correctly
-by running `spctl -a -vvv -t install <binary name>`.  If all is good, you
-should see output like
-```
-dist/ccloud/ccloud_darwin_amd64/ccloud: accepted
-source=Notarized Developer ID
-origin=Developer ID Application: Confluent, Inc. (RTSX8FNWR2)
-```
 
 ## Installers
 


### PR DESCRIPTION
We maintain updated/correct release info in the wiki now, so this outdated info should be removed from the readme.