### PR TITLE
CLI-1375: Rename `resource_id` to `id` in `confluent iam user` and `confluent iam service-account`

### DIFF
--- a/internal/cmd/iam/command_service_account.go
+++ b/internal/cmd/iam/command_service_account.go
@@ -23,8 +23,8 @@ type serviceAccountCommand struct {
 
 var (
 	describeFields            = []string{"ResourceId", "ServiceName", "ServiceDescription"}
-	describeHumanRenames      = map[string]string{"ServiceName": "Name", "ServiceDescription": "Description", "ResourceId": "Resource ID"}
-	describeStructuredRenames = map[string]string{"ServiceName": "name", "ServiceDescription": "description", "ResourceId": "resource_id"}
+	describeHumanRenames      = map[string]string{"ServiceName": "Name", "ServiceDescription": "Description", "ResourceId": "ID"}
+	describeStructuredRenames = map[string]string{"ServiceName": "name", "ServiceDescription": "description", "ResourceId": "id"}
 )
 
 const nameLength = 64
@@ -105,7 +105,7 @@ func (c *serviceAccountCommand) init() {
 		RunE:  pcmd.NewCLIRunE(c.update),
 		Example: examples.BuildExampleString(
 			examples.Example{
-				Text: "Update the description of a service account with resource ID `sa-lqv3mm`",
+				Text: "Update the description of service account `sa-lqv3mm`",
 				Code: `confluent service-account update sa-lqv3mm --description "Update demo service account information."`,
 			},
 		),
@@ -122,7 +122,7 @@ func (c *serviceAccountCommand) init() {
 		RunE:  pcmd.NewCLIRunE(c.delete),
 		Example: examples.BuildExampleString(
 			examples.Example{
-				Text: "Delete a service account with resource ID `sa-lqv3mm`",
+				Text: "Delete service account `sa-lqv3mm`",
 				Code: "confluent service-account delete sa-lqv3mm",
 			},
 		),
@@ -209,8 +209,8 @@ func (c *serviceAccountCommand) list(cmd *cobra.Command, _ []string) error {
 
 	var (
 		listFields           = []string{"ResourceId", "ServiceName", "ServiceDescription"}
-		listHumanLabels      = []string{"Resource ID", "Name", "Description"}
-		listStructuredLabels = []string{"resource_id", "name", "description"}
+		listHumanLabels      = []string{"ID", "Name", "Description"}
+		listStructuredLabels = []string{"id", "name", "description"}
 	)
 
 	outputWriter, err := output.NewListOutputWriter(cmd, listFields, listHumanLabels, listStructuredLabels)

--- a/internal/cmd/iam/command_user.go
+++ b/internal/cmd/iam/command_user.go
@@ -17,19 +17,19 @@ import (
 )
 
 var (
-	listFields    = []string{"ResourceId", "Email", "FirstName", "LastName", "Status", "AuthenticationMethod"}
-	humanLabels   = []string{"Resource ID", "Email", "First Name", "Last Name", "Status", "Authentication Method"}
+	listFields    = []string{"Id", "Email", "FirstName", "LastName", "Status", "AuthenticationMethod"}
+	humanLabels   = []string{"ID", "Email", "First Name", "Last Name", "Status", "Authentication Method"}
 	humanLabelMap = map[string]string{
-		"ResourceId":           "Resource ID",
+		"Id":                   "ID",
 		"Email":                "Email",
 		"FirstName":            "First Name",
 		"LastName":             "Last Name",
 		"Status":               "Status",
 		"AuthenticationMethod": "Authentication Method",
 	}
-	structuredLabels   = []string{"resource_id", "email", "first_name", "last_name", "status", "authentication_method"}
+	structuredLabels   = []string{"id", "email", "first_name", "last_name", "status", "authentication_method"}
 	structuredLabelMap = map[string]string{
-		"ResourceId":           "resource_id",
+		"Id":                   "id",
 		"Email":                "email",
 		"FirstName":            "first_name",
 		"LastName":             "last_name",
@@ -55,7 +55,7 @@ type userCommand struct {
 }
 
 type userStruct struct {
-	ResourceId           string
+	Id                   string
 	Email                string
 	FirstName            string
 	LastName             string
@@ -84,7 +84,7 @@ func NewUserCommand(prerunner pcmd.PreRunner) *cobra.Command {
 
 func (c userCommand) newUserDescribeCommand() *cobra.Command {
 	describeCmd := &cobra.Command{
-		Use:   "describe <resource id>",
+		Use:   "describe <id>",
 		Short: "Describe a user.",
 		Args:  cobra.ExactArgs(1),
 		RunE:  pcmd.NewCLIRunE(c.describe),
@@ -121,7 +121,7 @@ func (c userCommand) describe(cmd *cobra.Command, args []string) error {
 	}
 
 	return output.DescribeObject(cmd, &userStruct{
-		ResourceId:           userProfile.ResourceId,
+		Id:                   userProfile.ResourceId,
 		Email:                userProfile.Email,
 		FirstName:            userProfile.FirstName,
 		LastName:             userProfile.LastName,
@@ -174,7 +174,7 @@ func (c userCommand) list(cmd *cobra.Command, _ []string) error {
 		}
 
 		outputWriter.AddElement(&userStruct{
-			ResourceId:           userProfile.ResourceId,
+			Id:                   userProfile.ResourceId,
 			Email:                userProfile.Email,
 			FirstName:            userProfile.FirstName,
 			LastName:             userProfile.LastName,
@@ -212,7 +212,7 @@ func (c userCommand) invite(cmd *cobra.Command, args []string) error {
 
 func (c userCommand) newUserDeleteCommand() *cobra.Command {
 	deleteCmd := &cobra.Command{
-		Use:   "delete <resource id>",
+		Use:   "delete <id>",
 		Short: "Delete a user from your organization.",
 		Args:  cobra.ExactArgs(1),
 		RunE:  pcmd.NewCLIRunE(c.delete),

--- a/test/fixtures/output/iam/service-account/create-json.golden
+++ b/test/fixtures/output/iam/service-account/create-json.golden
@@ -1,5 +1,5 @@
 {
   "name": "json-service",
   "description": "json-output",
-  "resource_id": "sa-55555"
+  "id": "sa-55555"
 }

--- a/test/fixtures/output/iam/service-account/create-yaml.golden
+++ b/test/fixtures/output/iam/service-account/create-yaml.golden
@@ -1,3 +1,3 @@
 description: yaml-output
+id: sa-55555
 name: yaml-service
-resource_id: sa-55555

--- a/test/fixtures/output/iam/service-account/create.golden
+++ b/test/fixtures/output/iam/service-account/create.golden
@@ -1,5 +1,5 @@
 +-------------+---------------+
-| Resource ID | sa-55555      |
+| ID          | sa-55555      |
 | Name        | human-service |
 | Description | human-output  |
 +-------------+---------------+

--- a/test/fixtures/output/iam/service-account/list-json.golden
+++ b/test/fixtures/output/iam/service-account/list-json.golden
@@ -1,7 +1,7 @@
 [
   {
     "description": "at your service.",
-    "name": "service_account",
-    "resource_id": "sa-12345"
+    "id": "sa-12345",
+    "name": "service_account"
   }
 ]

--- a/test/fixtures/output/iam/service-account/list-yaml.golden
+++ b/test/fixtures/output/iam/service-account/list-yaml.golden
@@ -1,3 +1,3 @@
 - description: at your service.
+  id: sa-12345
   name: service_account
-  resource_id: sa-12345

--- a/test/fixtures/output/iam/service-account/list.golden
+++ b/test/fixtures/output/iam/service-account/list.golden
@@ -1,3 +1,3 @@
-  Resource ID |      Name       |   Description     
---------------+-----------------+-------------------
-  sa-12345    | service_account | at your service.  
+     ID    |      Name       |   Description     
+-----------+-----------------+-------------------
+  sa-12345 | service_account | at your service.  

--- a/test/fixtures/output/iam/user/describe.golden
+++ b/test/fixtures/output/iam/user/describe.golden
@@ -1,5 +1,5 @@
 +-----------------------+------------------------+
-| Resource ID           | u-17                   |
+| ID                    | u-17                   |
 | Email                 | mtodzo@confluent.io    |
 | First Name            | Miles                  |
 | Last Name             | Todzo                  |

--- a/test/fixtures/output/iam/user/list.golden
+++ b/test/fixtures/output/iam/user/list.golden
@@ -1,8 +1,8 @@
-  Resource ID |         Email         | First Name | Last Name |   Status   | Authentication Method   
---------------+-----------------------+------------+-----------+------------+-------------------------
-  u11         | bstrauch@confluent.io | Brian      | Strauch   | Unverified | Username/Password, SSO  
-  u-17        | mtodzo@confluent.io   | Miles      | Todzo     | Unverified | Username/Password, SSO  
-  u-11aaa     | u-11aaa@confluent.io  |         11 | Aaa       | Unverified | Username/Password, SSO  
-  u-22bbb     | u-22bbb@confluent.io  |         22 | Bbb       | Unverified | Username/Password, SSO  
-  u-33ccc     | u-33ccc@confluent.io  |         33 | Ccc       | Unverified | Username/Password, SSO  
-  u-44ddd     | mhe@confluent.io      | Muwei      | He        | Unverified | Username/Password, SSO  
+    ID    |         Email         | First Name | Last Name |   Status   | Authentication Method   
+----------+-----------------------+------------+-----------+------------+-------------------------
+  u11     | bstrauch@confluent.io | Brian      | Strauch   | Unverified | Username/Password, SSO  
+  u-17    | mtodzo@confluent.io   | Miles      | Todzo     | Unverified | Username/Password, SSO  
+  u-11aaa | u-11aaa@confluent.io  |         11 | Aaa       | Unverified | Username/Password, SSO  
+  u-22bbb | u-22bbb@confluent.io  |         22 | Bbb       | Unverified | Username/Password, SSO  
+  u-33ccc | u-33ccc@confluent.io  |         33 | Ccc       | Unverified | Username/Password, SSO  
+  u-44ddd | mhe@confluent.io      | Muwei      | He        | Unverified | Username/Password, SSO  


### PR DESCRIPTION
Checklist
---
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok
   
2. Did you add/update any commands that accept secrets as args/flags?
   * no: ok

What
----
Rename `resource_id` to `id` in Cloud `iam user` and `iam service-account` commands for consistency.

References
----------
[CLI-1375](https://confluentinc.atlassian.net/browse/CLI-1375)

Test&Review
------------
Updated tests.