### PR TITLE
Autocompletion: `confluent api-key`

### DIFF
--- a/internal/cmd/api-key/command_delete.go
+++ b/internal/cmd/api-key/command_delete.go
@@ -14,10 +14,11 @@ import (
 
 func (c *command) newDeleteCommand() *cobra.Command {
 	return &cobra.Command{
-		Use:   "delete <api-key>",
-		Short: "Delete an API key.",
-		Args:  cobra.ExactArgs(1),
-		RunE:  pcmd.NewCLIRunE(c.delete),
+		Use:               "delete <api-key>",
+		Short:             "Delete an API key.",
+		Args:              cobra.ExactArgs(1),
+		ValidArgsFunction: pcmd.NewValidArgsFunction(c.validArgs),
+		RunE:              pcmd.NewCLIRunE(c.delete),
 	}
 }
 

--- a/internal/cmd/api-key/command_update.go
+++ b/internal/cmd/api-key/command_update.go
@@ -13,10 +13,11 @@ import (
 
 func (c *command) newUpdateCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "update <api-key>",
-		Short: "Update an API key.",
-		Args:  cobra.ExactArgs(1),
-		RunE:  pcmd.NewCLIRunE(c.update),
+		Use:               "update <api-key>",
+		Short:             "Update an API key.",
+		Args:              cobra.ExactArgs(1),
+		ValidArgsFunction: pcmd.NewValidArgsFunction(c.validArgs),
+		RunE:              pcmd.NewCLIRunE(c.update),
 	}
 
 	cmd.Flags().String("description", "", "Description of the API key.")

--- a/internal/cmd/api-key/command_use.go
+++ b/internal/cmd/api-key/command_use.go
@@ -12,11 +12,12 @@ import (
 
 func (c *command) newUseCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "use <api-key>",
-		Short: "Set the active API key for use in other commands.",
-		Long:  "Set the active API key for use in any command which supports passing an API key with the `--api-key` flag.",
-		Args:  cobra.ExactArgs(1),
-		RunE:  pcmd.NewCLIRunE(c.use),
+		Use:               "use <api-key>",
+		Short:             "Set the active API key for use in other commands.",
+		Long:              "Set the active API key for use in any command which supports passing an API key with the `--api-key` flag.",
+		Args:              cobra.ExactArgs(1),
+		ValidArgsFunction: pcmd.NewValidArgsFunction(c.validArgs),
+		RunE:              pcmd.NewCLIRunE(c.use),
 	}
 
 	cmd.Flags().String(resourceFlagName, "", "The resource ID.")


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok
   
2. Did you add/update any commands that accept secrets as args/flags?
   * no: ok

What
----
Autocomplete API key names.

```
% confluent api-key delete
DM2XTZYIR5ZB3TNL  -- ak for source
ELM5IHFWXR2UEPER  -- ak for dest
```