### PR TITLE
Bump CP to 7.2 in Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -78,7 +78,7 @@ def job = {
                                 export confluent_s3="https://s3-us-west-2.amazonaws.com"
                                 git clone git@github.com:confluentinc/muckrake.git
                                 cd muckrake
-                                git checkout 7.1.x
+                                git checkout 7.2.x
                                 sed -i "s?\\(confluent-cli-\\(.*\\)=\\)\\(.*\\)?\\1${confluent_s3}/confluent.cloud/confluent-cli-system-test-builds/confluent_SNAPSHOT-${HASH}_linux_amd64\\.tar\\.gz\\"?" ducker/ducker
                                 sed -i "s?get_cli .*?& ${confluent_s3}/confluent.cloud/confluent-cli-system-test-builds/confluent_SNAPSHOT-${HASH}_linux_amd64\\.tar\\.gz?g" vagrant/base-ubuntu.sh
                                 sed -i "s?get_cli .*?& ${confluent_s3}/confluent.cloud/confluent-cli-system-test-builds/confluent_SNAPSHOT-${HASH}_linux_amd64\\.tar\\.gz?g" vagrant/base-redhat.sh
@@ -103,7 +103,7 @@ def job = {
                     ["sonatype/confluent", "user", "SONATYPE_OSSRH_USER"],
                     ["sonatype/confluent", "password", "SONATYPE_OSSRH_PASSWORD"]]) {
                     withEnv(["GIT_CREDENTIAL=${env.GIT_USER}:${env.GIT_TOKEN}",
-                        "AWS_KEYPAIR_FILE=${pem_file}", "GIT_BRANCH=7.1.x"]) {
+                        "AWS_KEYPAIR_FILE=${pem_file}", "GIT_BRANCH=7.2.x"]) {
                         withVaultFile([["gradle/gradle_properties_maven", "gradle_properties_file",
                             "gradle.properties", "GRADLE_PROPERTIES_FILE"]]) {
                             sh '''#!/usr/bin/env bash


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok

What
----
On to the next version of CP! In general we should wait as long as possible to bump this (for better stability), but https://github.com/confluentinc/cli/pull/1189 introduced some changes that aren't compatible with the 7.1.x branch of muckrake.

This quarter I want to start using nightly builds to run our tests so we don't have to worry about muckrake stability ever again (and don't need to keep bumping the CP version every couple months 🤦‍♂️)