### PR TITLE
Hide "Allow sso.test to accept incoming connections?" during unit tests

### DIFF
--- a/internal/pkg/auth/sso/auth_server_test.go
+++ b/internal/pkg/auth/sso/auth_server_test.go
@@ -11,16 +11,18 @@ import (
 )
 
 func TestServerTimeout(t *testing.T) {
+	req := require.New(t)
+
 	state, err := newState("https://devel.cpdev.cloud", false)
-	require.NoError(t, err)
+	req.NoError(err)
+
 	server := newServer(state)
+	req.NoError(server.startServer())
 
-	require.NoError(t, server.startServer())
-
-	err = server.awaitAuthorizationCode(1 * time.Second)
-	require.Error(t, err)
-	require.Equal(t, err.Error(), errors.BrowserAuthTimedOutErrorMsg)
-	errors.VerifyErrorAndSuggestions(require.New(t), err, errors.BrowserAuthTimedOutErrorMsg, errors.BrowserAuthTimedOutSuggestions)
+	err = server.awaitAuthorizationCode(time.Duration(0))
+	req.Error(err)
+	req.Equal(err.Error(), errors.BrowserAuthTimedOutErrorMsg)
+	errors.VerifyErrorAndSuggestions(req, err, errors.BrowserAuthTimedOutErrorMsg, errors.BrowserAuthTimedOutSuggestions)
 }
 
 func TestCallback(t *testing.T) {


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok

What
----
https://github.com/confluentinc/cli/pull/349 introduced a unit test that made a popup appear on macOS that asked "Allow sso.test to accept incoming connections?" which was pretty annoying. I changed the timeout to 0s so the timeout doesn't have a chance to appear. Reduced the running time of our tests by 1s, which'll add up over time :smile:.

Test & Review
-------------
Test still passes