### PR TITLE
CLI-1092: Fix `confluent admin promo list`

### DIFF
--- a/internal/cmd/admin/command_promo.go
+++ b/internal/cmd/admin/command_promo.go
@@ -84,7 +84,7 @@ type structuredRow struct {
 }
 
 func (c *promoCommand) listRunE(cmd *cobra.Command, _ []string) error {
-	org := &orgv1.Organization{Id: c.State.Auth.User.OrganizationId}
+	org := &orgv1.Organization{Id: c.State.Auth.Account.OrganizationId}
 
 	codes, err := c.Client.Billing.GetClaimedPromoCodes(context.Background(), org, true)
 	if err != nil {


### PR DESCRIPTION
Checklist
---
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok
   
2. Did you add/update any commands that accept secrets as args/flags?
   * no: ok

What
----
Before:
```
$ confluent admin promo list
Error: CCloud backend error: 1 error occurred:
        * failed to get claimed promo codes: Forbidden
```

After:
```
$ confluent admin promo list
    Code   |     Balance      |  Expiration   
-----------+------------------+---------------
  60PDCAST | $60.00/60.00 USD | Sep 13, 2021  
  CCLOUD50 | $50.00/50.00 USD | Jan 25, 2022  
  CL60BLOG | $60.00/60.00 USD | Sep 13, 2021
```

References
----------
[CLI-1092](https://confluentinc.atlassian.net/browse/CLI-1092)

Test&Review
------------
Looks like we need a system test for this command.