### PR TITLE
Autocompletion: `confluent context`

### DIFF
--- a/internal/cmd/context/command.go
+++ b/internal/cmd/context/command.go
@@ -4,6 +4,7 @@ import (
 	"github.com/spf13/cobra"
 
 	pcmd "github.com/confluentinc/cli/internal/pkg/cmd"
+	v1 "github.com/confluentinc/cli/internal/pkg/config/v1"
 	"github.com/confluentinc/cli/internal/pkg/errors"
 )
 
@@ -45,4 +46,24 @@ func (c *command) context(args []string) (*pcmd.DynamicContext, error) {
 	} else {
 		return nil, errors.NewErrorWithSuggestions("no context selected", "Select an existing context with `confluent context use`, or supply a specific context name as an argument.")
 	}
+}
+
+func (c *command) validArgs(cmd *cobra.Command, args []string) []string {
+	if len(args) > 0 {
+		return nil
+	}
+
+	if err := c.PersistentPreRunE(cmd, args); err != nil {
+		return nil
+	}
+
+	return autocompleteContexts(c.Config.Config)
+}
+
+func autocompleteContexts(cfg *v1.Config) []string {
+	var contexts []string
+	for context := range cfg.Contexts {
+		contexts = append(contexts, context)
+	}
+	return contexts
 }

--- a/internal/cmd/context/command_delete.go
+++ b/internal/cmd/context/command_delete.go
@@ -9,10 +9,11 @@ import (
 
 func (c *command) newDeleteCommand() *cobra.Command {
 	return &cobra.Command{
-		Use:   "delete <context>",
-		Short: "Delete a context.",
-		Args:  cobra.ExactArgs(1),
-		RunE:  pcmd.NewCLIRunE(c.delete),
+		Use:               "delete <context>",
+		Short:             "Delete a context.",
+		Args:              cobra.ExactArgs(1),
+		ValidArgsFunction: pcmd.NewValidArgsFunction(c.validArgs),
+		RunE:              pcmd.NewCLIRunE(c.delete),
 	}
 }
 

--- a/internal/cmd/context/command_describe.go
+++ b/internal/cmd/context/command_describe.go
@@ -13,11 +13,11 @@ import (
 
 func (c *command) newDescribeCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "describe [context]",
-		Short: "Describe a context.",
-		Long:  "Describe a context or a specific context field.",
-		Args:  cobra.MaximumNArgs(1),
-		RunE:  pcmd.NewCLIRunE(c.describe),
+		Use:               "describe [context]",
+		Short:             "Describe a context.",
+		Long:              "Describe a context or a specific context field.",
+		ValidArgsFunction: pcmd.NewValidArgsFunction(c.validArgs),
+		RunE:              pcmd.NewCLIRunE(c.describe),
 	}
 
 	cmd.Flags().Bool("api-key", false, "Get the API key for a context.")

--- a/internal/cmd/context/command_update.go
+++ b/internal/cmd/context/command_update.go
@@ -12,10 +12,10 @@ import (
 
 func (c *command) newUpdateCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "update [context]",
-		Short: "Update a context field.",
-		Args:  cobra.MaximumNArgs(1),
-		RunE:  pcmd.NewCLIRunE(c.update),
+		Use:               "update [context]",
+		Short:             "Update a context field.",
+		ValidArgsFunction: pcmd.NewValidArgsFunction(c.validArgs),
+		RunE:              pcmd.NewCLIRunE(c.update),
 	}
 
 	cmd.Flags().String("name", "", "Set the name of the context.")

--- a/internal/cmd/context/command_use.go
+++ b/internal/cmd/context/command_use.go
@@ -8,10 +8,11 @@ import (
 
 func (c *command) newUseCommand() *cobra.Command {
 	return &cobra.Command{
-		Use:   "use [context]",
-		Short: "Use a context.",
-		Args:  cobra.ExactArgs(1),
-		RunE:  pcmd.NewCLIRunE(c.use),
+		Use:               "use <context>",
+		Short:             "Use a context.",
+		Args:              cobra.ExactArgs(1),
+		ValidArgsFunction: pcmd.NewValidArgsFunction(c.validArgs),
+		RunE:              pcmd.NewCLIRunE(c.use),
 	}
 }
 

--- a/internal/pkg/cmd/cobra.go
+++ b/internal/pkg/cmd/cobra.go
@@ -26,3 +26,11 @@ func NewCLIPreRunnerE(prerunnerE ...func(*cobra.Command, []string) error) func(*
 		return nil
 	}
 }
+
+// NewValidArgsFunction is a wrapper around cobra.ValidArgsFunction() that ignores the `toComplete` argument and
+// `ShellCompDirective` return value, which are almost always ignored and "NoFileComp", respectively.
+func NewValidArgsFunction(f func(*cobra.Command, []string) []string) func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
+	return func(cmd *cobra.Command, args []string, _ string) ([]string, cobra.ShellCompDirective) {
+		return f(cmd, args), cobra.ShellCompDirectiveNoFileComp
+	}
+}


### PR DESCRIPTION
Checklist
---
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok
   
2. Did you add/update any commands that accept secrets as args/flags?
   * no: ok

What
----
Autocomplete context names for
* `confluent context delete`
* `confluent context describe`
* `confluent context update`
* `confluent context use`

`confluent context update --kafka-cluster` should autocomplete available cluster names, but there is no infrastructure for it (`confluent context` is not an authenticated command, but listing clusters requires auth). This'll be a later PR.

Test & Review
------------
```
% confluent context list
  Current |  Name  |     Platform      |                Credential                  
----------+--------+-------------------+--------------------------------------------
          | test-0 | devel.cpdev.cloud | username-caas-team+integ-cli@confluent.io  
  *       | test-1 | devel.cpdev.cloud | username-bstrauch+sso@confluent.io         
% confluent context describe test-
test-0  test-1
```