### PR TITLE
CLI-1317: Release to GitHub

### DIFF
--- a/.goreleaser-alpine.yml
+++ b/.goreleaser-alpine.yml
@@ -1,6 +1,6 @@
 project_name: confluent
 
-dist: dist/confluent
+dist: dist
 
 before:
   hooks:

--- a/.goreleaser-build.yml
+++ b/.goreleaser-build.yml
@@ -1,6 +1,6 @@
 project_name: confluent
 
-dist: dist/confluent
+dist: dist
 
 builds:
   - binary: confluent

--- a/.goreleaser-fake.yml
+++ b/.goreleaser-fake.yml
@@ -1,6 +1,6 @@
 project_name: confluent
 
-dist: dist/confluent
+dist: dist
 
 before:
   hooks:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,6 +1,6 @@
 project_name: confluent
 
-dist: dist/confluent
+dist: dist
 
 before:
   hooks:
@@ -49,7 +49,7 @@ builds:
         - cmd: make download-licenses
           env:
             - LICENSE_BIN=confluent
-            - LICENSE_BIN_PATH=./dist/confluent/signed-amd64_darwin_amd64/confluent
+            - LICENSE_BIN_PATH=./dist/signed-amd64_darwin_amd64/confluent
         - cmd: gon gon_confluent_amd64.hcl
   - binary: confluent
     id: signed-arm64
@@ -71,11 +71,8 @@ builds:
         - cmd: make download-licenses
           env:
             - LICENSE_BIN=confluent
-            - LICENSE_BIN_PATH=./dist/confluent/signed-arm64_darwin_arm64/confluent
+            - LICENSE_BIN_PATH=./dist/signed-arm64_darwin_arm64/confluent
         - cmd: gon gon_confluent_arm64.hcl
-
-release:
-  disable: true
 
 archives:
   - id: binary

--- a/Dockerfile_alpine
+++ b/Dockerfile_alpine
@@ -24,6 +24,6 @@ RUN chmod 600 /root/.netrc
 
 RUN cd /go/src/github.com/confluentinc/cli && \
     make gorelease-alpine ; \
-    for file in dist/confluent/*linux*; do mv -v "$file" "${file/linux/alpine}"; done ; \
-    for file in dist/confluent/*.txt; do mv -v "$file" "${file/checksums/checksums_alpine}"; done; \
-    for file in dist/confluent/*.txt; do sed -i 's/linux/alpine/g' $file ; done
+    for file in dist/*linux*; do mv -v "$file" "${file/linux/alpine}"; done ; \
+    for file in dist/*.txt; do mv -v "$file" "${file/checksums/checksums_alpine}"; done; \
+    for file in dist/*.txt; do sed -i 's/linux/alpine/g' $file ; done

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -48,7 +48,7 @@ def job = {
                             echo "machine github.com\n\tlogin $GIT_USER\n\tpassword $GIT_TOKEN" > ~/.netrc
                             make jenkins-deps || exit 1
                             make build
-                            cd dist/confluent
+                            cd dist
                             dir=confluent_SNAPSHOT-${HASH}_linux_amd64
                             mv confluent_linux_amd64 $dir
                             tarball=$dir.tar.gz

--- a/Makefile
+++ b/Makefile
@@ -166,10 +166,9 @@ lint-installers:
 ## Scan and validate third-party dependency licenses
 lint-licenses: build
 	$(eval token := $(shell (grep github.com ~/.netrc -A 2 | grep password || grep github.com ~/.netrc -A 2 | grep login) | head -1 | awk -F' ' '{ print $$2 }'))
-	@binary="confluent" ; \
-	echo Licenses for $${binary} binary ; \
+	echo Licenses for confluent binary ; \
 	[ -t 0 ] && args="" || args="-plain" ; \
-	GITHUB_TOKEN=$(token) golicense $${args} .golicense.hcl ./dist/$${binary}/$${binary}_$(shell go env GOOS)_$(shell go env GOARCH)/$${binary} || true
+	GITHUB_TOKEN=$(token) golicense $${args} .golicense.hcl ./dist/confluent_$(shell go env GOOS)_$(shell go env GOARCH)/confluent || true
 
 .PHONY: coverage-unit
 coverage-unit:

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ To install the CLI:
 ```
 $ make deps
 $ make build
-$ dist/confluent/confluent_$(go env GOOS)_$(go env GOARCH)/confluent -h
+$ dist/confluent_$(go env GOOS)_$(go env GOARCH)/confluent -h
 ```
 
 If `make deps` fails with an "unknown revision" error, you probably need to put your username and a
@@ -397,7 +397,7 @@ With an entirely new command, we would also need to register it with the base to
 To build the CLI binary, we run `make build`. After this, we can run our command in the following way, and see that it (hopefully) works!
 
 ```
-dist/confluent/confluent_<platform>_<arch>/confluent config file show 3
+dist/confluent_<platform>_<arch>/confluent config file show 3
 ```
 
 ### Integration Testing

--- a/debian/patches/standard_build_layout.patch
+++ b/debian/patches/standard_build_layout.patch
@@ -1,6 +1,6 @@
---- cli/Makefile	2021-09-22 14:16:50.000000000 -0700
-+++ debian/Makefile	2021-08-26 16:04:24.000000000 -0700
-@@ -1,217 +1,130 @@
+--- cli/Makefile	2021-10-07 11:10:55.000000000 -0700
++++ debian/Makefile	2021-09-27 13:48:33.000000000 -0700
+@@ -1,216 +1,130 @@
 -SHELL           := /bin/bash
 -ALL_SRC         := $(shell find . -name "*.go" | grep -v -e vendor)
 -GIT_REMOTE_NAME ?= origin
@@ -256,10 +256,9 @@
 -## Scan and validate third-party dependency licenses
 -lint-licenses: build
 -	$(eval token := $(shell (grep github.com ~/.netrc -A 2 | grep password || grep github.com ~/.netrc -A 2 | grep login) | head -1 | awk -F' ' '{ print $$2 }'))
--	@binary="confluent" ; \
--	echo Licenses for $${binary} binary ; \
+-	echo Licenses for confluent binary ; \
 -	[ -t 0 ] && args="" || args="-plain" ; \
--	GITHUB_TOKEN=$(token) golicense $${args} .golicense.hcl ./dist/$${binary}/$${binary}_$(shell go env GOOS)_$(shell go env GOARCH)/$${binary} || true
+-	GITHUB_TOKEN=$(token) golicense $${args} .golicense.hcl ./dist/confluent_$(shell go env GOOS)_$(shell go env GOARCH)/confluent || true
 -
 -.PHONY: coverage-unit
 -coverage-unit:

--- a/gon_confluent_amd64.hcl
+++ b/gon_confluent_amd64.hcl
@@ -1,4 +1,4 @@
-source = ["./dist/confluent/signed-amd64_darwin_amd64/confluent"]
+source = ["./dist/signed-amd64_darwin_amd64/confluent"]
 bundle_id = "io.confluent.cli.confluent"
 
 apple_id {
@@ -9,5 +9,5 @@ sign {
 }
 
 zip {
-  output_path = "./dist/confluent/confluent_darwin_amd64/confluent_signed.zip"
+  output_path = "./dist/confluent_darwin_amd64/confluent_signed.zip"
 }

--- a/gon_confluent_arm64.hcl
+++ b/gon_confluent_arm64.hcl
@@ -1,4 +1,4 @@
-source = ["./dist/confluent/signed-arm64_darwin_arm64/confluent"]
+source = ["./dist/signed-arm64_darwin_arm64/confluent"]
 bundle_id = "io.confluent.cli.confluent"
 
 apple_id {
@@ -9,5 +9,5 @@ sign {
 }
 
 zip {
-  output_path = "./dist/confluent/confluent_darwin_arm64/confluent_signed.zip"
+  output_path = "./dist/confluent_darwin_arm64/confluent_signed.zip"
 }

--- a/mk-files/cli-cpd.mk
+++ b/mk-files/cli-cpd.mk
@@ -18,4 +18,4 @@ run-system-tests:
 .PHONY: replace-cli-binary
 replace-cli-binary:
 	echo $$(ls)
-	cp ./dist/confluent/confluent_linux_amd64/confluent $(CC_SYSTEM_TEST_CHECKOUT_DIR)/test/cli/cli_bin/linux_amd64/confluent 
+	cp ./dist/confluent_linux_amd64/confluent $(CC_SYSTEM_TEST_CHECKOUT_DIR)/test/cli/cli_bin/linux_amd64/confluent 

--- a/mk-files/release-test.mk
+++ b/mk-files/release-test.mk
@@ -25,7 +25,6 @@ test-installer:
 verify-binaries:
 	$(eval TEMP_DIR=$(shell mktemp -d))
 	@$(caasenv-authenticate) && \
-	binary="confluent"; \
 	for os in linux darwin windows alpine; do \
 		for arch in arm64 amd64 386; do \
 			if [ "$${os}" != "darwin" ] && [ "$${arch}" = "arm64" ] ; then \
@@ -41,7 +40,7 @@ verify-binaries:
 			if [ "$${os}" = "windows" ] ; then \
 				suffix=".exe"; \
 			fi ; \
-			FILE=$(VERIFY_BIN_FOLDER)/$${binary}-cli/binaries/$(CLEAN_VERSION)/$${binary}_$(CLEAN_VERSION)_$${os}_$${arch}$${suffix}; \
+			FILE=$(VERIFY_BIN_FOLDER)/confluent-cli/binaries/$(CLEAN_VERSION)/confluent_$(CLEAN_VERSION)_$${os}_$${arch}$${suffix}; \
 			echo "Checking binary: $${FILE}"; \
 			aws s3 cp $$FILE $(TEMP_DIR) || { rm -rf $(TEMP_DIR) && exit 1; }; \
 		done; \


### PR DESCRIPTION
Checklist
---
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok
   
2. Did you add/update any commands that accept secrets as args/flags?
   * no: ok

What
----
On `make goreleaser`, release the CLI to GitHub. Also, rename `dist/confluent/` to `dist/` now that there's only one CLI.

We used to have two goreleaser files, and it wouldn't make sense to release to GitHub twice. Now there's only one file, and we can release to GitHub again. This is important to have when we open-source the CLI.

References
----------
[CLI-1317](https://confluentinc.atlassian.net/browse/CLI-1317)

Test & Review
------------
Ran successfully for the v2.0.0 release: https://github.com/confluentinc/cli/releases
(I'll delete that release once this gets merged.)