### PR TITLE
[CLI-1472] Allow colon in role binding resources

### DIFF
--- a/internal/cmd/iam/command_rbac_role_binding.go
+++ b/internal/cmd/iam/command_rbac_role_binding.go
@@ -163,7 +163,7 @@ func (c *roleBindingCommand) parseCommon(cmd *cobra.Command) (*roleBindingOption
 	resourcesRequestV2 := mdsv2alpha1.ResourcesRequest{}
 	if resource != "" {
 		if isCloud && c.ccloudRbacDataplaneEnabled {
-			parsedResourcePattern, err := c.parseAndValidateResourcePatternV2(resource, prefix)
+			parsedResourcePattern, err := parseAndValidateResourcePatternV2(resource, prefix)
 			if err != nil {
 				return nil, err
 			}
@@ -185,7 +185,7 @@ func (c *roleBindingCommand) parseCommon(cmd *cobra.Command) (*roleBindingOption
 				ResourcePatterns: []mdsv2alpha1.ResourcePattern{parsedResourcePattern},
 			}
 		} else if !isCloud {
-			parsedResourcePattern, err := c.parseAndValidateResourcePattern(resource, prefix)
+			parsedResourcePattern, err := parseAndValidateResourcePattern(resource, prefix)
 			if err != nil {
 				return nil, err
 			}
@@ -328,7 +328,7 @@ func (c *roleBindingCommand) parseAndValidateScopeV2(cmd *cobra.Command) (*mdsv2
 	return scopeV2, nil
 }
 
-func (c *roleBindingCommand) parseAndValidateResourcePatternV2(typename string, prefix bool) (mdsv2alpha1.ResourcePattern, error) {
+func parseAndValidateResourcePatternV2(resource string, prefix bool) (mdsv2alpha1.ResourcePattern, error) {
 	var result mdsv2alpha1.ResourcePattern
 	if prefix {
 		result.PatternType = "PREFIXED"
@@ -336,7 +336,7 @@ func (c *roleBindingCommand) parseAndValidateResourcePatternV2(typename string, 
 		result.PatternType = "LITERAL"
 	}
 
-	parts := strings.Split(typename, ":")
+	parts := strings.SplitN(resource, ":", 2)
 	if len(parts) != 2 {
 		return result, errors.NewErrorWithSuggestions(errors.ResourceFormatErrorMsg, errors.ResourceFormatSuggestions)
 	}
@@ -413,7 +413,7 @@ func (c *roleBindingCommand) validateResourceTypeV2(resourceType string) error {
 	return nil
 }
 
-func (c *roleBindingCommand) parseAndValidateResourcePattern(typename string, prefix bool) (mds.ResourcePattern, error) {
+func parseAndValidateResourcePattern(resource string, prefix bool) (mds.ResourcePattern, error) {
 	var result mds.ResourcePattern
 	if prefix {
 		result.PatternType = "PREFIXED"
@@ -421,7 +421,7 @@ func (c *roleBindingCommand) parseAndValidateResourcePattern(typename string, pr
 		result.PatternType = "LITERAL"
 	}
 
-	parts := strings.Split(typename, ":")
+	parts := strings.SplitN(resource, ":", 2)
 	if len(parts) != 2 {
 		return result, errors.NewErrorWithSuggestions(errors.ResourceFormatErrorMsg, errors.ResourceFormatSuggestions)
 	}

--- a/internal/cmd/iam/command_rbac_role_binding_list.go
+++ b/internal/cmd/iam/command_rbac_role_binding_list.go
@@ -252,7 +252,7 @@ func (c *roleBindingCommand) ccloudListRolePrincipals(cmd *cobra.Command, option
 		if err != nil {
 			return err
 		}
-		resource, err := c.parseAndValidateResourcePatternV2(r, false)
+		resource, err := parseAndValidateResourcePatternV2(r, false)
 		if err != nil {
 			return err
 		}
@@ -426,7 +426,7 @@ func (c *roleBindingCommand) confluentListRolePrincipals(cmd *cobra.Command, opt
 			return err
 		}
 
-		resource, err := c.parseAndValidateResourcePattern(r, false)
+		resource, err := parseAndValidateResourcePattern(r, false)
 		if err != nil {
 			return err
 		}

--- a/internal/cmd/iam/command_rbac_role_binding_test.go
+++ b/internal/cmd/iam/command_rbac_role_binding_test.go
@@ -14,6 +14,7 @@ import (
 	mds2mock "github.com/confluentinc/mds-sdk-go/mdsv2alpha1/mock"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	pcmd "github.com/confluentinc/cli/internal/pkg/cmd"
@@ -520,4 +521,34 @@ func (suite *RoleBindingTestSuite) TestRoleBindingsDelete() {
 			assert.Equal(suite.T(), tc.err, err)
 		}
 	}
+}
+
+func TestParseAndValidateResourcePattern_Prefixed(t *testing.T) {
+	pattern, err := parseAndValidateResourcePattern("Topic:test", true)
+	require.NoError(t, err)
+	require.Equal(t, "PREFIXED", pattern.PatternType)
+}
+
+func TestParseAndValidateResourcePattern_Literal(t *testing.T) {
+	pattern, err := parseAndValidateResourcePattern("Topic:a", false)
+	require.NoError(t, err)
+	require.Equal(t, "LITERAL", pattern.PatternType)
+}
+
+func TestParseAndValidateResourcePattern_Topic(t *testing.T) {
+	pattern, err := parseAndValidateResourcePattern("Topic:a", true)
+	require.NoError(t, err)
+	require.Equal(t, "Topic", pattern.ResourceType)
+	require.Equal(t, "a", pattern.Name)
+}
+
+func TestParseAndValidateResourcePattern_TopicWithColon(t *testing.T) {
+	pattern, err := parseAndValidateResourcePattern("Topic:a:b", true)
+	require.NoError(t, err)
+	require.Equal(t, "a:b", pattern.Name)
+}
+
+func TestParseAndValidateResourcePattern_ErrIncorrectResourceFormat(t *testing.T) {
+	_, err := parseAndValidateResourcePattern("string with no colon", true)
+	require.Error(t, err)
 }


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok

What
----
Previously, role binding resources could not contain colons. Changed parsing logic so they can.

References
----------
https://confluentinc.atlassian.net/browse/CLI-1472

Test & Review
-------------
Wrote new unit tests

<!--
Open questions / Follow ups
---------------------------
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->

<!--
Review stakeholders
-------------------
Optional: mention stakeholders or special context that is required to review.
-->
