### PR TITLE
CLI-1161: Update long description for `ccloud api-key use`

### DIFF
--- a/cmd/lint/main.go
+++ b/cmd/lint/main.go
@@ -65,7 +65,7 @@ var rules = []linter.Rule{
 				"environment":    {CreateCommandArg: "<name>", OtherCommandsArg: "<environment-id>"},
 				"role":           {CreateCommandArg: "<name>", OtherCommandsArg: "<name>"},
 				"topic":          {CreateCommandArg: "<topic>", OtherCommandsArg: "<topic>"},
-				"api-key":        {CreateCommandArg: "N/A", OtherCommandsArg: "<apikey>"},
+				"api-key":        {CreateCommandArg: "N/A", OtherCommandsArg: "<api-key>"},
 				"consumer-group": {CreateCommandArg: "<consumer-group>", OtherCommandsArg: "<consumer-group>"},
 				"lag":            {CreateCommandArg: "N/A", OtherCommandsArg: "<consumer-group>"},
 			},
@@ -83,7 +83,7 @@ var rules = []linter.Rule{
 		// skip local which delegates to external bash scripts
 		linter.ExcludeCommandContains("local"),
 		// skip for api-key store command since KEY is not last argument
-		linter.ExcludeCommand("api-key store <apikey> <secret>"),
+		linter.ExcludeCommand("api-key store <api-key> <secret>"),
 		// skip for rolebindings since they don't have names/IDs
 		linter.ExcludeCommandContains("iam rolebinding"),
 		// skip for register command since they don't have names/IDs

--- a/internal/cmd/api-key/command.go
+++ b/internal/cmd/api-key/command.go
@@ -123,7 +123,7 @@ func (c *command) init() {
 	c.AddCommand(createCmd)
 
 	updateCmd := &cobra.Command{
-		Use:   "update <apikey>",
+		Use:   "update <api-key>",
 		Short: "Update an API key.",
 		Args:  cobra.ExactArgs(1),
 		RunE:  pcmd.NewCLIRunE(c.update),
@@ -133,7 +133,7 @@ func (c *command) init() {
 	c.AddCommand(updateCmd)
 
 	deleteCmd := &cobra.Command{
-		Use:   "delete <apikey>",
+		Use:   "delete <api-key>",
 		Short: "Delete an API key.",
 		Args:  cobra.ExactArgs(1),
 		RunE:  pcmd.NewCLIRunE(c.delete),
@@ -141,7 +141,7 @@ func (c *command) init() {
 	c.AddCommand(deleteCmd)
 
 	storeCmd := &cobra.Command{
-		Use:   "store <apikey> <secret>",
+		Use:   "store <api-key> <secret>",
 		Short: "Store an API key/secret locally to use in the CLI.",
 		Long:  longDescription,
 		Args:  cobra.MaximumNArgs(2),
@@ -153,8 +153,9 @@ func (c *command) init() {
 	c.AddCommand(storeCmd)
 
 	useCmd := &cobra.Command{
-		Use:   "use <apikey>",
-		Short: "Make an API key active for use in other commands.",
+		Use:   "use <api-key>",
+		Short: "Set the active API key for use in other commands.",
+		Long:  "Set the active API key for use in any command which supports passing an API key with the `--api-key` flag.",
 		Args:  cobra.ExactArgs(1),
 		RunE:  pcmd.NewCLIRunE(c.use),
 	}

--- a/test/fixtures/output/apikey/37.golden
+++ b/test/fixtures/output/apikey/37.golden
@@ -1,6 +1,6 @@
 Error: required flag(s) "resource" not set
 Usage:
-  ccloud api-key use <apikey> [flags]
+  ccloud api-key use <api-key> [flags]
 
 Flags:
       --resource string   REQUIRED: The resource ID.


### PR DESCRIPTION
Checklist
---
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok
   
2. Did you add/update any commands that accept secrets as args/flags?
   * no: ok

What
----
Improve long description for `confluent/ccloud api-key use` to make it clear that this command is used in place of writing `--api-key <api-key>` for supported commands.

References
----------
[CLI-1161](https://confluentinc.atlassian.net/browse/CLI-1161)