### PR TITLE
Fix `panic()` on login

### DIFF
--- a/internal/pkg/auth/login_credentials_manager.go
+++ b/internal/pkg/auth/login_credentials_manager.go
@@ -157,7 +157,7 @@ func (h *LoginCredentialsManagerImpl) GetCredentialsFromConfig(cfg *v1.Config) f
 		credentials, _ := h.GetPrerunCredentialsFromConfig(cfg)()
 
 		// For `confluent login`, only retrieve credentials from the config file if SSO (prevents a breaking change)
-		if credentials.IsSSO {
+		if credentials != nil && credentials.IsSSO {
 			return credentials, nil
 		}
 


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok

What
----
`credentials` can be `nil` if there is no current context in the user's config.

Before:
```
% confluent login
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x55107ed]

goroutine 1 [running]:
github.com/confluentinc/cli/internal/pkg/auth.(*LoginCredentialsManagerImpl).GetCredentialsFromConfig.func1()
        go/src/github.com/confluentinc/cli/internal/pkg/auth/login_credentials_manager.go:160 +0x2d
github.com/confluentinc/cli/internal/pkg/auth.GetLoginCredentials({0xc000553ad8, 0x4, 0x0})
        go/src/github.com/confluentinc/cli/internal/pkg/auth/login_credentials_manager.go:54 +0x58
github.com/confluentinc/cli/internal/cmd/login.(*command).getCCloudCredentials(0xc00042f000, 0x0, {0x60fc4f8, 0x17}, {0x0, 0x0})
        go/src/github.com/confluentinc/cli/internal/cmd/login/command.go:150 +0x285
github.com/confluentinc/cli/internal/cmd/login.(*command).loginCCloud(0xc00042f000, 0x17, {0x60fc4f8, 0x17})
        go/src/github.com/confluentinc/cli/internal/cmd/login/command.go:99 +0x89
github.com/confluentinc/cli/internal/cmd/login.(*command).login(0x8211108, 0x20, {0xc000580000, 0xc000618120, 0x0})
        go/src/github.com/confluentinc/cli/internal/cmd/login/command.go:87 +0xe5
github.com/confluentinc/cli/internal/pkg/cmd.Chain.func1(0xc00058f640, {0x7963f70, 0x0, 0x0})
        go/src/github.com/confluentinc/cli/internal/pkg/cmd/cobra.go:24 +0x83
github.com/confluentinc/cli/internal/pkg/cmd.CatchErrors.func1(0xc0003e9b80, {0x7963f70, 0x0, 0x0})
        go/src/github.com/confluentinc/cli/internal/pkg/cmd/cobra.go:12 +0x69
github.com/spf13/cobra.(*Command).execute(0xc0003e9b80, {0x7963f70, 0x0, 0x0})
        go/1.17.6/pkg/mod/github.com/spf13/cobra@v1.3.0/command.go:856 +0x60e
github.com/spf13/cobra.(*Command).ExecuteC(0xc00029a000)
        go/1.17.6/pkg/mod/github.com/spf13/cobra@v1.3.0/command.go:974 +0x3bc
github.com/spf13/cobra.(*Command).Execute(...)
        go/1.17.6/pkg/mod/github.com/spf13/cobra@v1.3.0/command.go:902
github.com/confluentinc/cli/internal/cmd.(*command).Execute(0xc0003d0d80, {0xc00004e050, 0xc00042e280, 0x8})
        go/src/github.com/confluentinc/cli/internal/cmd/command.go:125 +0x56
main.main()
        go/src/github.com/confluentinc/cli/cmd/confluent/main.go:42 +0x28a
```

After:
```
% confluent login
Enter your Confluent Cloud credentials:
Email: bstrauch@confluent.io
Password: ************
Logged in as "bstrauch@confluent.io" for organization "a372b35d-47a7-4f1d-a857-0782be2cff4c" ("Confluent").
```

References
----------
<!--
Copy & paste links to Jira tickets, other PRs, issues, Slack conversations, etc.
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test & Review
-------------
<!--
Has it been tested? how?
Copy & paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

<!--
Open questions / Follow ups
---------------------------
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->

<!--
Review stakeholders
-------------------
Optional: mention stakeholders or special context that is required to review.
-->
