### PR TITLE
[FF-6418] Hide unlisted users in role binding list

### DIFF
--- a/internal/cmd/iam/command_rbac_role_binding.go
+++ b/internal/cmd/iam/command_rbac_role_binding.go
@@ -891,14 +891,16 @@ func (c *roleBindingCommand) ccloudListRolePrincipals(cmd *cobra.Command, option
 		return err
 	}
 	for _, principal := range principals {
-		displayStruct := &struct {
-			Principal string
-			Email     string
-		}{
-			Principal: principal,
-			Email:     userToEmailMap[principal],
+		if email, ok := userToEmailMap[principal]; ok {
+			displayStruct := &struct {
+				Principal string
+				Email     string
+			}{
+				Principal: principal,
+				Email:     email,
+			}
+			outputWriter.AddElement(displayStruct)
 		}
-		outputWriter.AddElement(displayStruct)
 	}
 	return outputWriter.Out()
 }

--- a/test/test-server/cloud_mdsv2_routes_and_roles.go
+++ b/test/test-server/cloud_mdsv2_routes_and_roles.go
@@ -290,7 +290,7 @@ var v2RoutesAndReplies = map[string]string{
 			"User:u-22bbb"
 		]`,
 	"/api/metadata/security/v2alpha1/lookup/role/CloudClusterAdmin": `[
-			"User:u-33ccc", "User:u-44ddd"
+			"User:u-33ccc", "User:u-44ddd", "User:u-unlisted"
 		]`,
 	"/api/metadata/security/v2alpha1/lookup/role/ResourceOwner/resource/Topic/name/food":          `["User:u-11aaa"]`,
 	"/api/metadata/security/v2alpha1/lookup/role/ResourceOwner/resource/Topic/name/shire-parties": `["User:u-11aaa"]`,


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok

What
----
An unlisted user is a user that has been deleted or whose invitation has expired. Those users should not show up in the list of role bindings.

Before:
```
    Principal     |        Email          
------------------+-----------------------
  User:u-33ccc    | u-33ccc@confluent.io  
  User:u-44ddd    | mhe@confluent.io      
  User:u-unlisted |
```

After:
```
   Principal   |        Email          
---------------+-----------------------
  User:u-33ccc | u-33ccc@confluent.io  
  User:u-44ddd | mhe@confluent.io      
```

References
----------
https://confluentinc.atlassian.net/browse/FF-6418

Test & Review
-------------
Added an unlisted user to the mocked list of role bindings; verified through TDD.