### PR TITLE
Standardize return type for `kafka cluster`

### DIFF
--- a/internal/cmd/kafka/command.go
+++ b/internal/cmd/kafka/command.go
@@ -19,12 +19,10 @@ func New(cfg *v1.Config, prerunner pcmd.PreRunner, clientID string) *cobra.Comma
 
 	c := &command{pcmd.NewCLICommand(cmd, prerunner)}
 
-	clusterCmd := newClusterCommand(cfg, prerunner)
-
 	cmd.AddCommand(newAclCommand(cfg, prerunner))
 	cmd.AddCommand(newBrokerCommand(prerunner))
 	cmd.AddCommand(newClientConfigCommand(prerunner, clientID))
-	cmd.AddCommand(clusterCmd.Command)
+	cmd.AddCommand(newClusterCommand(cfg, prerunner))
 	cmd.AddCommand(newConsumerGroupCommand(prerunner))
 	cmd.AddCommand(newLinkCommand(cfg, prerunner))
 	cmd.AddCommand(newMirrorCommand(prerunner))

--- a/internal/cmd/kafka/command_cluster.go
+++ b/internal/cmd/kafka/command_cluster.go
@@ -28,7 +28,7 @@ type clusterCommand struct {
 	*pcmd.AuthenticatedStateFlagCommand
 }
 
-func newClusterCommand(cfg *v1.Config, prerunner pcmd.PreRunner) *clusterCommand {
+func newClusterCommand(cfg *v1.Config, prerunner pcmd.PreRunner) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:         "cluster",
 		Short:       "Manage Kafka clusters.",
@@ -43,19 +43,19 @@ func newClusterCommand(cfg *v1.Config, prerunner pcmd.PreRunner) *clusterCommand
 		c.AuthenticatedStateFlagCommand = pcmd.NewAuthenticatedWithMDSStateFlagCommand(cmd, prerunner)
 	}
 
-	c.AddCommand(c.newCreateCommand(cfg))
-	c.AddCommand(c.newDeleteCommand(cfg))
-	c.AddCommand(c.newDescribeCommand(cfg))
-	c.AddCommand(c.newUpdateCommand(cfg))
-	c.AddCommand(c.newUseCommand(cfg))
+	cmd.AddCommand(c.newCreateCommand(cfg))
+	cmd.AddCommand(c.newDeleteCommand(cfg))
+	cmd.AddCommand(c.newDescribeCommand(cfg))
+	cmd.AddCommand(c.newUpdateCommand(cfg))
+	cmd.AddCommand(c.newUseCommand(cfg))
 
 	if cfg.IsCloudLogin() {
-		c.AddCommand(c.newListCommand())
+		cmd.AddCommand(c.newListCommand())
 	} else {
-		c.AddCommand(c.newListCommandOnPrem())
+		cmd.AddCommand(c.newListCommandOnPrem())
 	}
 
-	return c
+	return cmd
 }
 
 func (c *clusterCommand) validArgs(cmd *cobra.Command, args []string) []string {

--- a/internal/cmd/kafka/command_cluster_test.go
+++ b/internal/cmd/kafka/command_cluster_test.go
@@ -1,28 +1,26 @@
 package kafka
 
 import (
-	"bytes"
 	"context"
 	"net/http"
 	"testing"
 	"time"
 
-	orgv1 "github.com/confluentinc/cc-structs/kafka/org/v1"
 	corev1 "github.com/confluentinc/cc-structs/kafka/product/core/v1"
 	schedv1 "github.com/confluentinc/cc-structs/kafka/scheduler/v1"
 	"github.com/confluentinc/ccloud-sdk-go-v1"
 	ccsdkmock "github.com/confluentinc/ccloud-sdk-go-v1/mock"
-	"github.com/google/go-cmp/cmp"
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	cmkv2 "github.com/confluentinc/ccloud-sdk-go-v2/cmk/v2"
 	cmkmock "github.com/confluentinc/ccloud-sdk-go-v2/cmk/v2/mock"
+
 	"github.com/confluentinc/cli/internal/pkg/ccloudv2"
 	pcmd "github.com/confluentinc/cli/internal/pkg/cmd"
 	v1 "github.com/confluentinc/cli/internal/pkg/config/v1"
 	"github.com/confluentinc/cli/internal/pkg/errors"
-	"github.com/confluentinc/cli/internal/pkg/mock"
 	cliMock "github.com/confluentinc/cli/mock"
 )
 
@@ -192,7 +190,7 @@ func (suite *KafkaClusterTestSuite) SetupTest() {
 	}
 }
 
-func (suite *KafkaClusterTestSuite) newCmd(conf *v1.Config) *clusterCommand {
+func (suite *KafkaClusterTestSuite) newCmd(conf *v1.Config) *cobra.Command {
 	client := &ccloud.Client{
 		Kafka:               suite.kafkaMock,
 		EnvironmentMetadata: suite.envMetadataMock,
@@ -204,115 +202,6 @@ func (suite *KafkaClusterTestSuite) newCmd(conf *v1.Config) *clusterCommand {
 	}
 	prerunner := cliMock.NewPreRunnerMock(client, &ccloudv2.Client{CmkClient: cmkClient, AuthToken: "auth-token"}, nil, nil, conf)
 	return newClusterCommand(conf, prerunner)
-}
-
-func (suite *KafkaClusterTestSuite) TestCreateGCPBYOK() {
-	req := require.New(suite.T())
-	root := suite.newCmd(v1.AuthenticatedCloudConfigMock())
-	kafkaMock := &ccsdkmock.Kafka{
-		DescribeFunc: func(ctx context.Context, cluster *schedv1.KafkaCluster) (*schedv1.KafkaCluster, error) {
-			return &schedv1.KafkaCluster{
-				ApiEndpoint: "api-endpoint",
-			}, nil
-		},
-	}
-	idMock := &ccsdkmock.ExternalIdentity{
-		CreateExternalIdentityFunc: func(_ context.Context, cloud, accountID string) (string, error) {
-			return "id-xyz", nil
-		},
-	}
-	client := &ccloud.Client{
-		Kafka:            kafkaMock,
-		ExternalIdentity: idMock,
-		EnvironmentMetadata: &ccsdkmock.EnvironmentMetadata{
-			GetFunc: func(ctx context.Context) ([]*schedv1.CloudMetadata, error) {
-				return []*schedv1.CloudMetadata{{
-					Id:       "gcp",
-					Accounts: []*schedv1.AccountMetadata{{Id: "account-xyz"}},
-					Regions:  []*schedv1.Region{{IsSchedulable: true, Id: "us-central1"}},
-				}}, nil
-			},
-		},
-	}
-	cmkApiMock := &cmkmock.ClustersCmkV2Api{
-		CreateCmkV2ClusterFunc: func(ctx context.Context) cmkv2.ApiCreateCmkV2ClusterRequest {
-			return cmkv2.ApiCreateCmkV2ClusterRequest{}
-		},
-		CreateCmkV2ClusterExecuteFunc: func(req cmkv2.ApiCreateCmkV2ClusterRequest) (cmkv2.CmkV2Cluster, *http.Response, error) {
-			return cmkByokCluster, nil, nil
-		},
-	}
-	cmkClient := &cmkv2.APIClient{ClustersCmkV2Api: cmkApiMock}
-	root.AuthenticatedCLICommand.State = &v1.ContextState{
-		Auth: &v1.AuthConfig{
-			Account: &orgv1.Account{
-				Id: environmentId,
-			},
-		},
-	}
-	root.Client = client
-	root.V2Client = &ccloudv2.Client{CmkClient: cmkClient, AuthToken: "auth-token"}
-	var buf bytes.Buffer
-	root.SetOut(&buf)
-	cmd, args, err := root.Command.Find([]string{
-		"create",
-		"gcp-byok-test",
-	})
-	req.NoError(err)
-	err = cmd.ParseFlags([]string{
-		"--cloud=gcp",
-		"--region=us-central1",
-		"--type=dedicated",
-		"--cku=1",
-		"--encryption-key=xyz",
-	})
-	req.NoError(err)
-	err = root.create(cmd, args, mock.NewPromptMock(
-		"y", // yes customer has granted key access
-	))
-	req.NoError(err)
-	got, want := buf.Bytes(), []byte(`Create a role with these permissions, add the identity as a member of your key, and grant your role to the member:
-
-Permissions:
-  - cloudkms.cryptoKeyVersions.useToDecrypt
-  - cloudkms.cryptoKeyVersions.useToEncrypt
-  - cloudkms.cryptoKeys.get
-
-Identity:
-  id-xyz
-
-
-Please confirm you've authorized the key for this identity: id-xyz (y/n): It may take up to 1 hour for the Kafka cluster to be ready. The organization admin will receive an email once the dedicated cluster is provisioned.
-+-------------------+---------------+
-| ID                | lkc-xyz       |
-| Name              | gcp-byok-test |
-| Type              | DEDICATED     |
-| Ingress           |            50 |
-| Egress            |           150 |
-| Storage           | Infinite      |
-| Provider          | gcp           |
-| Availability      | single-zone   |
-| Region            | us-central1   |
-| Status            | PROVISIONING  |
-| Endpoint          |               |
-| API Endpoint      | api-endpoint  |
-| REST Endpoint     |               |
-| Cluster Size      |             1 |
-| Encryption Key ID | xyz           |
-+-------------------+---------------+
-`)
-	req.True(cmp.Equal(got, want), cmp.Diff(got, want))
-	req.Equal("abc", idMock.CreateExternalIdentityCalls()[0].AccountID)
-	req.Equal("gcp", idMock.CreateExternalIdentityCalls()[0].Cloud)
-	createdCluster, _, _ := cmkApiMock.CreateCmkV2ClusterExecuteFunc(cmkv2.ApiCreateCmkV2ClusterRequest{})
-	req.Equal("abc", createdCluster.Spec.Environment.Id)
-	req.Equal("gcp", *createdCluster.Spec.Cloud)
-	req.Equal("us-central1", *createdCluster.Spec.Region)
-	req.Equal("xyz", *createdCluster.Spec.Config.CmkV2Dedicated.EncryptionKey)
-	req.NotEqual(nil, createdCluster.Spec.Config.CmkV2Dedicated)
-	req.Equal(int32(1), createdCluster.Spec.Config.CmkV2Dedicated.Cku)
-
-	req.False(suite.metricsApi.QueryV2Called())
 }
 
 func (suite *KafkaClusterTestSuite) TestClusterShrinkShouldPrompt() {
@@ -376,17 +265,19 @@ func (suite *KafkaClusterTestSuite) TestDeleteKafkaCluster() {
 
 func (suite *KafkaClusterTestSuite) TestGetLkcForDescribe() {
 	req := require.New(suite.T())
-	conf := v1.AuthenticatedCloudConfigMock()
-	cmd := suite.newCmd(conf)
-	cmd.Config = pcmd.NewDynamicConfig(conf, nil, nil, nil)
-	lkc, err := cmd.getLkcForDescribe([]string{"lkc-123"})
+	cmd := new(cobra.Command)
+	cfg := v1.AuthenticatedCloudConfigMock()
+	prerunner := &pcmd.PreRun{Config: cfg}
+	c := &clusterCommand{pcmd.NewAuthenticatedStateFlagCommand(cmd, prerunner)}
+	c.Config = pcmd.NewDynamicConfig(cfg, nil, nil, nil)
+	lkc, err := c.getLkcForDescribe([]string{"lkc-123"})
 	req.Equal("lkc-123", lkc)
 	req.NoError(err)
-	lkc, err = cmd.getLkcForDescribe([]string{})
-	req.Equal(cmd.Config.Context().KafkaClusterContext.GetActiveKafkaClusterId(), lkc)
+	lkc, err = c.getLkcForDescribe([]string{})
+	req.Equal(c.Config.Context().KafkaClusterContext.GetActiveKafkaClusterId(), lkc)
 	req.NoError(err)
-	cmd.Config.Context().KafkaClusterContext.GetCurrentKafkaEnvContext().ActiveKafkaCluster = ""
-	lkc, err = cmd.getLkcForDescribe([]string{})
+	c.Config.Context().KafkaClusterContext.GetCurrentKafkaEnvContext().ActiveKafkaCluster = ""
+	lkc, err = c.getLkcForDescribe([]string{})
 	req.Equal("", lkc)
 	req.Equal(errors.NewErrorWithSuggestions(errors.NoKafkaSelectedErrorMsg, errors.NoKafkaForDescribeSuggestions).Error(), err.Error())
 }

--- a/internal/pkg/cmd/dynamic_context.go
+++ b/internal/pkg/cmd/dynamic_context.go
@@ -88,21 +88,13 @@ func (d *DynamicContext) verifyEnvironmentId(envId string, environments []*orgv1
 }
 
 func (d *DynamicContext) GetKafkaClusterForCommand() (*v1.KafkaClusterConfig, error) {
-	clusterId, err := d.getKafkaClusterIDForCommand()
-	if err != nil {
-		return nil, err
+	clusterId := d.KafkaClusterContext.GetActiveKafkaClusterId()
+	if clusterId == "" {
+		return nil, errors.NewErrorWithSuggestions(errors.NoKafkaSelectedErrorMsg, errors.NoKafkaSelectedSuggestions)
 	}
 
 	cluster, err := d.FindKafkaCluster(clusterId)
 	return cluster, errors.CatchKafkaNotFoundError(err, clusterId)
-}
-
-func (d *DynamicContext) getKafkaClusterIDForCommand() (string, error) {
-	clusterId := d.KafkaClusterContext.GetActiveKafkaClusterId()
-	if clusterId == "" {
-		return "", errors.NewErrorWithSuggestions(errors.NoKafkaSelectedErrorMsg, errors.NoKafkaSelectedSuggestions)
-	}
-	return clusterId, nil
 }
 
 func (d *DynamicContext) FindKafkaCluster(clusterId string) (*v1.KafkaClusterConfig, error) {

--- a/test/fixtures/output/kafka/cluster/gcp-byok.golden
+++ b/test/fixtures/output/kafka/cluster/gcp-byok.golden
@@ -1,0 +1,29 @@
+Create a role with these permissions, add the identity as a member of your key, and grant your role to the member:
+
+Permissions:
+  - cloudkms.cryptoKeyVersions.useToDecrypt
+  - cloudkms.cryptoKeyVersions.useToEncrypt
+  - cloudkms.cryptoKeys.get
+
+Identity:
+  id-xyz
+
+
+Please confirm you've authorized the key for this identity: id-xyz (y/n): It may take up to 1 hour for the Kafka cluster to be ready. The organization admin will receive an email once the dedicated cluster is provisioned.
++-------------------+---------------------------+
+| ID                | lkc-def963                |
+| Name              | gcp-byok-test             |
+| Type              | DEDICATED                 |
+| Ingress           |                        50 |
+| Egress            |                       150 |
+| Storage           | Infinite                  |
+| Provider          | gcp                       |
+| Availability      | single-zone               |
+| Region            | asia-southeast1           |
+| Status            | PROVISIONING              |
+| Endpoint          | SASL_SSL://kafka-endpoint |
+| API Endpoint      | http://kafka-api-url      |
+| REST Endpoint     | https://pkc-endpoint      |
+| Cluster Size      |                         1 |
+| Encryption Key ID | xyz                       |
++-------------------+---------------------------+

--- a/test/kafka_test.go
+++ b/test/kafka_test.go
@@ -152,6 +152,17 @@ func (s *CLITestSuite) TestKafka() {
 	}
 }
 
+func (s *CLITestSuite) TestKafkaClusterCreate_GcpByok() {
+	test := CLITest{
+		login:       "cloud",
+		args:        "kafka cluster create gcp-byok-test --cloud gcp --region asia-southeast1 --type dedicated --cku 1 --encryption-key xyz",
+		preCmdFuncs: []bincover.PreCmdFunc{stdinPipeFunc(strings.NewReader("y\n"))},
+		fixture:     "kafka/cluster/gcp-byok.golden",
+	}
+
+	s.runIntegrationTest(test)
+}
+
 func (s *CLITestSuite) TestClientConfig() {
 	// TODO: add --config flag to all commands or ENVVAR instead of using standard config file location
 	tests := []CLITest{

--- a/test/test-server/ccloud_handlers.go
+++ b/test/test-server/ccloud_handlers.go
@@ -23,6 +23,7 @@ import (
 	schedv1 "github.com/confluentinc/cc-structs/kafka/scheduler/v1"
 	utilv1 "github.com/confluentinc/cc-structs/kafka/util/v1"
 	opv1 "github.com/confluentinc/cc-structs/operator/v1"
+	bucketv1 "github.com/confluentinc/cire-bucket-service/protos/bucket/v1"
 	mds "github.com/confluentinc/mds-sdk-go/mdsv1"
 
 	"github.com/confluentinc/cli/internal/pkg/errors"
@@ -929,6 +930,15 @@ func (c *CloudRouter) HandleLaunchDarkly(t *testing.T) func(w http.ResponseWrite
 		jsonVal := map[string]interface{}{"key": "val"}
 		flags := map[string]interface{}{"testBool": true, "testString": "string", "testInt": 1, "testJson": jsonVal}
 		err := json.NewEncoder(w).Encode(&flags)
+		require.NoError(t, err)
+	}
+}
+
+// Handler for: "/api/external_identities"
+func handleExternalIdentities(t *testing.T) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		res := &bucketv1.CreateExternalIdentityResponse{IdentityName: "id-xyz"}
+		err := json.NewEncoder(w).Encode(res)
 		require.NoError(t, err)
 	}
 }

--- a/test/test-server/cloud_router.go
+++ b/test/test-server/cloud_router.go
@@ -47,6 +47,7 @@ const (
 	metricsApi          = "/{version}/metrics/{view}/{query}"
 	accessTokens        = "/api/access_tokens"
 	launchDarklyProxy   = "/ldapi/sdk/eval/{env}/users/{user:[a-zA-Z0-9=\\-\\/]+}"
+	externalIdentities  = "/api/external_identities"
 )
 
 type CloudRouter struct {
@@ -79,6 +80,7 @@ func (c *CloudRouter) buildCcloudRouter(t *testing.T, isAuditLogEnabled bool) {
 	c.HandleFunc(verifyEmail, c.HandleSendVerificationEmail(t))
 	c.HandleFunc(envMetadata, c.HandleEnvMetadata(t))
 	c.HandleFunc(launchDarklyProxy, c.HandleLaunchDarkly(t))
+	c.HandleFunc(externalIdentities, handleExternalIdentities(t))
 	c.addSchemaRegistryRoutes(t)
 	c.addEnvironmentRoutes(t)
 	c.addOrgRoutes(t)


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok

What
----
Similar to #1255, but for `kafka cluster`.

Test & Review
-------------
BYOK kafka cluster create test was better suited for the integration test suite, so I rewrote it