### PR TITLE
Mention `CONFLUENT_SECURITY_MASTER_KEY` in `secret file` docs

### DIFF
--- a/internal/cmd/secret/command_file.go
+++ b/internal/cmd/secret/command_file.go
@@ -7,13 +7,14 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/confluentinc/cli/internal/pkg/secret"
-
 	mds "github.com/confluentinc/mds-sdk-go/mdsv1"
 
 	pcmd "github.com/confluentinc/cli/internal/pkg/cmd"
 	"github.com/confluentinc/cli/internal/pkg/errors"
+	"github.com/confluentinc/cli/internal/pkg/secret"
 )
+
+const masterKeyNotSetWarning = "This command fails if a master key has not been set in the environment variable `CONFLUENT_SECURITY_MASTER_KEY`. Create a master key using `confluent secret master-key generate`."
 
 func (c *command) newFileCommand() *cobra.Command {
 	cmd := &cobra.Command{

--- a/internal/cmd/secret/command_file_add.go
+++ b/internal/cmd/secret/command_file_add.go
@@ -10,7 +10,7 @@ func (c *command) newAddCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "add",
 		Short: "Add secrets to a configuration properties file.",
-		Long:  "This command encrypts the password and adds it to the configuration file specified in --config-file. This command returns a failure if a master key has not already been set using the \"master-key generate\" command.",
+		Long:  "This command encrypts the password and adds it to the configuration file specified by `--config-file`. " + masterKeyNotSetWarning,
 		Args:  cobra.NoArgs,
 		RunE:  pcmd.NewCLIRunE(c.add),
 	}

--- a/internal/cmd/secret/command_file_decrypt.go
+++ b/internal/cmd/secret/command_file_decrypt.go
@@ -10,7 +10,7 @@ func (c *command) newDecryptCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "decrypt",
 		Short: "Decrypt secrets in a configuration properties file.",
-		Long:  "This command decrypts the passwords in file specified in `--config-file`. This command returns a failure if a master key has not already been set using the `master-key generate` command.",
+		Long:  "This command decrypts the passwords in the file specified by `--config-file`. " + masterKeyNotSetWarning,
 		Args:  cobra.NoArgs,
 		RunE:  pcmd.NewCLIRunE(c.decrypt),
 	}

--- a/internal/cmd/secret/command_file_encrypt.go
+++ b/internal/cmd/secret/command_file_encrypt.go
@@ -10,7 +10,7 @@ func (c *command) newEncryptCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "encrypt",
 		Short: "Encrypt secrets in a configuration properties file.",
-		Long:  "This command encrypts the passwords in file specified in --config-file. This command returns a failure if a master key has not already been set in the environment variable. Create master key using \"master-key generate\" command and save the generated master key in environment variable.",
+		Long:  "This command encrypts the passwords in the file specified by `--config-file`. " + masterKeyNotSetWarning,
 		Args:  cobra.NoArgs,
 		RunE:  pcmd.NewCLIRunE(c.encrypt),
 	}


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok

What
----
While looking at https://confluent.slack.com/archives/C9Y6NAM6X/p1650642630386559, I noticed the docs for `confluent secret file [encrypt|decrypt|add]` refer to `CONFLUENT_SECURITY_MASTER_KEY` as "the environment variable". I had to do some digging to figure out its actual name.

References
----------
https://confluent.slack.com/archives/C9Y6NAM6X/p1650642630386559