### PR TITLE
Fix makefile errors in update-whitelist

### DIFF
--- a/mk-files/usage.mk
+++ b/mk-files/usage.mk
@@ -8,13 +8,16 @@ endef
 
 export MIGRATEDOWN
 update-whitelist:
-	$(eval CC_CLI_SERVICE=$(shell mktemp -d)/cc-cli-service) && \
+	$(eval CC_CLI_SERVICE=$(shell mktemp -d)/cc-cli-service)
+	
 	git clone git@github.com:confluentinc/cc-cli-service.git $(CC_CLI_SERVICE) && \
 	cd $(CC_CLI_SERVICE) && \
 	git checkout -b update-whitelist-$(BUMPED_VERSION) && \
-	make db-migrate-create NAME=$(BUMPED_VERSION) && \
-	go run -ldflags "-X main.version=$(BUMPED_VERSION)" cmd/usage/main.go > $$(find $(CC_CLI_SERVICE)/db/migrations/ -name "*_$(BUMPED_VERSION).up.sql") && \
-	echo "$$MIGRATEDOWN" > $$(find $(CC_CLI_SERVICE)/db/migrations/ -name "*_$(BUMPED_VERSION).down.sql") && \
+	make db-migrate-create NAME=$(BUMPED_VERSION)
+	
+	go run -ldflags "-X main.version=$(BUMPED_VERSION)" cmd/usage/main.go > $$(find $(CC_CLI_SERVICE)/db/migrations/ -name "*_$(BUMPED_VERSION).up.sql")
+	echo "$$MIGRATEDOWN" > $$(find $(CC_CLI_SERVICE)/db/migrations/ -name "*_$(BUMPED_VERSION).down.sql")
+	
 	cd $(CC_CLI_SERVICE) && \
 	make db-migrate-up && \
 	git add . && \


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok

What
----
The first line (`eval`) is not allowed to end with `&& \`. Furthermore, we need quotes around the `find` command when either of those lines end with `&& \`, which is impossible due to nested quoting... gotta love Makefile syntax 😕

Test & Review
-------------
Ran manually as part of v2.21.0 release.