### PR TITLE
Add persistent flags to usage whitelist

### DIFF
--- a/internal/pkg/usage/whitelist.go
+++ b/internal/pkg/usage/whitelist.go
@@ -12,6 +12,9 @@ func WhitelistCommandsAndFlags(cmd *cobra.Command, whitelist set.Set) {
 	cmd.Flags().VisitAll(func(flag *pflag.Flag) {
 		whitelist.Add(flag.Name)
 	})
+	cmd.PersistentFlags().VisitAll(func(flag *pflag.Flag) {
+		whitelist.Add(flag.Name)
+	})
 
 	for _, subcommand := range cmd.Commands() {
 		WhitelistCommandsAndFlags(subcommand, whitelist)


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok

What
----
In last release, `--verbose` had to be manually added to the whitelist. This also adds `--help` and any other flags that might be labeled as persistent later on.