### PR TITLE
CLI-1356: Sort installation versions in semver order

### DIFF
--- a/install-ccloud.sh
+++ b/install-ccloud.sh
@@ -137,7 +137,7 @@ s3_releases() {
   versions=$(echo "$xml" | sed -n 's/</\
 </gp' | sed -n "s/<Prefix>${PROJECT_NAME}\/archives\/\(.*\)\//\1/p") || return 1
   test -z "$versions" && return 1
-  echo "$versions"
+  echo "$versions" | sort --version-sort
 }
 s3_release() {
   version=$1

--- a/install-confluent.sh
+++ b/install-confluent.sh
@@ -137,7 +137,7 @@ s3_releases() {
   versions=$(echo "$xml" | sed -n 's/</\
 </gp' | sed -n "s/<Prefix>${PROJECT_NAME}\/archives\/\(.*\)\//\1/p") || return 1
   test -z "$versions" && return 1
-  echo "$versions"
+  echo "$versions" | sort --version-sort
 }
 s3_release() {
   version=$1


### PR DESCRIPTION
Checklist
---
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok
   
2. Did you add/update any commands that accept secrets as args/flags?
   * no: ok

What
----
Use `sort --version-sort` to sort installation versions in semver order. Conveniently, `latest` is put at the end of the list 😄 
```
$ curl -sL --http1.1 https://cnfl.io/cli | sh -s -- -l
...
1.38.0
1.39.0
1.39.1
1.40.0
1.40.1
1.41.0
latest
```

References
----------
[CLI-1356](https://confluentinc.atlassian.net/browse/CLI-1356)

Test&Review
------------
Manual verification