### PR TITLE
Restrict `--cluster` and `--environment` flags to cloud `kafka link` commands

### DIFF
--- a/internal/cmd/kafka/command_link_create.go
+++ b/internal/cmd/kafka/command_link_create.go
@@ -71,13 +71,14 @@ func (c *linkCommand) newCreateCommand() *cobra.Command {
 	cmd.Flags().Bool(dryrunFlagName, false, "DEPRECATED: Validate a link, but do not create it (this flag is no longer active).")
 	cmd.Flags().Bool(noValidateFlagName, false, "DEPRECATED: Create a link even if the source cluster cannot be reached (this flag is no longer active).")
 
-	if c.cfg.IsOnPremLogin() {
+	if c.cfg.IsCloudLogin() {
+		pcmd.AddClusterFlag(cmd, c.AuthenticatedCLICommand)
+		pcmd.AddEnvironmentFlag(cmd, c.AuthenticatedCLICommand)
+	} else {
 		cmd.Flags().AddFlagSet(pcmd.OnPremKafkaRestSet())
 	}
 
-	pcmd.AddClusterFlag(cmd, c.AuthenticatedCLICommand)
 	pcmd.AddContextFlag(cmd, c.CLICommand)
-	pcmd.AddEnvironmentFlag(cmd, c.AuthenticatedCLICommand)
 
 	if c.cfg.IsCloudLogin() {
 		_ = cmd.MarkFlagRequired(sourceBootstrapServerFlagName)

--- a/internal/cmd/kafka/command_link_delete.go
+++ b/internal/cmd/kafka/command_link_delete.go
@@ -16,13 +16,14 @@ func (c *linkCommand) newDeleteCommand() *cobra.Command {
 		RunE:  c.delete,
 	}
 
-	if c.cfg.IsOnPremLogin() {
+	if c.cfg.IsCloudLogin() {
+		pcmd.AddClusterFlag(cmd, c.AuthenticatedCLICommand)
+		pcmd.AddEnvironmentFlag(cmd, c.AuthenticatedCLICommand)
+	} else {
 		cmd.Flags().AddFlagSet(pcmd.OnPremKafkaRestSet())
 	}
 
-	pcmd.AddClusterFlag(cmd, c.AuthenticatedCLICommand)
 	pcmd.AddContextFlag(cmd, c.CLICommand)
-	pcmd.AddEnvironmentFlag(cmd, c.AuthenticatedCLICommand)
 
 	return cmd
 }

--- a/internal/cmd/kafka/command_link_describe.go
+++ b/internal/cmd/kafka/command_link_describe.go
@@ -30,13 +30,14 @@ func (c *linkCommand) newDescribeCommand() *cobra.Command {
 		RunE:  c.describe,
 	}
 
-	if c.cfg.IsOnPremLogin() {
+	if c.cfg.IsCloudLogin() {
+		pcmd.AddClusterFlag(cmd, c.AuthenticatedCLICommand)
+		pcmd.AddEnvironmentFlag(cmd, c.AuthenticatedCLICommand)
+	} else {
 		cmd.Flags().AddFlagSet(pcmd.OnPremKafkaRestSet())
 	}
 
-	pcmd.AddClusterFlag(cmd, c.AuthenticatedCLICommand)
 	pcmd.AddContextFlag(cmd, c.CLICommand)
-	pcmd.AddEnvironmentFlag(cmd, c.AuthenticatedCLICommand)
 	pcmd.AddOutputFlag(cmd)
 
 	return cmd

--- a/internal/cmd/kafka/command_link_list.go
+++ b/internal/cmd/kafka/command_link_list.go
@@ -44,13 +44,14 @@ func (c *linkCommand) newListCommand() *cobra.Command {
 
 	cmd.Flags().Bool(includeTopicsFlagName, false, "If set, will list mirrored topics for the links returned.")
 
-	if c.cfg.IsOnPremLogin() {
+	if c.cfg.IsCloudLogin() {
+		pcmd.AddClusterFlag(cmd, c.AuthenticatedCLICommand)
+		pcmd.AddEnvironmentFlag(cmd, c.AuthenticatedCLICommand)
+	} else {
 		cmd.Flags().AddFlagSet(pcmd.OnPremKafkaRestSet())
 	}
 
-	pcmd.AddClusterFlag(cmd, c.AuthenticatedCLICommand)
 	pcmd.AddContextFlag(cmd, c.CLICommand)
-	pcmd.AddEnvironmentFlag(cmd, c.AuthenticatedCLICommand)
 	pcmd.AddOutputFlag(cmd)
 
 	return cmd

--- a/internal/cmd/kafka/command_link_update.go
+++ b/internal/cmd/kafka/command_link_update.go
@@ -28,13 +28,14 @@ func (c *linkCommand) newUpdateCommand() *cobra.Command {
 	cmd.Flags().String(configFileFlagName, "", "Name of the file containing link config overrides. "+
 		"Each property key-value pair should have the format of key=value. Properties are separated by new-line characters.")
 
-	if c.cfg.IsOnPremLogin() {
+	if c.cfg.IsCloudLogin() {
+		pcmd.AddClusterFlag(cmd, c.AuthenticatedCLICommand)
+		pcmd.AddEnvironmentFlag(cmd, c.AuthenticatedCLICommand)
+	} else {
 		cmd.Flags().AddFlagSet(pcmd.OnPremKafkaRestSet())
 	}
 
-	pcmd.AddClusterFlag(cmd, c.AuthenticatedCLICommand)
 	pcmd.AddContextFlag(cmd, c.CLICommand)
-	pcmd.AddEnvironmentFlag(cmd, c.AuthenticatedCLICommand)
 
 	_ = cmd.MarkFlagRequired(configFileFlagName)
 


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok

What
----
As pointed out by @mtodzo in https://github.com/confluentinc/docs-confluent-cli/pull/254#discussion_r807600435, The `--cluster` and `--environment` flags were mistakenly added to the on-prem `confluent kafka link` commands.