### PR TITLE
CLI-265: Use temporary home directory for integration tests

### DIFF
--- a/test/cli_test.go
+++ b/test/cli_test.go
@@ -126,6 +126,11 @@ func (s *CLITestSuite) SetupSuite() {
 
 	err = os.Setenv("XX_CCLOUD_RBAC_DATAPLANE", "yes")
 	req.NoError(err)
+
+	// Temporarily change $HOME, so the current config file isn't altered.
+	err = os.Setenv("HOME", os.TempDir())
+	req.NoError(err)
+
 	for _, binary := range []string{ccloudTestBin, confluentTestBin} {
 		if _, err = os.Stat(binaryPath(s.T(), binary)); os.IsNotExist(err) || !*noRebuild {
 			var makeArgs string


### PR DESCRIPTION
Checklist
---
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok
   
2. Did you add/update any commands that accept secrets as args/flags?
   * no: ok

What
----
Should've done this a long time ago! Change `$HOME` to `$TMPDIR` for integration tests so the current configuration file no longer gets overridden.