### PR TITLE
Revert disable update check in integration tests

### DIFF
--- a/test/cli_test.go
+++ b/test/cli_test.go
@@ -479,7 +479,6 @@ func resetConfiguration(t *testing.T, cliName string) {
 	// HACK: delete your current config to isolate tests cases for non-workflow tests...
 	// probably don't really want to do this or devs will get mad
 	cfg := v3.New(&config.Params{CLIName: cliName})
-	cfg.DisableUpdateCheck = true
 
 	err := cfg.Save()
 	require.NoError(t, err)


### PR DESCRIPTION
I added this while I was attempting to write integration tests for `confluent update` & forgot to remove it. Sorry!