### PR TITLE
Fix quote parsing in CP CLI

### DIFF
--- a/packaging/confluent.sh
+++ b/packaging/confluent.sh
@@ -222,4 +222,4 @@ check_executable
 init_config
 
 # call the underlying executable
-${EXECUTABLE} $@
+${EXECUTABLE} "$@"


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok

What
----
The `confluent` CLI packaged with CP does not handle commands with quotes. This was not apparent during v1.x but is a greater issue in v2.x.

References
----------
https://confluent.slack.com/archives/C010Y0EP5MZ/p1653065340538739

Test & Review
-------------
Manually tested. Before:
```
% confluent iam service-account create xt12345 --description '{"name": "Joe Doe", "mail": "xt12345@cn.ca", "created": "2022-05-19 10:06:34", "creator": "confluent-ldap-sync"}'
Error: accepts 1 arg(s), received 10
```

After:
```
% confluent iam service-account create xt12345 --description '{"name": "Joe Doe", "mail": "xt12345@cn.ca", "created": "2022-05-19 10:06:34", "creator": "confluent-ldap-sync"}'
+-------------+--------------------------------+
| ID          | sa-o317n9                      |
| Name        | xt12345                        |
| Description | {"name": "Joe Doe",            |
|             | "mail": "xt12345@cn.ca",       |
|             | "created": "2022-05-19         |
|             | 10:06:34", "creator":          |
|             | "confluent-ldap-sync"}         |
+-------------+--------------------------------+
```