### PR TITLE
Prevent API key deletion in Kafka REST client

### DIFF
--- a/internal/pkg/cmd/client.go
+++ b/internal/pkg/cmd/client.go
@@ -15,9 +15,7 @@ type contextClient struct {
 
 // NewContextClient returns a new contextClient, with the specified context and a client.
 func NewContextClient(ctx *DynamicContext) *contextClient {
-	return &contextClient{
-		context: ctx,
-	}
+	return &contextClient{context: ctx}
 }
 
 func (c *contextClient) FetchCluster(clusterId string) (*schedv1.KafkaCluster, error) {

--- a/internal/pkg/cmd/dynamic_context.go
+++ b/internal/pkg/cmd/dynamic_context.go
@@ -109,34 +109,33 @@ func (d *DynamicContext) FindKafkaCluster(clusterId string) (*v1.KafkaClusterCon
 	if cluster := d.KafkaClusterContext.GetKafkaClusterConfig(clusterId); cluster != nil {
 		return cluster, nil
 	}
+
 	if d.client == nil {
 		return nil, errors.Errorf(errors.FindKafkaNoClientErrorMsg, clusterId)
 	}
+
 	// Resolve cluster details if not found locally.
-	ctxClient := NewContextClient(d)
-	kcc, err := ctxClient.FetchCluster(clusterId)
+	kcc, err := NewContextClient(d).FetchCluster(clusterId)
 	if err != nil {
 		return nil, err
 	}
-	cluster := KafkaClusterToKafkaClusterConfig(kcc)
+
+	cluster := kafkaClusterToKafkaClusterConfig(kcc, make(map[string]*v1.APIKeyPair))
 	d.KafkaClusterContext.AddKafkaClusterConfig(cluster)
 	err = d.Save()
-	if err != nil {
-		return nil, err
-	}
-	return cluster, nil
+
+	return cluster, err
 }
 
-func KafkaClusterToKafkaClusterConfig(kcc *schedv1.KafkaCluster) *v1.KafkaClusterConfig {
-	clusterConfig := &v1.KafkaClusterConfig{
+func kafkaClusterToKafkaClusterConfig(kcc *schedv1.KafkaCluster, apiKeys map[string]*v1.APIKeyPair) *v1.KafkaClusterConfig {
+	return &v1.KafkaClusterConfig{
 		ID:           kcc.Id,
 		Name:         kcc.Name,
 		Bootstrap:    strings.TrimPrefix(kcc.Endpoint, "SASL_SSL://"),
 		APIEndpoint:  kcc.ApiEndpoint,
-		APIKeys:      make(map[string]*v1.APIKeyPair),
+		APIKeys:      apiKeys,
 		RestEndpoint: kcc.RestEndpoint,
 	}
-	return clusterConfig
 }
 
 func (d *DynamicContext) SetActiveKafkaCluster(clusterId string) error {


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok

What
----
After #1201 was merged, the `getKafkaRestEndpoint()` function no longer short-circuited when it was called by the prerunner, and in the case of https://confluent.slack.com/archives/C010Y0EP5MZ/p1649083309126679, the function made it to the part where it transforms a `KafkaCluster` to a `KafkaClusterConfig`. If API keys existed locally, this would overwrite them with an empty `map`. Now, we pass the API keys alongside the `KafkaCluster` and combine the two to make a `KafkaClusterConfig`.

References
----------
https://confluent.slack.com/archives/C010Y0EP5MZ/p1649083309126679

Test & Review
-------------
Verified that the frontend-vault e2e test passes