### PR TITLE
Add check for missing audit log service account ID

### DIFF
--- a/internal/cmd/api-key/command.go
+++ b/internal/cmd/api-key/command.go
@@ -190,23 +190,26 @@ func (c *command) resourceFlagCompleterFunc() []prompt.Suggest {
 }
 
 func (c *command) getAllUsers() ([]*orgv1.User, error) {
-	serviceAccounts, err := c.Client.User.GetServiceAccounts(context.Background())
+	users, err := c.Client.User.GetServiceAccounts(context.Background())
 	if err != nil {
 		return nil, err
 	}
-	auditLog, enabled := pcmd.IsAuditLogsEnabled(c.State)
-	if enabled {
-		auditLogServiceAccount, err := c.Client.User.GetServiceAccount(context.Background(), auditLog.ServiceAccountId)
+
+	if auditLog, ok := pcmd.AreAuditLogsEnabled(c.State); ok {
+		serviceAccount, err := c.Client.User.GetServiceAccount(context.Background(), auditLog.ServiceAccountId)
 		if err != nil {
 			return nil, err
 		}
-		serviceAccounts = append(serviceAccounts, auditLogServiceAccount)
+		users = append(users, serviceAccount)
 	}
+
 	adminUsers, err := c.Client.User.List(context.Background())
 	if err != nil {
 		return nil, err
 	}
-	return append(serviceAccounts, adminUsers...), nil
+	users = append(users, adminUsers...)
+
+	return users, nil
 }
 
 func (c *command) resolveResourceId(cmd *cobra.Command, resolver pcmd.FlagResolver, client *ccloud.Client) (resourceType string, clusterId string, currentKey string, err error) {

--- a/internal/cmd/api-key/command_list.go
+++ b/internal/cmd/api-key/command_list.go
@@ -143,7 +143,7 @@ func (c *command) list(cmd *cobra.Command, _ []string) error {
 		if _, ok := serviceAccountsMap[apiKey.UserId]; ok {
 			email = "<service account>"
 		} else {
-			auditLog, enabled := pcmd.IsAuditLogsEnabled(c.State)
+			auditLog, enabled := pcmd.AreAuditLogsEnabled(c.State)
 			if enabled && auditLog.ServiceAccountId == apiKey.UserId {
 				email = "<auditlog service account>"
 			} else {

--- a/internal/cmd/audit-log/command_describe.go
+++ b/internal/cmd/audit-log/command_describe.go
@@ -54,7 +54,7 @@ func newDescribeCommand(prerunner pcmd.PreRunner) *cobra.Command {
 }
 
 func (c describeCmd) describe(cmd *cobra.Command, _ []string) error {
-	if _, enabled := pcmd.IsAuditLogsEnabled(c.State); !enabled {
+	if _, enabled := pcmd.AreAuditLogsEnabled(c.State); !enabled {
 		return errors.New(errors.AuditLogsNotEnabledErrorMsg)
 	}
 

--- a/internal/pkg/cmd/auditlog.go
+++ b/internal/pkg/cmd/auditlog.go
@@ -6,8 +6,8 @@ import (
 	v1 "github.com/confluentinc/cli/internal/pkg/config/v1"
 )
 
-func IsAuditLogsEnabled(state *v1.ContextState) (*orgv1.AuditLog, bool) {
-	if state.Auth == nil || state.Auth.Organization == nil || state.Auth.Organization.AuditLog == nil {
+func AreAuditLogsEnabled(state *v1.ContextState) (*orgv1.AuditLog, bool) {
+	if state.Auth == nil || state.Auth.Organization == nil || state.Auth.Organization.AuditLog == nil || state.Auth.Organization.AuditLog.ServiceAccountId == 0 {
 		return nil, false
 	}
 	return state.Auth.Organization.AuditLog, true


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok
   
2. Did you add/update any commands that accept secrets as args/flags?
   * no: ok

What
----
For users with audit logs disabled (was able to reproduce this with a basic prod account), a user's audit log was not `nil` as handled by the code, but instead is an empty struct with default values (this is what is returned by the API).

To fix, we check that the audit log service account ID is not the default value (0).

```
% confluent audit-log describe
Error: Audit Logs are not enabled for this organization.
```

(I've also verified that `confluent api-key list` no longer errs)

References
----------
https://confluent.slack.com/archives/C010Y0EP5MZ/p1639150237174500