### PR TITLE
KGLOBAL-1026: Upgrade cli to use kafka-rest-sdk-go version v0.3.13

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/confluentinc/go-netrc v0.0.0-20201015001751-d8d220f17928
 	github.com/confluentinc/go-printer v0.13.0
 	github.com/confluentinc/go-ps1 v1.0.2
-	github.com/confluentinc/kafka-rest-sdk-go/kafkarestv3 v0.3.7
+	github.com/confluentinc/kafka-rest-sdk-go/kafkarestv3 v0.3.13
 	github.com/confluentinc/mds-sdk-go/mdsv1 v0.0.27
 	github.com/confluentinc/mds-sdk-go/mdsv2alpha1 v0.0.37
 	github.com/confluentinc/properties v0.0.0-20190814194548-42c10394a787

--- a/go.sum
+++ b/go.sum
@@ -369,8 +369,8 @@ github.com/confluentinc/go-printer v0.13.0 h1:zgmoYZPQ51xjOPSW4G+QimPcoZEAflCb4U
 github.com/confluentinc/go-printer v0.13.0/go.mod h1:bOK/pPNm4ao7bZIcRnGPGca1B64nW+lApFXHZEZ0PcM=
 github.com/confluentinc/go-ps1 v1.0.2 h1:+4cKOzWs3AWmxL2s96oHu0QutZESDRXECnhFzm2ic4o=
 github.com/confluentinc/go-ps1 v1.0.2/go.mod h1:qmgG9xQgFd4u7/CS6eA9nNP8eQqOtXuRHmZ4+w7Vprs=
-github.com/confluentinc/kafka-rest-sdk-go/kafkarestv3 v0.3.7 h1:ALMl2S8zhmejmdfrt9XwzUQ9NngxFL1iMZzvoUhk6Os=
-github.com/confluentinc/kafka-rest-sdk-go/kafkarestv3 v0.3.7/go.mod h1:qJAUraWU9BERQWyalrPsxt+ECELWPV+qsyOaP00VidY=
+github.com/confluentinc/kafka-rest-sdk-go/kafkarestv3 v0.3.13 h1:8Hfwv+eT69FfQ+92lUjceJxq/svVOZdOtNpn0sEEuKU=
+github.com/confluentinc/kafka-rest-sdk-go/kafkarestv3 v0.3.13/go.mod h1:qJAUraWU9BERQWyalrPsxt+ECELWPV+qsyOaP00VidY=
 github.com/confluentinc/mds-sdk-go/mdsv1 v0.0.27 h1:RLTwQzW0LyIB8j2lRqx29bpLJSTwX4gnHRWrcC58Zzo=
 github.com/confluentinc/mds-sdk-go/mdsv1 v0.0.27/go.mod h1:wyYeXb6d0I/RRhPV7LaAFneTGqbT7chHZtpzfKwdrh0=
 github.com/confluentinc/mds-sdk-go/mdsv2alpha1 v0.0.37 h1:nrdPc0eYNTrXpL5N9WqjqGeh5oVs9qGnptgBvG5II4w=

--- a/internal/cmd/kafka/command_acl_create.go
+++ b/internal/cmd/kafka/command_acl_create.go
@@ -78,7 +78,7 @@ func (c *aclCommand) create(cmd *cobra.Command, _ []string) error {
 		kafkaRestExists := true
 		for i, binding := range bindings {
 			opts := aclBindingToClustersClusterIdAclsPostOpts(binding)
-			httpResp, err := kafkaREST.Client.ACLApi.ClustersClusterIdAclsPost(kafkaREST.Context, lkc, &opts)
+			httpResp, err := kafkaREST.Client.ACLV3Api.CreateKafkaAcls(kafkaREST.Context, lkc, &opts)
 
 			if err != nil && httpResp == nil {
 				if i == 0 {

--- a/internal/cmd/kafka/command_acl_create_onprem.go
+++ b/internal/cmd/kafka/command_acl_create_onprem.go
@@ -49,7 +49,7 @@ func (c *aclCommand) createOnPrem(cmd *cobra.Command, _ []string) error {
 	}
 
 	opts := aclutil.AclRequestToCreateAclReqest(acl)
-	httpResp, err := restClient.ACLApi.ClustersClusterIdAclsPost(restContext, clusterId, opts)
+	httpResp, err := restClient.ACLV3Api.CreateKafkaAcls(restContext, clusterId, opts)
 	if err != nil {
 		return kafkaRestError(restClient.GetConfig().BasePath, err, httpResp)
 	}

--- a/internal/cmd/kafka/command_acl_delete.go
+++ b/internal/cmd/kafka/command_acl_delete.go
@@ -68,7 +68,7 @@ func (c *aclCommand) delete(cmd *cobra.Command, _ []string) error {
 		matchingBindingCount := 0
 		for i, filter := range filters {
 			deleteOpts := aclFilterToClustersClusterIdAclsDeleteOpts(filter)
-			deleteResp, httpResp, err := kafkaREST.Client.ACLApi.ClustersClusterIdAclsDelete(kafkaREST.Context, lkc, &deleteOpts)
+			deleteResp, httpResp, err := kafkaREST.Client.ACLV3Api.DeleteKafkaAcls(kafkaREST.Context, lkc, &deleteOpts)
 
 			if err != nil && httpResp == nil {
 				if i == 0 {

--- a/internal/cmd/kafka/command_acl_delete_onprem.go
+++ b/internal/cmd/kafka/command_acl_delete_onprem.go
@@ -48,7 +48,7 @@ func (c *aclCommand) deleteOnPrem(cmd *cobra.Command, _ []string) error {
 	}
 
 	opts := aclutil.AclRequestToDeleteAclReqest(acl)
-	aclDeleteResp, httpResp, err := restClient.ACLApi.ClustersClusterIdAclsDelete(restContext, clusterId, opts)
+	aclDeleteResp, httpResp, err := restClient.ACLV3Api.DeleteKafkaAcls(restContext, clusterId, opts)
 	if err != nil {
 		return kafkaRestError(restClient.GetConfig().BasePath, err, httpResp)
 	}

--- a/internal/cmd/kafka/command_acl_list.go
+++ b/internal/cmd/kafka/command_acl_list.go
@@ -61,7 +61,7 @@ func (c *aclCommand) list(cmd *cobra.Command, _ []string) error {
 		}
 		lkc := kafkaClusterConfig.ID
 
-		aclGetResp, httpResp, err := kafkaREST.Client.ACLApi.ClustersClusterIdAclsGet(kafkaREST.Context, lkc, &opts)
+		aclGetResp, httpResp, err := kafkaREST.Client.ACLV3Api.GetKafkaAcls(kafkaREST.Context, lkc, &opts)
 
 		if err != nil && httpResp != nil {
 			// Kafka REST is available, but an error occurred

--- a/internal/cmd/kafka/command_acl_list_onprem.go
+++ b/internal/cmd/kafka/command_acl_list_onprem.go
@@ -51,7 +51,7 @@ func (c *aclCommand) listOnPrem(cmd *cobra.Command, _ []string) error {
 	}
 
 	opts := aclutil.AclRequestToListAclReqest(acl)
-	aclGetResp, httpResp, err := restClient.ACLApi.ClustersClusterIdAclsGet(restContext, clusterId, opts)
+	aclGetResp, httpResp, err := restClient.ACLV3Api.GetKafkaAcls(restContext, clusterId, opts)
 	if err != nil {
 		return kafkaRestError(restClient.GetConfig().BasePath, err, httpResp)
 	}

--- a/internal/cmd/kafka/command_broker_delete.go
+++ b/internal/cmd/kafka/command_broker_delete.go
@@ -43,7 +43,7 @@ func (c *brokerCommand) delete(cmd *cobra.Command, args []string) error {
 	}
 
 	opts := kafkarestv3.ClustersClusterIdBrokersBrokerIdDeleteOpts{ShouldShutdown: optional.NewBool(true)}
-	_, resp, err := restClient.BrokerApi.ClustersClusterIdBrokersBrokerIdDelete(restContext, clusterId, brokerId, &opts)
+	_, resp, err := restClient.BrokerV3Api.ClustersClusterIdBrokersBrokerIdDelete(restContext, clusterId, brokerId, &opts)
 	if err != nil {
 		return kafkaRestError(restClient.GetConfig().BasePath, err, resp)
 	}

--- a/internal/cmd/kafka/command_broker_describe.go
+++ b/internal/cmd/kafka/command_broker_describe.go
@@ -155,10 +155,10 @@ func getIndividualBrokerConfigs(restClient *kafkarestv3.APIClient, restContext c
 	var err error
 	if configName != "" {
 		var brokerNameData kafkarestv3.BrokerConfigData
-		brokerNameData, resp, err = restClient.ConfigsApi.ClustersClusterIdBrokersBrokerIdConfigsNameGet(restContext, clusterId, brokerId, configName)
+		brokerNameData, resp, err = restClient.ConfigsV3Api.ClustersClusterIdBrokersBrokerIdConfigsNameGet(restContext, clusterId, brokerId, configName)
 		brokerConfig.Data = []kafkarestv3.BrokerConfigData{brokerNameData}
 	} else {
-		brokerConfig, resp, err = restClient.ConfigsApi.ClustersClusterIdBrokersBrokerIdConfigsGet(restContext, clusterId, brokerId)
+		brokerConfig, resp, err = restClient.ConfigsV3Api.ClustersClusterIdBrokersBrokerIdConfigsGet(restContext, clusterId, brokerId)
 	}
 	if err != nil {
 		return brokerConfig, kafkaRestError(restClient.GetConfig().BasePath, err, resp)
@@ -173,10 +173,10 @@ func getClusterWideConfigs(restClient *kafkarestv3.APIClient, restContext contex
 	var err error
 	if configName != "" { // Get config specified by configName
 		var configNameData kafkarestv3.ClusterConfigData
-		configNameData, resp, err = restClient.ConfigsApi.ClustersClusterIdBrokerConfigsNameGet(restContext, clusterId, configName)
+		configNameData, resp, err = restClient.ConfigsV3Api.GetKafkaClusterConfig(restContext, clusterId, configName)
 		clusterConfig.Data = []kafkarestv3.ClusterConfigData{configNameData}
 	} else { // Get all configs
-		clusterConfig, resp, err = restClient.ConfigsApi.ClustersClusterIdBrokerConfigsGet(restContext, clusterId)
+		clusterConfig, resp, err = restClient.ConfigsV3Api.ListKafkaClusterConfigs(restContext, clusterId)
 	}
 	if err != nil {
 		return clusterConfig, kafkaRestError(restClient.GetConfig().BasePath, err, resp)

--- a/internal/cmd/kafka/command_broker_gettasks.go
+++ b/internal/cmd/kafka/command_broker_gettasks.go
@@ -125,7 +125,7 @@ func parseBrokerTaskData(entry kafkarestv3.BrokerTaskData) brokerTaskData {
 		ClusterId:       entry.ClusterId,
 		BrokerId:        entry.BrokerId,
 		TaskType:        entry.TaskType,
-		TaskStatus:      entry.TaskStatus,
+		TaskStatus:      string(entry.TaskStatus),
 		CreatedAt:       entry.CreatedAt,
 		UpdatedAt:       entry.UpdatedAt,
 		SubTaskStatuses: mapToKeyValueString(entry.SubTaskStatuses),

--- a/internal/cmd/kafka/command_broker_list.go
+++ b/internal/cmd/kafka/command_broker_list.go
@@ -34,7 +34,7 @@ func (c *brokerCommand) list(cmd *cobra.Command, _ []string) error {
 	}
 
 	// Get Brokers
-	brokersGetResp, resp, err := restClient.BrokerApi.ClustersClusterIdBrokersGet(restContext, clusterId)
+	brokersGetResp, resp, err := restClient.BrokerV3Api.ClustersClusterIdBrokersGet(restContext, clusterId)
 	if err != nil {
 		return kafkaRestError(restClient.GetConfig().BasePath, err, resp)
 	}

--- a/internal/cmd/kafka/command_broker_update.go
+++ b/internal/cmd/kafka/command_broker_update.go
@@ -75,15 +75,15 @@ func (c *brokerCommand) update(cmd *cobra.Command, args []string) error {
 	configs := toAlterConfigBatchRequestData(configsMap)
 
 	if all {
-		resp, err := restClient.ConfigsApi.ClustersClusterIdBrokerConfigsalterPost(restContext, clusterId,
-			&kafkarestv3.ClustersClusterIdBrokerConfigsalterPostOpts{
+		resp, err := restClient.ConfigsV3Api.UpdateKafkaClusterConfigs(restContext, clusterId,
+			&kafkarestv3.UpdateKafkaClusterConfigsOpts{
 				AlterConfigBatchRequestData: optional.NewInterface(kafkarestv3.AlterConfigBatchRequestData{Data: configs}),
 			})
 		if err != nil {
 			return kafkaRestError(restClient.GetConfig().BasePath, err, resp)
 		}
 	} else {
-		resp, err := restClient.ConfigsApi.ClustersClusterIdBrokersBrokerIdConfigsalterPost(restContext, clusterId, brokerId,
+		resp, err := restClient.ConfigsV3Api.ClustersClusterIdBrokersBrokerIdConfigsalterPost(restContext, clusterId, brokerId,
 			&kafkarestv3.ClustersClusterIdBrokersBrokerIdConfigsalterPostOpts{
 				AlterConfigBatchRequestData: optional.NewInterface(kafkarestv3.AlterConfigBatchRequestData{Data: configs}),
 			})

--- a/internal/cmd/kafka/command_consumergroup.go
+++ b/internal/cmd/kafka/command_consumergroup.go
@@ -135,7 +135,7 @@ func listConsumerGroups(flagCmd *pcmd.AuthenticatedStateFlagCommand) (*kafkarest
 		return nil, err
 	}
 
-	groupCmdResp, httpResp, err := kafkaREST.Client.ConsumerGroupApi.ClustersClusterIdConsumerGroupsGet(kafkaREST.Context, lkc)
+	groupCmdResp, httpResp, err := kafkaREST.Client.ConsumerGroupV3Api.ListKafkaConsumerGroups(kafkaREST.Context, lkc)
 	if err != nil {
 		return nil, kafkaRestError(kafkaREST.Client.GetConfig().BasePath, err, httpResp)
 	}

--- a/internal/cmd/kafka/command_consumergroup_describe.go
+++ b/internal/cmd/kafka/command_consumergroup_describe.go
@@ -54,12 +54,12 @@ func (c *consumerGroupCommand) describe(cmd *cobra.Command, args []string) error
 		return err
 	}
 
-	groupCmdResp, httpResp, err := kafkaREST.Client.ConsumerGroupApi.ClustersClusterIdConsumerGroupsConsumerGroupIdGet(kafkaREST.Context, lkc, consumerGroupId)
+	groupCmdResp, httpResp, err := kafkaREST.Client.ConsumerGroupV3Api.GetKafkaConsumerGroup(kafkaREST.Context, lkc, consumerGroupId)
 	if err != nil {
 		return kafkaRestError(kafkaREST.Client.GetConfig().BasePath, err, httpResp)
 	}
 
-	groupCmdConsumersResp, httpResp, err := kafkaREST.Client.ConsumerGroupApi.ClustersClusterIdConsumerGroupsConsumerGroupIdConsumersGet(kafkaREST.Context, lkc, consumerGroupId)
+	groupCmdConsumersResp, httpResp, err := kafkaREST.Client.ConsumerGroupV3Api.ListKafkaConsumers(kafkaREST.Context, lkc, consumerGroupId)
 	if err != nil {
 		return kafkaRestError(kafkaREST.Client.GetConfig().BasePath, err, httpResp)
 	}

--- a/internal/cmd/kafka/command_consumergroup_lag_get.go
+++ b/internal/cmd/kafka/command_consumergroup_lag_get.go
@@ -56,7 +56,7 @@ func (c *lagCommand) getLag(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	lagGetResp, httpResp, err := kafkaREST.Client.PartitionApi.ClustersClusterIdConsumerGroupsConsumerGroupIdLagsTopicNamePartitionsPartitionIdGet(kafkaREST.Context, lkc, consumerGroupId, topicName, partitionId)
+	lagGetResp, httpResp, err := kafkaREST.Client.PartitionV3Api.GetKafkaConsumerLag(kafkaREST.Context, lkc, consumerGroupId, topicName, partitionId)
 	if err != nil {
 		return kafkaRestError(kafkaREST.Client.GetConfig().BasePath, err, httpResp)
 	}

--- a/internal/cmd/kafka/command_consumergroup_lag_list.go
+++ b/internal/cmd/kafka/command_consumergroup_lag_list.go
@@ -40,7 +40,7 @@ func (c *lagCommand) list(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	lagSummaryResp, httpResp, err := kafkaREST.Client.ConsumerGroupApi.ClustersClusterIdConsumerGroupsConsumerGroupIdLagsGet(kafkaREST.Context, lkc, consumerGroupId)
+	lagSummaryResp, httpResp, err := kafkaREST.Client.ConsumerGroupV3Api.ListKafkaConsumerLags(kafkaREST.Context, lkc, consumerGroupId)
 	if err != nil {
 		return kafkaRestError(kafkaREST.Client.GetConfig().BasePath, err, httpResp)
 	}

--- a/internal/cmd/kafka/command_consumergroup_lag_summarize.go
+++ b/internal/cmd/kafka/command_consumergroup_lag_summarize.go
@@ -65,7 +65,7 @@ func (c *lagCommand) summarize(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	lagSummaryResp, httpResp, err := kafkaREST.Client.ConsumerGroupApi.ClustersClusterIdConsumerGroupsConsumerGroupIdLagSummaryGet(kafkaREST.Context, lkc, consumerGroupId)
+	lagSummaryResp, httpResp, err := kafkaREST.Client.ConsumerGroupV3Api.GetKafkaConsumerGroupLagSummary(kafkaREST.Context, lkc, consumerGroupId)
 	if err != nil {
 		return kafkaRestError(kafkaREST.Client.GetConfig().BasePath, err, httpResp)
 	}

--- a/internal/cmd/kafka/command_consumergroup_list.go
+++ b/internal/cmd/kafka/command_consumergroup_list.go
@@ -43,7 +43,7 @@ func (c *consumerGroupCommand) list(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	groupCmdResp, httpResp, err := kafkaREST.Client.ConsumerGroupApi.ClustersClusterIdConsumerGroupsGet(kafkaREST.Context, lkc)
+	groupCmdResp, httpResp, err := kafkaREST.Client.ConsumerGroupV3Api.ListKafkaConsumerGroups(kafkaREST.Context, lkc)
 	if err != nil {
 		return kafkaRestError(kafkaREST.Client.GetConfig().BasePath, err, httpResp)
 	}

--- a/internal/cmd/kafka/command_link_create.go
+++ b/internal/cmd/kafka/command_link_create.go
@@ -86,7 +86,7 @@ func (c *linkCommand) create(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	skipValidatingLink, err := cmd.Flags().GetBool(noValidateFlagName)
+	_, err = cmd.Flags().GetBool(noValidateFlagName)
 	if err != nil {
 		return err
 	}
@@ -146,16 +146,14 @@ func (c *linkCommand) create(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	createLinkOpt := &kafkarestv3.ClustersClusterIdLinksPostOpts{
-		ValidateOnly: optional.NewBool(validateOnly),
-		ValidateLink: optional.NewBool(!skipValidatingLink),
+	createLinkOpt := &kafkarestv3.CreateKafkaLinkOpts{
 		CreateLinkRequestData: optional.NewInterface(kafkarestv3.CreateLinkRequestData{
 			SourceClusterId: sourceClusterId,
 			Configs:         toCreateTopicConfigs(configMap),
 		}),
 	}
 
-	httpResp, err := kafkaREST.Client.ClusterLinkingApi.ClustersClusterIdLinksPost(
+	httpResp, err := kafkaREST.Client.ClusterLinkingV3Api.CreateKafkaLink(
 		kafkaREST.Context, lkc, linkName, createLinkOpt)
 
 	if err == nil {

--- a/internal/cmd/kafka/command_link_delete.go
+++ b/internal/cmd/kafka/command_link_delete.go
@@ -38,7 +38,7 @@ func (c *linkCommand) delete(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	httpResp, err := kafkaREST.Client.ClusterLinkingApi.ClustersClusterIdLinksLinkNameDelete(kafkaREST.Context, lkc, linkName)
+	httpResp, err := kafkaREST.Client.ClusterLinkingV3Api.DeleteKafkaLink(kafkaREST.Context, lkc, linkName)
 	if err == nil {
 		utils.Printf(cmd, errors.DeletedLinkMsg, linkName)
 	}

--- a/internal/cmd/kafka/command_link_describe.go
+++ b/internal/cmd/kafka/command_link_describe.go
@@ -54,7 +54,7 @@ func (c *linkCommand) describe(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	listLinkConfigsRespData, httpResp, err := kafkaREST.Client.ClusterLinkingApi.ClustersClusterIdLinksLinkNameConfigsGet(kafkaREST.Context, lkc, linkName)
+	listLinkConfigsRespData, httpResp, err := kafkaREST.Client.ClusterLinkingV3Api.ListKafkaLinkConfigs(kafkaREST.Context, lkc, linkName)
 	if err != nil {
 		return handleOpenApiError(httpResp, err, kafkaREST)
 	}

--- a/internal/cmd/kafka/command_link_list.go
+++ b/internal/cmd/kafka/command_link_list.go
@@ -61,7 +61,7 @@ func (c *linkCommand) list(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	listLinksRespDataList, httpResp, err := kafkaREST.Client.ClusterLinkingApi.ClustersClusterIdLinksGet(kafkaREST.Context, lkc)
+	listLinksRespDataList, httpResp, err := kafkaREST.Client.ClusterLinkingV3Api.ListKafkaLinks(kafkaREST.Context, lkc)
 	if err != nil {
 		return handleOpenApiError(httpResp, err, kafkaREST)
 	}
@@ -73,8 +73,8 @@ func (c *linkCommand) list(cmd *cobra.Command, _ []string) error {
 		}
 
 		for _, link := range listLinksRespDataList.Data {
-			if len(link.TopicNames) > 0 {
-				for _, topic := range link.TopicNames {
+			if len(link.TopicsNames) > 0 {
+				for _, topic := range link.TopicsNames {
 					outputWriter.AddElement(
 						&LinkTopicWriter{
 							LinkName:        link.LinkName,

--- a/internal/cmd/kafka/command_link_update.go
+++ b/internal/cmd/kafka/command_link_update.go
@@ -67,8 +67,8 @@ func (c *linkCommand) update(cmd *cobra.Command, args []string) error {
 
 	kafkaRestConfigs := toAlterConfigBatchRequestData(configsMap)
 
-	opts := &kafkarestv3.ClustersClusterIdLinksLinkNameConfigsalterPutOpts{AlterConfigBatchRequestData: optional.NewInterface(kafkarestv3.AlterConfigBatchRequestData{Data: kafkaRestConfigs})}
-	httpResp, err := kafkaREST.Client.ClusterLinkingApi.ClustersClusterIdLinksLinkNameConfigsalterPut(kafkaREST.Context, lkc, linkName, opts)
+	opts := &kafkarestv3.UpdateKafkaLinkConfigBatchOpts{AlterConfigBatchRequestData: optional.NewInterface(kafkarestv3.AlterConfigBatchRequestData{Data: kafkaRestConfigs})}
+	httpResp, err := kafkaREST.Client.ClusterLinkingV3Api.UpdateKafkaLinkConfigBatch(kafkaREST.Context, lkc, linkName, opts)
 	if err != nil {
 		return handleOpenApiError(httpResp, err, kafkaREST)
 	}

--- a/internal/cmd/kafka/command_mirror_create.go
+++ b/internal/cmd/kafka/command_mirror_create.go
@@ -78,7 +78,7 @@ func (c *mirrorCommand) create(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	createMirrorOpt := &kafkarestv3.ClustersClusterIdLinksLinkNameMirrorsPostOpts{
+	createMirrorOpt := &kafkarestv3.CreateKafkaMirrorTopicOpts{
 		CreateMirrorTopicRequestData: optional.NewInterface(
 			kafkarestv3.CreateMirrorTopicRequestData{
 				SourceTopicName:   sourceTopicName,
@@ -88,7 +88,7 @@ func (c *mirrorCommand) create(cmd *cobra.Command, args []string) error {
 		),
 	}
 
-	httpResp, err := kafkaREST.Client.ClusterLinkingApi.ClustersClusterIdLinksLinkNameMirrorsPost(kafkaREST.Context, lkc, linkName, createMirrorOpt)
+	httpResp, err := kafkaREST.Client.ClusterLinkingV3Api.CreateKafkaMirrorTopic(kafkaREST.Context, lkc, linkName, createMirrorOpt)
 	if err == nil {
 		utils.Printf(cmd, errors.CreatedMirrorMsg, sourceTopicName)
 	}

--- a/internal/cmd/kafka/command_mirror_describe.go
+++ b/internal/cmd/kafka/command_mirror_describe.go
@@ -55,7 +55,7 @@ func (c *mirrorCommand) describe(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	mirror, httpResp, err := kafkaREST.Client.ClusterLinkingApi.ClustersClusterIdLinksLinkNameMirrorsMirrorTopicNameGet(kafkaREST.Context, lkc, linkName, mirrorTopicName)
+	mirror, httpResp, err := kafkaREST.Client.ClusterLinkingV3Api.ReadKafkaMirrorTopic(kafkaREST.Context, lkc, linkName, mirrorTopicName)
 	if err != nil {
 		return kafkaRestError(kafkaREST.Client.GetConfig().BasePath, err, httpResp)
 	}
@@ -73,7 +73,7 @@ func (c *mirrorCommand) describe(cmd *cobra.Command, args []string) error {
 			MirrorStatus:          string(mirror.MirrorStatus),
 			StatusTimeMs:          mirror.StateTimeMs,
 			Partition:             partitionLag.Partition,
-			PartitionMirrorLag:    partitionLag.Lag,
+			PartitionMirrorLag:    int64(partitionLag.Lag),
 			LastSourceFetchOffset: partitionLag.LastSourceFetchOffset,
 		})
 	}

--- a/internal/cmd/kafka/command_mirror_failover.go
+++ b/internal/cmd/kafka/command_mirror_failover.go
@@ -60,12 +60,12 @@ func (c *mirrorCommand) failover(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	failoverMirrorOpt := &kafkarestv3.ClustersClusterIdLinksLinkNameMirrorsfailoverPostOpts{
+	failoverMirrorOpt := &kafkarestv3.UpdateKafkaMirrorTopicsFailoverOpts{
 		AlterMirrorsRequestData: optional.NewInterface(kafkarestv3.AlterMirrorsRequestData{MirrorTopicNames: args}),
 		ValidateOnly:            optional.NewBool(validateOnly),
 	}
 
-	results, httpResp, err := kafkaREST.Client.ClusterLinkingApi.ClustersClusterIdLinksLinkNameMirrorsfailoverPost(kafkaREST.Context, lkc, linkName, failoverMirrorOpt)
+	results, httpResp, err := kafkaREST.Client.ClusterLinkingV3Api.UpdateKafkaMirrorTopicsFailover(kafkaREST.Context, lkc, linkName, failoverMirrorOpt)
 	if err != nil {
 		return kafkaRestError(kafkaREST.Client.GetConfig().BasePath, err, httpResp)
 	}

--- a/internal/cmd/kafka/command_mirror_list.go
+++ b/internal/cmd/kafka/command_mirror_list.go
@@ -70,11 +70,11 @@ func (c *mirrorCommand) list(cmd *cobra.Command, _ []string) error {
 	var httpResp *http.Response
 
 	if linkName == "" {
-		opts := &kafkarestv3.ClustersClusterIdLinksMirrorsGetOpts{MirrorStatus: mirrorStatusOpt}
-		listMirrorTopicsResponseDataList, httpResp, err = kafkaREST.Client.ClusterLinkingApi.ClustersClusterIdLinksMirrorsGet(kafkaREST.Context, lkc, opts)
+		opts := &kafkarestv3.ListKafkaMirrorTopicsOpts{MirrorStatus: mirrorStatusOpt}
+		listMirrorTopicsResponseDataList, httpResp, err = kafkaREST.Client.ClusterLinkingV3Api.ListKafkaMirrorTopics(kafkaREST.Context, lkc, opts)
 	} else {
-		opts := &kafkarestv3.ClustersClusterIdLinksLinkNameMirrorsGetOpts{MirrorStatus: mirrorStatusOpt}
-		listMirrorTopicsResponseDataList, httpResp, err = kafkaREST.Client.ClusterLinkingApi.ClustersClusterIdLinksLinkNameMirrorsGet(kafkaREST.Context, lkc, linkName, opts)
+		opts := &kafkarestv3.ListKafkaMirrorTopicsUnderLinkOpts{MirrorStatus: mirrorStatusOpt}
+		listMirrorTopicsResponseDataList, httpResp, err = kafkaREST.Client.ClusterLinkingV3Api.ListKafkaMirrorTopicsUnderLink(kafkaREST.Context, lkc, linkName, opts)
 	}
 	if err != nil {
 		return handleOpenApiError(httpResp, err, kafkaREST)
@@ -86,7 +86,7 @@ func (c *mirrorCommand) list(cmd *cobra.Command, _ []string) error {
 	}
 
 	for _, mirror := range listMirrorTopicsResponseDataList.Data {
-		var maxLag int64 = 0
+		var maxLag int32 = 0
 		for _, mirrorLag := range mirror.MirrorLags {
 			if mirrorLag.Lag > maxLag {
 				maxLag = mirrorLag.Lag
@@ -100,7 +100,7 @@ func (c *mirrorCommand) list(cmd *cobra.Command, _ []string) error {
 			MirrorStatus:             string(mirror.MirrorStatus),
 			StatusTimeMs:             mirror.StateTimeMs,
 			NumPartition:             mirror.NumPartitions,
-			MaxPerPartitionMirrorLag: maxLag,
+			MaxPerPartitionMirrorLag: int64(maxLag),
 		})
 	}
 

--- a/internal/cmd/kafka/command_mirror_pause.go
+++ b/internal/cmd/kafka/command_mirror_pause.go
@@ -59,12 +59,12 @@ func (c *mirrorCommand) pause(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	pauseMirrorOpt := &kafkarestv3.ClustersClusterIdLinksLinkNameMirrorspausePostOpts{
+	pauseMirrorOpt := &kafkarestv3.UpdateKafkaMirrorTopicsPauseOpts{
 		AlterMirrorsRequestData: optional.NewInterface(kafkarestv3.AlterMirrorsRequestData{MirrorTopicNames: args}),
 		ValidateOnly:            optional.NewBool(validateOnly),
 	}
 
-	results, httpResp, err := kafkaREST.Client.ClusterLinkingApi.ClustersClusterIdLinksLinkNameMirrorspausePost(kafkaREST.Context, lkc, linkName, pauseMirrorOpt)
+	results, httpResp, err := kafkaREST.Client.ClusterLinkingV3Api.UpdateKafkaMirrorTopicsPause(kafkaREST.Context, lkc, linkName, pauseMirrorOpt)
 	if err != nil {
 		return kafkaRestError(kafkaREST.Client.GetConfig().BasePath, err, httpResp)
 	}

--- a/internal/cmd/kafka/command_mirror_promote.go
+++ b/internal/cmd/kafka/command_mirror_promote.go
@@ -60,12 +60,12 @@ func (c *mirrorCommand) promote(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	promoteMirrorOpt := &kafkarestv3.ClustersClusterIdLinksLinkNameMirrorspromotePostOpts{
+	promoteMirrorOpt := &kafkarestv3.UpdateKafkaMirrorTopicsPromoteOpts{
 		AlterMirrorsRequestData: optional.NewInterface(kafkarestv3.AlterMirrorsRequestData{MirrorTopicNames: args}),
 		ValidateOnly:            optional.NewBool(validateOnly),
 	}
 
-	results, httpResp, err := kafkaREST.Client.ClusterLinkingApi.ClustersClusterIdLinksLinkNameMirrorspromotePost(kafkaREST.Context, lkc, linkName, promoteMirrorOpt)
+	results, httpResp, err := kafkaREST.Client.ClusterLinkingV3Api.UpdateKafkaMirrorTopicsPromote(kafkaREST.Context, lkc, linkName, promoteMirrorOpt)
 	if err != nil {
 		return kafkaRestError(kafkaREST.Client.GetConfig().BasePath, err, httpResp)
 	}

--- a/internal/cmd/kafka/command_mirror_resume.go
+++ b/internal/cmd/kafka/command_mirror_resume.go
@@ -63,12 +63,12 @@ func (c *mirrorCommand) resume(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	resumeMirrorOpt := &kafkarestv3.ClustersClusterIdLinksLinkNameMirrorsresumePostOpts{
+	resumeMirrorOpt := &kafkarestv3.UpdateKafkaMirrorTopicsResumeOpts{
 		AlterMirrorsRequestData: optional.NewInterface(kafkarestv3.AlterMirrorsRequestData{MirrorTopicNames: args}),
 		ValidateOnly:            optional.NewBool(validateOnly),
 	}
 
-	results, httpResp, err := kafkaREST.Client.ClusterLinkingApi.ClustersClusterIdLinksLinkNameMirrorsresumePost(kafkaREST.Context, lkc, linkName, resumeMirrorOpt)
+	results, httpResp, err := kafkaREST.Client.ClusterLinkingV3Api.UpdateKafkaMirrorTopicsResume(kafkaREST.Context, lkc, linkName, resumeMirrorOpt)
 	if err != nil {
 		return kafkaRestError(kafkaREST.Client.GetConfig().BasePath, err, httpResp)
 	}
@@ -113,7 +113,7 @@ func printAlterMirrorResult(cmd *cobra.Command, results kafkarestv3.AlterMirrorS
 				Partition:             partitionLag.Partition,
 				ErrorMessage:          errMsg,
 				ErrorCode:             code,
-				PartitionMirrorLag:    partitionLag.Lag,
+				PartitionMirrorLag:    int64(partitionLag.Lag),
 				LastSourceFetchOffset: partitionLag.LastSourceFetchOffset,
 			})
 		}

--- a/internal/cmd/kafka/command_partitions_onprem.go
+++ b/internal/cmd/kafka/command_partitions_onprem.go
@@ -109,7 +109,7 @@ func (partitionCmd *partitionCommand) list(cmd *cobra.Command, _ []string) error
 	if err != nil {
 		return err
 	}
-	partitionListResp, resp, err := restClient.PartitionApi.ClustersClusterIdTopicsTopicNamePartitionsGet(restContext, clusterId, topic)
+	partitionListResp, resp, err := restClient.PartitionV3Api.ListKafkaPartitions(restContext, clusterId, topic)
 	if err != nil {
 		return kafkaRestError(restClient.GetConfig().BasePath, err, resp)
 	}
@@ -161,7 +161,7 @@ func (partitionCmd *partitionCommand) describe(cmd *cobra.Command, args []string
 	if err != nil {
 		return err
 	}
-	partitionGetResp, resp, err := restClient.PartitionApi.ClustersClusterIdTopicsTopicNamePartitionsPartitionIdGet(restContext, clusterId, topic, partitionId)
+	partitionGetResp, resp, err := restClient.PartitionV3Api.GetKafkaPartition(restContext, clusterId, topic, partitionId)
 	if err != nil {
 		return kafkaRestError(restClient.GetConfig().BasePath, err, resp)
 	}

--- a/internal/cmd/kafka/command_test.go
+++ b/internal/cmd/kafka/command_test.go
@@ -853,6 +853,31 @@ func TestCreateMirror(t *testing.T) {
 	defer os.Remove(dir + "/" + configFileName)
 }
 
+//func TestCreateMirrorWithLinkPrefix(t *testing.T) {
+//	const configFileName, topicName, clusterLinkPrefix = "prefixed-mirror-topic-config.in", "topic-1", "src_"
+//	configs := configMapWithJsonConfigValues()
+//	dir, err := createTestConfigFile(configFileName, configs)
+//	if err != nil {
+//		logger.Fatal("Cannot create the test config file")
+//	}
+//
+//	linkTestHelper(
+//		t,
+//		func(link testLink) []string {
+//			return []string{"mirror", "create", clusterLinkPrefix + topicName, "--link", "link-1", "--replication-factor", "2", "--config-file", configFileName, "--source-topic", topicName}
+//		},
+//		func(expect chan interface{}, link testLink) {
+//			expect <- cliMock.CreateMirrorMatcher{
+//				LinkName:        "link-1",
+//				SourceTopicName: clusterLinkPrefix + topicName,
+//				Configs:         configs,
+//				MirrorTopicName: topicName,
+//			}
+//		},
+//	)
+//	defer os.Remove(dir + "/" + configFileName)
+//}
+
 func TestListAllMirror(t *testing.T) {
 	linkTestHelper(
 		t,
@@ -1161,13 +1186,13 @@ func newMockCmd(kafkaExpect chan interface{}, kafkaRestExpect chan interface{}, 
 	provider := (pcmd.KafkaRESTProvider)(func() (*pcmd.KafkaREST, error) {
 		if enableREST {
 			restMock := krsdk.NewAPIClient(&krsdk.Configuration{BasePath: "/dummy-base-path"})
-			restMock.ACLApi = cliMock.NewACLMock()
-			restMock.TopicApi = cliMock.NewTopicMock()
-			restMock.PartitionApi = cliMock.NewPartitionMock(kafkaRestExpect)
-			restMock.ReplicaApi = cliMock.NewReplicaMock()
-			restMock.ConfigsApi = cliMock.NewConfigsMock()
-			restMock.ClusterLinkingApi = cliMock.NewClusterLinkingMock(kafkaRestExpect)
-			restMock.ConsumerGroupApi = cliMock.NewConsumerGroupMock(kafkaRestExpect)
+			restMock.ACLV3Api = cliMock.NewACLMock()
+			restMock.TopicV3Api = cliMock.NewTopicMock()
+			restMock.PartitionV3Api = cliMock.NewPartitionMock(kafkaRestExpect)
+			restMock.ReplicaV3Api = cliMock.NewReplicaMock()
+			restMock.ConfigsV3Api = cliMock.NewConfigsMock()
+			restMock.ClusterLinkingV3Api = cliMock.NewClusterLinkingMock(kafkaRestExpect)
+			restMock.ConsumerGroupV3Api = cliMock.NewConsumerGroupMock(kafkaRestExpect)
 			restMock.ReplicaStatusApi = cliMock.NewReplicaStatusMock()
 			ctx := context.WithValue(context.Background(), krsdk.ContextAccessToken, "dummy-bearer-token")
 			kafkaREST := pcmd.NewKafkaREST(restMock, ctx)

--- a/internal/cmd/kafka/command_topic.go
+++ b/internal/cmd/kafka/command_topic.go
@@ -296,7 +296,7 @@ func (a *authenticatedTopicCommand) list(cmd *cobra.Command, _ []string) error {
 		}
 		lkc := kafkaClusterConfig.ID
 
-		topicGetResp, httpResp, err := kafkaREST.Client.TopicApi.ClustersClusterIdTopicsGet(kafkaREST.Context, lkc)
+		topicGetResp, httpResp, err := kafkaREST.Client.TopicV3Api.ListKafkaTopics(kafkaREST.Context, lkc)
 
 		if err != nil && httpResp != nil {
 			// Kafka REST is available, but an error occurred
@@ -383,7 +383,7 @@ func (a *authenticatedTopicCommand) create(cmd *cobra.Command, args []string) er
 		}
 		lkc := kafkaClusterConfig.ID
 
-		_, httpResp, err := kafkaREST.Client.TopicApi.ClustersClusterIdTopicsPost(kafkaREST.Context, lkc, &kafkarestv3.ClustersClusterIdTopicsPostOpts{
+		_, httpResp, err := kafkaREST.Client.TopicV3Api.CreateKafkaTopic(kafkaREST.Context, lkc, &kafkarestv3.CreateKafkaTopicOpts{
 			CreateTopicRequestData: optional.NewInterface(kafkarestv3.CreateTopicRequestData{
 				TopicName:         topicName,
 				PartitionsCount:   numPartitions,
@@ -469,7 +469,7 @@ func (a *authenticatedTopicCommand) describe(cmd *cobra.Command, args []string) 
 		}
 		lkc := kafkaClusterConfig.ID
 
-		partitionsResp, httpResp, err := kafkaREST.Client.PartitionApi.ClustersClusterIdTopicsTopicNamePartitionsGet(kafkaREST.Context, lkc, topicName)
+		partitionsResp, httpResp, err := kafkaREST.Client.PartitionV3Api.ListKafkaPartitions(kafkaREST.Context, lkc, topicName)
 
 		if err != nil && httpResp != nil {
 			// Kafka REST is available, but there was an error
@@ -494,7 +494,7 @@ func (a *authenticatedTopicCommand) describe(cmd *cobra.Command, args []string) 
 			topicData := &topicData{}
 			topicData.TopicName = topicName
 			// Get topic config
-			configsResp, httpResp, err := kafkaREST.Client.ConfigsApi.ClustersClusterIdTopicsTopicNameConfigsGet(kafkaREST.Context, lkc, topicName)
+			configsResp, httpResp, err := kafkaREST.Client.ConfigsV3Api.ListKafkaTopicConfigs(kafkaREST.Context, lkc, topicName)
 			if err != nil {
 				return kafkaRestError(kafkaREST.Client.GetConfig().BasePath, err, httpResp)
 			} else if configsResp.Data == nil {
@@ -559,8 +559,8 @@ func (a *authenticatedTopicCommand) update(cmd *cobra.Command, args []string) er
 		}
 		lkc := kafkaClusterConfig.ID
 
-		httpResp, err := kafkaREST.Client.ConfigsApi.ClustersClusterIdTopicsTopicNameConfigsalterPost(kafkaREST.Context, lkc, topicName,
-			&kafkarestv3.ClustersClusterIdTopicsTopicNameConfigsalterPostOpts{
+		httpResp, err := kafkaREST.Client.ConfigsV3Api.UpdateKafkaTopicConfigBatch(kafkaREST.Context, lkc, topicName,
+			&kafkarestv3.UpdateKafkaTopicConfigBatchOpts{
 				AlterConfigBatchRequestData: optional.NewInterface(kafkarestv3.AlterConfigBatchRequestData{Data: kafkaRestConfigs}),
 			})
 
@@ -656,7 +656,7 @@ func (a *authenticatedTopicCommand) delete(cmd *cobra.Command, args []string) er
 		}
 		lkc := kafkaClusterConfig.ID
 
-		httpResp, err := kafkaREST.Client.TopicApi.ClustersClusterIdTopicsTopicNameDelete(kafkaREST.Context, lkc, topicName)
+		httpResp, err := kafkaREST.Client.TopicV3Api.DeleteKafkaTopic(kafkaREST.Context, lkc, topicName)
 		if err != nil && httpResp != nil {
 			// Kafka REST is available, but an error occurred
 			restErr, parseErr := parseOpenAPIError(err)

--- a/internal/cmd/kafka/command_topic_onprem.go
+++ b/internal/cmd/kafka/command_topic_onprem.go
@@ -147,7 +147,7 @@ func (c *authenticatedTopicCommand) onPremList(cmd *cobra.Command, _ []string) e
 		return err
 	}
 	// Get Topics
-	topicGetResp, resp, err := restClient.TopicApi.ClustersClusterIdTopicsGet(restContext, clusterId)
+	topicGetResp, resp, err := restClient.TopicV3Api.ListKafkaTopics(restContext, clusterId)
 	if err != nil {
 		return kafkaRestError(restClient.GetConfig().BasePath, err, resp)
 	}
@@ -225,7 +225,7 @@ func (c *authenticatedTopicCommand) onPremCreate(cmd *cobra.Command, args []stri
 		i++
 	}
 	// Create new topic
-	_, resp, err := restClient.TopicApi.ClustersClusterIdTopicsPost(restContext, clusterId, &kafkarestv3.ClustersClusterIdTopicsPostOpts{
+	_, resp, err := restClient.TopicV3Api.CreateKafkaTopic(restContext, clusterId, &kafkarestv3.CreateKafkaTopicOpts{
 		CreateTopicRequestData: optional.NewInterface(kafkarestv3.CreateTopicRequestData{
 			TopicName:         topicName,
 			PartitionsCount:   numPartitions,
@@ -279,7 +279,7 @@ func (c *authenticatedTopicCommand) onPremDelete(cmd *cobra.Command, args []stri
 		return err
 	}
 	// Delete Topic
-	resp, err := restClient.TopicApi.ClustersClusterIdTopicsTopicNameDelete(restContext, clusterId, topicName)
+	resp, err := restClient.TopicV3Api.DeleteKafkaTopic(restContext, clusterId, topicName)
 	if err != nil {
 		return kafkaRestError(restClient.GetConfig().BasePath, err, resp)
 	}
@@ -337,8 +337,8 @@ func (c *authenticatedTopicCommand) onPremUpdate(cmd *cobra.Command, args []stri
 		}
 		i++
 	}
-	resp, err := restClient.ConfigsApi.ClustersClusterIdTopicsTopicNameConfigsalterPost(restContext, clusterId, topicName,
-		&kafkarestv3.ClustersClusterIdTopicsTopicNameConfigsalterPostOpts{
+	resp, err := restClient.ConfigsV3Api.UpdateKafkaTopicConfigBatch(restContext, clusterId, topicName,
+		&kafkarestv3.UpdateKafkaTopicConfigBatchOpts{
 			AlterConfigBatchRequestData: optional.NewInterface(kafkarestv3.AlterConfigBatchRequestData{Data: configs}),
 		})
 	if err != nil {
@@ -406,7 +406,7 @@ func (c *authenticatedTopicCommand) onPremDescribe(cmd *cobra.Command, args []st
 
 	// Get partitions
 	topicData := &TopicData{}
-	partitionsResp, resp, err := restClient.PartitionApi.ClustersClusterIdTopicsTopicNamePartitionsGet(restContext, clusterId, topicName)
+	partitionsResp, resp, err := restClient.PartitionV3Api.ListKafkaPartitions(restContext, clusterId, topicName)
 	if err != nil {
 		return kafkaRestError(restClient.GetConfig().BasePath, err, resp)
 	} else if partitionsResp.Data == nil {
@@ -447,7 +447,7 @@ func (c *authenticatedTopicCommand) onPremDescribe(cmd *cobra.Command, args []st
 	}
 
 	// Get configs
-	configsResp, resp, err := restClient.ConfigsApi.ClustersClusterIdTopicsTopicNameConfigsGet(restContext, clusterId, topicName)
+	configsResp, resp, err := restClient.ConfigsV3Api.ListKafkaTopicConfigs(restContext, clusterId, topicName)
 	if err != nil {
 		return kafkaRestError(restClient.GetConfig().BasePath, err, resp)
 	} else if configsResp.Data == nil {
@@ -497,7 +497,7 @@ func (c *authenticatedTopicCommand) onPremDescribe(cmd *cobra.Command, args []st
 }
 
 func getClusterIdForRestRequests(client *kafkarestv3.APIClient, ctx context.Context) (string, error) {
-	clusters, resp, err := client.ClusterApi.ClustersGet(ctx)
+	clusters, resp, err := client.ClusterV3Api.ClustersGet(ctx)
 	if err != nil {
 		return "", kafkaRestError(client.GetConfig().BasePath, err, resp)
 	}

--- a/internal/cmd/kafka/command_topic_onprem_test.go
+++ b/internal/cmd/kafka/command_topic_onprem_test.go
@@ -137,7 +137,7 @@ func checkURL(url string) error {
 func (suite *KafkaTopicOnPremTestSuite) createCommand() *cobra.Command {
 	// Define testAPIClient
 	suite.testClient = kafkarestv3.NewAPIClient(kafkarestv3.NewConfiguration())
-	suite.testClient.ClusterApi = &kafkarestv3mock.ClusterApi{
+	suite.testClient.ClusterV3Api = &kafkarestv3mock.ClusterV3Api{
 		ClustersGetFunc: func(ctx context.Context) (kafkarestv3.ClusterDataList, *http.Response, error) {
 			// Check if URL is valid
 			err := checkURL(suite.testClient.GetConfig().BasePath)
@@ -148,8 +148,8 @@ func (suite *KafkaTopicOnPremTestSuite) createCommand() *cobra.Command {
 			return *suite.clusterList, nil, nil
 		},
 	}
-	suite.testClient.TopicApi = &kafkarestv3mock.TopicApi{
-		ClustersClusterIdTopicsGetFunc: func(ctx context.Context, clusterId string) (kafkarestv3.TopicDataList, *http.Response, error) {
+	suite.testClient.TopicV3Api = &kafkarestv3mock.TopicV3Api{
+		ListKafkaTopicsFunc: func(ctx context.Context, clusterId string) (kafkarestv3.TopicDataList, *http.Response, error) {
 			// Check if URL is valid
 			err := checkURL(suite.testClient.GetConfig().BasePath)
 			if err != nil {
@@ -158,7 +158,7 @@ func (suite *KafkaTopicOnPremTestSuite) createCommand() *cobra.Command {
 			// Return canned data
 			return *suite.topicList, nil, nil
 		},
-		ClustersClusterIdTopicsPostFunc: func(ctx context.Context, clusterId string, localVarOptionals *kafkarestv3.ClustersClusterIdTopicsPostOpts) (kafkarestv3.TopicData, *http.Response, error) {
+		CreateKafkaTopicFunc: func(ctx context.Context, clusterId string, localVarOptionals *kafkarestv3.CreateKafkaTopicOpts) (kafkarestv3.TopicData, *http.Response, error) {
 			err := checkURL(suite.testClient.GetConfig().BasePath)
 			if err != nil {
 				return kafkarestv3.TopicData{}, nil, err
@@ -183,7 +183,7 @@ func (suite *KafkaTopicOnPremTestSuite) createCommand() *cobra.Command {
 				ReplicationFactor: topicCreateData.ReplicationFactor,
 			}, nil, nil
 		},
-		ClustersClusterIdTopicsTopicNameDeleteFunc: func(ctx context.Context, clusterId string, topicName string) (*http.Response, error) {
+		DeleteKafkaTopicFunc: func(ctx context.Context, clusterId string, topicName string) (*http.Response, error) {
 			// Check if URL is valid
 			err := checkURL(suite.testClient.GetConfig().BasePath)
 			if err != nil {
@@ -192,8 +192,8 @@ func (suite *KafkaTopicOnPremTestSuite) createCommand() *cobra.Command {
 			return nil, nil
 		},
 	}
-	suite.testClient.ConfigsApi = &kafkarestv3mock.ConfigsApi{
-		ClustersClusterIdTopicsTopicNameConfigsalterPostFunc: func(ctx context.Context, clusterId string, topicName string, localVarOptionals *kafkarestv3.ClustersClusterIdTopicsTopicNameConfigsalterPostOpts) (*http.Response, error) {
+	suite.testClient.ConfigsV3Api = &kafkarestv3mock.ConfigsV3Api{
+		UpdateKafkaTopicConfigBatchFunc: func(ctx context.Context, clusterId string, topicName string, localVarOptionals *kafkarestv3.UpdateKafkaTopicConfigBatchOpts) (*http.Response, error) {
 			err := checkURL(suite.testClient.GetConfig().BasePath)
 			if err != nil {
 				return nil, err
@@ -211,7 +211,7 @@ func (suite *KafkaTopicOnPremTestSuite) createCommand() *cobra.Command {
 			}
 			return nil, nil
 		},
-		ClustersClusterIdTopicsTopicNameConfigsGetFunc: func(ctx context.Context, clusterId string, topicName string) (kafkarestv3.TopicConfigDataList, *http.Response, error) {
+		ListKafkaTopicConfigsFunc: func(ctx context.Context, clusterId string, topicName string) (kafkarestv3.TopicConfigDataList, *http.Response, error) {
 			err := checkURL(suite.testClient.GetConfig().BasePath)
 			if err != nil {
 				return kafkarestv3.TopicConfigDataList{}, nil, err
@@ -219,8 +219,8 @@ func (suite *KafkaTopicOnPremTestSuite) createCommand() *cobra.Command {
 			return *suite.configDataList, nil, nil
 		},
 	}
-	suite.testClient.PartitionApi = &kafkarestv3mock.PartitionApi{
-		ClustersClusterIdTopicsTopicNamePartitionsGetFunc: func(ctx context.Context, clusterId string, topicName string) (kafkarestv3.PartitionDataList, *http.Response, error) {
+	suite.testClient.PartitionV3Api = &kafkarestv3mock.PartitionV3Api{
+		ListKafkaPartitionsFunc: func(ctx context.Context, clusterId string, topicName string) (kafkarestv3.PartitionDataList, *http.Response, error) {
 			err := checkURL(suite.testClient.GetConfig().BasePath)
 			if err != nil {
 				return kafkarestv3.PartitionDataList{}, nil, err

--- a/internal/cmd/kafka/kafka_rest.go
+++ b/internal/cmd/kafka/kafka_rest.go
@@ -67,8 +67,8 @@ func kafkaRestError(url string, err error, httpResp *http.Response) error {
 }
 
 // Converts ACLBinding to Kafka REST ClustersClusterIdAclsGetOpts
-func aclBindingToClustersClusterIdAclsGetOpts(acl *schedv1.ACLBinding) kafkarestv3.ClustersClusterIdAclsGetOpts {
-	var opts kafkarestv3.ClustersClusterIdAclsGetOpts
+func aclBindingToClustersClusterIdAclsGetOpts(acl *schedv1.ACLBinding) kafkarestv3.GetKafkaAclsOpts {
+	var opts kafkarestv3.GetKafkaAclsOpts
 
 	if acl.Pattern.ResourceType != schedv1.ResourceTypes_UNKNOWN {
 		opts.ResourceType = optional.NewInterface(kafkarestv3.AclResourceType(acl.Pattern.ResourceType.String()))
@@ -95,7 +95,7 @@ func aclBindingToClustersClusterIdAclsGetOpts(acl *schedv1.ACLBinding) kafkarest
 }
 
 // Converts ACLBinding to Kafka REST ClustersClusterIdAclsPostOpts
-func aclBindingToClustersClusterIdAclsPostOpts(acl *schedv1.ACLBinding) kafkarestv3.ClustersClusterIdAclsPostOpts {
+func aclBindingToClustersClusterIdAclsPostOpts(acl *schedv1.ACLBinding) kafkarestv3.CreateKafkaAclsOpts {
 	var aclRequestData kafkarestv3.CreateAclRequestData
 
 	if acl.Pattern.ResourceType != schedv1.ResourceTypes_UNKNOWN {
@@ -118,15 +118,15 @@ func aclBindingToClustersClusterIdAclsPostOpts(acl *schedv1.ACLBinding) kafkares
 		aclRequestData.Permission = kafkarestv3.AclPermission(acl.Entry.PermissionType.String())
 	}
 
-	var opts kafkarestv3.ClustersClusterIdAclsPostOpts
+	var opts kafkarestv3.CreateKafkaAclsOpts
 	opts.CreateAclRequestData = optional.NewInterface(aclRequestData)
 
 	return opts
 }
 
 // Converts ACLFilter to Kafka REST ClustersClusterIdAclsDeleteOpts
-func aclFilterToClustersClusterIdAclsDeleteOpts(acl *schedv1.ACLFilter) kafkarestv3.ClustersClusterIdAclsDeleteOpts {
-	var opts kafkarestv3.ClustersClusterIdAclsDeleteOpts
+func aclFilterToClustersClusterIdAclsDeleteOpts(acl *schedv1.ACLFilter) kafkarestv3.DeleteKafkaAclsOpts {
+	var opts kafkarestv3.DeleteKafkaAclsOpts
 
 	if acl.PatternFilter.ResourceType != schedv1.ResourceTypes_UNKNOWN {
 		opts.ResourceType = optional.NewInterface(kafkarestv3.AclResourceType(acl.PatternFilter.ResourceType.String()))

--- a/internal/cmd/kafka/utils.go
+++ b/internal/cmd/kafka/utils.go
@@ -34,12 +34,12 @@ func fileExists(filename string) bool {
 	return !info.IsDir()
 }
 
-func toCreateTopicConfigs(topicConfigsMap map[string]string) []kafkarestv3.CreateTopicRequestDataConfigs {
-	topicConfigs := make([]kafkarestv3.CreateTopicRequestDataConfigs, len(topicConfigsMap))
+func toCreateTopicConfigs(topicConfigsMap map[string]string) []kafkarestv3.ConfigData {
+	topicConfigs := make([]kafkarestv3.ConfigData, len(topicConfigsMap))
 	i := 0
 	for k, v := range topicConfigsMap {
 		val := v
-		topicConfigs[i] = kafkarestv3.CreateTopicRequestDataConfigs{
+		topicConfigs[i] = kafkarestv3.ConfigData{
 			Name:  k,
 			Value: &val,
 		}

--- a/internal/pkg/acl/acl.go
+++ b/internal/pkg/acl/acl.go
@@ -283,8 +283,8 @@ func ValidateCreateDeleteAclRequestData(aclConfiguration *AclRequestDataWithErro
 	return aclConfiguration
 }
 
-func AclRequestToCreateAclReqest(acl *AclRequestDataWithError) *kafkarestv3.ClustersClusterIdAclsPostOpts {
-	var opts kafkarestv3.ClustersClusterIdAclsPostOpts
+func AclRequestToCreateAclReqest(acl *AclRequestDataWithError) *kafkarestv3.CreateKafkaAclsOpts {
+	var opts kafkarestv3.CreateKafkaAclsOpts
 	requestData := kafkarestv3.CreateAclRequestData{
 		ResourceType: acl.ResourceType,
 		ResourceName: acl.ResourceName,
@@ -300,8 +300,8 @@ func AclRequestToCreateAclReqest(acl *AclRequestDataWithError) *kafkarestv3.Clus
 
 // Functions for converting AclRequestDataWithError into structs for create, delete, and list requests
 
-func AclRequestToListAclReqest(acl *AclRequestDataWithError) *kafkarestv3.ClustersClusterIdAclsGetOpts {
-	opts := kafkarestv3.ClustersClusterIdAclsGetOpts{}
+func AclRequestToListAclReqest(acl *AclRequestDataWithError) *kafkarestv3.GetKafkaAclsOpts {
+	opts := kafkarestv3.GetKafkaAclsOpts{}
 	if acl.ResourceType != "" {
 		opts.ResourceType = optional.NewInterface(acl.ResourceType)
 	}
@@ -326,8 +326,8 @@ func AclRequestToListAclReqest(acl *AclRequestDataWithError) *kafkarestv3.Cluste
 	return &opts
 }
 
-func AclRequestToDeleteAclReqest(acl *AclRequestDataWithError) *kafkarestv3.ClustersClusterIdAclsDeleteOpts {
-	opts := kafkarestv3.ClustersClusterIdAclsDeleteOpts{
+func AclRequestToDeleteAclReqest(acl *AclRequestDataWithError) *kafkarestv3.DeleteKafkaAclsOpts {
+	opts := kafkarestv3.DeleteKafkaAclsOpts{
 		ResourceType: optional.NewInterface(acl.ResourceType),
 		ResourceName: optional.NewString(acl.ResourceName),
 		PatternType:  optional.NewInterface(acl.PatternType),

--- a/mock/kafka_rest.go
+++ b/mock/kafka_rest.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Compile-time check interface adherence
-var _ krsdk.TopicApi = (*Topic)(nil)
+var _ krsdk.TopicV3Api = (*Topic)(nil)
 
 type Topic struct {
 }
@@ -19,7 +19,7 @@ func NewTopicMock() *Topic {
 	return &Topic{}
 }
 
-func (m *Topic) ClustersClusterIdTopicsGet(_ context.Context, _clusterId string) (krsdk.TopicDataList, *nethttp.Response, error) {
+func (m *Topic) ListKafkaTopics(_ context.Context, _clusterId string) (krsdk.TopicDataList, *nethttp.Response, error) {
 	httpResp := &nethttp.Response{
 		StatusCode: 200,
 	}
@@ -42,26 +42,26 @@ func (m *Topic) ClustersClusterIdTopicsGet(_ context.Context, _clusterId string)
 	}, httpResp, nil
 }
 
-func (m *Topic) ClustersClusterIdTopicsPost(_ context.Context, _ string, _ *krsdk.ClustersClusterIdTopicsPostOpts) (krsdk.TopicData, *nethttp.Response, error) {
+func (m *Topic) CreateKafkaTopic(_ context.Context, _ string, _ *krsdk.CreateKafkaTopicOpts) (krsdk.TopicData, *nethttp.Response, error) {
 	httpResp := &nethttp.Response{
 		StatusCode: 201,
 	}
 	return krsdk.TopicData{}, httpResp, nil
 }
 
-func (m *Topic) ClustersClusterIdTopicsTopicNameDelete(_ context.Context, _ string, _ string) (*nethttp.Response, error) {
+func (m *Topic) DeleteKafkaTopic(_ context.Context, _ string, _ string) (*nethttp.Response, error) {
 	httpResp := &nethttp.Response{
 		StatusCode: 204,
 	}
 	return httpResp, nil
 }
 
-func (m *Topic) ClustersClusterIdTopicsTopicNameGet(_ context.Context, _ string, _ string) (krsdk.TopicData, *nethttp.Response, error) {
+func (m *Topic) GetKafkaTopic(_ context.Context, _ string, _ string) (krsdk.TopicData, *nethttp.Response, error) {
 	return krsdk.TopicData{}, nil, nil
 }
 
 // Compile-time check interface adherence
-var _ krsdk.ACLApi = (*ACL)(nil)
+var _ krsdk.ACLV3Api = (*ACL)(nil)
 
 type ACL struct {
 }
@@ -70,7 +70,7 @@ func NewACLMock() *ACL {
 	return &ACL{}
 }
 
-func (m *ACL) ClustersClusterIdAclsDelete(_ context.Context, _ string, _ *krsdk.ClustersClusterIdAclsDeleteOpts) (krsdk.InlineResponse200, *nethttp.Response, error) {
+func (m *ACL) DeleteKafkaAcls(_ context.Context, _ string, _ *krsdk.DeleteKafkaAclsOpts) (krsdk.InlineResponse200, *nethttp.Response, error) {
 	httpResp := &nethttp.Response{
 		StatusCode: 200,
 	}
@@ -81,7 +81,7 @@ func (m *ACL) ClustersClusterIdAclsDelete(_ context.Context, _ string, _ *krsdk.
 	}, httpResp, nil
 }
 
-func (m *ACL) ClustersClusterIdAclsGet(_ context.Context, _clusterId string, _ *krsdk.ClustersClusterIdAclsGetOpts) (krsdk.AclDataList, *nethttp.Response, error) {
+func (m *ACL) GetKafkaAcls(_ context.Context, _clusterId string, _ *krsdk.GetKafkaAclsOpts) (krsdk.AclDataList, *nethttp.Response, error) {
 	httpResp := &nethttp.Response{
 		StatusCode: 200,
 	}
@@ -105,7 +105,7 @@ func (m *ACL) ClustersClusterIdAclsGet(_ context.Context, _clusterId string, _ *
 	}, httpResp, nil
 }
 
-func (m *ACL) ClustersClusterIdAclsPost(_ context.Context, _ string, _ *krsdk.ClustersClusterIdAclsPostOpts) (*nethttp.Response, error) {
+func (m *ACL) CreateKafkaAcls(_ context.Context, _ string, _ *krsdk.CreateKafkaAclsOpts) (*nethttp.Response, error) {
 	httpResp := &nethttp.Response{
 		StatusCode: 201,
 	}
@@ -113,7 +113,7 @@ func (m *ACL) ClustersClusterIdAclsPost(_ context.Context, _ string, _ *krsdk.Cl
 }
 
 // Compile-time check interface adherence
-var _ krsdk.ConsumerGroupApi = (*ConsumerGroup)(nil)
+var _ krsdk.ConsumerGroupV3Api = (*ConsumerGroup)(nil)
 
 type ConsumerGroup struct {
 	Expect chan interface{}
@@ -123,19 +123,19 @@ func NewConsumerGroupMock(expect chan interface{}) *ConsumerGroup {
 	return &ConsumerGroup{expect}
 }
 
-func (c ConsumerGroup) ClustersClusterIdConsumerGroupsConsumerGroupIdConsumersConsumerIdAssignmentsGet(_ context.Context, _ string, _ string, _ string) (krsdk.ConsumerAssignmentDataList, *nethttp.Response, error) {
+func (c ConsumerGroup) ListKafkaConsumerAssignment(_ context.Context, _ string, _ string, _ string) (krsdk.ConsumerAssignmentDataList, *nethttp.Response, error) {
 	panic("implement me")
 }
 
-func (c ConsumerGroup) ClustersClusterIdConsumerGroupsConsumerGroupIdConsumersConsumerIdAssignmentsTopicNamePartitionsPartitionIdGet(_ context.Context, _ string, _ string, _ string, _ string, _ int32) (krsdk.ConsumerAssignmentData, *nethttp.Response, error) {
+func (c ConsumerGroup) GetKafkaConsumerAssignment(_ context.Context, _ string, _ string, _ string, _ string, _ int32) (krsdk.ConsumerAssignmentData, *nethttp.Response, error) {
 	panic("implement me")
 }
 
-func (c ConsumerGroup) ClustersClusterIdConsumerGroupsConsumerGroupIdConsumersConsumerIdGet(_ context.Context, _ string, _ string, _ string) (krsdk.ConsumerData, *nethttp.Response, error) {
+func (c ConsumerGroup) GetKafkaConsumer(_ context.Context, _ string, _ string, _ string) (krsdk.ConsumerData, *nethttp.Response, error) {
 	panic("implement me")
 }
 
-func (c ConsumerGroup) ClustersClusterIdConsumerGroupsConsumerGroupIdConsumersGet(_ context.Context, clusterId string, consumerGroupId string) (krsdk.ConsumerDataList, *nethttp.Response, error) {
+func (c ConsumerGroup) ListKafkaConsumers(_ context.Context, clusterId string, consumerGroupId string) (krsdk.ConsumerDataList, *nethttp.Response, error) {
 	httpResp := &nethttp.Response{
 		StatusCode: nethttp.StatusOK,
 	}
@@ -163,7 +163,7 @@ type GroupMatcher struct {
 	ConsumerGroupId string
 }
 
-func (c ConsumerGroup) ClustersClusterIdConsumerGroupsConsumerGroupIdGet(_ context.Context, clusterId string, consumerGroupId string) (krsdk.ConsumerGroupData, *nethttp.Response, error) {
+func (c ConsumerGroup) GetKafkaConsumerGroup(_ context.Context, clusterId string, consumerGroupId string) (krsdk.ConsumerGroupData, *nethttp.Response, error) {
 	expect := <-c.Expect
 	matcher := expect.(GroupMatcher)
 	if err := assertEqualValues(consumerGroupId, matcher.ConsumerGroupId); err != nil {
@@ -188,7 +188,7 @@ func (c ConsumerGroup) ClustersClusterIdConsumerGroupsConsumerGroupIdGet(_ conte
 	}, httpResp, nil
 }
 
-func (c ConsumerGroup) ClustersClusterIdConsumerGroupsConsumerGroupIdLagSummaryGet(_ context.Context, clusterId string, consumerGroupId string) (krsdk.ConsumerGroupLagSummaryData, *nethttp.Response, error) {
+func (c ConsumerGroup) GetKafkaConsumerGroupLagSummary(_ context.Context, clusterId string, consumerGroupId string) (krsdk.ConsumerGroupLagSummaryData, *nethttp.Response, error) {
 	expect := <-c.Expect
 	matcher := expect.(GroupMatcher)
 	if err := assertEqualValues(consumerGroupId, matcher.ConsumerGroupId); err != nil {
@@ -219,7 +219,7 @@ func (c ConsumerGroup) ClustersClusterIdConsumerGroupsConsumerGroupIdLagSummaryG
 
 }
 
-func (c ConsumerGroup) ClustersClusterIdConsumerGroupsConsumerGroupIdLagsGet(_ context.Context, clusterId string, consumerGroupId string) (krsdk.ConsumerLagDataList, *nethttp.Response, error) {
+func (c ConsumerGroup) ListKafkaConsumerLags(_ context.Context, clusterId string, consumerGroupId string) (krsdk.ConsumerLagDataList, *nethttp.Response, error) {
 	expect := <-c.Expect
 	matcher := expect.(GroupMatcher)
 	if err := assertEqualValues(consumerGroupId, matcher.ConsumerGroupId); err != nil {
@@ -268,7 +268,7 @@ func (c ConsumerGroup) ClustersClusterIdConsumerGroupsConsumerGroupIdLagsGet(_ c
 	}, httpResp, nil
 }
 
-func (c ConsumerGroup) ClustersClusterIdConsumerGroupsGet(_ context.Context, clusterId string) (krsdk.ConsumerGroupDataList, *nethttp.Response, error) {
+func (c ConsumerGroup) ListKafkaConsumerGroups(_ context.Context, clusterId string) (krsdk.ConsumerGroupDataList, *nethttp.Response, error) {
 	// lkc-12345 is the id of the mock cluster set in v3/mock.go
 	if err := assertEqualValues(clusterId, v1.MockKafkaClusterId()); err != nil {
 		return krsdk.ConsumerGroupDataList{}, nil, err
@@ -299,10 +299,15 @@ func (c ConsumerGroup) ClustersClusterIdConsumerGroupsGet(_ context.Context, clu
 }
 
 // Compile-time check interface adherence
-var _ krsdk.PartitionApi = (*Partition)(nil)
+var _ krsdk.PartitionV3Api = (*Partition)(nil)
 
 type Partition struct {
 	Expect chan interface{}
+}
+
+func (m *Partition) GetKafkaPartition(ctx context.Context, clusterId string, topicName string, partitionId int32) (krsdk.PartitionData, *nethttp.Response, error) {
+	//TODO implement me
+	panic("implement me")
 }
 
 func NewPartitionMock(expect chan interface{}) *Partition {
@@ -315,7 +320,7 @@ type PartitionLagMatcher struct {
 	PartitionId     int32
 }
 
-func (m *Partition) ClustersClusterIdConsumerGroupsConsumerGroupIdLagsTopicNamePartitionsPartitionIdGet(_ context.Context, clusterId string, consumerGroupId string, topicName string, partitionId int32) (krsdk.ConsumerLagData, *nethttp.Response, error) {
+func (m *Partition) GetKafkaConsumerLag(_ context.Context, clusterId string, consumerGroupId string, topicName string, partitionId int32) (krsdk.ConsumerLagData, *nethttp.Response, error) {
 	expect := <-m.Expect
 	matcher := expect.(PartitionLagMatcher)
 	if err := assertEqualValues(consumerGroupId, matcher.ConsumerGroupId); err != nil {
@@ -354,7 +359,7 @@ func (m *Partition) ClustersClusterIdTopicsPartitionsReassignmentGet(_ context.C
 	return krsdk.ReassignmentDataList{}, nil, nil
 }
 
-func (m *Partition) ClustersClusterIdTopicsTopicNamePartitionsGet(_ context.Context, clusterId string, topicName string) (krsdk.PartitionDataList, *nethttp.Response, error) {
+func (m *Partition) ListKafkaPartitions(_ context.Context, clusterId string, topicName string) (krsdk.PartitionDataList, *nethttp.Response, error) {
 	httpResp := &nethttp.Response{
 		StatusCode: 200,
 	}
@@ -389,7 +394,7 @@ func (m *Partition) ClustersClusterIdTopicsTopicNamePartitionsReassignmentGet(_ 
 }
 
 // Compile-time check interface adherence
-var _ krsdk.ReplicaApi = (*Replica)(nil)
+var _ krsdk.ReplicaV3Api = (*Replica)(nil)
 
 type Replica struct {
 }
@@ -427,6 +432,11 @@ func (m *Replica) ClustersClusterIdTopicsTopicNamePartitionsPartitionIdReplicasG
 }
 
 type ReplicaStatus struct{}
+
+func (m *ReplicaStatus) ClustersClusterIdTopicsPartitionsReplicaStatusGet(ctx context.Context, clusterId string) (krsdk.ReplicaStatusDataList, *nethttp.Response, error) {
+	//TODO implement me
+	panic("implement me")
+}
 
 func NewReplicaStatusMock() *ReplicaStatus {
 	return &ReplicaStatus{}
@@ -471,32 +481,47 @@ func (m *ReplicaStatus) ClustersClusterIdTopicsTopicNamePartitionsReplicaStatusG
 }
 
 // Compile-time check interface adherence
-var _ krsdk.ConfigsApi = (*Configs)(nil)
+var _ krsdk.ConfigsV3Api = (*Configs)(nil)
 
 type Configs struct {
+}
+
+func (m *Configs) ClustersClusterIdBrokersConfigsGet(ctx context.Context, clusterId string) (krsdk.BrokerConfigDataList, *nethttp.Response, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (m *Configs) ListKafkaAllTopicConfigs(ctx context.Context, clusterId string) (krsdk.TopicConfigDataList, *nethttp.Response, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (m *Configs) ListKafkaDefaultTopicConfigs(ctx context.Context, clusterId string, topicName string) (krsdk.TopicConfigDataList, *nethttp.Response, error) {
+	//TODO implement me
+	panic("implement me")
 }
 
 func NewConfigsMock() *Configs {
 	return &Configs{}
 }
 
-func (m *Configs) ClustersClusterIdBrokerConfigsGet(_ context.Context, _ string) (krsdk.ClusterConfigDataList, *nethttp.Response, error) {
+func (m *Configs) ListKafkaClusterConfigs(_ context.Context, _ string) (krsdk.ClusterConfigDataList, *nethttp.Response, error) {
 	return krsdk.ClusterConfigDataList{}, nil, nil
 }
 
-func (m *Configs) ClustersClusterIdBrokerConfigsNameDelete(_ context.Context, _ string, _ string) (*nethttp.Response, error) {
+func (m *Configs) DeleteKafkaClusterConfig(_ context.Context, _ string, _ string) (*nethttp.Response, error) {
 	return nil, nil
 }
 
-func (m *Configs) ClustersClusterIdBrokerConfigsNameGet(_ context.Context, _ string, _ string) (krsdk.ClusterConfigData, *nethttp.Response, error) {
+func (m *Configs) GetKafkaClusterConfig(_ context.Context, _ string, _ string) (krsdk.ClusterConfigData, *nethttp.Response, error) {
 	return krsdk.ClusterConfigData{}, nil, nil
 }
 
-func (m *Configs) ClustersClusterIdBrokerConfigsNamePut(_ context.Context, _ string, _ string, _ *krsdk.ClustersClusterIdBrokerConfigsNamePutOpts) (*nethttp.Response, error) {
+func (m *Configs) UpdateKafkaClusterConfig(_ context.Context, _ string, _ string, _ *krsdk.UpdateKafkaClusterConfigOpts) (*nethttp.Response, error) {
 	return nil, nil
 }
 
-func (m *Configs) ClustersClusterIdBrokerConfigsalterPost(_ context.Context, _ string, _ *krsdk.ClustersClusterIdBrokerConfigsalterPostOpts) (*nethttp.Response, error) {
+func (m *Configs) UpdateKafkaClusterConfigs(_ context.Context, _ string, _ *krsdk.UpdateKafkaClusterConfigsOpts) (*nethttp.Response, error) {
 	return nil, nil
 }
 
@@ -520,7 +545,7 @@ func (m *Configs) ClustersClusterIdBrokersBrokerIdConfigsalterPost(_ context.Con
 	return nil, nil
 }
 
-func (m *Configs) ClustersClusterIdTopicsTopicNameConfigsGet(_ context.Context, _clusterId string, topicName string) (krsdk.TopicConfigDataList, *nethttp.Response, error) {
+func (m *Configs) ListKafkaTopicConfigs(_ context.Context, _clusterId string, topicName string) (krsdk.TopicConfigDataList, *nethttp.Response, error) {
 	v := "configValue1"
 	return krsdk.TopicConfigDataList{
 		Kind:     "",
@@ -543,19 +568,19 @@ func (m *Configs) ClustersClusterIdTopicsTopicNameConfigsGet(_ context.Context, 
 	}, nil, nil
 }
 
-func (m *Configs) ClustersClusterIdTopicsTopicNameConfigsNameDelete(_ context.Context, _ string, _ string, _ string) (*nethttp.Response, error) {
+func (m *Configs) DeleteKafkaTopicConfig(_ context.Context, _ string, _ string, _ string) (*nethttp.Response, error) {
 	return nil, nil
 }
 
-func (m *Configs) ClustersClusterIdTopicsTopicNameConfigsNameGet(_ context.Context, _ string, _ string, _ string) (krsdk.TopicConfigData, *nethttp.Response, error) {
+func (m *Configs) GetKafkaTopicConfig(_ context.Context, _ string, _ string, _ string) (krsdk.TopicConfigData, *nethttp.Response, error) {
 	return krsdk.TopicConfigData{}, nil, nil
 }
 
-func (m *Configs) ClustersClusterIdTopicsTopicNameConfigsNamePut(_ context.Context, _ string, _ string, _ string, _ *krsdk.ClustersClusterIdTopicsTopicNameConfigsNamePutOpts) (*nethttp.Response, error) {
+func (m *Configs) UpdateKafkaTopicConfig(_ context.Context, _ string, _ string, _ string, _ *krsdk.UpdateKafkaTopicConfigOpts) (*nethttp.Response, error) {
 	return nil, nil
 }
 
-func (m *Configs) ClustersClusterIdTopicsTopicNameConfigsalterPost(_ context.Context, _ string, _ string, _ *krsdk.ClustersClusterIdTopicsTopicNameConfigsalterPostOpts) (*nethttp.Response, error) {
+func (m *Configs) UpdateKafkaTopicConfigBatch(_ context.Context, _ string, _ string, _ *krsdk.UpdateKafkaTopicConfigBatchOpts) (*nethttp.Response, error) {
 	httpResp := &nethttp.Response{
 		StatusCode: 204,
 	}
@@ -563,13 +588,13 @@ func (m *Configs) ClustersClusterIdTopicsTopicNameConfigsalterPost(_ context.Con
 }
 
 // Compile-time check interface adherence
-var _ krsdk.ClusterLinkingApi = (*ClusterLinking)(nil)
+var _ krsdk.ClusterLinkingV3Api = (*ClusterLinking)(nil)
 
 type ClusterLinking struct {
 	Expect chan interface{}
 }
 
-func (m *ClusterLinking) ClustersClusterIdLinksMirrorsGet(_ context.Context, _ string, localVarOptionals *krsdk.ClustersClusterIdLinksMirrorsGetOpts) (krsdk.ListMirrorTopicsResponseDataList, *nethttp.Response, error) {
+func (m *ClusterLinking) ListKafkaMirrorTopics(_ context.Context, _ string, localVarOptionals *krsdk.ListKafkaMirrorTopicsOpts) (krsdk.ListMirrorTopicsResponseDataList, *nethttp.Response, error) {
 	expect := <-m.Expect
 	matcher := expect.(ListMirrorMatcher)
 
@@ -635,7 +660,7 @@ func NewClusterLinkingMock(expect chan interface{}) *ClusterLinking {
 	return &ClusterLinking{expect}
 }
 
-func (m *ClusterLinking) ClustersClusterIdLinksGet(_ context.Context, clusterId string) (krsdk.ListLinksResponseDataList, *nethttp.Response, error) {
+func (m *ClusterLinking) ListKafkaLinks(_ context.Context, clusterId string) (krsdk.ListLinksResponseDataList, *nethttp.Response, error) {
 	httpResp := &nethttp.Response{
 		StatusCode: nethttp.StatusOK,
 	}
@@ -649,7 +674,7 @@ func (m *ClusterLinking) ClustersClusterIdLinksGet(_ context.Context, clusterId 
 				SourceClusterId: clusterId,
 				LinkName:        "link-1",
 				LinkId:          "LinkId",
-				TopicNames:      []string{"topic-1", "topic-2", "topic-3"},
+				TopicsNames:     []string{"topic-1", "topic-2", "topic-3"},
 			},
 		},
 	}, httpResp, nil
@@ -659,7 +684,7 @@ type DeleteLinkConfigMatcher struct {
 	LinkName string
 }
 
-func (m *ClusterLinking) ClustersClusterIdLinksLinkNameConfigsConfigNameDelete(_ context.Context, _ string, linkName string, _ string) (*nethttp.Response, error) {
+func (m *ClusterLinking) DeleteKafkaLinkConfig(_ context.Context, _ string, linkName string, _ string) (*nethttp.Response, error) {
 	expect := <-m.Expect
 	matcher := expect.(DeleteLinkConfigMatcher)
 	if err := assertEqualValues(linkName, matcher.LinkName); err != nil {
@@ -677,7 +702,7 @@ type GetLinkConfigMatcher struct {
 	ConfigName string
 }
 
-func (m *ClusterLinking) ClustersClusterIdLinksLinkNameConfigsConfigNameGet(_ context.Context, clusterId string, linkName string, configName string) (krsdk.ListLinkConfigsResponseData, *nethttp.Response, error) {
+func (m *ClusterLinking) GetKafkaLinkConfigs(_ context.Context, clusterId string, linkName string, configName string) (krsdk.ListLinkConfigsResponseData, *nethttp.Response, error) {
 	expect := <-m.Expect
 	matcher := expect.(GetLinkConfigMatcher)
 	if err := assertEqualValues(linkName, matcher.LinkName); err != nil {
@@ -709,7 +734,7 @@ type UpdateLinkConfigMatcher struct {
 	ConfigValue string
 }
 
-func (m *ClusterLinking) ClustersClusterIdLinksLinkNameConfigsConfigNamePut(_ context.Context, _ string, linkName string, configName string, localVarOptionals *krsdk.ClustersClusterIdLinksLinkNameConfigsConfigNamePutOpts) (*nethttp.Response, error) {
+func (m *ClusterLinking) UpdateKafkaLinkConfig(_ context.Context, _ string, linkName string, configName string, localVarOptionals *krsdk.UpdateKafkaLinkConfigOpts) (*nethttp.Response, error) {
 	expect := <-m.Expect
 	matcher := expect.(UpdateLinkConfigMatcher)
 	if err := assertEqualValues(linkName, matcher.LinkName); err != nil {
@@ -732,7 +757,7 @@ type ListLinkConfigMatcher struct {
 	LinkName string
 }
 
-func (m *ClusterLinking) ClustersClusterIdLinksLinkNameConfigsGet(_ context.Context, clusterId string, linkName string) (krsdk.ListLinkConfigsResponseDataList, *nethttp.Response, error) {
+func (m *ClusterLinking) ListKafkaLinkConfigs(_ context.Context, clusterId string, linkName string) (krsdk.ListLinkConfigsResponseDataList, *nethttp.Response, error) {
 	expect := <-m.Expect
 	matcher := expect.(DescribeLinkMatcher)
 	if err := assertEqualValues(linkName, matcher.LinkName); err != nil {
@@ -767,7 +792,7 @@ type BatchUpdateLinkConfigMatcher struct {
 	Configs  map[string]string
 }
 
-func (m *ClusterLinking) ClustersClusterIdLinksLinkNameConfigsalterPut(_ context.Context, _ string, _ string, localVarOptionals *krsdk.ClustersClusterIdLinksLinkNameConfigsalterPutOpts) (*nethttp.Response, error) {
+func (m *ClusterLinking) UpdateKafkaLinkConfigBatch(_ context.Context, _ string, _ string, localVarOptionals *krsdk.UpdateKafkaLinkConfigBatchOpts) (*nethttp.Response, error) {
 	expect := <-m.Expect
 	matcher := expect.(BatchUpdateLinkConfigMatcher)
 	for _, batchOp := range localVarOptionals.AlterConfigBatchRequestData.Value().(krsdk.AlterConfigBatchRequestData).Data {
@@ -786,7 +811,7 @@ type DeleteLinkMatcher struct {
 	LinkName string
 }
 
-func (m *ClusterLinking) ClustersClusterIdLinksLinkNameDelete(_ context.Context, _ string, linkName string) (*nethttp.Response, error) {
+func (m *ClusterLinking) DeleteKafkaLink(_ context.Context, _ string, linkName string) (*nethttp.Response, error) {
 	expect := <-m.Expect
 	matcher := expect.(DeleteLinkMatcher)
 	if err := assertEqualValues(linkName, matcher.LinkName); err != nil {
@@ -803,7 +828,7 @@ type DescribeLinkMatcher struct {
 	LinkName string
 }
 
-func (m *ClusterLinking) ClustersClusterIdLinksLinkNameGet(_ context.Context, clusterId string, linkName string) (krsdk.ListLinksResponseData, *nethttp.Response, error) {
+func (m *ClusterLinking) GetKafkaLink(_ context.Context, clusterId string, linkName string) (krsdk.ListLinksResponseData, *nethttp.Response, error) {
 	expect := <-m.Expect
 	matcher := expect.(DescribeLinkMatcher)
 	if err := assertEqualValues(linkName, matcher.LinkName); err != nil {
@@ -819,7 +844,7 @@ func (m *ClusterLinking) ClustersClusterIdLinksLinkNameGet(_ context.Context, cl
 		SourceClusterId: clusterId,
 		LinkName:        linkName,
 		LinkId:          "link-1",
-		TopicNames:      []string{"topic-1", "topic-2", "topic-3"},
+		TopicsNames:     []string{"topic-1", "topic-2", "topic-3"},
 	}, httpResp, nil
 }
 
@@ -828,7 +853,7 @@ type DescribeMirrorMatcher struct {
 	MirrorTopicName string
 }
 
-func (m *ClusterLinking) ClustersClusterIdLinksLinkNameMirrorsMirrorTopicNameGet(_ context.Context, _ string, linkName string, mirrorTopicName string) (krsdk.ListMirrorTopicsResponseData, *nethttp.Response, error) {
+func (m *ClusterLinking) ReadKafkaMirrorTopic(_ context.Context, _ string, linkName string, mirrorTopicName string) (krsdk.ListMirrorTopicsResponseData, *nethttp.Response, error) {
 	expect := <-m.Expect
 	matcher := expect.(DescribeMirrorMatcher)
 	if err := assertEqualValues(linkName, matcher.LinkName); err != nil {
@@ -872,7 +897,7 @@ type AlterMirrorMatcher struct {
 	MirrorTopicNames map[string]bool
 }
 
-func (m *ClusterLinking) ClustersClusterIdLinksLinkNameMirrorsfailoverPost(_ context.Context, _ string, _ string, localVarOptionals *krsdk.ClustersClusterIdLinksLinkNameMirrorsfailoverPostOpts) (krsdk.AlterMirrorStatusResponseDataList, *nethttp.Response, error) {
+func (m *ClusterLinking) UpdateKafkaMirrorTopicsFailover(_ context.Context, _ string, _ string, localVarOptionals *krsdk.UpdateKafkaMirrorTopicsFailoverOpts) (krsdk.AlterMirrorStatusResponseDataList, *nethttp.Response, error) {
 	expect := <-m.Expect
 	matcher := expect.(AlterMirrorMatcher)
 	for _, topic := range localVarOptionals.AlterMirrorsRequestData.Value().(krsdk.AlterMirrorsRequestData).MirrorTopicNames {
@@ -889,7 +914,7 @@ type ListMirrorMatcher struct {
 	Status   string
 }
 
-func (m *ClusterLinking) ClustersClusterIdLinksLinkNameMirrorsGet(_ context.Context, _ string, linkName string, localVarOptionals *krsdk.ClustersClusterIdLinksLinkNameMirrorsGetOpts) (krsdk.ListMirrorTopicsResponseDataList, *nethttp.Response, error) {
+func (m *ClusterLinking) ListKafkaMirrorTopicsUnderLink(_ context.Context, _ string, linkName string, localVarOptionals *krsdk.ListKafkaMirrorTopicsUnderLinkOpts) (krsdk.ListMirrorTopicsResponseDataList, *nethttp.Response, error) {
 	expect := <-m.Expect
 	matcher := expect.(ListMirrorMatcher)
 	if err := assertEqualValues(linkName, matcher.LinkName); err != nil {
@@ -953,7 +978,7 @@ func (m *ClusterLinking) ClustersClusterIdLinksLinkNameMirrorsGet(_ context.Cont
 	}, httpResp, nil
 }
 
-func (m *ClusterLinking) ClustersClusterIdLinksLinkNameMirrorspausePost(_ context.Context, _ string, _ string, localVarOptionals *krsdk.ClustersClusterIdLinksLinkNameMirrorspausePostOpts) (krsdk.AlterMirrorStatusResponseDataList, *nethttp.Response, error) {
+func (m *ClusterLinking) UpdateKafkaMirrorTopicsPause(_ context.Context, _ string, _ string, localVarOptionals *krsdk.UpdateKafkaMirrorTopicsPauseOpts) (krsdk.AlterMirrorStatusResponseDataList, *nethttp.Response, error) {
 	expect := <-m.Expect
 	matcher := expect.(AlterMirrorMatcher)
 	for _, topic := range localVarOptionals.AlterMirrorsRequestData.Value().(krsdk.AlterMirrorsRequestData).MirrorTopicNames {
@@ -969,9 +994,10 @@ type CreateMirrorMatcher struct {
 	LinkName        string
 	SourceTopicName string
 	Configs         map[string]string
+	MirrorTopicName string
 }
 
-func (m *ClusterLinking) ClustersClusterIdLinksLinkNameMirrorsPost(_ context.Context, _ string, linkName string, localVarOptionals *krsdk.ClustersClusterIdLinksLinkNameMirrorsPostOpts) (*nethttp.Response, error) {
+func (m *ClusterLinking) CreateKafkaMirrorTopic(_ context.Context, _ string, linkName string, localVarOptionals *krsdk.CreateKafkaMirrorTopicOpts) (*nethttp.Response, error) {
 	data := localVarOptionals.CreateMirrorTopicRequestData.Value().(krsdk.CreateMirrorTopicRequestData)
 	expect := <-m.Expect
 	matcher := expect.(CreateMirrorMatcher)
@@ -994,7 +1020,7 @@ func (m *ClusterLinking) ClustersClusterIdLinksLinkNameMirrorsPost(_ context.Con
 	return httpResp, nil
 }
 
-func (m *ClusterLinking) ClustersClusterIdLinksLinkNameMirrorspromotePost(_ context.Context, _ string, _ string, localVarOptionals *krsdk.ClustersClusterIdLinksLinkNameMirrorspromotePostOpts) (krsdk.AlterMirrorStatusResponseDataList, *nethttp.Response, error) {
+func (m *ClusterLinking) UpdateKafkaMirrorTopicsPromote(_ context.Context, _ string, _ string, localVarOptionals *krsdk.UpdateKafkaMirrorTopicsPromoteOpts) (krsdk.AlterMirrorStatusResponseDataList, *nethttp.Response, error) {
 	expect := <-m.Expect
 	matcher := expect.(AlterMirrorMatcher)
 	for _, topic := range localVarOptionals.AlterMirrorsRequestData.Value().(krsdk.AlterMirrorsRequestData).MirrorTopicNames {
@@ -1006,7 +1032,7 @@ func (m *ClusterLinking) ClustersClusterIdLinksLinkNameMirrorspromotePost(_ cont
 	return m.AlterMirrorResultResponse()
 }
 
-func (m *ClusterLinking) ClustersClusterIdLinksLinkNameMirrorsresumePost(_ context.Context, _ string, _ string, localVarOptionals *krsdk.ClustersClusterIdLinksLinkNameMirrorsresumePostOpts) (krsdk.AlterMirrorStatusResponseDataList, *nethttp.Response, error) {
+func (m *ClusterLinking) UpdateKafkaMirrorTopicsResume(_ context.Context, _ string, _ string, localVarOptionals *krsdk.UpdateKafkaMirrorTopicsResumeOpts) (krsdk.AlterMirrorStatusResponseDataList, *nethttp.Response, error) {
 	expect := <-m.Expect
 	matcher := expect.(AlterMirrorMatcher)
 	for _, topic := range localVarOptionals.AlterMirrorsRequestData.Value().(krsdk.AlterMirrorsRequestData).MirrorTopicNames {
@@ -1026,7 +1052,7 @@ type CreateLinkMatcher struct {
 	Configs         map[string]string
 }
 
-func (m *ClusterLinking) ClustersClusterIdLinksPost(_ context.Context, _ string, linkName string, localVarOptionals *krsdk.ClustersClusterIdLinksPostOpts) (*nethttp.Response, error) {
+func (m *ClusterLinking) CreateKafkaLink(_ context.Context, _ string, linkName string, localVarOptionals *krsdk.CreateKafkaLinkOpts) (*nethttp.Response, error) {
 	expect := <-m.Expect
 	matcher := expect.(CreateLinkMatcher)
 	data := localVarOptionals.CreateLinkRequestData.Value().(krsdk.CreateLinkRequestData)

--- a/test/test-server/kafka_rest_handlers.go
+++ b/test/test-server/kafka_rest_handlers.go
@@ -68,14 +68,14 @@ func (r KafkaRestProxyRouter) HandleKafkaRPACLs(t *testing.T) func(http.Response
 		case http.MethodPost:
 			w.WriteHeader(http.StatusCreated)
 			w.Header().Set("Content-Type", "application/json")
-			var req kafkarestv3.ClustersClusterIdAclsPostOpts
+			var req kafkarestv3.CreateKafkaAclsOpts
 			err := json.NewDecoder(r.Body).Decode(&req)
 			require.NoError(t, err)
-			err = json.NewEncoder(w).Encode(kafkarestv3.ClustersClusterIdAclsPostOpts{})
+			err = json.NewEncoder(w).Encode(kafkarestv3.CreateKafkaAclsOpts{})
 			require.NoError(t, err)
 		case http.MethodDelete:
 			w.Header().Set("Content-Type", "application/json")
-			var req kafkarestv3.ClustersClusterIdAclsDeleteOpts
+			var req kafkarestv3.DeleteKafkaAclsOpts
 			_ = json.NewDecoder(r.Body).Decode(&req)
 			err := json.NewEncoder(w).Encode(kafkarestv3.InlineResponse200{Data: []kafkarestv3.AclData{
 				{
@@ -506,7 +506,7 @@ func (r KafkaRestProxyRouter) HandleKafkaRPLinks(t *testing.T) func(http.Respons
 		case http.MethodPost:
 			w.WriteHeader(http.StatusNoContent)
 			w.Header().Set("Content-Type", "application/json")
-			var req kafkarestv3.ClustersClusterIdLinksPostOpts
+			var req kafkarestv3.CreateKafkaLinkOpts
 			err := json.NewDecoder(r.Body).Decode(&req)
 			require.NoError(t, err)
 		case http.MethodGet:
@@ -518,7 +518,7 @@ func (r KafkaRestProxyRouter) HandleKafkaRPLinks(t *testing.T) func(http.Respons
 					SourceClusterId: "cluster-1",
 					LinkName:        "link-1",
 					LinkId:          "LINKID1",
-					TopicNames:      []string{"link-1-topic-1", "link-1-topic-2"},
+					TopicsNames:     []string{"link-1-topic-1", "link-1-topic-2"},
 				},
 				{
 					Kind:            "",
@@ -526,7 +526,7 @@ func (r KafkaRestProxyRouter) HandleKafkaRPLinks(t *testing.T) func(http.Respons
 					SourceClusterId: "cluster-1",
 					LinkName:        "link-2",
 					LinkId:          "LINKID2",
-					TopicNames:      []string{"link-2-topic-1", "link-2-topic-2"},
+					TopicsNames:     []string{"link-2-topic-1", "link-2-topic-2"},
 				},
 			}})
 			require.NoError(t, err)
@@ -587,7 +587,7 @@ func (r KafkaRestProxyRouter) HandleKafkaRPLink(t *testing.T) func(http.Response
 				SourceClusterId: "cluster-1",
 				LinkName:        "link-1",
 				LinkId:          "LINKID1",
-				TopicNames:      []string{"link-1-topic-1", "link-1-topic-2"},
+				TopicsNames:     []string{"link-1-topic-1", "link-1-topic-2"},
 			})
 			require.NoError(t, err)
 		case http.MethodDelete:
@@ -633,7 +633,7 @@ func (r KafkaRestProxyRouter) HandleKafkaRPAllMirrors(t *testing.T) func(http.Re
 		case http.MethodPost:
 			w.WriteHeader(http.StatusNoContent)
 			w.Header().Set("Content-Type", "application/json")
-			var req kafkarestv3.ClustersClusterIdLinksLinkNameMirrorsPostOpts
+			var req kafkarestv3.ListKafkaMirrorTopicsOpts
 			err := json.NewDecoder(r.Body).Decode(&req)
 			require.NoError(t, err)
 		case http.MethodGet:
@@ -740,7 +740,7 @@ func (r KafkaRestProxyRouter) HandleKafkaRPMirrors(t *testing.T) func(http.Respo
 		case http.MethodPost:
 			w.WriteHeader(http.StatusNoContent)
 			w.Header().Set("Content-Type", "application/json")
-			var req kafkarestv3.ClustersClusterIdLinksLinkNameMirrorsPostOpts
+			var req kafkarestv3.ListKafkaMirrorTopicsUnderLinkOpts
 			err := json.NewDecoder(r.Body).Decode(&req)
 			require.NoError(t, err)
 		case http.MethodGet:
@@ -1263,7 +1263,7 @@ func (r KafkaRestProxyRouter) HandleKafkaBrokerConfigsAlter(t *testing.T) func(h
 	return func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusCreated)
 		w.Header().Set("Content-Type", "application/json")
-		var req kafkarestv3.ClustersClusterIdBrokerConfigsalterPostOpts
+		var req kafkarestv3.UpdateKafkaClusterConfigsOpts
 		err := json.NewDecoder(r.Body).Decode(&req)
 		require.NoError(t, err)
 	}


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok
   * no: DO NOT MERGE until the required functionalites are live in prod  

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->
Needed to upgrade `kafka-rest-sdk-go` to version `v0.3.13` in order to pull in changes made to `CreateMirrorTopicRequestData`. The enhancement was required as a enhancement that is planned to happen to the cli. More context here: [here]([KGLOBAL-1015](https://confluentinc.atlassian.net/browse/KGLOBAL-1015))

References
----------
<!--
Copy & paste links to Jira tickets, other PRs, issues, Slack conversations, etc.
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->
[KGLOBAL-1026](https://confluentinc.atlassian.net/browse/KGLOBAL-1026)
[KGLOBAL-1015](https://confluentinc.atlassian.net/browse/KGLOBAL-1015)
[Update SDK to pull in CreateMirrorTopicRequestData changes](https://github.com/confluentinc/kafka-rest-sdk-go/pull/30)
[KGLOBAL-1002: Enhance REST API to support cluster link prefix PR](https://github.com/confluentinc/ce-kafka-rest/pull/283)

Test & Review
-------------
<!--
Has it been tested? how?
Copy & paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->
Tested using the following and all succeded:

- make build
- make test
- make lint

<!--
Open questions / Follow ups
---------------------------
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->

<!--
Review stakeholders
-------------------
Optional: mention stakeholders or special context that is required to review.
-->
