### PR TITLE
Use `user.auth_type` instead of deprecated `user.sso`

### DIFF
--- a/internal/pkg/auth/login_credentials_manager.go
+++ b/internal/pkg/auth/login_credentials_manager.go
@@ -6,10 +6,10 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/spf13/cobra"
-
 	flowv1 "github.com/confluentinc/cc-structs/kafka/flow/v1"
+	orgv1 "github.com/confluentinc/cc-structs/kafka/org/v1"
 	"github.com/confluentinc/ccloud-sdk-go-v1"
+	"github.com/spf13/cobra"
 
 	"github.com/confluentinc/cli/internal/pkg/auth/sso"
 	v1 "github.com/confluentinc/cli/internal/pkg/config/v1"
@@ -173,7 +173,7 @@ func (h *LoginCredentialsManagerImpl) GetPrerunCredentialsFromConfig(cfg *v1.Con
 		}
 
 		credentials := &Credentials{
-			IsSSO:            ctx.GetUser().GetSso().GetEnabled() || ctx.GetUser().GetSocialConnection() != "",
+			IsSSO:            ctx.GetUser().GetAuthType() == orgv1.AuthType_AUTH_TYPE_SSO || ctx.GetUser().GetSocialConnection() != "",
 			Username:         ctx.GetUser().GetEmail(),
 			AuthToken:        ctx.GetAuthToken(),
 			AuthRefreshToken: ctx.GetAuthRefreshToken(),


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok

What
----
It turns out `user.sso` is deprecated, so certain SSO users were getting logged out after their auth token expired (5 minutes) since the refresh token failed to refresh. Instead, we should be using `user.auth_type`. Confusingly, social logins are not considered "SSO" due to the enterprise definition of "SSO", so that's still a separate case.

References
----------
https://confluent.slack.com/archives/C03G00M01T6/p1653342651171629

Test & Review
-------------
Manual verification that SSO still works. We would like to have integration tests for SSO, but that's waiting on a PR that enables text input for integration tests.