### PR TITLE
[DOCS-14527] Update suggested API key command in ksql cluster create flag help

### DIFF
--- a/internal/cmd/ksql/command_create.go
+++ b/internal/cmd/ksql/command_create.go
@@ -33,7 +33,7 @@ func (c *ksqlCommand) newCreateCommand(isApp bool) *cobra.Command {
 		RunE:  runCommand,
 	}
 
-	cmd.Flags().String("api-key", "", "Kafka API key for the ksqlDB cluster to use (use \"confluent api-key create --resource cloud\" to create one if none exist).")
+	cmd.Flags().String("api-key", "", "Kafka API key for the ksqlDB cluster to use (use \"confluent api-key create --resource lkc-abc123\" to create one if none exist).")
 	cmd.Flags().String("api-secret", "", "Secret for the Kafka API key.")
 	cmd.Flags().String("image", "", "Image to run (internal).")
 	cmd.Flags().Int32("csu", 4, "Number of CSUs to use in the cluster.")


### PR DESCRIPTION


Checklist
---------
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok
   * no: DO NOT MERGE until the required functionalites are live in prod  

What
----
Update the help text for the `confluent ksql cluster create` command to suggest using a Kafka API key instead of a a Cloud API key.

References
----------
[DOCS-14527](https://confluentinc.atlassian.net/browse/DOCS-14527)

Test & Review
-------------
<!--
Has it been tested? how?
Copy & paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

<!--
Open questions / Follow ups
---------------------------
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->

<!--
Review stakeholders
-------------------
Optional: mention stakeholders or special context that is required to review.
-->
