### PR TITLE
Remove release target of renaming archives checksums file

### DIFF
--- a/mk-files/release.mk
+++ b/mk-files/release.mk
@@ -161,4 +161,5 @@ publish-installer:
 upload-linux-build-to-github:
 	hub release edit --attach dist/confluent_$(VERSION)_linux_amd64.tar.gz $(VERSION) -m "" && \
 	mv dist/confluent_linux_amd64_v1/confluent dist/confluent_linux_amd64_v1/confluent_$(VERSION_NO_V)_linux_amd64 && \
-	hub release edit --attach dist/confluent_linux_amd64_v1/confluent_$(VERSION_NO_V)_linux_amd64 $(VERSION) -m ""
+	hub release edit --attach dist/confluent_linux_amd64_v1/confluent_$(VERSION_NO_V)_linux_amd64 $(VERSION) -m "" && \
+	hub release edit --attach dist/confluent_$(VERSION_NO_V)_checksums.txt $(VERSION) -m ""


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->
We used to rename it from `2.x.x` to `v2.x.x` as the auto upload of goreleaser doesn't include the `v`, and our install script requires that `v`. The new gorelease block we have now has already renamed it when uploading checksums files (after cating checksums of linux build), and this block would overwrite that.

Keeping this `patch` block in case we need anything in the future.

Also upload the cated checksums to github to overwrite the previous one without linux checksum.

References
----------
<!--
Copy & paste links to Jira tickets, other PRs, issues, Slack conversations, etc.
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test & Review
-------------
<!--
Has it been tested? how?
Copy & paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

<!--
Open questions / Follow ups
---------------------------
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->

<!--
Review stakeholders
-------------------
Optional: mention stakeholders or special context that is required to review.
-->
