### PR TITLE
Check branch is RELEASE_BRANCH before doing release

### DIFF
--- a/mk-files/release.mk
+++ b/mk-files/release.mk
@@ -1,7 +1,7 @@
 ARCHIVE_TYPES=darwin_amd64.tar.gz darwin_arm64.tar.gz linux_amd64.tar.gz windows_amd64.zip
 
 .PHONY: release
-release: commit-release tag-release
+release: check-branch commit-release tag-release
 	$(call print-boxed-message,"RELEASING TO STAGING FOLDER $(S3_STAG_PATH)")
 	make release-to-stag
 	$(call print-boxed-message,"RELEASING TO PROD FOLDER $(S3_BUCKET_PATH)")
@@ -11,6 +11,13 @@ release: commit-release tag-release
 	git checkout go.sum
 	$(call print-boxed-message,"PUBLISHING NEW DOCKER HUB IMAGES")
 	make publish-dockerhub
+
+.PHONY: check-branch
+check-branch:
+	@if [ $(shell git rev-parse --abbrev-ref HEAD) != $(RELEASE_BRANCH) ] ; then \
+		echo -n "WARNING: Current branch \"$(shell git rev-parse --abbrev-ref HEAD)\" is not the default release branch \"$(RELEASE_BRANCH)\"!  Do you want to proceed? (y/n): " ; \
+		read line; if [ $$line != "y" ] && [ $$line != "Y" ]; then echo "Release cancelled."; exit 0; fi ; \
+	fi
 
 .PHONY: release-to-stag
 release-to-stag:


### PR DESCRIPTION
This is just a safeguard for unintentional releases not done on main (RELEASE_BRANCH).

Tested manually on main and on a feature branch to make sure this behaves as expected.