### PR TITLE
Rename UUID in `kafka topic consume` docs

### DIFF
--- a/mk-files/docs.mk
+++ b/mk-files/docs.mk
@@ -44,7 +44,7 @@ publish-docs-internal:
 	git checkout -b cli-$(VERSION) origin/$(DOCS_BASE_BRANCH) || exit 1; \
 	rm -rf command-reference; \
 	cp -R ~/git/go/src/github.com/confluentinc/cli/docs command-reference; \
-	[ ! -f "command-reference/kafka/topic/confluent_kafka_topic_consume.rst" ] || sed -i '' 's/default "confluent_cli_consumer_[^"]*"/default "confluent_cli_consumer_<uuid>"/' command-reference/kafka/topic/confluent_kafka_topic_consume.rst || exit 1; \
+	[ ! -f "command-reference/kafka/topic/confluent_kafka_topic_consume.rst" ] || sed -i '' 's/default "confluent_cli_consumer_[^"]*"/default "confluent_cli_consumer_<randomly-generated-id>"/' command-reference/kafka/topic/confluent_kafka_topic_consume.rst || exit 1; \
 	git add . || exit 1; \
 	git diff --cached --exit-code > /dev/null && echo "nothing to update for docs" && exit 0; \
 	git commit -m "[ci skip] chore: update CLI docs for $(VERSION)" || exit 1; \


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok

What
----
UUID = Unique User ID, which implies that it's user-based, not consumer-based (every time you run the command, it should be different)