### PR TITLE
Add `__complete` to whitelist

### DIFF
--- a/cmd/usage/main.go
+++ b/cmd/usage/main.go
@@ -59,6 +59,8 @@ func buildWhitelist() []string {
 		whitelist.Add(arch)
 	}
 
+	whitelist.Add("__complete")
+
 	// Compile a whitelist for all three subsets of commands: no context, cloud, and on-prem
 	configs := []*v1.Config{
 		{CurrentContext: "No Context"},


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok

What
----
Still seeing a few 500s in cc-cli-service when people use `confluent shell` (which uses `confluent __complete` under the hood).