### PR TITLE
Refresh SSO tokens on auto-login and without `--save` flag

### DIFF
--- a/internal/cmd/command.go
+++ b/internal/cmd/command.go
@@ -103,7 +103,7 @@ func NewConfluentCommand(cfg *v1.Config, isTest bool, ver *pversion.Version) *co
 	cmd.AddCommand(kafka.New(cfg, prerunner, ver.ClientID))
 	cmd.AddCommand(ksql.New(cfg, prerunner))
 	cmd.AddCommand(local.New(prerunner))
-	cmd.AddCommand(login.New(prerunner, ccloudClientFactory, mdsClientManager, netrcHandler, loginCredentialsManager, authTokenHandler, isTest).Command)
+	cmd.AddCommand(login.New(cfg, prerunner, ccloudClientFactory, mdsClientManager, netrcHandler, loginCredentialsManager, authTokenHandler, isTest).Command)
 	cmd.AddCommand(logout.New(cfg, prerunner, netrcHandler).Command)
 	cmd.AddCommand(price.New(prerunner))
 	cmd.AddCommand(prompt.New(cfg))

--- a/internal/cmd/login/command.go
+++ b/internal/cmd/login/command.go
@@ -22,6 +22,7 @@ import (
 
 type Command struct {
 	*pcmd.CLICommand
+	cfg                      *v1.Config
 	ccloudClientFactory      pauth.CCloudClientFactory
 	mdsClientManager         pauth.MDSClientManager
 	netrcHandler             netrc.NetrcHandler
@@ -31,7 +32,7 @@ type Command struct {
 	isTest                   bool
 }
 
-func New(prerunner pcmd.PreRunner, ccloudClientFactory pauth.CCloudClientFactory, mdsClientManager pauth.MDSClientManager, netrcHandler netrc.NetrcHandler, loginCredentialsManager pauth.LoginCredentialsManager, authTokenHandler pauth.AuthTokenHandler, isTest bool) *Command {
+func New(cfg *v1.Config, prerunner pcmd.PreRunner, ccloudClientFactory pauth.CCloudClientFactory, mdsClientManager pauth.MDSClientManager, netrcHandler netrc.NetrcHandler, loginCredentialsManager pauth.LoginCredentialsManager, authTokenHandler pauth.AuthTokenHandler, isTest bool) *Command {
 	cmd := &cobra.Command{
 		Use:   "login",
 		Short: "Log in to Confluent Cloud or Confluent Platform.",
@@ -52,6 +53,7 @@ func New(prerunner pcmd.PreRunner, ccloudClientFactory pauth.CCloudClientFactory
 
 	c := &Command{
 		CLICommand:               pcmd.NewAnonymousCLICommand(cmd, prerunner),
+		cfg:                      cfg,
 		mdsClientManager:         mdsClientManager,
 		ccloudClientFactory:      ccloudClientFactory,
 		netrcHandler:             netrcHandler,
@@ -140,16 +142,17 @@ func (c *Command) getCCloudCredentials(cmd *cobra.Command, url, orgResourceId st
 	if err != nil {
 		return nil, err
 	}
-
 	if promptOnly {
 		return pauth.GetLoginCredentials(c.loginCredentialsManager.GetCloudCredentialsFromPrompt(cmd, orgResourceId))
 	}
+
 	netrcFilterParams := netrc.NetrcMachineParams{
 		IsCloud: true,
 		URL:     url,
 	}
 	return pauth.GetLoginCredentials(
-		c.loginCredentialsManager.GetCloudCredentialsFromEnvVar(cmd, orgResourceId),
+		c.loginCredentialsManager.GetCloudCredentialsFromEnvVar(orgResourceId),
+		c.loginCredentialsManager.GetCredentialsFromConfig(c.cfg),
 		c.loginCredentialsManager.GetCredentialsFromNetrc(cmd, netrcFilterParams),
 		c.loginCredentialsManager.GetCloudCredentialsFromPrompt(cmd, orgResourceId),
 	)
@@ -240,7 +243,7 @@ func (c *Command) getConfluentCredentials(cmd *cobra.Command, url string) (*paut
 	}
 
 	return pauth.GetLoginCredentials(
-		c.loginCredentialsManager.GetOnPremCredentialsFromEnvVar(cmd),
+		c.loginCredentialsManager.GetOnPremCredentialsFromEnvVar(),
 		c.loginCredentialsManager.GetCredentialsFromNetrc(cmd, netrcFilterParams),
 		c.loginCredentialsManager.GetOnPremCredentialsFromPrompt(cmd),
 	)

--- a/internal/cmd/logout/command_test.go
+++ b/internal/cmd/logout/command_test.go
@@ -36,7 +36,7 @@ const (
 
 var (
 	mockLoginCredentialsManager = &cliMock.MockLoginCredentialsManager{
-		GetCloudCredentialsFromEnvVarFunc: func(_ *cobra.Command, orgResourceId string) func() (*pauth.Credentials, error) {
+		GetCloudCredentialsFromEnvVarFunc: func(orgResourceId string) func() (*pauth.Credentials, error) {
 			return func() (*pauth.Credentials, error) {
 				return nil, nil
 			}
@@ -49,7 +49,7 @@ var (
 				}, nil
 			}
 		},
-		GetOnPremCredentialsFromEnvVarFunc: func(_ *cobra.Command) func() (*pauth.Credentials, error) {
+		GetOnPremCredentialsFromEnvVarFunc: func() func() (*pauth.Credentials, error) {
 			return func() (*pauth.Credentials, error) {
 				return nil, nil
 			}
@@ -62,13 +62,17 @@ var (
 				}, nil
 			}
 		},
+		GetCredentialsFromConfigFunc: func(_ *v1.Config) func() (*pauth.Credentials, error) {
+			return func() (*pauth.Credentials, error) {
+				return nil, nil
+			}
+		},
 		GetCredentialsFromNetrcFunc: func(_ *cobra.Command, _ netrc.NetrcMachineParams) func() (*pauth.Credentials, error) {
 			return func() (*pauth.Credentials, error) {
 				return nil, nil
 			}
 		},
-		SetCloudClientFunc: func(arg0 *ccloud.Client) {
-		},
+		SetCloudClientFunc: func(_ *ccloud.Client) {},
 	}
 	orgManagerImpl               = pauth.NewLoginOrganizationManagerImpl()
 	mockLoginOrganizationManager = &cliMock.MockLoginOrganizationManager{
@@ -187,7 +191,7 @@ func newLoginCmd(auth *sdkMock.Auth, user *sdkMock.User, isCloud bool, req *requ
 		},
 	}
 	prerunner := cliMock.NewPreRunnerMock(ccloudClientFactory.AnonHTTPClientFactory(ccloudURL), nil, mdsClient, nil, cfg)
-	loginCmd := login.New(prerunner, ccloudClientFactory, mdsClientManager, netrcHandler, loginCredentialsManager, authTokenHandler, true)
+	loginCmd := login.New(cfg, prerunner, ccloudClientFactory, mdsClientManager, netrcHandler, loginCredentialsManager, authTokenHandler, true)
 	return loginCmd, cfg
 }
 

--- a/internal/pkg/auth/login_credentials_manager.go
+++ b/internal/pkg/auth/login_credentials_manager.go
@@ -6,13 +6,13 @@ import (
 	"fmt"
 	"os"
 
-	flowv1 "github.com/confluentinc/cc-structs/kafka/flow/v1"
-
 	"github.com/spf13/cobra"
 
+	flowv1 "github.com/confluentinc/cc-structs/kafka/flow/v1"
 	"github.com/confluentinc/ccloud-sdk-go-v1"
 
 	"github.com/confluentinc/cli/internal/pkg/auth/sso"
+	v1 "github.com/confluentinc/cli/internal/pkg/config/v1"
 	"github.com/confluentinc/cli/internal/pkg/errors"
 	"github.com/confluentinc/cli/internal/pkg/form"
 	"github.com/confluentinc/cli/internal/pkg/log"
@@ -25,9 +25,16 @@ type Credentials struct {
 	Password string
 	IsSSO    bool
 
+	AuthToken        string
+	AuthRefreshToken string
+
 	// Only for Confluent Prerun login
 	PrerunLoginURL        string
 	PrerunLoginCaCertPath string
+}
+
+func (c *Credentials) IsFullSet() bool {
+	return c.Username != "" && (c.IsSSO || c.Password != "" || c.AuthRefreshToken != "")
 }
 
 type environmentVariables struct {
@@ -44,7 +51,7 @@ func GetLoginCredentials(credentialsFuncs ...func() (*Credentials, error)) (*Cre
 	var err error
 	for _, credentialsFunc := range credentialsFuncs {
 		credentials, err = credentialsFunc()
-		if err == nil && credentials != nil && credentials.Username != "" {
+		if err == nil && credentials != nil && credentials.IsFullSet() {
 			return credentials, nil
 		}
 	}
@@ -55,14 +62,15 @@ func GetLoginCredentials(credentialsFuncs ...func() (*Credentials, error)) (*Cre
 }
 
 type LoginCredentialsManager interface {
-	GetCloudCredentialsFromEnvVar(cmd *cobra.Command, orgResourceId string) func() (*Credentials, error)
-	GetCloudCredentialsFromPrompt(cmd *cobra.Command, orgResourceId string) func() (*Credentials, error)
-	GetOnPremCredentialsFromEnvVar(cmd *cobra.Command) func() (*Credentials, error)
-	GetOnPremCredentialsFromPrompt(cmd *cobra.Command) func() (*Credentials, error)
+	GetCloudCredentialsFromEnvVar(orgResourceId string) func() (*Credentials, error)
+	GetOnPremCredentialsFromEnvVar() func() (*Credentials, error)
+	GetCredentialsFromConfig(cfg *v1.Config) func() (*Credentials, error)
 	GetCredentialsFromNetrc(cmd *cobra.Command, filterParams netrc.NetrcMachineParams) func() (*Credentials, error)
+	GetCloudCredentialsFromPrompt(cmd *cobra.Command, orgResourceId string) func() (*Credentials, error)
+	GetOnPremCredentialsFromPrompt(cmd *cobra.Command) func() (*Credentials, error)
 
 	// Only for Confluent Prerun login
-	GetOnPremPrerunCredentialsFromEnvVar(*cobra.Command) func() (*Credentials, error)
+	GetOnPremPrerunCredentialsFromEnvVar() func() (*Credentials, error)
 	GetOnPremPrerunCredentialsFromNetrc(*cobra.Command, netrc.NetrcMachineParams) func() (*Credentials, error)
 
 	// Needed SSO login for non-prod accounts
@@ -83,26 +91,26 @@ func NewLoginCredentialsManager(netrcHandler netrc.NetrcHandler, prompt form.Pro
 	}
 }
 
-func (h *LoginCredentialsManagerImpl) GetCloudCredentialsFromEnvVar(cmd *cobra.Command, orgResourceId string) func() (*Credentials, error) {
+func (h *LoginCredentialsManagerImpl) GetCloudCredentialsFromEnvVar(orgResourceId string) func() (*Credentials, error) {
 	envVars := environmentVariables{
 		username:           ConfluentCloudEmail,
 		password:           ConfluentCloudPassword,
 		deprecatedUsername: DeprecatedConfluentCloudEmail,
 		deprecatedPassword: DeprecatedConfluentCloudPassword,
 	}
-	return h.getCredentialsFromEnvVarFunc(cmd, envVars, orgResourceId)
+	return h.getCredentialsFromEnvVarFunc(envVars, orgResourceId)
 }
 
-func (h *LoginCredentialsManagerImpl) getCredentialsFromEnvVarFunc(cmd *cobra.Command, envVars environmentVariables, orgResourceId string) func() (*Credentials, error) {
+func (h *LoginCredentialsManagerImpl) getCredentialsFromEnvVarFunc(envVars environmentVariables, orgResourceId string) func() (*Credentials, error) {
 	return func() (*Credentials, error) {
-		email, password := h.getEnvVarCredentials(cmd, envVars.username, envVars.password)
+		email, password := h.getEnvVarCredentials(envVars.username, envVars.password)
 		if h.isSSOUser(email, orgResourceId) {
 			log.CliLogger.Debugf("%s=%s belongs to an SSO user.", ConfluentCloudEmail, email)
 			return &Credentials{Username: email, IsSSO: true}, nil
 		}
 
 		if email == "" {
-			email, password = h.getEnvVarCredentials(cmd, envVars.deprecatedUsername, envVars.deprecatedPassword)
+			email, password = h.getEnvVarCredentials(envVars.deprecatedUsername, envVars.deprecatedPassword)
 			if email != "" {
 				_, _ = fmt.Fprintf(os.Stderr, errors.DeprecatedEnvVarWarningMsg, envVars.deprecatedUsername, envVars.username)
 			}
@@ -120,7 +128,7 @@ func (h *LoginCredentialsManagerImpl) getCredentialsFromEnvVarFunc(cmd *cobra.Co
 	}
 }
 
-func (h *LoginCredentialsManagerImpl) getEnvVarCredentials(cmd *cobra.Command, userEnvVar string, passwordEnvVar string) (string, string) {
+func (h *LoginCredentialsManagerImpl) getEnvVarCredentials(userEnvVar string, passwordEnvVar string) (string, string) {
 	username := os.Getenv(userEnvVar)
 	if len(username) == 0 {
 		return "", ""
@@ -133,14 +141,31 @@ func (h *LoginCredentialsManagerImpl) getEnvVarCredentials(cmd *cobra.Command, u
 	return username, password
 }
 
-func (h *LoginCredentialsManagerImpl) GetOnPremCredentialsFromEnvVar(cmd *cobra.Command) func() (*Credentials, error) {
+func (h *LoginCredentialsManagerImpl) GetOnPremCredentialsFromEnvVar() func() (*Credentials, error) {
 	envVars := environmentVariables{
 		username:           ConfluentPlatformUsername,
 		password:           ConfluentPlatformPassword,
 		deprecatedUsername: DeprecatedConfluentPlatformUsername,
 		deprecatedPassword: DeprecatedConfluentPlatformPassword,
 	}
-	return h.getCredentialsFromEnvVarFunc(cmd, envVars, "")
+	return h.getCredentialsFromEnvVarFunc(envVars, "")
+}
+
+func (h *LoginCredentialsManagerImpl) GetCredentialsFromConfig(cfg *v1.Config) func() (*Credentials, error) {
+	return func() (*Credentials, error) {
+		ctx := cfg.Context()
+		if ctx == nil {
+			return nil, nil
+		}
+
+		credentials := &Credentials{
+			Username:         ctx.GetEmail(),
+			AuthToken:        ctx.GetAuthToken(),
+			AuthRefreshToken: ctx.GetAuthRefreshToken(),
+		}
+
+		return credentials, nil
+	}
 }
 
 func (h *LoginCredentialsManagerImpl) GetCredentialsFromNetrc(cmd *cobra.Command, filterParams netrc.NetrcMachineParams) func() (*Credentials, error) {
@@ -153,7 +178,13 @@ func (h *LoginCredentialsManagerImpl) GetCredentialsFromNetrc(cmd *cobra.Command
 		if log.CliLogger.GetLevel() >= log.WARN {
 			utils.ErrPrintf(cmd, errors.FoundNetrcCredMsg, netrcMachine.User, h.netrcHandler.GetFileName())
 		}
-		return &Credentials{Username: netrcMachine.User, Password: netrcMachine.Password, IsSSO: netrcMachine.IsSSO}, nil
+
+		// TODO: Deprecate the use of SSO tokens in the netrc. They should be tracked in the user's config file instead.
+		if netrcMachine.IsSSO {
+			return &Credentials{Username: netrcMachine.User, AuthRefreshToken: netrcMachine.Password, IsSSO: true}, nil
+		}
+
+		return &Credentials{Username: netrcMachine.User, Password: netrcMachine.Password}, nil
 	}
 }
 
@@ -230,7 +261,7 @@ func (h *LoginCredentialsManagerImpl) isSSOUser(email, orgId string) bool {
 // Prerun login for Confluent has two extra environment variables settings: CONFLUENT_MDS_URL (required), CONFLUNET_CA_CERT_PATH (optional)
 // Those two variables are passed as flags for login command, but for prerun logins they are required as environment variables.
 // URL and ca-cert-path (if exists) are returned in addition to username and password
-func (h *LoginCredentialsManagerImpl) GetOnPremPrerunCredentialsFromEnvVar(cmd *cobra.Command) func() (*Credentials, error) {
+func (h *LoginCredentialsManagerImpl) GetOnPremPrerunCredentialsFromEnvVar() func() (*Credentials, error) {
 	return func() (*Credentials, error) {
 		url := GetEnvWithFallback(ConfluentPlatformMDSURL, DeprecatedConfluentPlatformMDSURL)
 		if url == "" {
@@ -244,7 +275,7 @@ func (h *LoginCredentialsManagerImpl) GetOnPremPrerunCredentialsFromEnvVar(cmd *
 			deprecatedPassword: DeprecatedConfluentPlatformPassword,
 		}
 
-		creds, _ := h.getCredentialsFromEnvVarFunc(cmd, envVars, "")()
+		creds, _ := h.getCredentialsFromEnvVarFunc(envVars, "")()
 		if creds == nil {
 			return nil, errors.New(errors.NoCredentialsFoundErrorMsg)
 		}

--- a/internal/pkg/auth/login_credentials_manager_test.go
+++ b/internal/pkg/auth/login_credentials_manager_test.go
@@ -59,9 +59,9 @@ var (
 		IsSSO:    false,
 	}
 	ssoCredentials = &Credentials{
-		Username: ssoUsername,
-		Password: refreshToken,
-		IsSSO:    true,
+		Username:         ssoUsername,
+		AuthRefreshToken: refreshToken,
+		IsSSO:            true,
 	}
 	promptCredentials = &Credentials{
 		Username: promptUsername,
@@ -186,17 +186,17 @@ func (suite *LoginCredentialsManagerTestSuite) SetupTest() {
 func (suite *LoginCredentialsManagerTestSuite) TestGetCCloudCredentialsFromEnvVar() {
 	// incomplete credentials, setting on username but not password
 	suite.require.NoError(os.Setenv(ConfluentCloudEmail, envUsername))
-	creds, err := suite.loginCredentialsManager.GetCloudCredentialsFromEnvVar(&cobra.Command{}, "")()
+	creds, err := suite.loginCredentialsManager.GetCloudCredentialsFromEnvVar("")()
 	suite.require.NoError(err)
 	suite.require.Nil(creds)
 
 	suite.require.NoError(os.Setenv(ConfluentCloudEmail, "test+sso@confluent.io"))
-	creds, err = suite.loginCredentialsManager.GetCloudCredentialsFromEnvVar(&cobra.Command{}, "")()
+	creds, err = suite.loginCredentialsManager.GetCloudCredentialsFromEnvVar("")()
 	suite.require.NoError(err)
 	suite.compareCredentials(&Credentials{Username: "test+sso@confluent.io", IsSSO: true, Password: ""}, creds)
 
 	suite.setCCEnvVars()
-	creds, err = suite.loginCredentialsManager.GetCloudCredentialsFromEnvVar(&cobra.Command{}, "")()
+	creds, err = suite.loginCredentialsManager.GetCloudCredentialsFromEnvVar("")()
 	suite.require.NoError(err)
 	suite.compareCredentials(envCredentials, creds)
 }
@@ -204,12 +204,12 @@ func (suite *LoginCredentialsManagerTestSuite) TestGetCCloudCredentialsFromEnvVa
 func (suite *LoginCredentialsManagerTestSuite) TestGetCCloudCredentialsFromDeprecatedEnvVar() {
 	// incomplete credentials, setting on username but not password
 	suite.require.NoError(os.Setenv(DeprecatedConfluentCloudEmail, deprecatedEnvUser))
-	creds, err := suite.loginCredentialsManager.GetCloudCredentialsFromEnvVar(&cobra.Command{}, "")()
+	creds, err := suite.loginCredentialsManager.GetCloudCredentialsFromEnvVar("")()
 	suite.require.NoError(err)
 	suite.require.Nil(creds)
 
 	suite.setDeprecatedCCEnvVars()
-	creds, err = suite.loginCredentialsManager.GetCloudCredentialsFromEnvVar(&cobra.Command{}, "")()
+	creds, err = suite.loginCredentialsManager.GetCloudCredentialsFromEnvVar("")()
 	suite.require.NoError(err)
 	suite.compareCredentials(deprecateEnvCredentials, creds)
 }
@@ -217,7 +217,7 @@ func (suite *LoginCredentialsManagerTestSuite) TestGetCCloudCredentialsFromDepre
 func (suite *LoginCredentialsManagerTestSuite) TestGetCCloudCredentialsFromEnvVarOrderOfPrecedence() {
 	suite.setCCEnvVars()
 	suite.setDeprecatedCCEnvVars()
-	creds, err := suite.loginCredentialsManager.GetCloudCredentialsFromEnvVar(&cobra.Command{}, "")()
+	creds, err := suite.loginCredentialsManager.GetCloudCredentialsFromEnvVar("")()
 	suite.require.NoError(err)
 	suite.compareCredentials(envCredentials, creds)
 }
@@ -225,12 +225,12 @@ func (suite *LoginCredentialsManagerTestSuite) TestGetCCloudCredentialsFromEnvVa
 func (suite *LoginCredentialsManagerTestSuite) TestGetConfluentTokenAndCredentialsFromEnvVar() {
 	// incomplete credentials, setting on username but not password
 	suite.require.NoError(os.Setenv(ConfluentPlatformUsername, deprecatedEnvUser))
-	creds, err := suite.loginCredentialsManager.GetOnPremCredentialsFromEnvVar(&cobra.Command{})()
+	creds, err := suite.loginCredentialsManager.GetOnPremCredentialsFromEnvVar()()
 	suite.require.NoError(err)
 	suite.require.Nil(creds)
 
 	suite.setCPEnvVars()
-	creds, err = suite.loginCredentialsManager.GetOnPremCredentialsFromEnvVar(&cobra.Command{})()
+	creds, err = suite.loginCredentialsManager.GetOnPremCredentialsFromEnvVar()()
 	suite.require.NoError(err)
 	suite.compareCredentials(envCredentials, creds)
 }
@@ -238,12 +238,12 @@ func (suite *LoginCredentialsManagerTestSuite) TestGetConfluentTokenAndCredentia
 func (suite *LoginCredentialsManagerTestSuite) TestGetConfluentCredentialsFromDeprecatedEnvVar() {
 	// incomplete credentials, setting on username but not password
 	suite.require.NoError(os.Setenv(DeprecatedConfluentPlatformUsername, deprecatedEnvUser))
-	creds, err := suite.loginCredentialsManager.GetOnPremCredentialsFromEnvVar(&cobra.Command{})()
+	creds, err := suite.loginCredentialsManager.GetOnPremCredentialsFromEnvVar()()
 	suite.require.NoError(err)
 	suite.require.Nil(creds)
 
 	suite.setDeprecatedCPEnvVars()
-	creds, err = suite.loginCredentialsManager.GetOnPremCredentialsFromEnvVar(&cobra.Command{})()
+	creds, err = suite.loginCredentialsManager.GetOnPremCredentialsFromEnvVar()()
 	suite.require.NoError(err)
 	suite.compareCredentials(deprecateEnvCredentials, creds)
 }
@@ -251,7 +251,7 @@ func (suite *LoginCredentialsManagerTestSuite) TestGetConfluentCredentialsFromDe
 func (suite *LoginCredentialsManagerTestSuite) TestGetConfluentCredentialsFromEnvVarOrderOfPrecedence() {
 	suite.setCPEnvVars()
 	suite.setDeprecatedCPEnvVars()
-	creds, err := suite.loginCredentialsManager.GetOnPremCredentialsFromEnvVar(&cobra.Command{})()
+	creds, err := suite.loginCredentialsManager.GetOnPremCredentialsFromEnvVar()()
 	suite.require.NoError(err)
 	suite.compareCredentials(envCredentials, creds)
 }
@@ -299,14 +299,14 @@ func (suite *LoginCredentialsManagerTestSuite) TestGetConfluentCredentialsFromPr
 func (suite *LoginCredentialsManagerTestSuite) TestGetConfluentPrerunCredentialsFromEnvVar() {
 	// incomplete and should, as there is no credentials set
 	suite.require.NoError(os.Setenv(ConfluentPlatformMDSURL, prerunURL))
-	creds, err := suite.loginCredentialsManager.GetOnPremPrerunCredentialsFromEnvVar(&cobra.Command{})()
+	creds, err := suite.loginCredentialsManager.GetOnPremPrerunCredentialsFromEnvVar()()
 	suite.require.Error(err)
 	suite.require.Equal(errors.NoCredentialsFoundErrorMsg, err.Error())
 	suite.require.Nil(creds)
 
 	// incomplete and should return nil cred, as there is no password set even though username is set
 	suite.require.NoError(os.Setenv(ConfluentPlatformUsername, envUsername))
-	creds, err = suite.loginCredentialsManager.GetOnPremPrerunCredentialsFromEnvVar(&cobra.Command{})()
+	creds, err = suite.loginCredentialsManager.GetOnPremPrerunCredentialsFromEnvVar()()
 	suite.require.Error(err)
 	suite.require.Equal(errors.NoCredentialsFoundErrorMsg, err.Error())
 	suite.require.Nil(creds)
@@ -314,20 +314,20 @@ func (suite *LoginCredentialsManagerTestSuite) TestGetConfluentPrerunCredentials
 	// incomplete as this only sets username and password but not URL which is needed for Prerun login
 	suite.require.NoError(os.Unsetenv(ConfluentPlatformMDSURL))
 	suite.setCPEnvVars()
-	creds, err = suite.loginCredentialsManager.GetOnPremPrerunCredentialsFromEnvVar(&cobra.Command{})()
+	creds, err = suite.loginCredentialsManager.GetOnPremPrerunCredentialsFromEnvVar()()
 	suite.require.Error(err)
 	suite.require.Equal(errors.NoURLEnvVarErrorMsg, err.Error())
 	suite.require.Nil(creds)
 
 	// Set URL
 	suite.require.NoError(os.Setenv(ConfluentPlatformMDSURL, prerunURL))
-	creds, err = suite.loginCredentialsManager.GetOnPremPrerunCredentialsFromEnvVar(&cobra.Command{})()
+	creds, err = suite.loginCredentialsManager.GetOnPremPrerunCredentialsFromEnvVar()()
 	suite.require.NoError(err)
 	suite.compareCredentials(envPrerunCredentials, creds)
 
 	// Set ca-cert-path
 	suite.require.NoError(os.Setenv(ConfluentPlatformCACertPath, caCertPath))
-	creds, err = suite.loginCredentialsManager.GetOnPremPrerunCredentialsFromEnvVar(&cobra.Command{})()
+	creds, err = suite.loginCredentialsManager.GetOnPremPrerunCredentialsFromEnvVar()()
 	suite.require.NoError(err)
 	suite.compareCredentials(envPrerunCredentialsWithCaCertPath, creds)
 }
@@ -377,7 +377,7 @@ func (suite *LoginCredentialsManagerTestSuite) TestGetCredentialsFunction() {
 	// No credentials in env var and netrc so should look for prompt
 	loginCredentialsManager := NewLoginCredentialsManager(noCredentialsNetrcHandler, suite.prompt, suite.ccloudClient)
 	creds, err := GetLoginCredentials(
-		loginCredentialsManager.GetCloudCredentialsFromEnvVar(&cobra.Command{}, ""),
+		loginCredentialsManager.GetCloudCredentialsFromEnvVar(""),
 		loginCredentialsManager.GetCredentialsFromNetrc(&cobra.Command{}, netrc.NetrcMachineParams{
 			IsCloud: true,
 			IsSSO:   false,
@@ -390,7 +390,7 @@ func (suite *LoginCredentialsManagerTestSuite) TestGetCredentialsFunction() {
 	// No credentials in env var but credentials in netrc so netrc credentials should be returned
 	loginCredentialsManager = NewLoginCredentialsManager(suite.netrcHandler, suite.prompt, suite.ccloudClient)
 	creds, err = GetLoginCredentials(
-		loginCredentialsManager.GetCloudCredentialsFromEnvVar(&cobra.Command{}, ""),
+		loginCredentialsManager.GetCloudCredentialsFromEnvVar(""),
 		loginCredentialsManager.GetCredentialsFromNetrc(&cobra.Command{}, netrc.NetrcMachineParams{
 			IsCloud: true,
 			IsSSO:   false,
@@ -404,7 +404,7 @@ func (suite *LoginCredentialsManagerTestSuite) TestGetCredentialsFunction() {
 	suite.setCCEnvVars()
 	loginCredentialsManager = NewLoginCredentialsManager(suite.netrcHandler, suite.prompt, suite.ccloudClient)
 	creds, err = GetLoginCredentials(
-		loginCredentialsManager.GetCloudCredentialsFromEnvVar(&cobra.Command{}, ""),
+		loginCredentialsManager.GetCloudCredentialsFromEnvVar(""),
 		loginCredentialsManager.GetCredentialsFromNetrc(&cobra.Command{}, netrc.NetrcMachineParams{
 			IsCloud: true,
 			IsSSO:   false,

--- a/internal/pkg/cmd/prerunner.go
+++ b/internal/pkg/cmd/prerunner.go
@@ -339,11 +339,12 @@ func (r *PreRun) getCCloudTokenAndCredentials(cmd *cobra.Command, netrcMachineNa
 	}
 
 	credentials, err := pauth.GetLoginCredentials(
-		r.LoginCredentialsManager.GetCloudCredentialsFromEnvVar(cmd, orgResourceId),
+		r.LoginCredentialsManager.GetCloudCredentialsFromEnvVar(orgResourceId),
+		r.LoginCredentialsManager.GetCredentialsFromConfig(r.Config),
 		r.LoginCredentialsManager.GetCredentialsFromNetrc(cmd, netrcFilterParams),
 	)
 	if err != nil {
-		log.CliLogger.Debugf("Prerun login getting credentials failed: %v", err.Error())
+		log.CliLogger.Debugf("Auto-login failed to get credentials: %v", err)
 		return "", "", nil, err
 	}
 
@@ -560,7 +561,7 @@ func (r *PreRun) getConfluentTokenAndCredentials(cmd *cobra.Command, netrcMachin
 	}
 
 	credentials, err := pauth.GetLoginCredentials(
-		r.LoginCredentialsManager.GetOnPremPrerunCredentialsFromEnvVar(cmd),
+		r.LoginCredentialsManager.GetOnPremPrerunCredentialsFromEnvVar(),
 		r.LoginCredentialsManager.GetOnPremPrerunCredentialsFromNetrc(cmd, netrcMachineParams),
 	)
 	if err != nil {

--- a/internal/pkg/cmd/prerunner_test.go
+++ b/internal/pkg/cmd/prerunner_test.go
@@ -52,7 +52,7 @@ const (
 
 var (
 	mockLoginCredentialsManager = &cliMock.MockLoginCredentialsManager{
-		GetCloudCredentialsFromEnvVarFunc: func(_ *cobra.Command, _ string) func() (*pauth.Credentials, error) {
+		GetCloudCredentialsFromEnvVarFunc: func(_ string) func() (*pauth.Credentials, error) {
 			return func() (*pauth.Credentials, error) {
 				return nil, nil
 			}
@@ -439,7 +439,7 @@ func TestPrerun_AutoLogin(t *testing.T) {
 			var confluentEnvVarCalled bool
 			var confluentNetrcCalled bool
 			r.LoginCredentialsManager = &cliMock.MockLoginCredentialsManager{
-				GetCloudCredentialsFromEnvVarFunc: func(_ *cobra.Command, orgResourceId string) func() (*pauth.Credentials, error) {
+				GetCloudCredentialsFromEnvVarFunc: func(orgResourceId string) func() (*pauth.Credentials, error) {
 					return func() (*pauth.Credentials, error) {
 						ccloudEnvVarCalled = true
 						return tt.envVarReturn.creds, tt.envVarReturn.err
@@ -451,7 +451,12 @@ func TestPrerun_AutoLogin(t *testing.T) {
 						return tt.netrcReturn.creds, tt.netrcReturn.err
 					}
 				},
-				GetOnPremPrerunCredentialsFromEnvVarFunc: func(_ *cobra.Command) func() (*pauth.Credentials, error) {
+				GetCredentialsFromConfigFunc: func(_ *v1.Config) func() (*pauth.Credentials, error) {
+					return func() (*pauth.Credentials, error) {
+						return nil, nil
+					}
+				},
+				GetOnPremPrerunCredentialsFromEnvVarFunc: func() func() (*pauth.Credentials, error) {
 					return func() (*pauth.Credentials, error) {
 						confluentEnvVarCalled = true
 						return tt.envVarReturn.creds, tt.envVarReturn.err
@@ -536,9 +541,14 @@ func TestPrerun_ReLoginToLastOrgUsed(t *testing.T) {
 	}
 	r.LoginCredentialsManager = &cliMock.MockLoginCredentialsManager{
 		GetCredentialsFromNetrcFunc: mockLoginCredentialsManager.GetCredentialsFromNetrcFunc,
-		GetCloudCredentialsFromEnvVarFunc: func(cmd *cobra.Command, orgResourceId string) func() (*pauth.Credentials, error) {
+		GetCloudCredentialsFromEnvVarFunc: func(_ string) func() (*pauth.Credentials, error) {
 			return func() (*pauth.Credentials, error) {
 				return ccloudCreds, nil
+			}
+		},
+		GetCredentialsFromConfigFunc: func(_ *v1.Config) func() (*pauth.Credentials, error) {
+			return func() (*pauth.Credentials, error) {
+				return nil, nil
 			}
 		},
 	}
@@ -584,7 +594,7 @@ func TestPrerun_AutoLoginNotTriggeredIfLoggedIn(t *testing.T) {
 			var envVarCalled bool
 			var netrcCalled bool
 			mockLoginCredentialsManager := &cliMock.MockLoginCredentialsManager{
-				GetCloudCredentialsFromEnvVarFunc: func(_ *cobra.Command, orgResourceId string) func() (*pauth.Credentials, error) {
+				GetCloudCredentialsFromEnvVarFunc: func(_ string) func() (*pauth.Credentials, error) {
 					return func() (*pauth.Credentials, error) {
 						envVarCalled = true
 						return nil, nil
@@ -752,7 +762,7 @@ func TestInitializeOnPremKafkaRest(t *testing.T) {
 					return nil, nil
 				}
 			},
-			GetOnPremPrerunCredentialsFromEnvVarFunc: func(_ *cobra.Command) func() (*pauth.Credentials, error) {
+			GetOnPremPrerunCredentialsFromEnvVarFunc: func() func() (*pauth.Credentials, error) {
 				return func() (*pauth.Credentials, error) {
 					return nil, nil
 				}

--- a/internal/pkg/config/v1/context.go
+++ b/internal/pkg/config/v1/context.go
@@ -110,13 +110,13 @@ func (c *Context) DeleteUserAuth() error {
 	if c.State == nil {
 		return nil
 	}
-	c.State.AuthToken = ""
+
 	c.State.Auth = nil
+	c.State.AuthToken = ""
+	c.State.AuthRefreshToken = ""
+
 	err := c.Save()
-	if err != nil {
-		return errors.Wrap(err, errors.DeleteUserAuthErrorMsg)
-	}
-	return nil
+	return errors.Wrap(err, errors.DeleteUserAuthErrorMsg)
 }
 
 func (c *Context) GetCurrentEnvironmentId() string {
@@ -149,25 +149,53 @@ func (c *Context) IsCloud(isTest bool) bool {
 	return false
 }
 
-func (c *Context) GetUser() *orgv1.User {
-	if c.State != nil && c.State.Auth != nil {
-		return c.State.Auth.User
+func (c *Context) GetAuth() *AuthConfig {
+	if c.State != nil {
+		return c.State.Auth
 	}
 	return nil
 }
 
+func (c *Context) GetUser() *orgv1.User {
+	if auth := c.GetAuth(); auth != nil {
+		return auth.User
+	}
+	return nil
+}
+
+func (c *Context) GetEmail() string {
+	if user := c.GetUser(); user != nil {
+		return user.Email
+	}
+	return ""
+}
+
 func (c *Context) GetOrganization() *orgv1.Organization {
-	if c.State != nil && c.State.Auth != nil {
-		return c.State.Auth.Organization
+	if auth := c.GetAuth(); auth != nil {
+		return auth.Organization
 	}
 	return nil
 }
 
 func (c *Context) GetEnvironment() *orgv1.Account {
-	if c.State != nil && c.State.Auth != nil {
-		return c.State.Auth.Account
+	if auth := c.GetAuth(); auth != nil {
+		return auth.Account
 	}
 	return nil
+}
+
+func (c *Context) GetAuthToken() string {
+	if c.State != nil {
+		return c.State.AuthToken
+	}
+	return ""
+}
+
+func (c *Context) GetAuthRefreshToken() string {
+	if c.State != nil {
+		return c.State.AuthRefreshToken
+	}
+	return ""
 }
 
 func printApiKeysDictErrorMessage(missingKey, mismatchKey, missingSecret bool, cluster *KafkaClusterConfig, contextName string) {

--- a/internal/pkg/errors/error_message.go
+++ b/internal/pkg/errors/error_message.go
@@ -38,7 +38,7 @@ const (
 	UnneccessaryUrlFlagForCloudLoginErrorMsg    = "there is no need to pass the url flag if you are logging in to Confluent Cloud"
 	UnneccessaryUrlFlagForCloudLoginSuggestions = "Log in to Confluent Cloud with `confluent login`"
 	SSOCredentialsDoNotMatchLoginCredentials    = "expected SSO credentials for %s but got credentials for %s"
-	SSOCrdentialsDoNotMatchSuggestions          = "Please re-login and use the same email at the prompt and in the SSO portal."
+	SSOCredentialsDoNotMatchSuggestions         = "Please re-login and use the same email at the prompt and in the SSO portal."
 
 	// confluent cluster commands
 	FetchClusterMetadataErrorMsg     = "unable to fetch cluster metadata: %s - %s"

--- a/mock/login_credentials_manager.go
+++ b/mock/login_credentials_manager.go
@@ -8,31 +8,34 @@ import (
 	sync "sync"
 
 	github_com_confluentinc_ccloud_sdk_go_v1 "github.com/confluentinc/ccloud-sdk-go-v1"
-	github_com_spf13_cobra "github.com/spf13/cobra"
-
 	github_com_confluentinc_cli_internal_pkg_auth "github.com/confluentinc/cli/internal/pkg/auth"
+	github_com_confluentinc_cli_internal_pkg_config_v1 "github.com/confluentinc/cli/internal/pkg/config/v1"
 	github_com_confluentinc_cli_internal_pkg_netrc "github.com/confluentinc/cli/internal/pkg/netrc"
+	github_com_spf13_cobra "github.com/spf13/cobra"
 )
 
 // MockLoginCredentialsManager is a mock of LoginCredentialsManager interface
 type MockLoginCredentialsManager struct {
 	lockGetCloudCredentialsFromEnvVar sync.Mutex
-	GetCloudCredentialsFromEnvVarFunc func(cmd *github_com_spf13_cobra.Command, orgResourceId string) func() (*github_com_confluentinc_cli_internal_pkg_auth.Credentials, error)
-
-	lockGetCloudCredentialsFromPrompt sync.Mutex
-	GetCloudCredentialsFromPromptFunc func(cmd *github_com_spf13_cobra.Command, orgResourceId string) func() (*github_com_confluentinc_cli_internal_pkg_auth.Credentials, error)
+	GetCloudCredentialsFromEnvVarFunc func(orgResourceId string) func() (*github_com_confluentinc_cli_internal_pkg_auth.Credentials, error)
 
 	lockGetOnPremCredentialsFromEnvVar sync.Mutex
-	GetOnPremCredentialsFromEnvVarFunc func(cmd *github_com_spf13_cobra.Command) func() (*github_com_confluentinc_cli_internal_pkg_auth.Credentials, error)
+	GetOnPremCredentialsFromEnvVarFunc func() func() (*github_com_confluentinc_cli_internal_pkg_auth.Credentials, error)
 
-	lockGetOnPremCredentialsFromPrompt sync.Mutex
-	GetOnPremCredentialsFromPromptFunc func(cmd *github_com_spf13_cobra.Command) func() (*github_com_confluentinc_cli_internal_pkg_auth.Credentials, error)
+	lockGetCredentialsFromConfig sync.Mutex
+	GetCredentialsFromConfigFunc func(cfg *github_com_confluentinc_cli_internal_pkg_config_v1.Config) func() (*github_com_confluentinc_cli_internal_pkg_auth.Credentials, error)
 
 	lockGetCredentialsFromNetrc sync.Mutex
 	GetCredentialsFromNetrcFunc func(cmd *github_com_spf13_cobra.Command, filterParams github_com_confluentinc_cli_internal_pkg_netrc.NetrcMachineParams) func() (*github_com_confluentinc_cli_internal_pkg_auth.Credentials, error)
 
+	lockGetCloudCredentialsFromPrompt sync.Mutex
+	GetCloudCredentialsFromPromptFunc func(cmd *github_com_spf13_cobra.Command, orgResourceId string) func() (*github_com_confluentinc_cli_internal_pkg_auth.Credentials, error)
+
+	lockGetOnPremCredentialsFromPrompt sync.Mutex
+	GetOnPremCredentialsFromPromptFunc func(cmd *github_com_spf13_cobra.Command) func() (*github_com_confluentinc_cli_internal_pkg_auth.Credentials, error)
+
 	lockGetOnPremPrerunCredentialsFromEnvVar sync.Mutex
-	GetOnPremPrerunCredentialsFromEnvVarFunc func(arg0 *github_com_spf13_cobra.Command) func() (*github_com_confluentinc_cli_internal_pkg_auth.Credentials, error)
+	GetOnPremPrerunCredentialsFromEnvVarFunc func() func() (*github_com_confluentinc_cli_internal_pkg_auth.Credentials, error)
 
 	lockGetOnPremPrerunCredentialsFromNetrc sync.Mutex
 	GetOnPremPrerunCredentialsFromNetrcFunc func(arg0 *github_com_spf13_cobra.Command, arg1 github_com_confluentinc_cli_internal_pkg_netrc.NetrcMachineParams) func() (*github_com_confluentinc_cli_internal_pkg_auth.Credentials, error)
@@ -42,25 +45,25 @@ type MockLoginCredentialsManager struct {
 
 	calls struct {
 		GetCloudCredentialsFromEnvVar []struct {
-			Cmd           *github_com_spf13_cobra.Command
-			OrgResourceId string
-		}
-		GetCloudCredentialsFromPrompt []struct {
-			Cmd           *github_com_spf13_cobra.Command
 			OrgResourceId string
 		}
 		GetOnPremCredentialsFromEnvVar []struct {
-			Cmd *github_com_spf13_cobra.Command
 		}
-		GetOnPremCredentialsFromPrompt []struct {
-			Cmd *github_com_spf13_cobra.Command
+		GetCredentialsFromConfig []struct {
+			Cfg *github_com_confluentinc_cli_internal_pkg_config_v1.Config
 		}
 		GetCredentialsFromNetrc []struct {
 			Cmd          *github_com_spf13_cobra.Command
 			FilterParams github_com_confluentinc_cli_internal_pkg_netrc.NetrcMachineParams
 		}
+		GetCloudCredentialsFromPrompt []struct {
+			Cmd           *github_com_spf13_cobra.Command
+			OrgResourceId string
+		}
+		GetOnPremCredentialsFromPrompt []struct {
+			Cmd *github_com_spf13_cobra.Command
+		}
 		GetOnPremPrerunCredentialsFromEnvVar []struct {
-			Arg0 *github_com_spf13_cobra.Command
 		}
 		GetOnPremPrerunCredentialsFromNetrc []struct {
 			Arg0 *github_com_spf13_cobra.Command
@@ -73,7 +76,7 @@ type MockLoginCredentialsManager struct {
 }
 
 // GetCloudCredentialsFromEnvVar mocks base method by wrapping the associated func.
-func (m *MockLoginCredentialsManager) GetCloudCredentialsFromEnvVar(cmd *github_com_spf13_cobra.Command, orgResourceId string) func() (*github_com_confluentinc_cli_internal_pkg_auth.Credentials, error) {
+func (m *MockLoginCredentialsManager) GetCloudCredentialsFromEnvVar(orgResourceId string) func() (*github_com_confluentinc_cli_internal_pkg_auth.Credentials, error) {
 	m.lockGetCloudCredentialsFromEnvVar.Lock()
 	defer m.lockGetCloudCredentialsFromEnvVar.Unlock()
 
@@ -82,16 +85,14 @@ func (m *MockLoginCredentialsManager) GetCloudCredentialsFromEnvVar(cmd *github_
 	}
 
 	call := struct {
-		Cmd           *github_com_spf13_cobra.Command
 		OrgResourceId string
 	}{
-		Cmd:           cmd,
 		OrgResourceId: orgResourceId,
 	}
 
 	m.calls.GetCloudCredentialsFromEnvVar = append(m.calls.GetCloudCredentialsFromEnvVar, call)
 
-	return m.GetCloudCredentialsFromEnvVarFunc(cmd, orgResourceId)
+	return m.GetCloudCredentialsFromEnvVarFunc(orgResourceId)
 }
 
 // GetCloudCredentialsFromEnvVarCalled returns true if GetCloudCredentialsFromEnvVar was called at least once.
@@ -104,7 +105,6 @@ func (m *MockLoginCredentialsManager) GetCloudCredentialsFromEnvVarCalled() bool
 
 // GetCloudCredentialsFromEnvVarCalls returns the calls made to GetCloudCredentialsFromEnvVar.
 func (m *MockLoginCredentialsManager) GetCloudCredentialsFromEnvVarCalls() []struct {
-	Cmd           *github_com_spf13_cobra.Command
 	OrgResourceId string
 } {
 	m.lockGetCloudCredentialsFromEnvVar.Lock()
@@ -113,49 +113,8 @@ func (m *MockLoginCredentialsManager) GetCloudCredentialsFromEnvVarCalls() []str
 	return m.calls.GetCloudCredentialsFromEnvVar
 }
 
-// GetCloudCredentialsFromPrompt mocks base method by wrapping the associated func.
-func (m *MockLoginCredentialsManager) GetCloudCredentialsFromPrompt(cmd *github_com_spf13_cobra.Command, orgResourceId string) func() (*github_com_confluentinc_cli_internal_pkg_auth.Credentials, error) {
-	m.lockGetCloudCredentialsFromPrompt.Lock()
-	defer m.lockGetCloudCredentialsFromPrompt.Unlock()
-
-	if m.GetCloudCredentialsFromPromptFunc == nil {
-		panic("mocker: MockLoginCredentialsManager.GetCloudCredentialsFromPromptFunc is nil but MockLoginCredentialsManager.GetCloudCredentialsFromPrompt was called.")
-	}
-
-	call := struct {
-		Cmd           *github_com_spf13_cobra.Command
-		OrgResourceId string
-	}{
-		Cmd:           cmd,
-		OrgResourceId: orgResourceId,
-	}
-
-	m.calls.GetCloudCredentialsFromPrompt = append(m.calls.GetCloudCredentialsFromPrompt, call)
-
-	return m.GetCloudCredentialsFromPromptFunc(cmd, orgResourceId)
-}
-
-// GetCloudCredentialsFromPromptCalled returns true if GetCloudCredentialsFromPrompt was called at least once.
-func (m *MockLoginCredentialsManager) GetCloudCredentialsFromPromptCalled() bool {
-	m.lockGetCloudCredentialsFromPrompt.Lock()
-	defer m.lockGetCloudCredentialsFromPrompt.Unlock()
-
-	return len(m.calls.GetCloudCredentialsFromPrompt) > 0
-}
-
-// GetCloudCredentialsFromPromptCalls returns the calls made to GetCloudCredentialsFromPrompt.
-func (m *MockLoginCredentialsManager) GetCloudCredentialsFromPromptCalls() []struct {
-	Cmd           *github_com_spf13_cobra.Command
-	OrgResourceId string
-} {
-	m.lockGetCloudCredentialsFromPrompt.Lock()
-	defer m.lockGetCloudCredentialsFromPrompt.Unlock()
-
-	return m.calls.GetCloudCredentialsFromPrompt
-}
-
 // GetOnPremCredentialsFromEnvVar mocks base method by wrapping the associated func.
-func (m *MockLoginCredentialsManager) GetOnPremCredentialsFromEnvVar(cmd *github_com_spf13_cobra.Command) func() (*github_com_confluentinc_cli_internal_pkg_auth.Credentials, error) {
+func (m *MockLoginCredentialsManager) GetOnPremCredentialsFromEnvVar() func() (*github_com_confluentinc_cli_internal_pkg_auth.Credentials, error) {
 	m.lockGetOnPremCredentialsFromEnvVar.Lock()
 	defer m.lockGetOnPremCredentialsFromEnvVar.Unlock()
 
@@ -164,14 +123,11 @@ func (m *MockLoginCredentialsManager) GetOnPremCredentialsFromEnvVar(cmd *github
 	}
 
 	call := struct {
-		Cmd *github_com_spf13_cobra.Command
-	}{
-		Cmd: cmd,
-	}
+	}{}
 
 	m.calls.GetOnPremCredentialsFromEnvVar = append(m.calls.GetOnPremCredentialsFromEnvVar, call)
 
-	return m.GetOnPremCredentialsFromEnvVarFunc(cmd)
+	return m.GetOnPremCredentialsFromEnvVarFunc()
 }
 
 // GetOnPremCredentialsFromEnvVarCalled returns true if GetOnPremCredentialsFromEnvVar was called at least once.
@@ -184,7 +140,6 @@ func (m *MockLoginCredentialsManager) GetOnPremCredentialsFromEnvVarCalled() boo
 
 // GetOnPremCredentialsFromEnvVarCalls returns the calls made to GetOnPremCredentialsFromEnvVar.
 func (m *MockLoginCredentialsManager) GetOnPremCredentialsFromEnvVarCalls() []struct {
-	Cmd *github_com_spf13_cobra.Command
 } {
 	m.lockGetOnPremCredentialsFromEnvVar.Lock()
 	defer m.lockGetOnPremCredentialsFromEnvVar.Unlock()
@@ -192,42 +147,42 @@ func (m *MockLoginCredentialsManager) GetOnPremCredentialsFromEnvVarCalls() []st
 	return m.calls.GetOnPremCredentialsFromEnvVar
 }
 
-// GetOnPremCredentialsFromPrompt mocks base method by wrapping the associated func.
-func (m *MockLoginCredentialsManager) GetOnPremCredentialsFromPrompt(cmd *github_com_spf13_cobra.Command) func() (*github_com_confluentinc_cli_internal_pkg_auth.Credentials, error) {
-	m.lockGetOnPremCredentialsFromPrompt.Lock()
-	defer m.lockGetOnPremCredentialsFromPrompt.Unlock()
+// GetCredentialsFromConfig mocks base method by wrapping the associated func.
+func (m *MockLoginCredentialsManager) GetCredentialsFromConfig(cfg *github_com_confluentinc_cli_internal_pkg_config_v1.Config) func() (*github_com_confluentinc_cli_internal_pkg_auth.Credentials, error) {
+	m.lockGetCredentialsFromConfig.Lock()
+	defer m.lockGetCredentialsFromConfig.Unlock()
 
-	if m.GetOnPremCredentialsFromPromptFunc == nil {
-		panic("mocker: MockLoginCredentialsManager.GetOnPremCredentialsFromPromptFunc is nil but MockLoginCredentialsManager.GetOnPremCredentialsFromPrompt was called.")
+	if m.GetCredentialsFromConfigFunc == nil {
+		panic("mocker: MockLoginCredentialsManager.GetCredentialsFromConfigFunc is nil but MockLoginCredentialsManager.GetCredentialsFromConfig was called.")
 	}
 
 	call := struct {
-		Cmd *github_com_spf13_cobra.Command
+		Cfg *github_com_confluentinc_cli_internal_pkg_config_v1.Config
 	}{
-		Cmd: cmd,
+		Cfg: cfg,
 	}
 
-	m.calls.GetOnPremCredentialsFromPrompt = append(m.calls.GetOnPremCredentialsFromPrompt, call)
+	m.calls.GetCredentialsFromConfig = append(m.calls.GetCredentialsFromConfig, call)
 
-	return m.GetOnPremCredentialsFromPromptFunc(cmd)
+	return m.GetCredentialsFromConfigFunc(cfg)
 }
 
-// GetOnPremCredentialsFromPromptCalled returns true if GetOnPremCredentialsFromPrompt was called at least once.
-func (m *MockLoginCredentialsManager) GetOnPremCredentialsFromPromptCalled() bool {
-	m.lockGetOnPremCredentialsFromPrompt.Lock()
-	defer m.lockGetOnPremCredentialsFromPrompt.Unlock()
+// GetCredentialsFromConfigCalled returns true if GetCredentialsFromConfig was called at least once.
+func (m *MockLoginCredentialsManager) GetCredentialsFromConfigCalled() bool {
+	m.lockGetCredentialsFromConfig.Lock()
+	defer m.lockGetCredentialsFromConfig.Unlock()
 
-	return len(m.calls.GetOnPremCredentialsFromPrompt) > 0
+	return len(m.calls.GetCredentialsFromConfig) > 0
 }
 
-// GetOnPremCredentialsFromPromptCalls returns the calls made to GetOnPremCredentialsFromPrompt.
-func (m *MockLoginCredentialsManager) GetOnPremCredentialsFromPromptCalls() []struct {
-	Cmd *github_com_spf13_cobra.Command
+// GetCredentialsFromConfigCalls returns the calls made to GetCredentialsFromConfig.
+func (m *MockLoginCredentialsManager) GetCredentialsFromConfigCalls() []struct {
+	Cfg *github_com_confluentinc_cli_internal_pkg_config_v1.Config
 } {
-	m.lockGetOnPremCredentialsFromPrompt.Lock()
-	defer m.lockGetOnPremCredentialsFromPrompt.Unlock()
+	m.lockGetCredentialsFromConfig.Lock()
+	defer m.lockGetCredentialsFromConfig.Unlock()
 
-	return m.calls.GetOnPremCredentialsFromPrompt
+	return m.calls.GetCredentialsFromConfig
 }
 
 // GetCredentialsFromNetrc mocks base method by wrapping the associated func.
@@ -271,8 +226,87 @@ func (m *MockLoginCredentialsManager) GetCredentialsFromNetrcCalls() []struct {
 	return m.calls.GetCredentialsFromNetrc
 }
 
+// GetCloudCredentialsFromPrompt mocks base method by wrapping the associated func.
+func (m *MockLoginCredentialsManager) GetCloudCredentialsFromPrompt(cmd *github_com_spf13_cobra.Command, orgResourceId string) func() (*github_com_confluentinc_cli_internal_pkg_auth.Credentials, error) {
+	m.lockGetCloudCredentialsFromPrompt.Lock()
+	defer m.lockGetCloudCredentialsFromPrompt.Unlock()
+
+	if m.GetCloudCredentialsFromPromptFunc == nil {
+		panic("mocker: MockLoginCredentialsManager.GetCloudCredentialsFromPromptFunc is nil but MockLoginCredentialsManager.GetCloudCredentialsFromPrompt was called.")
+	}
+
+	call := struct {
+		Cmd           *github_com_spf13_cobra.Command
+		OrgResourceId string
+	}{
+		Cmd:           cmd,
+		OrgResourceId: orgResourceId,
+	}
+
+	m.calls.GetCloudCredentialsFromPrompt = append(m.calls.GetCloudCredentialsFromPrompt, call)
+
+	return m.GetCloudCredentialsFromPromptFunc(cmd, orgResourceId)
+}
+
+// GetCloudCredentialsFromPromptCalled returns true if GetCloudCredentialsFromPrompt was called at least once.
+func (m *MockLoginCredentialsManager) GetCloudCredentialsFromPromptCalled() bool {
+	m.lockGetCloudCredentialsFromPrompt.Lock()
+	defer m.lockGetCloudCredentialsFromPrompt.Unlock()
+
+	return len(m.calls.GetCloudCredentialsFromPrompt) > 0
+}
+
+// GetCloudCredentialsFromPromptCalls returns the calls made to GetCloudCredentialsFromPrompt.
+func (m *MockLoginCredentialsManager) GetCloudCredentialsFromPromptCalls() []struct {
+	Cmd           *github_com_spf13_cobra.Command
+	OrgResourceId string
+} {
+	m.lockGetCloudCredentialsFromPrompt.Lock()
+	defer m.lockGetCloudCredentialsFromPrompt.Unlock()
+
+	return m.calls.GetCloudCredentialsFromPrompt
+}
+
+// GetOnPremCredentialsFromPrompt mocks base method by wrapping the associated func.
+func (m *MockLoginCredentialsManager) GetOnPremCredentialsFromPrompt(cmd *github_com_spf13_cobra.Command) func() (*github_com_confluentinc_cli_internal_pkg_auth.Credentials, error) {
+	m.lockGetOnPremCredentialsFromPrompt.Lock()
+	defer m.lockGetOnPremCredentialsFromPrompt.Unlock()
+
+	if m.GetOnPremCredentialsFromPromptFunc == nil {
+		panic("mocker: MockLoginCredentialsManager.GetOnPremCredentialsFromPromptFunc is nil but MockLoginCredentialsManager.GetOnPremCredentialsFromPrompt was called.")
+	}
+
+	call := struct {
+		Cmd *github_com_spf13_cobra.Command
+	}{
+		Cmd: cmd,
+	}
+
+	m.calls.GetOnPremCredentialsFromPrompt = append(m.calls.GetOnPremCredentialsFromPrompt, call)
+
+	return m.GetOnPremCredentialsFromPromptFunc(cmd)
+}
+
+// GetOnPremCredentialsFromPromptCalled returns true if GetOnPremCredentialsFromPrompt was called at least once.
+func (m *MockLoginCredentialsManager) GetOnPremCredentialsFromPromptCalled() bool {
+	m.lockGetOnPremCredentialsFromPrompt.Lock()
+	defer m.lockGetOnPremCredentialsFromPrompt.Unlock()
+
+	return len(m.calls.GetOnPremCredentialsFromPrompt) > 0
+}
+
+// GetOnPremCredentialsFromPromptCalls returns the calls made to GetOnPremCredentialsFromPrompt.
+func (m *MockLoginCredentialsManager) GetOnPremCredentialsFromPromptCalls() []struct {
+	Cmd *github_com_spf13_cobra.Command
+} {
+	m.lockGetOnPremCredentialsFromPrompt.Lock()
+	defer m.lockGetOnPremCredentialsFromPrompt.Unlock()
+
+	return m.calls.GetOnPremCredentialsFromPrompt
+}
+
 // GetOnPremPrerunCredentialsFromEnvVar mocks base method by wrapping the associated func.
-func (m *MockLoginCredentialsManager) GetOnPremPrerunCredentialsFromEnvVar(arg0 *github_com_spf13_cobra.Command) func() (*github_com_confluentinc_cli_internal_pkg_auth.Credentials, error) {
+func (m *MockLoginCredentialsManager) GetOnPremPrerunCredentialsFromEnvVar() func() (*github_com_confluentinc_cli_internal_pkg_auth.Credentials, error) {
 	m.lockGetOnPremPrerunCredentialsFromEnvVar.Lock()
 	defer m.lockGetOnPremPrerunCredentialsFromEnvVar.Unlock()
 
@@ -281,14 +315,11 @@ func (m *MockLoginCredentialsManager) GetOnPremPrerunCredentialsFromEnvVar(arg0 
 	}
 
 	call := struct {
-		Arg0 *github_com_spf13_cobra.Command
-	}{
-		Arg0: arg0,
-	}
+	}{}
 
 	m.calls.GetOnPremPrerunCredentialsFromEnvVar = append(m.calls.GetOnPremPrerunCredentialsFromEnvVar, call)
 
-	return m.GetOnPremPrerunCredentialsFromEnvVarFunc(arg0)
+	return m.GetOnPremPrerunCredentialsFromEnvVarFunc()
 }
 
 // GetOnPremPrerunCredentialsFromEnvVarCalled returns true if GetOnPremPrerunCredentialsFromEnvVar was called at least once.
@@ -301,7 +332,6 @@ func (m *MockLoginCredentialsManager) GetOnPremPrerunCredentialsFromEnvVarCalled
 
 // GetOnPremPrerunCredentialsFromEnvVarCalls returns the calls made to GetOnPremPrerunCredentialsFromEnvVar.
 func (m *MockLoginCredentialsManager) GetOnPremPrerunCredentialsFromEnvVarCalls() []struct {
-	Arg0 *github_com_spf13_cobra.Command
 } {
 	m.lockGetOnPremPrerunCredentialsFromEnvVar.Lock()
 	defer m.lockGetOnPremPrerunCredentialsFromEnvVar.Unlock()
@@ -393,18 +423,21 @@ func (m *MockLoginCredentialsManager) Reset() {
 	m.lockGetCloudCredentialsFromEnvVar.Lock()
 	m.calls.GetCloudCredentialsFromEnvVar = nil
 	m.lockGetCloudCredentialsFromEnvVar.Unlock()
-	m.lockGetCloudCredentialsFromPrompt.Lock()
-	m.calls.GetCloudCredentialsFromPrompt = nil
-	m.lockGetCloudCredentialsFromPrompt.Unlock()
 	m.lockGetOnPremCredentialsFromEnvVar.Lock()
 	m.calls.GetOnPremCredentialsFromEnvVar = nil
 	m.lockGetOnPremCredentialsFromEnvVar.Unlock()
-	m.lockGetOnPremCredentialsFromPrompt.Lock()
-	m.calls.GetOnPremCredentialsFromPrompt = nil
-	m.lockGetOnPremCredentialsFromPrompt.Unlock()
+	m.lockGetCredentialsFromConfig.Lock()
+	m.calls.GetCredentialsFromConfig = nil
+	m.lockGetCredentialsFromConfig.Unlock()
 	m.lockGetCredentialsFromNetrc.Lock()
 	m.calls.GetCredentialsFromNetrc = nil
 	m.lockGetCredentialsFromNetrc.Unlock()
+	m.lockGetCloudCredentialsFromPrompt.Lock()
+	m.calls.GetCloudCredentialsFromPrompt = nil
+	m.lockGetCloudCredentialsFromPrompt.Unlock()
+	m.lockGetOnPremCredentialsFromPrompt.Lock()
+	m.calls.GetOnPremCredentialsFromPrompt = nil
+	m.lockGetOnPremCredentialsFromPrompt.Unlock()
 	m.lockGetOnPremPrerunCredentialsFromEnvVar.Lock()
 	m.calls.GetOnPremPrerunCredentialsFromEnvVar = nil
 	m.lockGetOnPremPrerunCredentialsFromEnvVar.Unlock()


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok

What
----
SSO tokens weren't actually getting refreshed on `confluent login` unless the `--save` flag was passed every time, and they were never getting refreshed on auto-login! This PR fixes both, using the auth refresh token stored in the config file by #1221. This PR simultaneously paves the way for username/password refresh tokens.

References
----------
https://confluent.slack.com/archives/C9Y6NAM6X/p1648153103359779

Test & Review
-------------
Updated all relevant tests and tested manually:
```
% confluent login --url https://devel.cpdev.cloud
Enter your Confluent Cloud credentials:
Email: bstrauch+sso@confluent.io
Logged in as "bstrauch+sso@confluent.io" for organization "1cb79071-48ed-4706-b174-bb6503fe74b7" ("Nexus Bug Bash Org 3 (SSO)").
% confluent login --url https://devel.cpdev.cloud
Logged in as "bstrauch+sso@confluent.io" for organization "1cb79071-48ed-4706-b174-bb6503fe74b7" ("Nexus Bug Bash Org 3 (SSO)").
```