### PR TITLE
KGLOBAL-729: Remove bootstrap arg as a required param for cluster lin…

### DIFF
--- a/internal/cmd/kafka/command_link_create.go
+++ b/internal/cmd/kafka/command_link_create.go
@@ -52,11 +52,11 @@ func (c *linkCommand) newCreateCommand() *cobra.Command {
 
 	// As of now, only CP --> CC links are supported.
 	if c.cfg.IsCloudLogin() {
-		cmd.Flags().String(sourceBootstrapServerFlagName, "", "Bootstrap server address of the source cluster. Can alternatively be set in the config file using key bootstrap.servers.")
 		cmd.Flags().String(sourceClusterIdFlagName, "", "Source cluster ID.")
+		cmd.Flags().String(sourceBootstrapServerFlagName, "", "Bootstrap server address of the source cluster. Can alternatively be set in the config file using key bootstrap.servers.")
 	} else {
-		cmd.Flags().String(destinationBootstrapServerFlagName, "", "Bootstrap server address of the destination cluster. Can alternatively be set in the config file using key bootstrap.servers.")
 		cmd.Flags().String(destinationClusterIdFlagName, "", "Destination cluster ID.")
+		cmd.Flags().String(destinationBootstrapServerFlagName, "", "Bootstrap server address of the destination cluster. Can alternatively be set in the config file using key bootstrap.servers.")
 	}
 
 	cmd.Flags().String(apiKeyFlagName, "", "An API key for the source cluster. "+


### PR DESCRIPTION
### JIRA
https://confluentinc.atlassian.net/browse/KGLOBAL-729

Checklist
---------
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok. All dependent code is in prod
   
What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->

Removes the requirement that the bootstrap servers are passed in as command line arguments. They can be provided in the config file. If neither is provided the backend server will return an error so I dont think we need to do the validation here in this frontend code.

References
----------
https://confluentinc.atlassian.net/browse/KGLOBAL-729


Test & Review
-------------
- Ran unit tests
- Manually ran CLI
```
agrant@C02GN0121PG2 cli % ./dist/confluent_darwin_amd64/confluent kafka link create  my-link-cli-five --source-cluster-id lkc-gqnnk1 --source-api-key aaa --source-api-secret aaa  --config-file link_config.properties
Created cluster link "my-link-cli-five".
```

<!--
Open questions / Follow ups
---------------------------
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->

<!--
Review stakeholders
-------------------
Optional: mention stakeholders or special context that is required to review.
-->
