### PR TITLE
CLI Unification: Fix migration bug

### DIFF
--- a/internal/pkg/config/v3/config.go
+++ b/internal/pkg/config/v3/config.go
@@ -105,9 +105,9 @@ func (c *Config) Load() error {
 	err = json.Unmarshal(input, c)
 
 	// The config file does not exist or is empty, so we default its version to the current version to avoid errors.
-	//if c.Ver.Version == nil {
-	//	c.Ver = config.Version{Version: Version}
-	//}
+	if c.Ver.Version == nil {
+		c.Ver = config.Version{Version: Version}
+	}
 
 	if c.Ver.Compare(currentVersion) < 0 {
 		return errors.Errorf(errors.ConfigNotUpToDateErrorMsg, c.Ver, currentVersion)


### PR DESCRIPTION
<!--
Is there any breaking changes?  If so this is a major release, make sure '#major' is in at least one
commit message to get CI to bump the major.  This will prevent automatic down stream dependency
bumping / consuming.  For more information about semantic versioning see: https://semver.org/


Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
Checklist
---
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok
   
2. Did you add/update any commands that accept secrets as args/flags?
   * no: ok

What
----
Running `ccloud update --major` with a versionless `confluent` config file present on the user's system will err. This sets the version to v3 before migrating to avoid an error.

References
----------
https://confluent.slack.com/archives/C010Y0EP5MZ/p1636479932006200