### PR TITLE
[CLI-1565] Fix `kafka cluster describe` panic

### DIFF
--- a/internal/cmd/kafka/command_cluster_describe.go
+++ b/internal/cmd/kafka/command_cluster_describe.go
@@ -120,7 +120,7 @@ func (c *clusterCommand) describe(cmd *cobra.Command, args []string) error {
 	req := &schedv1.KafkaCluster{AccountId: c.EnvironmentId(), Id: lkc}
 	cluster, err := c.Client.Kafka.Describe(context.Background(), req)
 	if err != nil {
-		return errors.CatchKafkaNotFoundError(err, args[0])
+		return errors.CatchKafkaNotFoundError(err, lkc)
 	}
 
 	return outputKafkaClusterDescriptionWithKAPI(cmd, cluster, all)


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok

What
----
CLI panicked when describing the current Kafka cluster after deleting its environment. The fix is to use the computed `lkc` value instead of `args[0]` which may not exist.

Before:
```
% confluent kafka cluster describe          
panic: runtime error: index out of range [0] with length 0

goroutine 1 [running]:
github.com/confluentinc/cli/internal/cmd/kafka.(*clusterCommand).describe(0xc00000fc38, 0xc000396f00, {0x74b2020, 0x53858e3, 0x0})
...
```

After:
```
% confluent kafka cluster describe
Error: Kafka cluster not found or access forbidden: error describing kafka cluster: Forbidden Access

Suggestions:
    Ensure the cluster ID you entered is valid.
    Ensure the cluster you are specifying belongs to the currently selected environment with `confluent kafka cluster list`, `confluent environment list`, and `confluent environment use`.
```

References
----------
https://confluentinc.atlassian.net/browse/CLI-1565

Test & Review
-------------
Tested manually. To write an integration test for this, we'd have to rewrite the test backend to include some state management for Kafka clusters, which would be a major rewrite.
