### PR TITLE
Fix docs generation

### DIFF
--- a/internal/pkg/config/v1/config.go
+++ b/internal/pkg/config/v1/config.go
@@ -524,7 +524,7 @@ func (c *Config) CheckIsCloudLoginAllowFreeTrialEnded() error {
 		return RequireCloudLoginErr
 	}
 
-	if c.isOrgSuspended() && c.isLoginBlockedByOrgSuspension() {
+	if c.isLoginBlockedByOrgSuspension() {
 		return RequireCloudLoginOrgUnsuspendedErr
 	}
 


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->

https://github.com/confluentinc/cli/pull/1299 modified logic in `Config` that determined whether a current context was a valid cloud login or not.  In particular, in the updated code, the context has to contain valid org information in order for the config to validate as a valid cloud login/context.  The way we generate docs is to create a fake cloud context and a fake on-prem context and then recurse through the commands that would be available were those configs valid (and take the unique union of those two trees).  This PR adds a valid organization struct to the fake cloud context so that the docs generator can (once again) loop through all the commands that require cloud logins.

I also made one change to the new function `CheckIsCloudLoginAllowFreeTrialEnded` -- not sure if this is required, but it seems like it should be there based on looking at `CheckIsCloudLogin`?