### PR TITLE
CLI-1405 Remove `iam acl` commands from cloud context

### DIFF
--- a/internal/cmd/iam/command_acl.go
+++ b/internal/cmd/iam/command_acl.go
@@ -25,8 +25,9 @@ type aclCommand struct {
 func NewACLCommand(prerunner pcmd.PreRunner) *cobra.Command {
 	cmd := &aclCommand{
 		AuthenticatedStateFlagCommand: pcmd.NewAuthenticatedWithMDSStateFlagCommand(&cobra.Command{
-			Use:   "acl",
-			Short: "Manage Kafka ACLs (5.4+ only).",
+			Use:         "acl",
+			Short:       "Manage Kafka ACLs (5.4+ only).",
+			Annotations: map[string]string{pcmd.RunRequirement: pcmd.RequireOnPremLogin},
 		}, prerunner, AclSubcommandFlags),
 	}
 
@@ -37,12 +38,11 @@ func NewACLCommand(prerunner pcmd.PreRunner) *cobra.Command {
 
 func (c *aclCommand) init() {
 	cmd := &cobra.Command{
-		Use:         "create",
-		Short:       "Create a Kafka ACL.",
-		Long:        "Create a Kafka ACL.\n\nThis command only works with centralized ACLs.",
-		Args:        cobra.NoArgs,
-		RunE:        pcmd.NewCLIRunE(c.create),
-		Annotations: map[string]string{pcmd.RunRequirement: pcmd.RequireOnPremLogin},
+		Use:   "create",
+		Short: "Create a Kafka ACL.",
+		Long:  "Create a Kafka ACL.\n\nThis command only works with centralized ACLs.",
+		Args:  cobra.NoArgs,
+		RunE:  pcmd.NewCLIRunE(c.create),
 		Example: examples.BuildExampleString(
 			examples.Example{
 				Text: "Create an ACL that grants the specified user READ permission to the specified consumer group in the specified Kafka cluster:",


### PR DESCRIPTION
<!--
Is there any breaking changes?  If so this is a major release, make sure '#major' is in at least one
commit message to get CI to bump the major.  This will prevent automatic down stream dependency
bumping / consuming.  For more information about semantic versioning see: https://semver.org/


Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
Checklist
---
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok
   
2. Did you add/update any commands that accept secrets as args/flags?
   * no: ok

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->
Added a `RequireOnPremLogin` for `iam acl` commands. It should only be available for on prem.

References
----------
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test&Review
------------

<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

<!--
Open questions / Follow ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
