### PR TITLE
RCCA-6035

### DIFF
--- a/internal/cmd/kafka/command_topic.go
+++ b/internal/cmd/kafka/command_topic.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
-	"strings"
 	"time"
 
 	ckafka "github.com/confluentinc/confluent-kafka-go/kafka"
@@ -226,10 +225,13 @@ func storeSchemaReferences(refs []srsdk.SchemaReference, srClient *srsdk.APIClie
 
 	referencePathMap := map[string]string{}
 	for _, ref := range refs {
-		name := strings.ReplaceAll(ref.Name, "/", ":")
-		tempStorePath := filepath.Join(dir, name)
+		tempStorePath := filepath.Join(dir, ref.Name)
 		if !fileExists(tempStorePath) {
 			schema, _, err := srClient.DefaultApi.GetSchemaByVersion(ctx, ref.Subject, strconv.Itoa(int(ref.Version)), &srsdk.GetSchemaByVersionOpts{})
+			if err != nil {
+				return nil, err
+			}
+			err = os.MkdirAll(filepath.Dir(tempStorePath), 0755)
 			if err != nil {
 				return nil, err
 			}

--- a/internal/pkg/serdes/protoserdes.go
+++ b/internal/pkg/serdes/protoserdes.go
@@ -2,6 +2,7 @@ package serdes
 
 import (
 	"path/filepath"
+	"strings"
 
 	"github.com/golang/protobuf/jsonpb" //nolint:staticcheck // deprecated module cannot be removed due to https://github.com/jhump/protoreflect/issues/301
 	"github.com/golang/protobuf/proto"  //nolint:staticcheck // deprecated module cannot be removed due to https://github.com/jhump/protoreflect/issues/301
@@ -88,12 +89,12 @@ func (protoProvider *ProtoDeserializationProvider) decode(data []byte) (string, 
 func parseMessage(schemaPath string, referencePathMap map[string]string) (proto.Message, error) {
 	importPaths := []string{filepath.Dir(schemaPath)}
 	for _, path := range referencePathMap {
-		importPaths = append(importPaths, filepath.Dir(path))
+		importPaths = append(importPaths, strings.SplitAfter(path, "ccloud-schema")[0])
 	}
 	parser := parse.Parser{ImportPaths: importPaths}
 	fileDescriptors, err := parser.ParseFiles(filepath.Base(schemaPath))
 	if err != nil {
-		return nil, errors.New(errors.ProtoSchemaInvalidErrorMsg)
+		return nil, errors.Wrap(err, errors.ProtoSchemaInvalidErrorMsg)
 	}
 	if len(fileDescriptors) == 0 {
 		return nil, errors.New(errors.ProtoSchemaInvalidErrorMsg)


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok
   * no: DO NOT MERGE until the required functionalites are live in prod  

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->

The issue in this RCCA was `name` fields in schema references containing `/`. This resulted in the ioutil.WriteFile failing since the subdirectories it was trying to create the file in didn't exist. i.e if name was `type/address.proto` it would try to create file ../tmp/blah/ccloud-schema/type/address.proto but fail since /type dir didn't exist. So now we first mkdir all dirs and then create the file.

This led to another point of failure where trying to read the file tmp ref file with parser.ParseFiles. We have to initiate the parser with some importPaths that it can look for imported proto files in -- so this has to be the path minus anything that's part of the schema ref name. Previously we were just calling filepath.Dir() which removes the last part of the path, but this doesn't remove enough for the case of names with backslashes, so now we trim all the way to ccloud-schema in the path which is right before the name part of the path starts.

References
----------
<!--
Copy & paste links to Jira tickets, other PRs, issues, Slack conversations, etc.
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->
https://confluentinc.atlassian.net/browse/RCCA-6035
Test & Review
-------------
<!--
Has it been tested? how?
Copy & paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->
Tested manually with a ref file with a backslash in the name

<!--
Open questions / Follow ups
---------------------------
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->
 This fix only applies to protobuf files .. not sure if similar actions are needed for json/avro
<!--
Review stakeholders
-------------------
Optional: mention stakeholders or special context that is required to review.
-->
