### PR TITLE
Autocompletion: `confluent ksql`

### DIFF
--- a/internal/cmd/ksql/command_app.go
+++ b/internal/cmd/ksql/command_app.go
@@ -1,6 +1,10 @@
 package ksql
 
 import (
+	"context"
+	"fmt"
+
+	"github.com/confluentinc/ccloud-sdk-go-v1"
 	"github.com/spf13/cobra"
 
 	schedv1 "github.com/confluentinc/cc-structs/kafka/scheduler/v1"
@@ -72,4 +76,30 @@ func (c *appCommand) updateKsqlClusterStatus(cluster *schedv1.KSQLCluster) *ksql
 		Endpoint:          cluster.Endpoint,
 		Status:            status,
 	}
+}
+
+func (c *appCommand) validArgs(cmd *cobra.Command, args []string) []string {
+	if len(args) > 0 {
+		return nil
+	}
+
+	if err := c.PersistentPreRunE(cmd, args); err != nil {
+		return nil
+	}
+
+	return autocompleteClusters(c.EnvironmentId(), c.Client)
+}
+
+func autocompleteClusters(environment string, client *ccloud.Client) []string {
+	req := &schedv1.KSQLCluster{AccountId: environment}
+	clusters, err := client.KSQL.List(context.Background(), req)
+	if err != nil {
+		return nil
+	}
+
+	suggestions := make([]string, len(clusters))
+	for i, cluster := range clusters {
+		suggestions[i] = fmt.Sprintf("%s\t%s", cluster.Id, cluster.Name)
+	}
+	return suggestions
 }

--- a/internal/cmd/ksql/command_app_configureacls.go
+++ b/internal/cmd/ksql/command_app_configureacls.go
@@ -16,10 +16,11 @@ import (
 
 func (c *appCommand) newConfigureAclsCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "configure-acls <id> TOPICS...",
-		Short: "Configure ACLs for a ksqlDB cluster.",
-		Args:  cobra.MinimumNArgs(1),
-		RunE:  pcmd.NewCLIRunE(c.configureACLs),
+		Use:               "configure-acls <id> TOPICS...",
+		Short:             "Configure ACLs for a ksqlDB cluster.",
+		Args:              cobra.MinimumNArgs(1),
+		ValidArgsFunction: pcmd.NewValidArgsFunction(c.validArgs),
+		RunE:              pcmd.NewCLIRunE(c.configureACLs),
 	}
 
 	cmd.Flags().Bool("dry-run", false, "If specified, print the ACLs that will be set and exit.")

--- a/internal/cmd/ksql/command_app_create.go
+++ b/internal/cmd/ksql/command_app_create.go
@@ -92,7 +92,7 @@ func (c *appCommand) create(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return err
 		}
-		count += 1
+		count++
 	}
 
 	if cluster.Endpoint == "" {

--- a/internal/cmd/ksql/command_app_describe.go
+++ b/internal/cmd/ksql/command_app_describe.go
@@ -19,10 +19,11 @@ var (
 
 func (c *appCommand) newDescribeCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "describe <id>",
-		Short: "Describe a ksqlDB app.",
-		Args:  cobra.ExactArgs(1),
-		RunE:  pcmd.NewCLIRunE(c.describe),
+		Use:               "describe <id>",
+		Short:             "Describe a ksqlDB app.",
+		Args:              cobra.ExactArgs(1),
+		ValidArgsFunction: pcmd.NewValidArgsFunction(c.validArgs),
+		RunE:              pcmd.NewCLIRunE(c.describe),
 	}
 
 	output.AddFlag(cmd)


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok
   
2. Did you add/update any commands that accept secrets as args/flags?
   * no: ok

What
----
Autocomplete the IDs of ksqlDB apps
```
confluent ksql app describe lksqlc-
lksqlc-dg7207  -- test-1
lksqlc-6o5j7j  -- test-2
```