### PR TITLE
Add trace logging for config file credentials

### DIFF
--- a/internal/pkg/auth/login_credentials_manager.go
+++ b/internal/pkg/auth/login_credentials_manager.go
@@ -179,6 +179,7 @@ func (h *LoginCredentialsManagerImpl) GetPrerunCredentialsFromConfig(cfg *v1.Con
 			AuthRefreshToken: ctx.GetAuthRefreshToken(),
 			OrgResourceId:    ctx.GetOrganization().GetResourceId(),
 		}
+		log.CliLogger.Tracef("credentials: %#v", credentials)
 
 		return credentials, nil
 	}


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok

What
----
In https://confluent.slack.com/archives/C03G00M01T6, auto login is failing to find a full set of credentials in the config file. This should not be the case, since a full set of credentials only needs a username and an auth token, which an SSO user should have at this point. Adding this trace to help investigate.

References
----------
https://confluent.slack.com/archives/C03G00M01T6

Test & Review
-------------
Manually verified the logs are visible