### PR TITLE
CLI-1693 add 'print-header' option to print out untruncated content of msg headers

### DIFF
--- a/internal/cmd/kafka/command_topic_consume.go
+++ b/internal/cmd/kafka/command_topic_consume.go
@@ -37,7 +37,7 @@ func (c *hasAPIKeyTopicCommand) newConsumeCommand() *cobra.Command {
 	cmd.Flags().BoolP("from-beginning", "b", false, "Consume from beginning of the topic.")
 	cmd.Flags().String("value-format", "string", "Format of message value as string, avro, protobuf, or jsonschema. Note that schema references are not supported for avro.")
 	cmd.Flags().Bool("print-key", false, "Print key of the message.")
-	cmd.Flags().Bool("print-header", false, "Print complete content of message headers.")
+	cmd.Flags().Bool("full-header", false, "Print complete content of message headers.")
 	cmd.Flags().String("delimiter", "\t", "The delimiter separating each key and value.")
 	cmd.Flags().String("context-name", "", "The Schema Registry context under which to lookup schema ID.")
 	cmd.Flags().String("sr-endpoint", "", "Endpoint for Schema Registry cluster.")
@@ -79,7 +79,7 @@ func (c *hasAPIKeyTopicCommand) consume(cmd *cobra.Command, args []string) error
 		return err
 	}
 
-	printHeader, err := cmd.Flags().GetBool("print-header")
+	fullHeader, err := cmd.Flags().GetBool("full-header")
 	if err != nil {
 		return err
 	}
@@ -158,7 +158,7 @@ func (c *hasAPIKeyTopicCommand) consume(cmd *cobra.Command, args []string) error
 		Format:     valueFormat,
 		Out:        cmd.OutOrStdout(),
 		Subject:    subject,
-		Properties: ConsumerProperties{PrintKey: printKey, PrintHeader: printHeader, Delimiter: delimiter, SchemaPath: dir},
+		Properties: ConsumerProperties{PrintKey: printKey, FullHeader: fullHeader, Delimiter: delimiter, SchemaPath: dir},
 	}
 	return runConsumer(cmd, consumer, groupHandler)
 }

--- a/internal/cmd/kafka/command_topic_consume_onprem.go
+++ b/internal/cmd/kafka/command_topic_consume_onprem.go
@@ -41,7 +41,7 @@ func (c *authenticatedTopicCommand) newConsumeCommandOnPrem() *cobra.Command {
 	cmd.Flags().String("group", "", "Consumer group ID.")
 	cmd.Flags().BoolP("from-beginning", "b", false, "Consume from beginning of the topic.")
 	cmd.Flags().Bool("print-key", false, "Print key of the message.")
-	cmd.Flags().Bool("print-header", false, "Print complete content of message headers.")
+	cmd.Flags().Bool("full-header", false, "Print complete content of message headers.")
 	cmd.Flags().String("delimiter", "\t", "The delimiter separating each key and value.")
 	cmd.Flags().String("value-format", "string", "Format of message value as string, avro, protobuf, or jsonschema.")
 	cmd.Flags().String("sr-endpoint", "", "The URL of the schema registry cluster.")
@@ -59,7 +59,7 @@ func (c *authenticatedTopicCommand) onPremConsume(cmd *cobra.Command, args []str
 		return err
 	}
 
-	printHeader, err := cmd.Flags().GetBool("print-header")
+	fullHeader, err := cmd.Flags().GetBool("full-header")
 	if err != nil {
 		return err
 	}
@@ -139,7 +139,7 @@ func (c *authenticatedTopicCommand) onPremConsume(cmd *cobra.Command, args []str
 		Ctx:        ctx,
 		Format:     valueFormat,
 		Out:        cmd.OutOrStdout(),
-		Properties: ConsumerProperties{PrintKey: printKey, PrintHeader: printHeader, Delimiter: delimiter, SchemaPath: dir},
+		Properties: ConsumerProperties{PrintKey: printKey, FullHeader: fullHeader, Delimiter: delimiter, SchemaPath: dir},
 	}
 	return runConsumer(cmd, consumer, groupHandler)
 }

--- a/internal/cmd/kafka/confluent_kafka.go
+++ b/internal/cmd/kafka/confluent_kafka.go
@@ -46,10 +46,10 @@ var (
 )
 
 type ConsumerProperties struct {
-	Delimiter   string
-	PrintHeader bool
-	PrintKey    bool
-	SchemaPath  string
+	Delimiter  string
+	FullHeader bool
+	PrintKey   bool
+	SchemaPath string
 }
 
 // GroupHandler instances are used to handle individual topic-partition claims.
@@ -436,8 +436,8 @@ func consumeMessage(e *ckafka.Message, h *GroupHandler) error {
 
 	if e.Headers != nil {
 		var headers interface{} = e.Headers
-		if h.Properties.PrintHeader {
-			headers = getFullMessageOfHeaders(e.Headers)
+		if h.Properties.FullHeader {
+			headers = getFullHeaders(e.Headers)
 		}
 		_, err = fmt.Fprintf(h.Out, "%% Headers: %v\n", headers)
 		if err != nil {
@@ -521,15 +521,15 @@ func setConsumerDebugOption(configMap *ckafka.ConfigMap) error {
 	return nil
 }
 
-func getFullMessageOfHeaders(headers []ckafka.Header) []string {
+func getFullHeaders(headers []ckafka.Header) []string {
 	headerStrings := make([]string, len(headers))
 	for i, header := range headers {
-		headerStrings[i] = getStringOfHeader(header)
+		headerStrings[i] = getHeaderString(header)
 	}
 	return headerStrings
 }
 
-func getStringOfHeader(header ckafka.Header) string {
+func getHeaderString(header ckafka.Header) string {
 	if header.Value == nil {
 		return fmt.Sprintf("%s=nil", header.Key)
 	} else if len(header.Value) == 0 {


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->
Adding a 'print-header' (? what's a better flag name?) option. When unset, client only prints out the first 50 bytes of message header. When it's set, it'll print out full content to help users debug the issue.

References
----------
<!--
Copy & paste links to Jira tickets, other PRs, issues, Slack conversations, etc.
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->
[CLI-1693 Confluent CLI unable to read Fully managed connector DLQ topics](https://confluentinc.atlassian.net/browse/CLI-1693)

Test & Review
-------------
<!--
Has it been tested? how?
Copy & paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->
output of this flag unset:
```
209	{"ordertime":1507759349796,"orderid":209,"itemid":"Item_454","orderunits":3.8217404169188343,"address":{"city":"City_64","state":"State_11","zipcode":44710}}
% Headers: [task.generation="0" task.id="0" current.iteration="209" __connect.errors.topic="test" __connect.errors.partition="1" __connect.errors.offset="26" __connect.errors.connector.name="lcc-jvmv1w" __connect.errors.task.id="0" __connect.errors.stage="VALUE_CONVERTER" __connect.errors.class.name="io.confluent.connect.protobuf.ProtobufConverter" __connect.errors.exception.class.name="org.apache.kafka.connect.errors.DataException" __connect.errors.exception.message="Failed to deserialize data for topic test to Protobuf: " __connect.errors.exception.stacktrace="org.apache.kafka.connect.errors.DataException: Fai"(2653 more bytes)]
```
When this flag is set:
```
94	{"ordertime":1511750394574,"orderid":94,"itemid":"Item_735","orderunits":5.249390564934522,"address":{"city":"City_67","state":"State_97","zipcode":51044}}
% Headers: [task.generation=0 task.id=0 current.iteration=94 __connect.errors.topic=test __connect.errors.partition=4 __connect.errors.offset=14 __connect.errors.connector.name=lcc-jvmv1w __connect.errors.task.id=0 __connect.errors.stage=VALUE_CONVERTER __connect.errors.class.name=io.confluent.connect.protobuf.ProtobufConverter __connect.errors.exception.class.name=org.apache.kafka.connect.errors.DataException __connect.errors.exception.message=Failed to deserialize data for topic test to Protobuf:  __connect.errors.exception.stacktrace=org.apache.kafka.connect.errors.DataException: Failed to deserialize data for topic test to Protobuf: 
	at io.confluent.connect.protobuf.ProtobufConverter.toConnectData(ProtobufConverter.java:130)
	at org.apache.kafka.connect.storage.Converter.toConnectData(Converter.java:87)
	at org.apache.kafka.connect.runtime.WorkerSinkTask.lambda$convertAndTransformRecord$3(WorkerSinkTask.java:500)
	at org.apache.kafka.connect.runtime.errors.RetryWithToleranceOperator.execAndRetry(RetryWithToleranceOperator.java:166)
	at org.apache.kafka.connect.runtime.errors.RetryWithToleranceOperator.execAndHandleError(RetryWithToleranceOperator.java:200)
	at org.apache.kafka.connect.runtime.errors.RetryWithToleranceOperator.execute(RetryWithToleranceOperator.java:142)
	at org.apache.kafka.connect.runtime.WorkerSinkTask.convertAndTransformRecord(WorkerSinkTask.java:500)
	at org.apache.kafka.connect.runtime.WorkerSinkTask.convertMessages(WorkerSinkTask.java:475)
	at org.apache.kafka.connect.runtime.WorkerSinkTask.poll(WorkerSinkTask.java:330)
	at org.apache.kafka.connect.runtime.WorkerSinkTask.iteration(WorkerSinkTask.java:233)
	at org.apache.kafka.connect.runtime.WorkerSinkTask.execute(WorkerSinkTask.java:202)
	at org.apache.kafka.connect.runtime.WorkerTask.doRun(WorkerTask.java:200)
	at org.apache.kafka.connect.runtime.WorkerTask.run(WorkerTask.java:255)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1130)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:630)
	at java.base/java.lang.Thread.run(Thread.java:831)
Caused by: org.apache.kafka.common.errors.SerializationException: Error deserializing Protobuf message for id -1
	at io.confluent.kafka.serializers.protobuf.AbstractKafkaProtobufDeserializer.deserialize(AbstractKafkaProtobufDeserializer.java:174)
	at io.confluent.kafka.serializers.protobuf.AbstractKafkaProtobufDeserializer.deserializeWithSchemaAndVersion(AbstractKafkaProtobufDeserializer.java:236)
	at io.confluent.connect.protobuf.ProtobufConverter$Deserializer.deserialize(ProtobufConverter.java:174)
	at io.confluent.connect.protobuf.ProtobufConverter.toConnectData(ProtobufConverter.java:113)
	... 17 more
Caused by: org.apache.kafka.common.errors.SerializationException: Unknown magic byte!
	at io.confluent.kafka.serializers.AbstractKafkaSchemaSerDe.getByteBuffer(AbstractKafkaSchemaSerDe.java:250)
	at io.confluent.kafka.serializers.protobuf.AbstractKafkaProtobufDeserializer.deserialize(AbstractKafkaProtobufDeserializer.java:120)
	... 20 more
]
```

<!--
Open questions / Follow ups
---------------------------
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->

<!--
Review stakeholders
-------------------
Optional: mention stakeholders or special context that is required to review.
-->
