### PR TITLE
Only collect usage for released versions

### DIFF
--- a/internal/cmd/command.go
+++ b/internal/cmd/command.go
@@ -120,7 +120,7 @@ func Execute(cmd *cobra.Command, cfg *v1.Config, ver *pversion.Version, isTest b
 	// Usage collection is a wrapper around Execute() instead of a post-run function so we can collect the error status.
 	u := usage.New(ver.Version)
 
-	if !isTest {
+	if !isTest && ver.IsReleased() {
 		cmd.PersistentPostRun = u.Collect
 	}
 


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok

What
----
As of https://github.com/confluentinc/cc-cli-service/pull/61, the backend returns a `403` when the version is irregular (i.e. `v2.21.0-6-g1fb9056f-dirty-bstrauch`), so don't send a request in this case.