### PR TITLE
Fix Kafka cluster resize error message

### DIFF
--- a/internal/cmd/kafka/command_cluster_update.go
+++ b/internal/cmd/kafka/command_cluster_update.go
@@ -104,7 +104,7 @@ func (c *clusterCommand) validateResize(cmd *cobra.Command, currentCluster *cmkv
 		}
 		// Ensure the cluster is a Dedicated Cluster
 		if currentCluster.GetSpec().Config.CmkV2Dedicated == nil {
-			return -1, errors.Errorf("error updating kafka cluster: %v", errors.ClusterResizeNotSupported)
+			return -1, errors.Errorf("failed to update kafka cluster: %v", errors.ClusterResizeNotSupported)
 		}
 		// Durability Checks
 		if *currentCluster.GetSpec().Availability == highAvailability && cku <= 1 {

--- a/internal/pkg/errors/error_message.go
+++ b/internal/pkg/errors/error_message.go
@@ -122,7 +122,7 @@ const (
 	BYOKSupportErrorMsg                           = "BYOK is available on AWS and GCP."
 	CKUMoreThanZeroErrorMsg                       = "`--cku` value must be greater than 0"
 	CKUMoreThanOneErrorMsg                        = "`--cku` value must be greater than 1 for High Durability"
-	ClusterResizeNotSupported                     = "Cluster resize is support only on dedicated clusters."
+	ClusterResizeNotSupported                     = "cluster resize is only supported on dedicated clusters"
 	CloudRegionNotAvailableErrorMsg               = "\"%s\" is not an available region for \"%s\""
 	CloudRegionNotAvailableSuggestions            = "To view a list of available regions for \"%s\", use `confluent kafka region list --cloud %s`."
 	CloudProviderNotAvailableErrorMsg             = "\"%s\" is not an available cloud provider"
@@ -206,7 +206,7 @@ const (
 	SchemaNotFoundErrorMsg                   = "schema registry subject or version not found"
 	SchemaNotFoundSuggestions                = "List available subjects with `confluent schema-registry subject list`.\n" +
 		"List available versions with `confluent schema-registry subject describe`"
-	NoSubjectLevelConfigErrorMsg 			 = `subject "%s" does not have subject-level compatibility configured`
+	NoSubjectLevelConfigErrorMsg = `subject "%s" does not have subject-level compatibility configured`
 
 	// secret commands
 	EnterInputTypeErrorMsg    = "enter %s"

--- a/test/fixtures/output/kafka/kafka-cluster-resize-error.golden
+++ b/test/fixtures/output/kafka/kafka-cluster-resize-error.golden
@@ -1,1 +1,1 @@
-Error: error updating kafka cluster: Cluster resize is support only on dedicated clusters.
+Error: failed to update kafka cluster: cluster resize is only supported on dedicated clusters


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok

What
----
Fixed bad grammar.
Before: `Error: error updating kafka cluster: Cluster resize is support only on dedicated clusters.`
After: `Error: failed to update kafka cluster: cluster resize is only supported on dedicated clusters`

Test & Review
-------------
Updated integration test