### PR TITLE
Migrate `caasenv` commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -157,7 +157,7 @@ build-integ-race:
 
 # If you setup your laptop following https://github.com/confluentinc/cc-documentation/blob/master/Operations/Laptop%20Setup.md
 # then assuming caas.sh lives here should be fine
-define caasenv-authenticate
+define aws-authenticate
 	source $$GOPATH/src/github.com/confluentinc/cc-dotfiles/caas.sh && eval $(gimme-aws-creds --output-format export --roles "arn:aws:iam::050879227952:role/administrator")
 endef
 

--- a/debian/patches/standard_build_layout.patch
+++ b/debian/patches/standard_build_layout.patch
@@ -1,4 +1,4 @@
---- cli/Makefile	2022-02-08 12:27:57.000000000 -0600
+--- cli/Makefile	2022-02-08 13:25:02.000000000 -0600
 +++ debian/Makefile	2022-01-24 13:34:02.000000000 -0600
 @@ -1,268 +1,130 @@
 -SHELL           := /bin/bash
@@ -173,7 +173,7 @@
 -
 -# If you setup your laptop following https://github.com/confluentinc/cc-documentation/blob/master/Operations/Laptop%20Setup.md
 -# then assuming caas.sh lives here should be fine
--define caasenv-authenticate
+-define aws-authenticate
 -	source $$GOPATH/src/github.com/confluentinc/cc-dotfiles/caas.sh && eval $(gimme-aws-creds --output-format export --roles "arn:aws:iam::050879227952:role/administrator")
 -endef
 -

--- a/mk-files/release-notes.mk
+++ b/mk-files/release-notes.mk
@@ -54,7 +54,7 @@ publish-release-notes-to-docs-repos:
 
 .PHONY: publish-release-notes-to-s3
 publish-release-notes-to-s3:
-	$(caasenv-authenticate); \
+	$(aws-authenticate); \
     aws s3 cp release-notes/latest-release.rst $(S3_BUCKET_PATH)/confluent-cli/release-notes/$(BUMPED_VERSION:v%=%)/release-notes.rst --acl public-read
 
 define print-publish-release-notes-next-steps

--- a/mk-files/release-test.mk
+++ b/mk-files/release-test.mk
@@ -24,7 +24,7 @@ test-installer:
 .PHONY: verify-binaries
 verify-binaries:
 	$(eval TEMP_DIR=$(shell mktemp -d))
-	@$(caasenv-authenticate) && \
+	@$(aws-authenticate) && \
 	for os in linux darwin windows; do \
 		for arch in arm64 amd64; do \
 			if [ "$${os}" != "darwin" ] && [ "$${arch}" = "arm64" ] ; then \

--- a/mk-files/unrelease.mk
+++ b/mk-files/unrelease.mk
@@ -32,14 +32,14 @@ unrelease-warn:
 
 .PHONY: delete-archives-and-binaries
 delete-archives-and-binaries:
-	$(caasenv-authenticate); \
+	$(aws-authenticate); \
 	$(call delete-release-folder,binaries); \
 	$(call delete-release-folder,archives)
 
 .PHONY: delete-release-notes
 delete-release-notes:
 	@echo -n "Do you want to delete the release notes from S3? (y/n): "
-	@read line; if [ $$line = "y" ] || [ $$line = "Y" ]; then $(caasenv-authenticate); $(call delete-release-folder,release-notes); fi
+	@read line; if [ $$line = "y" ] || [ $$line = "Y" ]; then $(aws-authenticate); $(call delete-release-folder,release-notes); fi
 
 define delete-release-folder
 	aws s3 rm $(S3_BUCKET_PATH)/confluent-cli/$1/$(CLEAN_VERSION) --recursive
@@ -48,7 +48,7 @@ endef
 .PHONY: restore-latest-archives
 restore-latest-archives: restore-latest-archives-warn
 	make copy-prod-archives-to-stag-latest
-	$(caasenv-authenticate); \
+	$(aws-authenticate); \
 	$(call copy-stag-content-to-prod,archives,latest)
 	@echo "Verifying latest archives with: make test-installer"
 	make test-installer
@@ -66,5 +66,5 @@ restore-latest-archives-warn:
 
 .PHONY: clean-staging-folder
 clean-staging-folder:
-	$(caasenv-authenticate); \
+	$(aws-authenticate); \
 	aws s3 rm $(S3_STAG_PATH) --recursive


### PR DESCRIPTION
Per https://confluentinc.atlassian.net/wiki/spaces/CIRE/pages/2728820943/Caasenv+equivalents+quick+reference , `caasenv` is being deprecated.  We only used it for getting AWS credentials for prod (e.g., to publish to our prod S3 buckets).  So for our case, it's fine to just use the suggested equivalent to `caasenv prod`.  I've already updated the wiki page for the release process.

Also, I checked with @camillsir , who said it's okay if we have the AWS account number here even if we make the repository source-available.  We'll have to obviously run that by legal as well, but from a technical point of view, this doesn't pose a security issue (e.g., customers have to use this account ID in order to use VPC peering or PrivateLink).