### PR TITLE
Warn CP users not to enable updates

### DIFF
--- a/internal/pkg/cmd/run_requirements.go
+++ b/internal/pkg/cmd/run_requirements.go
@@ -43,7 +43,7 @@ var (
 	)
 	requireUpdatesEnabledErr = errors.NewErrorWithSuggestions(
 		"you must enable updates to use this command",
-		"WARNING: Enabling updates is not recommended for Confluent Platform users.\n"+`In ~/.confluent/config.json, set "disable_updates": false`,
+		"WARNING: To guarantee compatibility, enabling updates is not recommended for Confluent Platform users.\n"+`In ~/.confluent/config.json, set "disable_updates": false`,
 	)
 )
 


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok
   
2. Did you add/update any commands that accept secrets as args/flags?
   * no: ok

What
----
```
% confluent update            
Error: you must enable updates to use this command

Suggestions:
    WARNING: Enabling updates is not recommended for Confluent Platform users.
    In ~/.confluent/config.json, set "disable_updates": false
```