### PR TITLE
Fix GitHub security notices

### DIFF
--- a/internal/cmd/api-key/command.go
+++ b/internal/cmd/api-key/command.go
@@ -225,8 +225,8 @@ func (c *command) list(cmd *cobra.Command, _ []string) error {
 				return errors.NewErrorWithSuggestions(fmt.Sprintf(errors.ServiceAccountNotFoundErrorMsg, serviceAccountId), errors.ServiceAccountNotFoundSuggestions)
 			}
 		} else { // if user inputs numeric ID, convert it to int32
-			userIdp, _ := strconv.Atoi(serviceAccountId)
-			userId = int32(userIdp)
+			n, _ := strconv.ParseInt(serviceAccountId, 10, 32)
+			userId = int32(n)
 		}
 	}
 
@@ -669,26 +669,26 @@ func (c *command) getAllUsers() ([]*orgv1.User, error) {
 	return append(serviceAccounts, adminUsers...), nil
 }
 
-func (c *command) completeKeyId(key *schedv1.ApiKey, Id string) (*schedv1.ApiKey, error) {
-	if Id != "" { // it has a service-account flag
+func (c *command) completeKeyId(key *schedv1.ApiKey, id string) (*schedv1.ApiKey, error) {
+	if id != "" { // it has a service-account flag
 		key.ServiceAccount = true
 		users, err := c.getAllUsers()
 		if err != nil {
 			return key, err
 		}
-		idp, err := strconv.Atoi(Id)
-		if err != nil { // it's a resource id
-			key.UserResourceId = Id
+
+		if userID, err := strconv.ParseInt(id, 10, 32); err == nil {
+			key.UserId = int32(userID)
 			for _, user := range users {
-				if Id == user.ResourceId {
-					key.UserId = user.Id
+				if int32(userID) == user.Id {
+					key.UserResourceId = user.ResourceId
 				}
 			}
-		} else { // it's a numeric id
-			key.UserId = int32(idp)
+		} else {
+			key.UserResourceId = id
 			for _, user := range users {
-				if int32(idp) == user.Id {
-					key.UserResourceId = user.ResourceId
+				if id == user.ResourceId {
+					key.UserId = user.Id
 				}
 			}
 		}

--- a/internal/cmd/cluster/command_registry.go
+++ b/internal/cmd/cluster/command_registry.go
@@ -123,9 +123,9 @@ func (c *registryCommand) parseHosts(cmd *cobra.Command) ([]mds.HostInfo, error)
 	hostInfos := make([]mds.HostInfo, 0)
 	for _, host := range strings.Split(hostStr, ",") {
 		hostInfo := strings.Split(host, ":")
-		port := 0
+		port := int64(0)
 		if len(hostInfo) > 1 {
-			port, _ = strconv.Atoi(hostInfo[1])
+			port, _ = strconv.ParseInt(hostInfo[1], 10, 32)
 		}
 		hostInfos = append(hostInfos, mds.HostInfo{Host: hostInfo[0], Port: int32(port)})
 	}

--- a/internal/cmd/schema-registry/command_schema.go
+++ b/internal/cmd/schema-registry/command_schema.go
@@ -249,14 +249,17 @@ func (c *schemaCommand) describeById(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	schema, err := strconv.Atoi(args[0])
+
+	schemaID, err := strconv.ParseInt(args[0], 10, 32)
 	if err != nil {
 		return errors.NewErrorWithSuggestions(fmt.Sprintf(errors.SchemaIntegerErrorMsg, args[0]), errors.SchemaIntegerSuggestions)
 	}
-	schemaString, _, err := srClient.DefaultApi.GetSchema(ctx, int32(schema), nil)
+
+	schemaString, _, err := srClient.DefaultApi.GetSchema(ctx, int32(schemaID), nil)
 	if err != nil {
 		return err
 	}
+
 	return c.printSchema(cmd, schemaString.Schema, schemaString.SchemaType, schemaString.References)
 }
 

--- a/internal/cmd/service-account/command.go
+++ b/internal/cmd/service-account/command.go
@@ -185,36 +185,33 @@ func (c *command) update(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	idp, err := strconv.Atoi(args[0])
-	user := &orgv1.User{
-		ServiceDescription: description,
-	}
-	if err == nil { // it's a numeric ID
-		user.Id = int32(idp)
-	} else { // it's a resource ID
+	user := &orgv1.User{ServiceDescription: description}
+	if userID, err := strconv.ParseInt(args[0], 10, 32); err == nil {
+		user.Id = int32(userID)
+	} else {
 		user.ResourceId = args[0]
 	}
 
-	err = c.Client.User.UpdateServiceAccount(context.Background(), user)
-	if err != nil {
+	if err := c.Client.User.UpdateServiceAccount(context.Background(), user); err != nil {
 		return err
 	}
+
 	utils.ErrPrintf(cmd, errors.UpdateSuccessMsg, "description", "service account", args[0], description)
 	return nil
 }
 
-func (c *command) delete(cmd *cobra.Command, args []string) error {
-	idp, err := strconv.Atoi(args[0])
+func (c *command) delete(_ *cobra.Command, args []string) error {
 	user := &orgv1.User{}
-	if err == nil { // it's a numeric ID
-		user.Id = int32(idp)
-	} else { // it's a resource ID
+	if userID, err := strconv.ParseInt(args[0], 10, 32); err == nil {
+		user.Id = int32(userID)
+	} else {
 		user.ResourceId = args[0]
 	}
-	err = c.Client.User.DeleteServiceAccount(context.Background(), user)
-	if err != nil {
+
+	if err := c.Client.User.DeleteServiceAccount(context.Background(), user); err != nil {
 		return err
 	}
+
 	c.analyticsClient.SetSpecialProperty(analytics.ResourceIDPropertiesKey, user.Id)
 	return nil
 }

--- a/internal/pkg/acl/acl.go
+++ b/internal/pkg/acl/acl.go
@@ -357,10 +357,8 @@ func PrintACLsFromKafkaRestResponseWithMap(cmd *cobra.Command, aclGetResp kafkar
 		principal := aclData.Principal
 		var resourceId string
 		if principal != "" {
-			UserId := principal[5:]
-			idp, err := strconv.Atoi(UserId)
-			if err == nil {
-				resourceId = IdMap[int32(idp)]
+			if userID, err := strconv.ParseInt(principal[5:], 10, 32); err == nil {
+				resourceId = IdMap[int32(userID)]
 			}
 		}
 		record := &struct {
@@ -404,10 +402,8 @@ func PrintACLsWithMap(cmd *cobra.Command, bindingsObj []*schedv1.ACLBinding, wri
 		principal := binding.Entry.Principal
 		var resourceId string
 		if principal != "" {
-			UserId := principal[5:]
-			idp, err := strconv.Atoi(UserId)
-			if err == nil {
-				resourceId = IdMap[int32(idp)]
+			if userID, err := strconv.ParseInt(principal[5:], 10, 32); err == nil {
+				resourceId = IdMap[int32(userID)]
 			}
 		}
 		record := &struct {


### PR DESCRIPTION
Checklist
---
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok
   
2. Did you add/update any commands that accept secrets as args/flags?
   * no: ok

What
----
If we're converting a `string` to `int32`, we shouldn't use `strconv.Atoi()` since it could produce integers greater than `int32`, which will overflow, and could potentially give users access to resource IDs not belonging to them (hopefully our APIs would protect against this... and all of our IDs seem to be well under `int32`, but it doesn't hurt to be extra safe)

References
----------
The specific alerts can be found here: https://github.com/confluentinc/cli/security/code-scanning