### PR TITLE
[CLI-1420] Only download licenses once during release process

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -98,10 +98,6 @@ builds:
         - cmd: make switch-librdkafka-arm64
       post:
         - cmd: make restore-librdkafka-amd64
-        - cmd: make download-licenses
-          env:
-            - LICENSE_BIN=confluent
-            - LICENSE_BIN_PATH=./dist/signed-arm64_darwin_arm64/confluent
         - cmd: gon gon_confluent_arm64.hcl
 
 archives:


### PR DESCRIPTION
We were downloading licenses once for darwin/amd64 and once for darwin/arm64, but this seems unnecessary since in either case the same licenses were being put in the same `legal/` folder.  This PR changes it to only download licenses once, for the amd64 build.

Moreover, it seems like an error was happening because of being unable to parse the arm64 binary.  This means we should be a bit careful: if we are attempting to do a release from an arm64 laptop, we might encounter the same error when trying to get the licenses for the amd64 binary.  In the end we might want to see if we can do this in a platform-dependent way 😬 