### PR TITLE
[CLI-1544] Improve `api-key create` error for invalid audit log service accounts

### DIFF
--- a/internal/cmd/api-key/command_create.go
+++ b/internal/cmd/api-key/command_create.go
@@ -2,6 +2,7 @@ package apikey
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	schedv1 "github.com/confluentinc/cc-structs/kafka/scheduler/v1"
@@ -58,7 +59,7 @@ func (c *command) create(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return err
 	}
-	serviceAccountID, err := cmd.Flags().GetString("service-account")
+	serviceAccountId, err := cmd.Flags().GetString("service-account")
 	if err != nil {
 		return err
 	}
@@ -69,7 +70,7 @@ func (c *command) create(cmd *cobra.Command, _ []string) error {
 	}
 
 	key := &schedv1.ApiKey{
-		UserResourceId: serviceAccountID,
+		UserResourceId: serviceAccountId,
 		Description:    description,
 		AccountId:      c.EnvironmentId(),
 	}
@@ -84,7 +85,7 @@ func (c *command) create(cmd *cobra.Command, _ []string) error {
 	}
 	userKey, err := c.Client.APIKey.Create(context.Background(), key)
 	if err != nil {
-		return err
+		return c.catchServiceAccountNotValidError(err, clusterId, serviceAccountId)
 	}
 
 	outputFormat, err := cmd.Flags().GetString(output.FlagName)
@@ -133,4 +134,25 @@ func (c *command) completeKeyUserId(key *schedv1.ApiKey) (*schedv1.ApiKey, error
 		key.ServiceAccount = false
 	}
 	return key, nil
+}
+
+// CLI-1544: Warn users if they try to create an API key with the predefined audit log Kafka cluster, but without the
+// predefined audit log service account
+func (c *command) catchServiceAccountNotValidError(err error, clusterId, serviceAccountId string) error {
+	if err == nil {
+		return nil
+	}
+
+	if err.Error() == "error creating api key: service account is not valid" && clusterId == c.State.Auth.Organization.AuditLog.ClusterId {
+		auditLogServiceAccount, err2 := c.Client.User.GetServiceAccount(context.Background(), c.State.Auth.Organization.AuditLog.ServiceAccountId)
+		if err2 != nil {
+			return err
+		}
+	
+		if serviceAccountId != auditLogServiceAccount.ResourceId {
+			return fmt.Errorf(`API keys for audit logs (limit of 2) must be created using the predefined service account, "%s"`, auditLogServiceAccount.ResourceId)
+		}
+	}
+
+	return err
 }

--- a/test/api-key_test.go
+++ b/test/api-key_test.go
@@ -142,3 +142,8 @@ func (s *CLITestSuite) TestAPIKey() {
 		s.runCcloudTest(tt)
 	}
 }
+
+func (s *CLITestSuite) TestAPIKeyCreate_ServiceAccountNotValid() {
+	tt := CLITest{args: "api-key create --resource lkc-ab123 --service-account sa-123456", login: "default", fixture: "apikey/55.golden", wantErrCode: 1}
+	s.runCcloudTest(tt)
+}

--- a/test/fixtures/output/apikey/55.golden
+++ b/test/fixtures/output/apikey/55.golden
@@ -1,0 +1,1 @@
+Error: API keys for audit logs (limit of 2) must be created using the predefined service account, "sa-1337"

--- a/test/test-server/ccloud_handlers.go
+++ b/test/test-server/ccloud_handlers.go
@@ -380,6 +380,14 @@ func (c *CloudRouter) HandleApiKeys(t *testing.T) func(w http.ResponseWriter, r 
 			err := utilv1.UnmarshalJSON(r.Body, req)
 			require.NoError(t, err)
 			require.NotEmpty(t, req.ApiKey.AccountId)
+
+			if req.ApiKey.UserResourceId == "sa-123456" {
+				b, err := utilv1.MarshalJSONToBytes(&schedv1.CreateApiKeyReply{Error: &corev1.Error{Message: "service account is not valid"}})
+				require.NoError(t, err)
+				_, err = io.WriteString(w, string(b))
+				require.NoError(t, err)
+			}
+
 			apiKey := req.ApiKey
 			apiKey.Id = keyIndex
 			apiKey.Key = fmt.Sprintf("MYKEY%d", keyIndex)


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok

What
----
Warn users if they try to create an API key with the predefined audit log Kafka cluster, but without the predefined audit log service account.

References
----------
https://confluentinc.atlassian.net/browse/CLI-1544

Test & Review
-------------
Added an integration test and manually tested