### PR TITLE
Don't clear the config version in unit tests

### DIFF
--- a/internal/pkg/config/v1/config.go
+++ b/internal/pkg/config/v1/config.go
@@ -84,7 +84,6 @@ func New() *Config {
 // Load reads the CLI config from disk.
 // Save a default version if none exists yet.
 func (c *Config) Load() error {
-	currentVersion := ver
 	filename := c.GetFilename()
 	input, err := ioutil.ReadFile(filename)
 	if err != nil {
@@ -98,8 +97,8 @@ func (c *Config) Load() error {
 		return errors.Wrapf(err, errors.UnableToReadConfigErrorMsg, filename)
 	}
 	err = json.Unmarshal(input, c)
-	if c.Ver.Compare(currentVersion) < 0 {
-		return errors.Errorf(errors.ConfigNotUpToDateErrorMsg, c.Ver, currentVersion)
+	if c.Ver.Compare(ver) < 0 {
+		return errors.Errorf(errors.ConfigNotUpToDateErrorMsg, c.Ver, ver)
 	} else if c.Ver.Compare(ver) > 0 {
 		if c.Ver.Equal(version.Must(version.NewVersion("3.0.0"))) {
 			// The user is a CP user who downloaded the v2 CLI instead of running `confluent update --major`,

--- a/internal/pkg/config/v1/config_test.go
+++ b/internal/pkg/config/v1/config_test.go
@@ -648,7 +648,7 @@ func TestConfig_AddContext(t *testing.T) {
 
 func TestConfig_CreateContext(t *testing.T) {
 	cfg := &Config{
-		BaseConfig:    &config.BaseConfig{Ver: config.Version{Version: new(version.Version)}},
+		BaseConfig:    &config.BaseConfig{Ver: config.Version{Version: version.Must(version.NewVersion("1.0.0"))}},
 		ContextStates: make(map[string]*ContextState),
 		Contexts:      make(map[string]*Context),
 		Credentials:   make(map[string]*Credential),


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok

What
----
This has been the source of a few slack threads (2 in the last week!) and flaky CI failures, so it's finally time to fix it :laughing: Basically, this test makes the "version" field empty in `~/.confluent/config.json` and `TestPreRun_Anonymous_SetLoggingLevel` tries to access it. Probably fails on 1% of runs, but still annoying.
* https://confluent.slack.com/archives/C9Y6NAM6X/p1649793538020619
* https://confluent.slack.com/archives/C010Y0EP5MZ/p1650583555273709
* https://dev.azure.com/confluentinc/cli/_build/results?buildId=7849&view=logs&j=022b0a5d-2698-5f72-7610-a845972a8b4c&t=5c0622ed-2d33-5375-62a9-8d63e22770dc

Test & Review
-------------
Test still works as intended. Unit tests should not be modifying local resources in the first place 😕  I plan to rewrite this test in CLI v3 when we remove the version field from the config file.