### PR TITLE
Ignore `--save` flag if user is SSO user

### DIFF
--- a/internal/cmd/login/command.go
+++ b/internal/cmd/login/command.go
@@ -205,8 +205,7 @@ func (c *command) loginMDS(cmd *cobra.Command, url string) error {
 		return err
 	}
 
-	err = c.saveLoginToNetrc(cmd, false, credentials)
-	if err != nil {
+	if err := c.saveLoginToNetrc(cmd, false, credentials); err != nil {
 		return err
 	}
 
@@ -277,6 +276,11 @@ func (c *command) saveLoginToNetrc(cmd *cobra.Command, isCloud bool, credentials
 	}
 
 	if save {
+		if credentials.IsSSO {
+			utils.ErrPrintln(cmd, "The `--save` flag was ignored since SSO credentials are not stored locally.")
+			return nil
+		}
+
 		if err := c.netrcHandler.WriteNetrcCredentials(isCloud, credentials.IsSSO, c.Config.Config.Context().NetrcMachineName, credentials.Username, credentials.Password); err != nil {
 			return err
 		}

--- a/internal/pkg/auth/login_credentials_manager.go
+++ b/internal/pkg/auth/login_credentials_manager.go
@@ -173,11 +173,11 @@ func (h *LoginCredentialsManagerImpl) GetPrerunCredentialsFromConfig(cfg *v1.Con
 		}
 
 		credentials := &Credentials{
-			IsSSO:            ctx.IsUserSsoEnabled(),
-			Username:         ctx.GetEmail(),
+			IsSSO:            ctx.GetUser().GetSso().GetEnabled() || ctx.GetUser().GetSocialConnection() != "",
+			Username:         ctx.GetUser().GetEmail(),
 			AuthToken:        ctx.GetAuthToken(),
 			AuthRefreshToken: ctx.GetAuthRefreshToken(),
-			OrgResourceId:    ctx.GetOrganizationResourceId(),
+			OrgResourceId:    ctx.GetOrganization().GetResourceId(),
 		}
 
 		return credentials, nil
@@ -271,7 +271,7 @@ func (h *LoginCredentialsManagerImpl) isSSOUser(email, orgId string) bool {
 	res, err := h.client.User.LoginRealm(context.Background(), req)
 	// Fine to ignore non-nil err for this request: e.g. what if this fails due to invalid/malicious
 	// email, we want to silently continue and give the illusion of password prompt.
-	return err == nil && res.IsSso
+	return err == nil && res.GetIsSso()
 }
 
 // Prerun login for Confluent has two extra environment variables settings: CONFLUENT_MDS_URL (required), CONFLUNET_CA_CERT_PATH (optional)

--- a/internal/pkg/config/v1/context.go
+++ b/internal/pkg/config/v1/context.go
@@ -160,39 +160,11 @@ func (c *Context) GetUser() *orgv1.User {
 	return nil
 }
 
-func (c *Context) GetEmail() string {
-	if user := c.GetUser(); user != nil {
-		return user.Email
-	}
-	return ""
-}
-
-func (c *Context) GetUserSso() *orgv1.Sso {
-	if user := c.GetUser(); user != nil {
-		return user.Sso
-	}
-	return nil
-}
-
 func (c *Context) GetOrganization() *orgv1.Organization {
 	if auth := c.GetAuth(); auth != nil {
 		return auth.Organization
 	}
 	return nil
-}
-
-func (c *Context) GetOrganizationResourceId() string {
-	if org := c.GetOrganization(); org != nil {
-		return org.ResourceId
-	}
-	return ""
-}
-
-func (c *Context) IsUserSsoEnabled() bool {
-	if sso := c.GetUserSso(); sso != nil {
-		return sso.Enabled
-	}
-	return false
 }
 
 func (c *Context) GetEnvironment() *orgv1.Account {


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok

What
----
The `--save` flag doesn't do anything for SSO users (their sessions will time out when the refresh token expires anyways). Previously this was causing a `panic()`. Instead, we choose to ignore this flag and notify the user that their session can't be permanently saved.

References
----------
https://confluent.slack.com/archives/C9Y6NAM6X/p1652230516677449

Test & Review
-------------
Integration tests don't support text input yet (I'll implement this soon!) so I had to test manually (social login, re-login, SSO login):

```
% confluent login --save     
Enter your Confluent Cloud credentials:
Email: bstrauch.sso@gmail.com
Logged in as "bstrauch.sso@gmail.com" for organization "b410a4fc-e828-4b04-9eea-98821d631386" ("Confluent").
The `--save` flag was ignored since SSO credentials are not stored locally.

% confluent login --save
Logged in as "bstrauch.sso@gmail.com" for organization "b410a4fc-e828-4b04-9eea-98821d631386" ("Confluent").
The `--save` flag was ignored since SSO credentials are not stored locally.

% confluent login --url https://devel.cpdev.cloud --save
Enter your Confluent Cloud credentials:
Email: bstrauch+sso@confluent.io
Logged in as "bstrauch+sso@confluent.io" for organization "1cb79071-48ed-4706-b174-bb6503fe74b7" ("Nexus Bug Bash Org 3 (SSO)").
The `--save` flag was ignored since SSO credentials are not stored locally.
```