### PR TITLE
Enable Semaphore for repo

### DIFF
--- a/service.yml
+++ b/service.yml
@@ -1,0 +1,8 @@
+name: cli
+lang: go
+lang_version: 1.17.6
+github:
+  enable: true
+  repo_name: confluentinc/cli
+semaphore:
+  enable: true


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok

What
----
Semaphore is added to repos with cc-service-bot. This is a bit annoying since we have to add yet another top-level file, and the file's called service.yml even though this isn't a service. Oh well... following the instructions here:
https://confluentinc.atlassian.net/wiki/spaces/TOOLS/pages/1342058645/Semaphore+FAQ#How-can-I-add-my-new-project-to-semaphore2%3F