### PR TITLE
Added quotation marks to eval line of shell profile instructions in C…

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ Then, add the following to your shell profile:
 
     export GOENV_ROOT="$HOME/.goenv"
     export PATH="$GOENV_ROOT/bin:$PATH"
-    eval $(goenv init -)
+    eval "$(goenv init -)"
     export PATH="$PATH:$GOPATH/bin"
 
 Finally, you can install the appropriate version of Go by running the following command inside the root directory of the repository:


### PR DESCRIPTION
…ONTRIBUTING.MD to avoid parse error

Checklist
---------
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   N/A  

What
----
Added quotation marks to the instructions in CONTRIBUTING.md for what to add to the shell profile while installing goenv. Purpose is to avoid an eval parse error when sourcing the zshrc file.

References
----------

Test & Review
-------------
