### PR TITLE
eval gimme-aws-creds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -158,7 +158,7 @@ build-integ-race:
 # If you setup your laptop following https://github.com/confluentinc/cc-documentation/blob/master/Operations/Laptop%20Setup.md
 # then assuming caas.sh lives here should be fine
 define aws-authenticate
-	source ~/git/go/src/github.com/confluentinc/cc-dotfiles/caas.sh && if ! aws sts get-caller-identity; then gimme-aws-creds --output-format export --roles "arn:aws:iam::050879227952:role/administrator"; fi
+	source ~/git/go/src/github.com/confluentinc/cc-dotfiles/caas.sh && if ! aws sts get-caller-identity; then eval $$(gimme-aws-creds --output-format export --roles "arn:aws:iam::050879227952:role/administrator"); fi
 endef
 
 .PHONY: fmt

--- a/debian/patches/standard_build_layout.patch
+++ b/debian/patches/standard_build_layout.patch
@@ -1,4 +1,4 @@
---- cli/Makefile	2022-03-04 17:49:26.000000000 -0800
+--- cli/Makefile	2022-03-07 18:20:50.000000000 -0800
 +++ debian/Makefile	2022-01-11 19:05:28.000000000 -0800
 @@ -1,268 +1,130 @@
 -SHELL           := /bin/bash
@@ -174,7 +174,7 @@
 -# If you setup your laptop following https://github.com/confluentinc/cc-documentation/blob/master/Operations/Laptop%20Setup.md
 -# then assuming caas.sh lives here should be fine
 -define aws-authenticate
--	source ~/git/go/src/github.com/confluentinc/cc-dotfiles/caas.sh && if ! aws sts get-caller-identity; then gimme-aws-creds --output-format export --roles "arn:aws:iam::050879227952:role/administrator"; fi
+-	source ~/git/go/src/github.com/confluentinc/cc-dotfiles/caas.sh && if ! aws sts get-caller-identity; then eval $$(gimme-aws-creds --output-format export --roles "arn:aws:iam::050879227952:role/administrator"); fi
 -endef
 -
 -.PHONY: fmt


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok

What
----
In #1204, I incorrectly assumed we don't need to `eval` the `gimme-aws-creds` command. The command returns a list of `export` calls, so it needs to be evaluated.