### PR TITLE
added on prem annotation to iam acl commands

### DIFF
--- a/internal/cmd/iam/command_acl.go
+++ b/internal/cmd/iam/command_acl.go
@@ -43,7 +43,6 @@ func (c *aclCommand) init() {
 		Long:        "Create a Kafka ACL.\n\nThis command only works with centralized ACLs.",
 		Args:        cobra.NoArgs,
 		RunE:        pcmd.NewCLIRunE(c.create),
-		Annotations: map[string]string{pcmd.RunRequirement: pcmd.RequireOnPremLogin},
 		Example: examples.BuildExampleString(
 			examples.Example{
 				Text: "Create an ACL that grants the specified user READ permission to the specified consumer group in the specified Kafka cluster:",
@@ -70,7 +69,6 @@ func (c *aclCommand) init() {
 		Long:  "Delete a Kafka ACL.\n\nThis command only works with centralized ACLs.",
 		Args:  cobra.NoArgs,
 		RunE:  pcmd.NewCLIRunE(c.delete),
-		Annotations: map[string]string{pcmd.RunRequirement: pcmd.RequireOnPremLogin},
 		Example: examples.BuildExampleString(
 			examples.Example{
 				Text: "Delete an ACL that granted the specified user access to the Test topic in the specified cluster:",
@@ -89,7 +87,6 @@ func (c *aclCommand) init() {
 		Long:  "List Kafka ACLs for a resource.\n\nThis command only works with centralized ACLs.",
 		Args:  cobra.NoArgs,
 		RunE:  pcmd.NewCLIRunE(c.list),
-		Annotations: map[string]string{pcmd.RunRequirement: pcmd.RequireOnPremLogin},
 		Example: examples.BuildExampleString(
 			examples.Example{
 				Text: "List all the ACLs for the specified Kafka cluster:",


### PR DESCRIPTION
<!--
Is there any breaking changes?  If so this is a major release, make sure '#major' is in at least one
commit message to get CI to bump the major.  This will prevent automatic down stream dependency
bumping / consuming.  For more information about semantic versioning see: https://semver.org/

no - shouldn't count as a breaking change since none of the commands being hidden now worked

Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
Checklist
---
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok
   
2. Did you add/update any commands that accept secrets as args/flags?
   * no: ok

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->

Added required on-prem verification annotation to all iam acl commands since they should only be present for on-prem contexts. Iam acl commands weren't part of ccloud https://docs.confluent.io/ccloud-cli/current/command-reference/iam/index.html#confluent-iam and they all don't work.

References
----------
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->
https://confluentinc.atlassian.net/browse/CLI-1405?atlOrigin=eyJpIjoiOTk4N2M3MGJjNDYzNDQ0Y2FiMWU2Mzc4NGM2NzQzODEiLCJwIjoiamlyYS1zbGFjay1pbnQifQ

Test&Review
------------

<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->
manually verified commands were correctly hidden when in cloud context or no context

<!--
Open questions / Follow ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
