### PR TITLE
Remove unnecessary multierror for backend errors

### DIFF
--- a/internal/pkg/errors/catcher.go
+++ b/internal/pkg/errors/catcher.go
@@ -9,13 +9,11 @@ import (
 	"regexp"
 	"strings"
 
-	srsdk "github.com/confluentinc/schema-registry-sdk-go"
-	"github.com/hashicorp/go-multierror"
-
 	corev1 "github.com/confluentinc/cc-structs/kafka/core/v1"
 	"github.com/confluentinc/ccloud-sdk-go-v1"
 	mds "github.com/confluentinc/mds-sdk-go/mdsv1"
 	"github.com/confluentinc/mds-sdk-go/mdsv2alpha1"
+	srsdk "github.com/confluentinc/schema-registry-sdk-go"
 )
 
 /*
@@ -87,11 +85,8 @@ func catchMDSErrors(err error) error {
 // This catcher function should then be used last to not accidentally convert errors that
 // are supposed to be caught by more specific catchers.
 func catchCoreV1Errors(err error) error {
-	e, ok := err.(*corev1.Error)
-	if ok {
-		var result error
-		result = multierror.Append(result, e)
-		return Wrap(result, CCloudBackendErrorPrefix)
+	if err, ok := err.(*corev1.Error); ok {
+		return Wrap(err, CCloudBackendErrorPrefix)
 	}
 	return err
 }

--- a/internal/pkg/errors/error_message.go
+++ b/internal/pkg/errors/error_message.go
@@ -364,7 +364,7 @@ const (
 	InvalidFlagValueSuggestions       = "The possible values for flag `%s` are: %s."
 
 	// catcher
-	CCloudBackendErrorPrefix           = "CCloud backend error"
+	CCloudBackendErrorPrefix           = "Confluent Cloud backend error"
 	UnexpectedBackendOutputPrefix      = "unexpected CCloud backend output"
 	UnexpectedBackendOutputSuggestions = "Please submit a support ticket."
 	BackendUnmarshallingErrorMsg       = "protobuf unmarshalling error"

--- a/test/fixtures/output/iam/user/invite-user-already-active.golden
+++ b/test/fixtures/output/iam/user/invite-user-already-active.golden
@@ -1,4 +1,1 @@
-Error: CCloud backend error: 1 error occurred:
-	* error creating user: User is already active
-
-
+Error: Confluent Cloud backend error: error creating user: User is already active

--- a/test/fixtures/output/iam/user/resource-not-found.golden
+++ b/test/fixtures/output/iam/user/resource-not-found.golden
@@ -1,4 +1,1 @@
-Error: CCloud backend error: 1 error occurred:
-	* error getting user profile: user not found
-
-
+Error: Confluent Cloud backend error: error getting user profile: user not found

--- a/test/fixtures/output/kafka/topic-delete-not-found.golden
+++ b/test/fixtures/output/kafka/topic-delete-not-found.golden
@@ -1,4 +1,1 @@
-Error: CCloud backend error: 1 error occurred:
-	* error deleting topic topic1: 
-
-
+Error: Confluent Cloud backend error: error deleting topic topic1: 

--- a/test/fixtures/output/kafka/topic-describe-not-found.golden
+++ b/test/fixtures/output/kafka/topic-describe-not-found.golden
@@ -1,4 +1,1 @@
-Error: CCloud backend error: 1 error occurred:
-	* error describing topic topic1: topic not found
-
-
+Error: Confluent Cloud backend error: error describing topic topic1: topic not found


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok

What
----
I was wondering if backend errors could ever return more than one error since they always look like the following:
```
Error: CCloud backend error: 1 error occurred:
```
It turns out they can't, so I removed the `multierror`.

Test & Review
-------------
Updated integration tests