### PR TITLE
[KGLOBAL-1015] Support cluster link prefix mirroring

### DIFF
--- a/test/fixtures/output/kafka/cluster-linking/create-mirror.golden
+++ b/test/fixtures/output/kafka/cluster-linking/create-mirror.golden
@@ -1,1 +1,0 @@
-Created mirror topic "topic1".

--- a/test/kafka_test.go
+++ b/test/kafka_test.go
@@ -1,7 +1,6 @@
 package test
 
 import (
-	"bytes"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -15,139 +14,135 @@ func (s *CLITestSuite) TestKafka() {
 	createLinkConfigFile := getCreateLinkConfigFile()
 	defer os.Remove(createLinkConfigFile)
 	tests := []CLITest{
-		//{args: "kafka cluster --help", fixture: "kafka/kafka-cluster-help.golden"},
-		//{args: "environment use a-595", fixture: "kafka/0.golden"},
-		//{args: "kafka cluster list", fixture: "kafka/6.golden"},
-		//{args: "kafka cluster list -o json", fixture: "kafka/7.golden"},
-		//{args: "kafka cluster list -o yaml", fixture: "kafka/8.golden"},
-		//
-		//{args: "environment use env-123", fixture: "kafka/46.golden"},
-		//{args: "kafka cluster create my-new-cluster --cloud aws --region us-east-1 --availability single-zone", fixture: "kafka/2.golden"},
-		//{args: "kafka cluster list", fixture: "kafka/6.golden"},
-		//{args: "kafka cluster list --all", fixture: "kafka/47.golden"},
-		//
-		//{args: "environment use a-595", fixture: "kafka/0.golden"},
-		//{args: "kafka cluster create", fixture: "kafka/1.golden", wantErrCode: 1},
-		//{args: "kafka cluster create my-new-cluster --cloud aws --region us-east-1 --availability single-zone", fixture: "kafka/2.golden"},
-		//{args: "kafka cluster create my-failed-cluster --cloud oops --region us-east1 --availability single-zone", fixture: "kafka/kafka-cloud-provider-error.golden", wantErrCode: 1},
-		//{args: "kafka cluster create my-failed-cluster --cloud aws --region oops --availability single-zone", fixture: "kafka/kafka-cloud-region-error.golden", wantErrCode: 1},
-		//{args: "kafka cluster create my-failed-cluster --cloud aws --region us-east-1 --availability single-zone --type oops", fixture: "kafka/kafka-create-type-error.golden", wantErrCode: 1},
-		//{args: "kafka cluster create my-failed-cluster --cloud aws --region us-east-1 --availability single-zone --type dedicated --cku 0", fixture: "kafka/kafka-cku-error.golden", wantErrCode: 1},
-		//{args: "kafka cluster create my-dedicated-cluster --cloud aws --region us-east-1 --type dedicated --cku 1", fixture: "kafka/22.golden"},
-		//{args: "kafka cluster create my-new-cluster --cloud aws --region us-east-1 --availability single-zone -o json", fixture: "kafka/23.golden"},
-		//{args: "kafka cluster create my-new-cluster --cloud aws --region us-east-1 --availability single-zone -o yaml", fixture: "kafka/24.golden"},
-		//{args: "kafka cluster create my-new-cluster --cloud aws --region us-east-1 --availability oops-zone", fixture: "kafka/kafka-availability-zone-error.golden", wantErrCode: 1},
-		//
-		//{args: "kafka cluster update lkc-update ", fixture: "kafka/kafka-create-flag-error.golden", wantErrCode: 1},
-		//{args: "kafka cluster update lkc-update --name lkc-update-name", fixture: "kafka/26.golden"},
-		//{args: "kafka cluster update lkc-update --name lkc-update-name -o json", fixture: "kafka/28.golden"},
-		//{args: "kafka cluster update lkc-update --name lkc-update-name -o yaml", fixture: "kafka/29.golden"},
-		//{args: "kafka cluster update lkc-update-dedicated-expand --name lkc-update-dedicated-name --cku 2", fixture: "kafka/27.golden"},
-		//{args: "kafka cluster update lkc-update-dedicated-expand --cku 2", fixture: "kafka/39.golden"},
-		//{args: "kafka cluster update lkc-update --cku 2", fixture: "kafka/kafka-cluster-resize-error.golden", wantErrCode: 1},
-		//{args: "kafka cluster update lkc-update-dedicated-shrink --name lkc-update-dedicated-name --cku 1", fixture: "kafka/44.golden"},
-		//{args: "kafka cluster update lkc-update-dedicated-shrink --cku 1", fixture: "kafka/45.golden"},
-		//{args: "kafka cluster update lkc-update --cku 1", fixture: "kafka/kafka-cluster-resize-error.golden", wantErrCode: 1},
-		//
-		//{args: "kafka cluster delete", fixture: "kafka/3.golden", wantErrCode: 1},
-		//{args: "kafka cluster delete lkc-unknown", fixture: "kafka/kafka-delete-unknown-error.golden", wantErrCode: 1},
-		//{args: "kafka cluster delete lkc-def973", fixture: "kafka/5.golden"},
-		//
-		//{args: "kafka cluster use a-595", fixture: "kafka/40.golden"},
-		//
-		//{args: "kafka region list", fixture: "kafka/14.golden"},
-		//{args: "kafka region list -o json", fixture: "kafka/15.golden"},
-		//{args: "kafka region list -o json", fixture: "kafka/16.golden"},
-		//{args: "kafka region list --cloud gcp", fixture: "kafka/9.golden"},
-		//{args: "kafka region list --cloud aws", fixture: "kafka/10.golden"},
-		//{args: "kafka region list --cloud azure", fixture: "kafka/11.golden"},
-		//
-		//{args: "kafka cluster describe lkc-describe", fixture: "kafka/17.golden"},
-		//{args: "kafka cluster describe lkc-describe --all", fixture: "kafka/48.golden"},
-		//{args: "kafka cluster describe lkc-describe -o json", fixture: "kafka/18.golden"},
-		//{args: "kafka cluster describe lkc-describe -o yaml", fixture: "kafka/19.golden"},
-		//
-		//{args: "kafka cluster describe lkc-describe-dedicated", fixture: "kafka/30.golden"},
-		//{args: "kafka cluster describe lkc-describe-dedicated -o json", fixture: "kafka/31.golden"},
-		//{args: "kafka cluster describe lkc-describe-dedicated -o yaml", fixture: "kafka/32.golden"},
-		//
-		//{args: "kafka cluster describe lkc-describe-dedicated-pending", fixture: "kafka/33.golden"},
-		//{args: "kafka cluster describe lkc-describe-dedicated-pending -o json", fixture: "kafka/34.golden"},
-		//{args: "kafka cluster describe lkc-describe-dedicated-pending -o yaml", fixture: "kafka/35.golden"},
-		//
-		//{args: "kafka cluster describe lkc-describe-dedicated-with-encryption", fixture: "kafka/36.golden"},
-		//{args: "kafka cluster describe lkc-describe-dedicated-with-encryption -o json", fixture: "kafka/37.golden"},
-		//{args: "kafka cluster describe lkc-describe-dedicated-with-encryption -o yaml", fixture: "kafka/38.golden"},
-		//
-		//{args: "kafka cluster describe lkc-describe-infinite", fixture: "kafka/41.golden"},
-		//{args: "kafka cluster describe lkc-describe-infinite -o json", fixture: "kafka/42.golden"},
-		//{args: "kafka cluster describe lkc-describe-infinite -o yaml", fixture: "kafka/43.golden"},
-		//
-		//{args: "kafka acl list --cluster lkc-acls-kafka-api", fixture: "kafka/kafka-acls-list.golden", env: []string{"XX_CCLOUD_USE_KAFKA_API=true"}},
-		//{args: "kafka acl list --cluster lkc-acls", fixture: "kafka/kafka-acls-list.golden", env: []string{"XX_CCLOUD_USE_KAFKA_REST=true"}},
-		//{args: "kafka acl list --cluster lkc-acls -o json", fixture: "kafka/kafka-acls-list-json.golden", env: []string{"XX_CCLOUD_USE_KAFKA_REST=true"}},
-		//{args: "kafka acl list --cluster lkc-acls -o yaml", fixture: "kafka/kafka-acls-list-yaml.golden", env: []string{"XX_CCLOUD_USE_KAFKA_REST=true"}},
-		//{args: "kafka acl create --cluster lkc-acls --allow --service-account 7272 --operation READ --operation DESCRIBED --topic 'test-topic'", fixture: "kafka/kafka-acls-invalid-operation.golden", wantErrCode: 1, env: []string{"XX_CCLOUD_USE_KAFKA_REST=true"}},
-		//{args: "kafka acl create --cluster lkc-acls --allow --service-account sa-12345 --operation READ --operation DESCRIBE --topic 'test-topic'", fixture: "kafka/kafka-acls-create.golden", env: []string{"XX_CCLOUD_USE_KAFKA_API=true"}},
-		//{args: "kafka acl create --cluster lkc-acls --allow --service-account sa-12345 --operation READ --operation DESCRIBE --topic 'test-topic'", fixture: "kafka/kafka-acls-create.golden", env: []string{"XX_CCLOUD_USE_KAFKA_REST=true"}},
-		//{args: "kafka acl create --cluster lkc-acls --allow --service-account sa-54321 --operation READ --operation DESCRIBE --topic 'test-topic'", fixture: "kafka/kafka-acls-invalid-service-account.golden", wantErrCode: 1, env: []string{"XX_CCLOUD_USE_KAFKA_REST=true"}},
-		//{args: "kafka acl delete --cluster lkc-acls --allow --service-account sa-12345 --operation READ --operation DESCRIBE --topic 'test-topic'", fixture: "kafka/kafka-acls-delete.golden", env: []string{"XX_CCLOUD_USE_KAFKA_REST=true"}},
-		//{args: "kafka acl delete --cluster lkc-acls --allow --service-account sa-12345 --operation READ --operation DESCRIBE --topic 'test-topic'", fixture: "kafka/kafka-acls-delete.golden", env: []string{"XX_CCLOUD_USE_KAFKA_REST=true"}},
-		//
-		//{args: "kafka topic list --cluster lkc-kafka-api-topics", login: "default", fixture: "kafka/topic-list.golden", env: []string{"XX_CCLOUD_USE_KAFKA_REST=true"}},
-		//{args: "kafka topic list --cluster lkc-topics", fixture: "kafka/topic-list.golden", env: []string{"XX_CCLOUD_USE_KAFKA_REST=true"}},
-		//{args: "kafka topic list --cluster lkc-topics", fixture: "kafka/topic-list.golden", env: []string{"XX_CCLOUD_USE_KAFKA_API=true"}},
-		//{args: "kafka topic list", login: "default", useKafka: "lkc-kafka-api-no-topics", fixture: "kafka/topic-list-empty.golden", env: []string{"XX_CCLOUD_USE_KAFKA_API=true"}},
-		//{args: "kafka topic list", login: "default", useKafka: "lkc-not-ready", fixture: "kafka/cluster-not-ready.golden", wantErrCode: 1, env: []string{"XX_CCLOUD_USE_KAFKA_API=true"}},
-		//
-		//{args: "kafka topic create", login: "default", useKafka: "lkc-create-topic", fixture: "kafka/topic-create.golden", wantErrCode: 1, env: []string{"XX_CCLOUD_USE_KAFKA_REST=true"}},
-		//{args: "kafka topic create topic1", login: "default", useKafka: "lkc-create-topic-kafka-api", fixture: "kafka/topic-create-success.golden", env: []string{"XX_CCLOUD_USE_KAFKA_API=true"}},
-		//{args: "kafka topic create topic1", useKafka: "lkc-create-topic", fixture: "kafka/topic-create-success.golden", env: []string{"XX_CCLOUD_USE_KAFKA_REST=true"}},
-		//{args: "kafka topic create topic-exist", login: "default", useKafka: "lkc-create-topic", fixture: "kafka/topic-create-dup-topic.golden", wantErrCode: 1, env: []string{"XX_CCLOUD_USE_KAFKA_REST=true"}},
-		//
-		//{args: "kafka topic describe", login: "default", useKafka: "lkc-describe-topic", fixture: "kafka/topic-describe.golden", wantErrCode: 1, env: []string{"XX_CCLOUD_USE_KAFKA_REST=true"}},
-		//{args: "kafka topic describe topic-exist", login: "default", useKafka: "lkc-describe-topic-kafka-api", fixture: "kafka/topic-describe-success.golden", env: []string{"XX_CCLOUD_USE_KAFKA_API=true"}},
-		//{args: "kafka topic describe topic-exist", useKafka: "lkc-describe-topic", fixture: "kafka/topic-describe-success.golden", env: []string{"XX_CCLOUD_USE_KAFKA_REST=true"}},
-		//{args: "kafka topic describe topic-exist --output json", login: "default", useKafka: "lkc-describe-topic", fixture: "kafka/topic-describe-json-success.golden", env: []string{"XX_CCLOUD_USE_KAFKA_REST=true"}},
-		//{args: "kafka topic describe topic1 --cluster lkc-create-topic-kafka-api", login: "default", fixture: "kafka/topic-describe-not-found.golden", wantErrCode: 1, env: []string{"XX_CCLOUD_USE_KAFKA_API=true"}},
-		//{args: "kafka topic describe topic2", login: "default", useKafka: "lkc-describe-topic", fixture: "kafka/topic2-describe-not-found.golden", wantErrCode: 1, env: []string{"XX_CCLOUD_USE_KAFKA_REST=true"}},
-		//
-		//{args: "kafka topic delete", login: "default", useKafka: "lkc-delete-topic", fixture: "kafka/topic-delete.golden", wantErrCode: 1, env: []string{"XX_CCLOUD_USE_KAFKA_REST=true"}},
-		//{args: "kafka topic delete topic-exist", useKafka: "lkc-delete-topic-kafka-api", fixture: "kafka/topic-delete-success.golden", env: []string{"XX_CCLOUD_USE_KAFKA_API=true"}},
-		//{args: "kafka topic delete topic-exist", useKafka: "lkc-delete-topic", fixture: "kafka/topic-delete-success.golden", env: []string{"XX_CCLOUD_USE_KAFKA_REST=true"}},
-		//{args: "kafka topic delete topic1 --cluster lkc-create-topic-kafka-api", login: "default", fixture: "kafka/topic-delete-not-found.golden", wantErrCode: 1, env: []string{"XX_CCLOUD_USE_KAFKA_API=true"}},
-		//{args: "kafka topic delete topic2", login: "default", useKafka: "lkc-delete-topic", fixture: "kafka/topic2-delete-not-found.golden", wantErrCode: 1, env: []string{"XX_CCLOUD_USE_KAFKA_REST=true"}},
-		//
-		//{args: "kafka topic update topic-exist --config retention.ms=1,compression.type=gzip", login: "default", useKafka: "lkc-describe-topic-kafka-api", fixture: "kafka/topic-update-success.golden", env: []string{"XX_CCLOUD_USE_KAFKA_REST=true"}},
-		//{args: "kafka topic update topic-exist --config retention.ms=1,compression.type=gzip", useKafka: "lkc-describe-topic", fixture: "kafka/topic-update-success.golden", env: []string{"XX_CCLOUD_USE_KAFKA_REST=true"}},
+		{args: "kafka cluster --help", fixture: "kafka/kafka-cluster-help.golden"},
+		{args: "environment use a-595", fixture: "kafka/0.golden"},
+		{args: "kafka cluster list", fixture: "kafka/6.golden"},
+		{args: "kafka cluster list -o json", fixture: "kafka/7.golden"},
+		{args: "kafka cluster list -o yaml", fixture: "kafka/8.golden"},
+
+		{args: "environment use env-123", fixture: "kafka/46.golden"},
+		{args: "kafka cluster create my-new-cluster --cloud aws --region us-east-1 --availability single-zone", fixture: "kafka/2.golden"},
+		{args: "kafka cluster list", fixture: "kafka/6.golden"},
+		{args: "kafka cluster list --all", fixture: "kafka/47.golden"},
+
+		{args: "environment use a-595", fixture: "kafka/0.golden"},
+		{args: "kafka cluster create", fixture: "kafka/1.golden", wantErrCode: 1},
+		{args: "kafka cluster create my-new-cluster --cloud aws --region us-east-1 --availability single-zone", fixture: "kafka/2.golden"},
+		{args: "kafka cluster create my-failed-cluster --cloud oops --region us-east1 --availability single-zone", fixture: "kafka/kafka-cloud-provider-error.golden", wantErrCode: 1},
+		{args: "kafka cluster create my-failed-cluster --cloud aws --region oops --availability single-zone", fixture: "kafka/kafka-cloud-region-error.golden", wantErrCode: 1},
+		{args: "kafka cluster create my-failed-cluster --cloud aws --region us-east-1 --availability single-zone --type oops", fixture: "kafka/kafka-create-type-error.golden", wantErrCode: 1},
+		{args: "kafka cluster create my-failed-cluster --cloud aws --region us-east-1 --availability single-zone --type dedicated --cku 0", fixture: "kafka/kafka-cku-error.golden", wantErrCode: 1},
+		{args: "kafka cluster create my-dedicated-cluster --cloud aws --region us-east-1 --type dedicated --cku 1", fixture: "kafka/22.golden"},
+		{args: "kafka cluster create my-new-cluster --cloud aws --region us-east-1 --availability single-zone -o json", fixture: "kafka/23.golden"},
+		{args: "kafka cluster create my-new-cluster --cloud aws --region us-east-1 --availability single-zone -o yaml", fixture: "kafka/24.golden"},
+		{args: "kafka cluster create my-new-cluster --cloud aws --region us-east-1 --availability oops-zone", fixture: "kafka/kafka-availability-zone-error.golden", wantErrCode: 1},
+
+		{args: "kafka cluster update lkc-update ", fixture: "kafka/kafka-create-flag-error.golden", wantErrCode: 1},
+		{args: "kafka cluster update lkc-update --name lkc-update-name", fixture: "kafka/26.golden"},
+		{args: "kafka cluster update lkc-update --name lkc-update-name -o json", fixture: "kafka/28.golden"},
+		{args: "kafka cluster update lkc-update --name lkc-update-name -o yaml", fixture: "kafka/29.golden"},
+		{args: "kafka cluster update lkc-update-dedicated-expand --name lkc-update-dedicated-name --cku 2", fixture: "kafka/27.golden"},
+		{args: "kafka cluster update lkc-update-dedicated-expand --cku 2", fixture: "kafka/39.golden"},
+		{args: "kafka cluster update lkc-update --cku 2", fixture: "kafka/kafka-cluster-resize-error.golden", wantErrCode: 1},
+		{args: "kafka cluster update lkc-update-dedicated-shrink --name lkc-update-dedicated-name --cku 1", fixture: "kafka/44.golden"},
+		{args: "kafka cluster update lkc-update-dedicated-shrink --cku 1", fixture: "kafka/45.golden"},
+		{args: "kafka cluster update lkc-update --cku 1", fixture: "kafka/kafka-cluster-resize-error.golden", wantErrCode: 1},
+
+		{args: "kafka cluster delete", fixture: "kafka/3.golden", wantErrCode: 1},
+		{args: "kafka cluster delete lkc-unknown", fixture: "kafka/kafka-delete-unknown-error.golden", wantErrCode: 1},
+		{args: "kafka cluster delete lkc-def973", fixture: "kafka/5.golden"},
+
+		{args: "kafka cluster use a-595", fixture: "kafka/40.golden"},
+
+		{args: "kafka region list", fixture: "kafka/14.golden"},
+		{args: "kafka region list -o json", fixture: "kafka/15.golden"},
+		{args: "kafka region list -o json", fixture: "kafka/16.golden"},
+		{args: "kafka region list --cloud gcp", fixture: "kafka/9.golden"},
+		{args: "kafka region list --cloud aws", fixture: "kafka/10.golden"},
+		{args: "kafka region list --cloud azure", fixture: "kafka/11.golden"},
+
+		{args: "kafka cluster describe lkc-describe", fixture: "kafka/17.golden"},
+		{args: "kafka cluster describe lkc-describe --all", fixture: "kafka/48.golden"},
+		{args: "kafka cluster describe lkc-describe -o json", fixture: "kafka/18.golden"},
+		{args: "kafka cluster describe lkc-describe -o yaml", fixture: "kafka/19.golden"},
+
+		{args: "kafka cluster describe lkc-describe-dedicated", fixture: "kafka/30.golden"},
+		{args: "kafka cluster describe lkc-describe-dedicated -o json", fixture: "kafka/31.golden"},
+		{args: "kafka cluster describe lkc-describe-dedicated -o yaml", fixture: "kafka/32.golden"},
+
+		{args: "kafka cluster describe lkc-describe-dedicated-pending", fixture: "kafka/33.golden"},
+		{args: "kafka cluster describe lkc-describe-dedicated-pending -o json", fixture: "kafka/34.golden"},
+		{args: "kafka cluster describe lkc-describe-dedicated-pending -o yaml", fixture: "kafka/35.golden"},
+
+		{args: "kafka cluster describe lkc-describe-dedicated-with-encryption", fixture: "kafka/36.golden"},
+		{args: "kafka cluster describe lkc-describe-dedicated-with-encryption -o json", fixture: "kafka/37.golden"},
+		{args: "kafka cluster describe lkc-describe-dedicated-with-encryption -o yaml", fixture: "kafka/38.golden"},
+
+		{args: "kafka cluster describe lkc-describe-infinite", fixture: "kafka/41.golden"},
+		{args: "kafka cluster describe lkc-describe-infinite -o json", fixture: "kafka/42.golden"},
+		{args: "kafka cluster describe lkc-describe-infinite -o yaml", fixture: "kafka/43.golden"},
+
+		{args: "kafka acl list --cluster lkc-acls-kafka-api", fixture: "kafka/kafka-acls-list.golden", env: []string{"XX_CCLOUD_USE_KAFKA_API=true"}},
+		{args: "kafka acl list --cluster lkc-acls", fixture: "kafka/kafka-acls-list.golden", env: []string{"XX_CCLOUD_USE_KAFKA_REST=true"}},
+		{args: "kafka acl list --cluster lkc-acls -o json", fixture: "kafka/kafka-acls-list-json.golden", env: []string{"XX_CCLOUD_USE_KAFKA_REST=true"}},
+		{args: "kafka acl list --cluster lkc-acls -o yaml", fixture: "kafka/kafka-acls-list-yaml.golden", env: []string{"XX_CCLOUD_USE_KAFKA_REST=true"}},
+		{args: "kafka acl create --cluster lkc-acls --allow --service-account 7272 --operation READ --operation DESCRIBED --topic 'test-topic'", fixture: "kafka/kafka-acls-invalid-operation.golden", wantErrCode: 1, env: []string{"XX_CCLOUD_USE_KAFKA_REST=true"}},
+		{args: "kafka acl create --cluster lkc-acls --allow --service-account sa-12345 --operation READ --operation DESCRIBE --topic 'test-topic'", fixture: "kafka/kafka-acls-create.golden", env: []string{"XX_CCLOUD_USE_KAFKA_API=true"}},
+		{args: "kafka acl create --cluster lkc-acls --allow --service-account sa-12345 --operation READ --operation DESCRIBE --topic 'test-topic'", fixture: "kafka/kafka-acls-create.golden", env: []string{"XX_CCLOUD_USE_KAFKA_REST=true"}},
+		{args: "kafka acl create --cluster lkc-acls --allow --service-account sa-54321 --operation READ --operation DESCRIBE --topic 'test-topic'", fixture: "kafka/kafka-acls-invalid-service-account.golden", wantErrCode: 1, env: []string{"XX_CCLOUD_USE_KAFKA_REST=true"}},
+		{args: "kafka acl delete --cluster lkc-acls --allow --service-account sa-12345 --operation READ --operation DESCRIBE --topic 'test-topic'", fixture: "kafka/kafka-acls-delete.golden", env: []string{"XX_CCLOUD_USE_KAFKA_REST=true"}},
+		{args: "kafka acl delete --cluster lkc-acls --allow --service-account sa-12345 --operation READ --operation DESCRIBE --topic 'test-topic'", fixture: "kafka/kafka-acls-delete.golden", env: []string{"XX_CCLOUD_USE_KAFKA_REST=true"}},
+
+		{args: "kafka topic list --cluster lkc-kafka-api-topics", login: "default", fixture: "kafka/topic-list.golden", env: []string{"XX_CCLOUD_USE_KAFKA_REST=true"}},
+		{args: "kafka topic list --cluster lkc-topics", fixture: "kafka/topic-list.golden", env: []string{"XX_CCLOUD_USE_KAFKA_REST=true"}},
+		{args: "kafka topic list --cluster lkc-topics", fixture: "kafka/topic-list.golden", env: []string{"XX_CCLOUD_USE_KAFKA_API=true"}},
+		{args: "kafka topic list", login: "default", useKafka: "lkc-kafka-api-no-topics", fixture: "kafka/topic-list-empty.golden", env: []string{"XX_CCLOUD_USE_KAFKA_API=true"}},
+		{args: "kafka topic list", login: "default", useKafka: "lkc-not-ready", fixture: "kafka/cluster-not-ready.golden", wantErrCode: 1, env: []string{"XX_CCLOUD_USE_KAFKA_API=true"}},
+
+		{args: "kafka topic create", login: "default", useKafka: "lkc-create-topic", fixture: "kafka/topic-create.golden", wantErrCode: 1, env: []string{"XX_CCLOUD_USE_KAFKA_REST=true"}},
+		{args: "kafka topic create topic1", login: "default", useKafka: "lkc-create-topic-kafka-api", fixture: "kafka/topic-create-success.golden", env: []string{"XX_CCLOUD_USE_KAFKA_API=true"}},
+		{args: "kafka topic create topic1", useKafka: "lkc-create-topic", fixture: "kafka/topic-create-success.golden", env: []string{"XX_CCLOUD_USE_KAFKA_REST=true"}},
+		{args: "kafka topic create topic-exist", login: "default", useKafka: "lkc-create-topic", fixture: "kafka/topic-create-dup-topic.golden", wantErrCode: 1, env: []string{"XX_CCLOUD_USE_KAFKA_REST=true"}},
+
+		{args: "kafka topic describe", login: "default", useKafka: "lkc-describe-topic", fixture: "kafka/topic-describe.golden", wantErrCode: 1, env: []string{"XX_CCLOUD_USE_KAFKA_REST=true"}},
+		{args: "kafka topic describe topic-exist", login: "default", useKafka: "lkc-describe-topic-kafka-api", fixture: "kafka/topic-describe-success.golden", env: []string{"XX_CCLOUD_USE_KAFKA_API=true"}},
+		{args: "kafka topic describe topic-exist", useKafka: "lkc-describe-topic", fixture: "kafka/topic-describe-success.golden", env: []string{"XX_CCLOUD_USE_KAFKA_REST=true"}},
+		{args: "kafka topic describe topic-exist --output json", login: "default", useKafka: "lkc-describe-topic", fixture: "kafka/topic-describe-json-success.golden", env: []string{"XX_CCLOUD_USE_KAFKA_REST=true"}},
+		{args: "kafka topic describe topic1 --cluster lkc-create-topic-kafka-api", login: "default", fixture: "kafka/topic-describe-not-found.golden", wantErrCode: 1, env: []string{"XX_CCLOUD_USE_KAFKA_API=true"}},
+		{args: "kafka topic describe topic2", login: "default", useKafka: "lkc-describe-topic", fixture: "kafka/topic2-describe-not-found.golden", wantErrCode: 1, env: []string{"XX_CCLOUD_USE_KAFKA_REST=true"}},
+
+		{args: "kafka topic delete", login: "default", useKafka: "lkc-delete-topic", fixture: "kafka/topic-delete.golden", wantErrCode: 1, env: []string{"XX_CCLOUD_USE_KAFKA_REST=true"}},
+		{args: "kafka topic delete topic-exist", useKafka: "lkc-delete-topic-kafka-api", fixture: "kafka/topic-delete-success.golden", env: []string{"XX_CCLOUD_USE_KAFKA_API=true"}},
+		{args: "kafka topic delete topic-exist", useKafka: "lkc-delete-topic", fixture: "kafka/topic-delete-success.golden", env: []string{"XX_CCLOUD_USE_KAFKA_REST=true"}},
+		{args: "kafka topic delete topic1 --cluster lkc-create-topic-kafka-api", login: "default", fixture: "kafka/topic-delete-not-found.golden", wantErrCode: 1, env: []string{"XX_CCLOUD_USE_KAFKA_API=true"}},
+		{args: "kafka topic delete topic2", login: "default", useKafka: "lkc-delete-topic", fixture: "kafka/topic2-delete-not-found.golden", wantErrCode: 1, env: []string{"XX_CCLOUD_USE_KAFKA_REST=true"}},
+
+		{args: "kafka topic update topic-exist --config retention.ms=1,compression.type=gzip", login: "default", useKafka: "lkc-describe-topic-kafka-api", fixture: "kafka/topic-update-success.golden", env: []string{"XX_CCLOUD_USE_KAFKA_REST=true"}},
+		{args: "kafka topic update topic-exist --config retention.ms=1,compression.type=gzip", useKafka: "lkc-describe-topic", fixture: "kafka/topic-update-success.golden", env: []string{"XX_CCLOUD_USE_KAFKA_REST=true"}},
 
 		// Cluster linking
 		{args: "kafka link create my_link --source-cluster-id lkc-describe-topic --source-bootstrap-server myhost:1234 --config-file " + getCreateLinkConfigFile(), fixture: "kafka/cluster-linking/create-link.golden", wantErrCode: 0, useKafka: "lkc-describe-topic"},
-		//{args: "kafka link list --cluster lkc-describe-topic", fixture: "kafka/cluster-linking/list-link-plain.golden", wantErrCode: 0, useKafka: "lkc-describe-topic"},
-		//{args: "kafka link list --cluster lkc-describe-topic -o json", fixture: "kafka/cluster-linking/list-link-json.golden", wantErrCode: 0, useKafka: "lkc-describe-topic"},
-		//{args: "kafka link list --cluster lkc-describe-topic -o yaml", fixture: "kafka/cluster-linking/list-link-yaml.golden", wantErrCode: 0, useKafka: "lkc-describe-topic"},
-		//{args: "kafka link describe --cluster lkc-describe-topic link-1", fixture: "kafka/cluster-linking/describe-link-plain.golden", wantErrCode: 0, useKafka: "lkc-describe-topic"},
-		//{args: "kafka link describe --cluster lkc-describe-topic link-1 -o json", fixture: "kafka/cluster-linking/describe-link-json.golden", wantErrCode: 0, useKafka: "lkc-describe-topic"},
-		//{args: "kafka link describe --cluster lkc-describe-topic link-1 -o yaml", fixture: "kafka/cluster-linking/describe-link-yaml.golden", wantErrCode: 0, useKafka: "lkc-describe-topic"},
-		//
-		//{args: "kafka mirror list --cluster lkc-describe-topic --link link-1", fixture: "kafka/cluster-linking/list-mirror.golden", wantErrCode: 0, useKafka: "lkc-describe-topic"},
-		//{args: "kafka mirror list --cluster lkc-describe-topic --link link-1 -o json", fixture: "kafka/cluster-linking/list-mirror-json.golden", wantErrCode: 0, useKafka: "lkc-describe-topic"},
-		//{args: "kafka mirror list --cluster lkc-describe-topic --link link-1 -o yaml", fixture: "kafka/cluster-linking/list-mirror-yaml.golden", wantErrCode: 0, useKafka: "lkc-describe-topic"},
-		//{args: "kafka mirror list --cluster lkc-describe-topic", fixture: "kafka/cluster-linking/list-all-mirror.golden", wantErrCode: 0, useKafka: "lkc-describe-topic"},
-		//{args: "kafka mirror list --cluster lkc-describe-topic -o json", fixture: "kafka/cluster-linking/list-all-mirror-json.golden", wantErrCode: 0, useKafka: "lkc-describe-topic"},
-		//{args: "kafka mirror list --cluster lkc-describe-topic -o yaml", fixture: "kafka/cluster-linking/list-all-mirror-yaml.golden", wantErrCode: 0, useKafka: "lkc-describe-topic"},
-		//{args: "kafka mirror describe topic-1 --link link-1 --cluster lkc-describe-topic", fixture: "kafka/cluster-linking/describe-mirror.golden", wantErrCode: 0, useKafka: "lkc-describe-topic"},
-		//{args: "kafka mirror describe topic-1 --link link-1 --cluster lkc-describe-topic -o json", fixture: "kafka/cluster-linking/describe-mirror-json.golden", wantErrCode: 0, useKafka: "lkc-describe-topic"},
-		//{args: "kafka mirror describe topic-1 --link link-1 --cluster lkc-describe-topic -o yaml", fixture: "kafka/cluster-linking/describe-mirror-yaml.golden", wantErrCode: 0, useKafka: "lkc-describe-topic"},
-		//{args: "kafka mirror promote topic1 topic2 --cluster lkc-describe-topic --link link-1", fixture: "kafka/cluster-linking/promote-mirror.golden", wantErrCode: 0, useKafka: "lkc-describe-topic"},
-		//{args: "kafka mirror promote topic1 topic2 --cluster lkc-describe-topic --link link-1 -o json", fixture: "kafka/cluster-linking/promote-mirror-json.golden", wantErrCode: 0, useKafka: "lkc-describe-topic"},
-		//{args: "kafka mirror promote topic1 topic2 --cluster lkc-describe-topic --link link-1 -o yaml", fixture: "kafka/cluster-linking/promote-mirror-yaml.golden", wantErrCode: 0, useKafka: "lkc-describe-topic"},
+		{args: "kafka link list --cluster lkc-describe-topic", fixture: "kafka/cluster-linking/list-link-plain.golden", wantErrCode: 0, useKafka: "lkc-describe-topic"},
+		{args: "kafka link list --cluster lkc-describe-topic -o json", fixture: "kafka/cluster-linking/list-link-json.golden", wantErrCode: 0, useKafka: "lkc-describe-topic"},
+		{args: "kafka link list --cluster lkc-describe-topic -o yaml", fixture: "kafka/cluster-linking/list-link-yaml.golden", wantErrCode: 0, useKafka: "lkc-describe-topic"},
+		{args: "kafka link describe --cluster lkc-describe-topic link-1", fixture: "kafka/cluster-linking/describe-link-plain.golden", wantErrCode: 0, useKafka: "lkc-describe-topic"},
+		{args: "kafka link describe --cluster lkc-describe-topic link-1 -o json", fixture: "kafka/cluster-linking/describe-link-json.golden", wantErrCode: 0, useKafka: "lkc-describe-topic"},
+		{args: "kafka link describe --cluster lkc-describe-topic link-1 -o yaml", fixture: "kafka/cluster-linking/describe-link-yaml.golden", wantErrCode: 0, useKafka: "lkc-describe-topic"},
 
-		{args: "kafka mirror create topic1  --link link-1", fixture: "kafka/cluster-linking/create-mirror.golden", wantErrCode: 0, useKafka: "lkc-describe-topic"},
-		{args: "kafka link update my_link --config-file " + getCreateLinkConfigFile(), wantErrCode: 0, useKafka: "lkc-describe-topic"},
-		{args: "kafka link describe my_link", wantErrCode: 0, useKafka: "lkc-describe-topic"},
+		{args: "kafka mirror list --cluster lkc-describe-topic --link link-1", fixture: "kafka/cluster-linking/list-mirror.golden", wantErrCode: 0, useKafka: "lkc-describe-topic"},
+		{args: "kafka mirror list --cluster lkc-describe-topic --link link-1 -o json", fixture: "kafka/cluster-linking/list-mirror-json.golden", wantErrCode: 0, useKafka: "lkc-describe-topic"},
+		{args: "kafka mirror list --cluster lkc-describe-topic --link link-1 -o yaml", fixture: "kafka/cluster-linking/list-mirror-yaml.golden", wantErrCode: 0, useKafka: "lkc-describe-topic"},
+		{args: "kafka mirror list --cluster lkc-describe-topic", fixture: "kafka/cluster-linking/list-all-mirror.golden", wantErrCode: 0, useKafka: "lkc-describe-topic"},
+		{args: "kafka mirror list --cluster lkc-describe-topic -o json", fixture: "kafka/cluster-linking/list-all-mirror-json.golden", wantErrCode: 0, useKafka: "lkc-describe-topic"},
+		{args: "kafka mirror list --cluster lkc-describe-topic -o yaml", fixture: "kafka/cluster-linking/list-all-mirror-yaml.golden", wantErrCode: 0, useKafka: "lkc-describe-topic"},
+		{args: "kafka mirror describe topic-1 --link link-1 --cluster lkc-describe-topic", fixture: "kafka/cluster-linking/describe-mirror.golden", wantErrCode: 0, useKafka: "lkc-describe-topic"},
+		{args: "kafka mirror describe topic-1 --link link-1 --cluster lkc-describe-topic -o json", fixture: "kafka/cluster-linking/describe-mirror-json.golden", wantErrCode: 0, useKafka: "lkc-describe-topic"},
+		{args: "kafka mirror describe topic-1 --link link-1 --cluster lkc-describe-topic -o yaml", fixture: "kafka/cluster-linking/describe-mirror-yaml.golden", wantErrCode: 0, useKafka: "lkc-describe-topic"},
+		{args: "kafka mirror promote topic1 topic2 --cluster lkc-describe-topic --link link-1", fixture: "kafka/cluster-linking/promote-mirror.golden", wantErrCode: 0, useKafka: "lkc-describe-topic"},
+		{args: "kafka mirror promote topic1 topic2 --cluster lkc-describe-topic --link link-1 -o json", fixture: "kafka/cluster-linking/promote-mirror-json.golden", wantErrCode: 0, useKafka: "lkc-describe-topic"},
+		{args: "kafka mirror promote topic1 topic2 --cluster lkc-describe-topic --link link-1 -o yaml", fixture: "kafka/cluster-linking/promote-mirror-yaml.golden", wantErrCode: 0, useKafka: "lkc-describe-topic"},
 	}
-	//getUpdateLinkConfigFile(map[string]string{"cluster.link.prefix": "src_"})
+
 	resetConfiguration(s.T())
 
 	for _, tt := range tests {
@@ -161,21 +156,6 @@ func getCreateLinkConfigFile() string {
 	file, _ := ioutil.TempFile(os.TempDir(), "test")
 	_, _ = file.Write([]byte("key=val\n key2=val2 \n key3=val password=pass"))
 	return file.Name()
-}
-
-func getUpdateLinkConfigFile(updateConfigMap map[string]string) string {
-	file, _ := ioutil.TempFile(os.TempDir(), "test")
-	println(createKeyValuePairs(updateConfigMap))
-	_, _ = file.Write([]byte("auto.create.mirror.topics.enable=true\n"))
-	return file.Name()
-}
-
-func createKeyValuePairs(m map[string]string) string {
-	b := new(bytes.Buffer)
-	for key, value := range m {
-		fmt.Fprintf(b, "%s=%s\n", key, value)
-	}
-	return b.String()
 }
 
 //func (s *CLITestSuite) TestCCloudKafkaConsumerGroup() {

--- a/test/test-server/kafka_rest_handlers.go
+++ b/test/test-server/kafka_rest_handlers.go
@@ -988,51 +988,6 @@ func (r KafkaRestProxyRouter) HandleKafkaRPLinkConfigs(t *testing.T) func(http.R
 	}
 }
 
-// Handler for: "/kafka/v3/clusters/{cluster_id}/links/{link_name}/configs/{config_name}"
-func (r KafkaRestProxyRouter) HandleKafkaRPLinkConfig(t *testing.T) func(http.ResponseWriter, *http.Request) {
-	return func(w http.ResponseWriter, r *http.Request) {
-		println("GOT HERE")
-		switch r.Method {
-		case http.MethodPost:
-			println("GOT HERE")
-			w.WriteHeader(http.StatusNoContent)
-			w.Header().Set("Content-Type", "application/json")
-			var req kafkarestv3.UpdateKafkaLinkConfigOpts
-			err := json.NewDecoder(r.Body).Decode(&req)
-			require.NoError(t, err)
-			//case http.MethodGet:
-			//	w.Header().Set("Content-Type", "application/json")
-			//	err := json.NewEncoder(w).Encode(kafkarestv3.ListLinkConfigsResponseData{Data: []kafkarestv3.ListLinkConfigsResponseData{
-			//		{
-			//			Kind:      "",
-			//			Metadata:  kafkarestv3.ResourceMetadata{},
-			//			ClusterId: "cluster-1",
-			//			Name:      "replica.fetch.max.bytes",
-			//			Value:     "1048576",
-			//			ReadOnly:  false,
-			//			Sensitive: false,
-			//			Source:    "source-1",
-			//			Synonyms:  []string{"rfmb", "bmfr"},
-			//			LinkName:  "link-1",
-			//		},
-			//		{
-			//			Kind:      "",
-			//			Metadata:  kafkarestv3.ResourceMetadata{},
-			//			ClusterId: "cluster-1",
-			//			Name:      "bootstrap.servers",
-			//			Value:     "bitcoin.com:8888",
-			//			ReadOnly:  false,
-			//			Sensitive: false,
-			//			Source:    "source-2",
-			//			Synonyms:  nil,
-			//			LinkName:  "link-1",
-			//		},
-			//	}})
-			//	require.NoError(t, err)
-		}
-	}
-}
-
 // Handler for: "/kafka/v3/clusters/{cluster_id}/links/{link_name}/mirrors/{mirror_name}"
 func (r KafkaRestProxyRouter) HandleKafkaRPMirror(t *testing.T) func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {

--- a/test/test-server/kafka_router.go
+++ b/test/test-server/kafka_router.go
@@ -32,7 +32,6 @@ const (
 	rpLink                     = "/kafka/v3/clusters/{cluster}/links/{link}"
 	rpLinks                    = "/kafka/v3/clusters/{cluster}/links"
 	rpLinkConfigs              = "/kafka/v3/clusters/{cluster}/links/{link}/configs"
-	rpLinkConfig               = "/kafka/v3/clusters/{cluster}/links/{link}/configs/{config_name}"
 	rpMirror                   = "/kafka/v3/clusters/{cluster}/links/{link}/mirrors/{mirror_topic_name}"
 	rpAllMirrors               = "/kafka/v3/clusters/{cluster}/links/-/mirrors"
 	rpMirrors                  = "/kafka/v3/clusters/{cluster}/links/{link}/mirrors"
@@ -119,7 +118,6 @@ func (r KafkaRestProxyRouter) buildKafkaRPHandler(t *testing.T) {
 	r.HandleFunc(rpLink, r.HandleKafkaRPLink(t))
 	r.HandleFunc(rpLinks, r.HandleKafkaRPLinks(t))
 	r.HandleFunc(rpLinkConfigs, r.HandleKafkaRPLinkConfigs(t))
-	r.HandleFunc(rpLinkConfig, r.HandleKafkaRPLinkConfig(t))
 	r.HandleFunc(rpMirrorPromote, r.HandleKafkaRPMirrorsPromote(t))
 	r.HandleFunc(rpMirror, r.HandleKafkaRPMirror(t))
 	r.HandleFunc(rpAllMirrors, r.HandleKafkaRPAllMirrors(t))


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok
   * no: DO NOT MERGE until the required functionalites are live in prod  

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->

We plan to introduce an optional --source-topic flag for users to specify the source topic name in cases where cluster link prefixing is enabled. More info here: [KGLOBAL-1026](https://confluentinc.atlassian.net/browse/KGLOBAL-1026)

References
----------
<!--
Copy & paste links to Jira tickets, other PRs, issues, Slack conversations, etc.
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->
[KGLOBAL-1026](https://confluentinc.atlassian.net/browse/KGLOBAL-1026)
[KGLOBAL-1015](https://confluentinc.atlassian.net/browse/KGLOBAL-1015)
[Update SDK to pull in CreateMirrorTopicRequestData changes](https://github.com/confluentinc/kafka-rest-sdk-go/pull/30)
[KGLOBAL-1002: Enhance REST API to support cluster link prefix PR](https://github.com/confluentinc/ce-kafka-rest/pull/283)

Test & Review
-------------
<!--
Has it been tested? how?
Copy & paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

Tested using the following and all succeeded:

- make build
- make test
- make lint

<!--
Open questions / Follow ups
---------------------------
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->

Integration tests were attempted, but most of the functions mocked in the [kafka_rest_handlers.go](https://github.com/confluentinc/cli/blob/main/test/test-server/kafka_rest_handlers.go) were hardcoded to return certain responses. For example, updating a link config would return errors for previous tests because the response returned is hardcoded (situation where response includes updated link config values). Integration tests are lacking in general and some of the rest handlers are missing.

<!--
Review stakeholders
-------------------
Optional: mention stakeholders or special context that is required to review.
-->
