### PR TITLE
[CLI-1536] Support autocompletion with `source` in Zsh

### DIFF
--- a/internal/cmd/completion/completion.go
+++ b/internal/cmd/completion/completion.go
@@ -2,6 +2,7 @@ package completion
 
 import (
 	"bytes"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -95,13 +96,12 @@ func New() *cobra.Command {
 
 func completion(root *cobra.Command, shell string) (string, error) {
 	buf := new(bytes.Buffer)
-	var err error
 
 	if shell == "zsh" {
-		err = root.GenZshCompletion(buf)
+		err := root.GenZshCompletion(buf)
+		return "#compdef confluent\n" + strings.TrimPrefix(buf.String(), "#"), err
 	} else {
-		err = root.GenBashCompletion(buf)
+		err := root.GenBashCompletion(buf)
+		return buf.String(), err
 	}
-
-	return buf.String(), err
 }


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok

What
----
Edited the autogenerated Zsh completion code to work with the `source` command. This involves uncommenting the `compdef` section of the header to match the header of `kubectl`.

Before:
```
#compdef _confluent confluent
```

After:
```
#compdef confluent
compdef _confluent confluent
```

References
----------
https://confluentinc.atlassian.net/browse/CLI-1536

Test & Review
-------------
Manually verified that the following autocompletion setup steps work:

```
% source <(confluent completion zsh)
% confluent <TAB>
admin            -- Perform administrative tasks for the current organizatio
api-key          -- Manage the API keys.
audit-log        -- Manage audit log configuration.
```

```
% confluent completion zsh > ${fpath[1]}/_confluent
% autoload -U compinit; compinit
% confluent <TAB>
admin            -- Perform administrative tasks for the current organizatio
api-key          -- Manage the API keys.
audit-log        -- Manage audit log configuration.
```
