### PR TITLE
[CPG-1925] Fix GetClaimedPromoCodes forbidden access when printing remaining free credit

### DIFF
--- a/internal/cmd/login/command.go
+++ b/internal/cmd/login/command.go
@@ -150,7 +150,7 @@ func (c *command) printRemainingFreeCredit(cmd *cobra.Command, client *ccloud.Cl
 	org := &orgv1.Organization{Id: c.Config.Context().State.Auth.Account.OrganizationId}
 	promoCodes, err := client.Billing.GetClaimedPromoCodes(context.Background(), org, true)
 	if err != nil {
-		log.CliLogger.Debugf("Failed to print remaining free credit: %s", err.Error())
+		log.CliLogger.Warnf("Failed to print remaining free credit: %v", err)
 		return
 	}
 


### PR DESCRIPTION
Follow up to https://github.com/confluentinc/cli/pull/1299.

If user does not have access to get claimed promo codes, skip printing remaining free credit without bubbling up the error.