### PR TITLE
[CLI-1332] Add pre commit config to repo

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,8 @@
+repos:
+-  repo: https://github.com/confluentinc/gitleaks
+    rev: v7.6.1.1
+    hooks:
+    - id: gitleaks
+        name: default-rules
+        args:
+          - --verbose


### PR DESCRIPTION
What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->

Adds configuration for `gitleaks` pre-commit hook to repo per [CLI-1332].

References
----------

https://confluentinc.atlassian.net/wiki/spaces/trustsecurity/pages/2564260728/Pre-commit+Secret+Detection+Hooks



[CLI-1332]: https://confluentinc.atlassian.net/browse/CLI-1332?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ