### PR TITLE
Hide `~/git` in `panic()` dumps

### DIFF
--- a/.goreleaser-alpine.yml
+++ b/.goreleaser-alpine.yml
@@ -20,9 +20,9 @@ builds:
     ldflags:
       - -s -w -X main.version={{.Env.VERSION}} -X main.commit={{.ShortCommit}} -X main.date={{.Date}} -X main.host={{.Env.HOSTNAME}}
     gcflags:
-      - all=-trimpath={{.Env.GOPATH}}
+      - all=-trimpath={{.Env.HOME}}/git
     asmflags:
-      - all=-trimpath={{.Env.GOPATH}}
+      - all=-trimpath={{.Env.HOME}}/git
     goos:
       - linux
     goarch:

--- a/.goreleaser-build.yml
+++ b/.goreleaser-build.yml
@@ -11,6 +11,6 @@ builds:
     ldflags:
       - -s -w -X main.version={{.Env.VERSION}} -X main.commit={{.ShortCommit}} -X main.date={{.Date}} -X main.host={{.Env.HOSTNAME}}
     gcflags:
-      - all=-trimpath={{.Env.GOPATH}}
+      - all=-trimpath={{.Env.HOME}}/git
     asmflags:
-      - all=-trimpath={{.Env.GOPATH}}
+      - all=-trimpath={{.Env.HOME}}/git

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -22,9 +22,9 @@ builds:
     ldflags:
       - -s -w -X main.version={{.Env.VERSION}} -X main.commit={{.ShortCommit}} -X main.date={{.Date}} -X main.host={{.Env.HOSTNAME}}
     gcflags:
-      - all=-trimpath={{.Env.GOPATH}}
+      - all=-trimpath={{.Env.HOME}}/git
     asmflags:
-      - all=-trimpath={{.Env.GOPATH}}
+      - all=-trimpath={{.Env.HOME}}/git
     env:
       - CGO_ENABLED=1
       - CC=x86_64-linux-musl-gcc
@@ -42,9 +42,9 @@ builds:
     ldflags:
       - -s -w -X main.version={{.Env.VERSION}} -X main.commit={{.ShortCommit}} -X main.date={{.Date}} -X main.host={{.Env.HOSTNAME}} -buildmode=exe  
     gcflags:
-      - all=-trimpath={{.Env.GOPATH}}
+      - all=-trimpath={{.Env.HOME}}/git
     asmflags:
-      - all=-trimpath={{.Env.GOPATH}}
+      - all=-trimpath={{.Env.HOME}}/git
     env:
       - CGO_ENABLED=1
       - CC=x86_64-w64-mingw32-gcc
@@ -62,9 +62,9 @@ builds:
     ldflags:
       - -s -w -X main.version={{.Env.VERSION}} -X main.commit={{.ShortCommit}} -X main.date={{.Date}} -X main.host={{.Env.HOSTNAME}}
     gcflags:
-      - all=-trimpath={{.Env.GOPATH}}
+      - all=-trimpath={{.Env.HOME}}/git
     asmflags:
-      - all=-trimpath={{.Env.GOPATH}}
+      - all=-trimpath={{.Env.HOME}}/git
     goos:
       - darwin
     goarch:
@@ -86,9 +86,9 @@ builds:
     ldflags:
       - -s -w -X main.version={{.Env.VERSION}} -X main.commit={{.ShortCommit}} -X main.date={{.Date}} -X main.host={{.Env.HOSTNAME}}
     gcflags:
-      - all=-trimpath={{.Env.GOPATH}}
+      - all=-trimpath={{.Env.HOME}}/git
     asmflags:
-      - all=-trimpath={{.Env.GOPATH}}
+      - all=-trimpath={{.Env.HOME}}/git
     goos:
       - darwin
     goarch:


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok

What
----
Previously, we were hiding `$GOPATH` in `panic()` dumps. When `goenv` is set up properly according to [CONTRIBUTING.md](https://github.com/confluentinc/cli/blob/main/CONTRIBUTING.md#development-environment), the user's `$GOPATH` is set to `~/git/go/1.17.6` but the CLI is located at `~/git/go/`.

This PR hides `~/git`, since the output looks the best that way:
```
% confluent panic
panic: panic!

goroutine 1 [running]:
github.com/confluentinc/cli/internal/cmd.NewConfluentCommand.func2(0xc00085aa00, {0x6087f0f, 0x0, 0x0})
        go/src/github.com/confluentinc/cli/internal/cmd/command.go:116 +0x27
github.com/spf13/cobra.(*Command).execute(0xc00085aa00, {0x78cf990, 0x0, 0x0})
        go/1.17.6/pkg/mod/github.com/spf13/cobra@v1.3.0/command.go:860 +0x5f8
github.com/spf13/cobra.(*Command).ExecuteC(0xc00022d400)
        go/1.17.6/pkg/mod/github.com/spf13/cobra@v1.3.0/command.go:974 +0x3bc
github.com/spf13/cobra.(*Command).Execute(...)
        go/1.17.6/pkg/mod/github.com/spf13/cobra@v1.3.0/command.go:902
github.com/confluentinc/cli/internal/cmd.(*command).Execute(0xc000228100, {0xc00004e050, 0xc000228b80, 0x8})
        go/src/github.com/confluentinc/cli/internal/cmd/command.go:126 +0x56
main.main()
        go/src/github.com/confluentinc/cli/cmd/confluent/main.go:42 +0x28a
```

References
----------
https://confluent.slack.com/archives/C0356H5QB4J/p1648663629008439?thread_ts=1648661521.649309&cid=C0356H5QB4J

Test & Review
-------------
Tested manually