### PR TITLE
Fix formatting for `ccloud api-key store` docs

### DIFF
--- a/internal/cmd/api-key/command.go
+++ b/internal/cmd/api-key/command.go
@@ -33,15 +33,7 @@ machine, the secret is not available for CLI use until you "store" it. This is b
 secrets are irretrievable after creation.
 
 You must have an API secret stored locally for certain CLI commands to
-work. For example, the Kafka topic consume and produce commands require an API secret.
-
-There are five ways to pass the secret:
-1. api-key store <key> <secret>.
-2. api-key store; you will be prompted for both API key and secret.
-3. api-key store <key>; you will be prompted for API secret.
-4. api-key store <key> -; for piping API secret.
-5. api-key store <key> @<filepath>.
-`
+work. For example, the Kafka topic consume and produce commands require an API secret.`
 
 type command struct {
 	*pcmd.AuthenticatedStateFlagCommand
@@ -141,11 +133,33 @@ func (c *command) init() {
 	c.AddCommand(deleteCmd)
 
 	storeCmd := &cobra.Command{
-		Use:   "store <api-key> <secret>",
+		Use:   "store [api-key] [secret]",
 		Short: "Store an API key/secret locally to use in the CLI.",
 		Long:  longDescription,
 		Args:  cobra.MaximumNArgs(2),
 		RunE:  pcmd.NewCLIRunE(c.store),
+		Example: examples.BuildExampleString(
+			examples.Example{
+				Text: "Pass the API key and secret as arguments",
+				Code: "ccloud api-key store my-key my-secret",
+			},
+			examples.Example{
+				Text: "Get prompted for both the API key and secret",
+				Code: "ccloud api-key store",
+			},
+			examples.Example{
+				Text: "Get prompted for only the API secret",
+				Code: "ccloud api-key store my-key",
+			},
+			examples.Example{
+				Text: "Pipe the API secret",
+				Code: "ccloud api-key store my-key -",
+			},
+			examples.Example{
+				Text: "Provide the API secret in a file",
+				Code: "ccloud api-key store my-key @my-secret.txt",
+			},
+		),
 	}
 	storeCmd.Flags().String(resourceFlagName, "", "The resource ID of the resource the API key is for.")
 	storeCmd.Flags().BoolP("force", "f", false, "Force overwrite existing secret for this key.")


### PR DESCRIPTION
Checklist
---
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok
   
2. Did you add/update any commands that accept secrets as args/flags?
   * no: ok

Before
-
![Screen Shot 2021-10-01 at 4 38 07 PM](https://user-images.githubusercontent.com/7474900/135696142-c716fe2e-91d6-4e80-986a-55a9d074421f.png)

After
-
![Screen Shot 2021-10-01 at 4 39 54 PM](https://user-images.githubusercontent.com/7474900/135696210-a0a9834c-cf34-4fd1-84e6-12e21288c71a.png)