### PR TITLE
[CPG-1925] Use fake LaunchDarkly result when testing

### DIFF
--- a/internal/cmd/command.go
+++ b/internal/cmd/command.go
@@ -91,7 +91,7 @@ func NewConfluentCommand(cfg *v1.Config, ver *pversion.Version, isTest bool) *co
 	cmd.AddCommand(apikey.New(prerunner, nil, flagResolver))
 	cmd.AddCommand(auditlog.New(prerunner))
 	cmd.AddCommand(cluster.New(prerunner, ver.UserAgent))
-	cmd.AddCommand(cloudsignup.New(prerunner, ver.UserAgent, ccloudClientFactory))
+	cmd.AddCommand(cloudsignup.New(prerunner, ver.UserAgent, ccloudClientFactory, isTest))
 	cmd.AddCommand(completion.New())
 	cmd.AddCommand(context.New(prerunner, flagResolver))
 	cmd.AddCommand(connect.New(prerunner))

--- a/test/test-server/ccloud_handlers.go
+++ b/test/test-server/ccloud_handlers.go
@@ -70,6 +70,8 @@ const (
 
 	auditLogServiceAccountID         = int32(1337)
 	auditLogServiceAccountResourceID = "sa-1337"
+
+	PromoTestCode = "PromoTestCode"
 )
 
 // Fill API keyStore with default data
@@ -283,7 +285,7 @@ func (c *CloudRouter) HandlePromoCodeClaims(t *testing.T) http.HandlerFunc {
 			freeTrialCode := &billingv1.GetPromoCodeClaimsReply{
 				Claims: []*billingv1.PromoCodeClaim{
 					{
-						Code:                 "SignUpPromo01",
+						Code:                 PromoTestCode,
 						Amount:               400 * 10000,
 						Balance:              0,
 						CreditExpirationDate: expiration,


### PR DESCRIPTION
Some integration tests introduced by free trial enhancements make requests to launchdarkly (instead of mocking those requests). There was a launchdarkly outage that caused those tests to fail on every run (example output [https://dev.azure.com/confluentinc/cli/_build/results?buildId=8465&view=logs&j=022b[…]-5f72-7610-a845972a8b4c&t=5c0622ed-2d33-5375-62a9-8d63e22770dc](https://dev.azure.com/confluentinc/cli/_build/results?buildId=8465&view=logs&j=022b0a5d-2698-5f72-7610-a845972a8b4c&t=5c0622ed-2d33-5375-62a9-8d63e22770dc)).

This PR fakes the result value that launchdarkly returns when in testing mode.