### PR TITLE
Escape ReST targets

### DIFF
--- a/internal/pkg/docs/index_page_test.go
+++ b/internal/pkg/docs/index_page_test.go
@@ -174,8 +174,12 @@ func TestPrintLongestDescription_Long(t *testing.T) {
 	require.Equal(t, "Long description.", printLongestDescription(cmd))
 }
 
-func TestFormatReST(t *testing.T) {
+func TestFormatReST_CodeSnippet(t *testing.T) {
 	require.Equal(t, "Description of ``command``.", formatReST("Description of `command`."))
+}
+
+func TestFormatReST_Target(t *testing.T) {
+	require.Equal(t, `"target\_" "target\_"`, formatReST(`"target_" "target_"`))
 }
 
 func TestPrintSubcommands(t *testing.T) {


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok

What
----
Restructured Text (ReST) targets are formatted like "target_" and should be escaped as "target\_" in our descriptions and examples since they can be replaced inline. This was an issue in the last release (v2.18.0) from this example: https://github.com/confluentinc/cli/blob/936bd9e8c8946fef0eed91b42b73a44cda023102/internal/cmd/kafka/command_mirror_create.go#L32

Test & Review
-------------
Updated unit tests