### PR TITLE
[CLI-1591] Support parsing resource IDs from principal in `kafka acl list`

### DIFF
--- a/internal/pkg/acl/acl_test.go
+++ b/internal/pkg/acl/acl_test.go
@@ -110,3 +110,36 @@ func TestValidateCreateDeleteAclRequestData(t *testing.T) {
 		}
 	}
 }
+
+func TestGetPrefixAndResourceIdFromPrincipal_Empty(t *testing.T) {
+	prefix, resourceId, err := getPrefixAndResourceIdFromPrincipal("", nil)
+	require.NoError(t, err)
+	require.Equal(t, "", prefix)
+	require.Equal(t, "", resourceId)
+}
+
+func TestGetPrefixAndResourceIdFromPrincipal_UnrecognizedFormat(t *testing.T) {
+	_, _, err := getPrefixAndResourceIdFromPrincipal("string with no colon", nil)
+	require.Error(t, err)
+}
+
+func TestGetPrefixAndResourceIdFromPrincipal_ResourceId(t *testing.T) {
+	prefix, resourceId, err := getPrefixAndResourceIdFromPrincipal("User:sa-123456", nil)
+	require.NoError(t, err)
+	require.Equal(t, "User", prefix)
+	require.Equal(t, "sa-123456", resourceId)
+}
+
+func TestGetPrefixAndResourceIdFromPrincipal_NumericId(t *testing.T) {
+	prefix, resourceId, err := getPrefixAndResourceIdFromPrincipal("User:123456", map[int32]string{123456: "sa-123456"})
+	require.NoError(t, err)
+	require.Equal(t, "User", prefix)
+	require.Equal(t, "sa-123456", resourceId)
+}
+
+func TestGetPrefixAndResourceIdFromPrincipal_UserIdNotValid(t *testing.T) {
+	for _, principal := range []string{"User:123456", "User:abcdef"} {
+		_, _, err := getPrefixAndResourceIdFromPrincipal(principal, nil)
+		require.Error(t, err)
+	}
+}


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok

What
----
Before, we assumed that principals could only contain numeric IDs. Resource IDs are also valid, as learned from RCCA-5759

References
----------
https://confluentinc.atlassian.net/browse/CLI-1591
https://confluent.slack.com/archives/C032Q3P6DTJ

Test & Review
-------------
100% coverage with unit tests