### PR TITLE
Deprecate broken cluster linking flags

### DIFF
--- a/internal/cmd/kafka/command_link_create.go
+++ b/internal/cmd/kafka/command_link_create.go
@@ -56,8 +56,8 @@ func (c *linkCommand) newCreateCommand() *cobra.Command {
 		"Must be used with --source-api-key.")
 	cmd.Flags().String(configFileFlagName, "", "Name of the file containing link config overrides. "+
 		"Each property key-value pair should have the format of key=value. Properties are separated by new-line characters.")
-	cmd.Flags().Bool(dryrunFlagName, false, "If set, will NOT actually create the link, but simply validates it.")
-	cmd.Flags().Bool(noValidateFlagName, false, "If set, will create the link even if the source cluster cannot be reached with the supplied bootstrap server and credentials.")
+	cmd.Flags().Bool(dryrunFlagName, false, "DEPRECATED: Validate a link, but do not create it (this flag is no longer active).")
+	cmd.Flags().Bool(noValidateFlagName, false, "DEPRECATED: Create a link even if the source cluster cannot be reached (this flag is no longer active).")
 	pcmd.AddClusterFlag(cmd, c.AuthenticatedCLICommand)
 	pcmd.AddContextFlag(cmd, c.CLICommand)
 	pcmd.AddEnvironmentFlag(cmd, c.AuthenticatedCLICommand)
@@ -77,16 +77,6 @@ func (c *linkCommand) create(cmd *cobra.Command, args []string) error {
 	}
 
 	sourceClusterId, err := cmd.Flags().GetString(sourceClusterIdFlagName)
-	if err != nil {
-		return err
-	}
-
-	validateOnly, err := cmd.Flags().GetBool(dryrunFlagName)
-	if err != nil {
-		return err
-	}
-
-	_, err = cmd.Flags().GetBool(noValidateFlagName)
 	if err != nil {
 		return err
 	}
@@ -157,11 +147,7 @@ func (c *linkCommand) create(cmd *cobra.Command, args []string) error {
 		kafkaREST.Context, lkc, linkName, createLinkOpt)
 
 	if err == nil {
-		msg := errors.CreatedLinkMsg
-		if validateOnly {
-			msg = errors.DryRunPrefix + msg
-		}
-		utils.Printf(cmd, msg, linkName)
+		utils.Printf(cmd, errors.CreatedLinkMsg, linkName)
 		return nil
 	}
 

--- a/internal/pkg/errors/strings.go
+++ b/internal/pkg/errors/strings.go
@@ -57,7 +57,6 @@ const (
 	UpdateTopicConfigMsg = "Updated the following configs for topic \"%s\":\n"
 
 	// kafka link commands
-	DryRunPrefix   = "[DRY RUN] "
 	DeletedLinkMsg = "Deleted cluster link \"%s\".\n"
 	CreatedLinkMsg = "Created cluster link \"%s\".\n"
 	UpdatedLinkMsg = "Updated cluster link \"%s\".\n"


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok

What
----
A breaking change in a minor version of Kafka REST resulted in two broken flags in `confluent kafka link create`: `--dry-run` and `--no-validate`. :confused: Notify users that these flags no longer do anything. The messaging I've chosen here is these flags are "no longer active".