### PR TITLE
[CLI-1659] Display org name and ID on login

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -625,12 +625,8 @@ github.com/confluentinc/cc-structs/scheduler_plugins/kafka v0.445.0/go.mod h1:jB
 github.com/confluentinc/cc-utils v0.225.0/go.mod h1:uI+SKDqDL/l1j7VIaXpXxGPBrbbYlyG7n/j8ra1MNcc=
 github.com/confluentinc/cc-utils v0.240.0/go.mod h1:l5vuobVLiwFY9S+M7aLwHzFBc354HevGtbFQkBtqG4c=
 github.com/confluentinc/cc-utils/idgen v0.203.0/go.mod h1:vKsrR9u7tqRE/9MP1sQn0bqNrDQSVbNe0qbqSU/xWYc=
-github.com/confluentinc/ccloud-sdk-go-v1 v0.0.97 h1:YqrA7D65itna0z3XVgkkDYU5XvJJzmODTHXFTJmDAX4=
-github.com/confluentinc/ccloud-sdk-go-v1 v0.0.97/go.mod h1:5pA883HWkymMrWwlCvgr2Tn49qN36jdjOWo+QCBhrDE=
 github.com/confluentinc/ccloud-sdk-go-v1 v0.0.100 h1:K3PA/9K3ufk0CttIys6my1Pnkf0edeXR3ecv3H5lMrI=
 github.com/confluentinc/ccloud-sdk-go-v1 v0.0.100/go.mod h1:5pA883HWkymMrWwlCvgr2Tn49qN36jdjOWo+QCBhrDE=
-github.com/confluentinc/ccloud-sdk-go-v1 v0.0.102 h1:iRJggeCkABaB8ypYoOolkHhcGWsOjxn5gwqht6UPids=
-github.com/confluentinc/ccloud-sdk-go-v1 v0.0.102/go.mod h1:5pA883HWkymMrWwlCvgr2Tn49qN36jdjOWo+QCBhrDE=
 github.com/confluentinc/ccloud-sdk-go-v2-internal/networking v0.0.5/go.mod h1:b0fKj4FlWseVcd8CsjXUdvvDtAGHu8nDUJjPykqWInQ=
 github.com/confluentinc/ccloud-sdk-go-v2/service-quota v0.1.0 h1:4Fh6u+0LqvlU/poWV44SIVDfnizSekH3sAYOHZbAabA=
 github.com/confluentinc/ccloud-sdk-go-v2/service-quota v0.1.0/go.mod h1:zZWZoGWJuO0Qm4lO6H2KlXMx4OoB/yhD8y6J1ZB/97Q=

--- a/internal/cmd/cloud-signup/command.go
+++ b/internal/cmd/cloud-signup/command.go
@@ -163,13 +163,15 @@ func (c *command) signup(cmd *cobra.Command, prompt form.Prompt, client *ccloud.
 		}
 
 		utils.Println(cmd, "Success! Welcome to Confluent Cloud.")
+
 		authorizedClient := c.clientFactory.JwtHTTPClientFactory(context.Background(), token, client.BaseURL)
 		_, currentOrg, err := pauth.PersistCCloudLoginToConfig(c.Config.Config, fEmailName.Responses["email"].(string), client.BaseURL, token, authorizedClient)
 		if err != nil {
 			utils.Println(cmd, "Failed to persist login to local config. Run `confluent login` to log in using the new credentials.")
 			return nil
 		}
-		log.CliLogger.Debugf(errors.LoggedInAsMsgWithOrg, fEmailName.Responses["email"].(string), currentOrg.ResourceId, currentOrg.Name)
+
+		utils.Printf(cmd, errors.LoggedInAsMsgWithOrg, fEmailName.Responses["email"].(string), currentOrg.ResourceId, currentOrg.Name)
 		return nil
 	}
 }

--- a/internal/cmd/login/command.go
+++ b/internal/cmd/login/command.go
@@ -120,19 +120,14 @@ func (c *Command) loginCCloud(cmd *cobra.Command, url string) error {
 		return err
 	}
 
+	utils.Printf(cmd, errors.LoggedInAsMsgWithOrg, credentials.Username, currentOrg.ResourceId, currentOrg.Name)
+	log.CliLogger.Debugf(errors.LoggedInUsingEnvMsg, currentEnv.Id, currentEnv.Name)
+
 	// If refresh token is available, we want to save that in the place of password
 	if refreshToken != "" {
 		credentials.Password = refreshToken
 	}
-
-	if err := c.saveLoginToNetrc(cmd, true, credentials); err != nil {
-		return err
-	}
-
-	log.CliLogger.Debugf(errors.LoggedInAsMsgWithOrg, credentials.Username, currentOrg.ResourceId, currentOrg.Name)
-	log.CliLogger.Debugf(errors.LoggedInUsingEnvMsg, currentEnv.Id, currentEnv.Name)
-
-	return err
+	return c.saveLoginToNetrc(cmd, true, credentials)
 }
 
 // Order of precedence: env vars > netrc > prompt

--- a/internal/pkg/cmd/prerunner.go
+++ b/internal/pkg/cmd/prerunner.go
@@ -306,18 +306,22 @@ func (r *PreRun) ccloudAutoLogin(cmd *cobra.Command, netrcMachineName string) er
 	if err != nil {
 		return err
 	}
+
 	if token == "" || credentials == nil {
 		log.CliLogger.Debug("Non-interactive login failed: no credentials")
 		return nil
 	}
+
 	client := r.CCloudClientFactory.JwtHTTPClientFactory(context.Background(), token, pauth.CCloudURL)
 	currentEnv, currentOrg, err := pauth.PersistCCloudLoginToConfig(r.Config, credentials.Username, pauth.CCloudURL, token, client)
 	if err != nil {
 		return err
 	}
+
 	log.CliLogger.Debug(errors.AutoLoginMsg)
 	log.CliLogger.Debugf(errors.LoggedInAsMsgWithOrg, credentials.Username, currentOrg.ResourceId, currentOrg.Name)
 	log.CliLogger.Debugf(errors.LoggedInUsingEnvMsg, currentEnv.Id, currentEnv.Name)
+
 	return nil
 }
 

--- a/test/fixtures/output/cloud-signup/reprompt-on-no-success.golden
+++ b/test/fixtures/output/cloud-signup/reprompt-on-no-success.golden
@@ -4,3 +4,4 @@ I have read and agree to the Terms of Service (https://www.confluent.io/confluen
 By entering "y" to submit this form, you agree that your personal data will be processed in accordance with our Privacy Policy (https://www.confluent.io/confluent-privacy-statement/) (y/n): A verification email has been sent to test-signup@confluent.io.
 Type "y" once verified, or type "n" to resend. (y/n): A new verification email has been sent to test-signup@confluent.io. If this email is not received, please contact support@confluent.io.
 Type "y" once verified, or type "n" to resend. (y/n): Success! Welcome to Confluent Cloud.
+Logged in as "test-signup@confluent.io" for organization "abc-123" ("Confluent").

--- a/test/fixtures/output/cloud-signup/success.golden
+++ b/test/fixtures/output/cloud-signup/success.golden
@@ -1,3 +1,4 @@
 Sign up for Confluent Cloud. Use Ctrl+C to quit at any time.
 Email: First Name: Last Name: Two-letter country code (https://github.com/confluentinc/countrycode/blob/master/codes.go): You entered US for United States of America / USA. Is that correct? (y/n): Organization: Password (must contain at least 8 characters, including 1 lowercase character, 1 uppercase character, and 1 number): I have read and agree to the Terms of Service (https://www.confluent.io/confluent-cloud-tos/) (y/n): By entering "y" to submit this form, you agree that your personal data will be processed in accordance with our Privacy Policy (https://www.confluent.io/confluent-privacy-statement/) (y/n): A verification email has been sent to test-signup@confluent.io.
 Type "y" once verified, or type "n" to resend. (y/n): Success! Welcome to Confluent Cloud.
+Logged in as "test-signup@confluent.io" for organization "abc-123" ("Confluent").


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok

What
----
Show the org name and ID after `confluent login` and `confluent cloud-signup`. Still logging the message for auto-logins so we don't overwhelm the user with auto-login messages.

For `confluent login`, printing the message before saving to `.netrc`, since the user gets logged in even if we can't save their credentials to their `.netrc`.

```
% confluent login
Logged in as "bstrauch@confluent.io" for organization "a372b35d-47a7-4f1d-a857-0782be2cff4c" ("Confluent").
```

References
----------
https://confluentinc.atlassian.net/browse/CLI-1659

Test & Review
-------------
* Manually tested for `confluent login`, since we don't have any positive integration tests (and we really should).
* Updated integration tests for `confluent signup`.