### PR TITLE
Replace tj/assert with testify/require

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -70,7 +70,6 @@ require (
 	github.com/tidwall/gjson v1.14.0
 	github.com/tidwall/pretty v1.2.0
 	github.com/tidwall/sjson v1.2.4
-	github.com/tj/assert v0.0.3
 	github.com/travisjeffery/mocker v1.1.1
 	github.com/xeipuuv/gojsonschema v1.2.0
 	golang.org/x/crypto v0.0.0-20220131195533-30dcbda58838

--- a/go.sum
+++ b/go.sum
@@ -667,8 +667,6 @@ github.com/confluentinc/go-printer v0.16.0 h1:V6QyEiN39zzcHY7zzMP5ClJYxBLbZshP1A
 github.com/confluentinc/go-printer v0.16.0/go.mod h1:o2sfQSpLyisht0oQqXN6WT/MgmLqUbtH+hOHBwaXe/c=
 github.com/confluentinc/go-ps1 v1.0.2 h1:+4cKOzWs3AWmxL2s96oHu0QutZESDRXECnhFzm2ic4o=
 github.com/confluentinc/go-ps1 v1.0.2/go.mod h1:qmgG9xQgFd4u7/CS6eA9nNP8eQqOtXuRHmZ4+w7Vprs=
-github.com/confluentinc/kafka-rest-sdk-go/kafkarestv3 v0.1.2-0.20220218025201-8726fa846a9f h1:sRmGPwuRhcZyAQJbnqghybJlgJbRM4OB2XvOVRCmOEk=
-github.com/confluentinc/kafka-rest-sdk-go/kafkarestv3 v0.1.2-0.20220218025201-8726fa846a9f/go.mod h1:qJAUraWU9BERQWyalrPsxt+ECELWPV+qsyOaP00VidY=
 github.com/confluentinc/kafka-rest-sdk-go/kafkarestv3 v0.3.14 h1:/ifiYRgvbtzTrMxsntzAc2NFXsZxfCpjHZG03X9BDxw=
 github.com/confluentinc/kafka-rest-sdk-go/kafkarestv3 v0.3.14/go.mod h1:qJAUraWU9BERQWyalrPsxt+ECELWPV+qsyOaP00VidY=
 github.com/confluentinc/mds-sdk-go/mdsv1 v0.0.40 h1:sitY5c+efIA1sQspTrlWM0YSEMDIibQJVZHnoXJjsCo=

--- a/internal/cmd/connect/command_test.go
+++ b/internal/cmd/connect/command_test.go
@@ -3,7 +3,6 @@ package connect
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"net/http"
 	"testing"
 
@@ -15,7 +14,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	"github.com/tj/assert"
 
 	"github.com/confluentinc/cli/internal/pkg/ccloudv2"
 	v1 "github.com/confluentinc/cli/internal/pkg/config/v1"
@@ -243,8 +241,7 @@ func (suite *ConnectTestSuite) TestCreateConnectorMalformedNewFormat() {
 	err := cmd.Execute()
 	req := require.New(suite.T())
 	req.NotNil(err)
-	fmt.Printf("error-- %s", err.Error())
-	assert.Contains(suite.T(), err.Error(), "unable to parse config")
+	req.Contains(err.Error(), "unable to parse config")
 }
 
 func (suite *ConnectTestSuite) TestCreateConnectorMalformedOldFormat() {
@@ -253,8 +250,7 @@ func (suite *ConnectTestSuite) TestCreateConnectorMalformedOldFormat() {
 	err := cmd.Execute()
 	req := require.New(suite.T())
 	req.NotNil(err)
-	fmt.Printf("error-- %s", err.Error())
-	assert.Contains(suite.T(), err.Error(), "unable to parse config")
+	req.Contains(err.Error(), "unable to parse config")
 }
 
 func (suite *ConnectTestSuite) TestUpdateConnector() {


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok

What
----
The tj/assert package was only being used in one spot (two tests) and has the same (redundant) functionality as testify/require.

Test & Review
-------------
Test cases still pass