### PR TITLE
[CLI-1332] Enable precommit hooks with Gitleaks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,8 @@
+repos:
+  -   repo: https://github.com/confluentinc/gitleaks
+      rev: v7.6.1.1
+      hooks:
+        -   id: gitleaks
+            name: default-rules
+            args:
+              - --verbose

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ The Confluent CLI lets you manage your Confluent Cloud and Confluent Platform de
   - [File Layout](#file-layout)
   - [Build Other Platforms](#build-other-platforms)
   - [URLS](#urls)
+  - [Security](#security)
 - [Installer](#installer)
 - [Documentation](#documentation)
   - [README](#readme)
@@ -189,6 +190,16 @@ Cross compilation from M1 Macbook (Darwin/arm64) to other platforms is also supp
 
 ### URLS
 Use the `login` command with the `--url` option to point to a different development environment
+
+### Security
+We use precommit hooks and Gitleaks to prevent potential secrets from being committed to this repo. 
+Please enable precommit hooks:
+
+* follow this [link](https://confluentinc.atlassian.net/wiki/spaces/trustsecurity/pages/2564260728/Pre-commit+Secret+Detection+Hooks#Pre-commitSecretDetectionHooks-InstallPre-commitcommand) 
+  to install precommit tool locally.  
+* go to the working directory of this repo
+* Run `pre-commit install`
+
 
 ## Installer
 


### PR DESCRIPTION
<!--
Is there any breaking changes?  If so this is a major release, make sure '#major' is in at least one
commit message to get CI to bump the major.  This will prevent automatic down stream dependency
bumping / consuming.  For more information about semantic versioning see: https://semver.org/


Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
Checklist
---
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * no: DO NOT MERGE until the required functionalites are live in prod  
   
2. Did you add/update any commands that accept secrets as args/flags?
   * no: ok

What
----
This enables precommit hooks with Gitleaks and adds instructions on how to enable it locally.

References
----------
https://confluentinc.atlassian.net/browse/APPSEC-554

Test&Review
------------
Tested locally
