### PR TITLE
Don't require login for `confluent secret`

### DIFF
--- a/internal/cmd/command_test.go
+++ b/internal/cmd/command_test.go
@@ -41,7 +41,8 @@ func TestHelp_NoContext(t *testing.T) {
 	require.NoError(t, err)
 
 	commands := []string{
-		"cloud-signup", "completion", "context", "help", "kafka", "local", "login", "logout", "update", "version",
+		"cloud-signup", "completion", "context", "help", "kafka", "local", "login", "logout", "secret", "update",
+		"version",
 	}
 	if runtime.GOOS == "windows" {
 		commands = utils.Remove(commands, "local")

--- a/internal/cmd/secret/command.go
+++ b/internal/cmd/secret/command.go
@@ -17,7 +17,7 @@ func New(prerunner pcmd.PreRunner, flagResolver pcmd.FlagResolver, plugin secret
 	cmd := &cobra.Command{
 		Use:         "secret",
 		Short:       "Manage secrets for Confluent Platform.",
-		Annotations: map[string]string{pcmd.RunRequirement: pcmd.RequireOnPremLogin},
+		Annotations: map[string]string{pcmd.RunRequirement: pcmd.RequireNonCloudLogin},
 	}
 
 	c := &command{

--- a/internal/pkg/cmd/run_requirements.go
+++ b/internal/pkg/cmd/run_requirements.go
@@ -4,26 +4,19 @@ import (
 	"github.com/spf13/cobra"
 
 	v1 "github.com/confluentinc/cli/internal/pkg/config/v1"
-	"github.com/confluentinc/cli/internal/pkg/errors"
 )
 
-const (
-	RunRequirement = "run-requirement"
+const RunRequirement = "run-requirement"
 
-	RequireNonAPIKeyCloudLogin              = "non-api-key-cloud-login"
-	RequireNonAPIKeyCloudLoginOrOnPremLogin = "non-api-key-cloud-login-or-on-prem-login"
+const (
 	RequireCloudLogin                       = "cloud-login"
 	RequireCloudLoginAllowFreeTrialEnded    = "cloud-login-allow-free-trial-ended"
 	RequireCloudLoginOrOnPremLogin          = "cloud-login-or-on-prem-login"
+	RequireNonAPIKeyCloudLogin              = "non-api-key-cloud-login"
+	RequireNonAPIKeyCloudLoginOrOnPremLogin = "non-api-key-cloud-login-or-on-prem-login"
+	RequireNonCloudLogin                    = "non-cloud-login"
 	RequireOnPremLogin                      = "on-prem-login"
 	RequireUpdatesEnabled                   = "updates-enabled"
-)
-
-var (
-	requireUpdatesEnabledErr = errors.NewErrorWithSuggestions(
-		"you must enable updates to use this command",
-		"WARNING: To guarantee compatibility, enabling updates is not recommended for Confluent Platform users.\n"+`In ~/.confluent/config.json, set "disable_updates": false`,
-	)
 )
 
 // ErrIfMissingRunRequirement returns an error when a command or its parent doesn't meet a requirement;
@@ -34,35 +27,29 @@ func ErrIfMissingRunRequirement(cmd *cobra.Command, cfg *v1.Config) error {
 	}
 
 	if requirement, ok := cmd.Annotations[RunRequirement]; ok {
+		var f func() error
+
 		switch requirement {
 		case RequireCloudLogin:
-			if err := cfg.CheckIsCloudLogin(); err != nil {
-				return err
-			}
+			f = cfg.CheckIsCloudLogin
 		case RequireCloudLoginAllowFreeTrialEnded:
-			if err := cfg.CheckIsCloudLoginAllowFreeTrialEnded(); err != nil {
-				return err
-			}
+			f = cfg.CheckIsCloudLoginAllowFreeTrialEnded
 		case RequireCloudLoginOrOnPremLogin:
-			if err := cfg.CheckIsCloudLoginOrOnPremLogin(); err != nil {
-				return err
-			}
+			f = cfg.CheckIsCloudLoginOrOnPremLogin
 		case RequireNonAPIKeyCloudLogin:
-			if err := cfg.CheckIsNonAPIKeyCloudLogin(); err != nil {
-				return err
-			}
+			f = cfg.CheckIsNonAPIKeyCloudLogin
 		case RequireNonAPIKeyCloudLoginOrOnPremLogin:
-			if err := cfg.CheckIsNonAPIKeyCloudLoginOrOnPremLogin(); err != nil {
-				return err
-			}
+			f = cfg.CheckIsNonAPIKeyCloudLoginOrOnPremLogin
+		case RequireNonCloudLogin:
+			f = cfg.CheckIsNonCloudLogin
 		case RequireOnPremLogin:
-			if err := cfg.CheckIsOnPremLogin(); err != nil {
-				return err
-			}
+			f = cfg.CheckIsOnPremLogin
 		case RequireUpdatesEnabled:
-			if cfg.DisableUpdates {
-				return requireUpdatesEnabledErr
-			}
+			f = cfg.CheckAreUpdatesEnabled
+		}
+
+		if err := f(); err != nil {
+			return err
 		}
 	}
 
@@ -72,18 +59,10 @@ func ErrIfMissingRunRequirement(cmd *cobra.Command, cfg *v1.Config) error {
 func CommandRequiresCloudAuth(cmd *cobra.Command, cfg *v1.Config) bool {
 	if requirement, ok := cmd.Annotations[RunRequirement]; ok {
 		switch requirement {
-		case RequireCloudLogin:
+		case RequireCloudLogin, RequireCloudLoginAllowFreeTrialEnded, RequireNonAPIKeyCloudLogin:
 			return true
-		case RequireCloudLoginAllowFreeTrialEnded:
-			return true
-		case RequireNonAPIKeyCloudLogin:
-			return true
-		case RequireCloudLoginOrOnPremLogin:
+		case RequireCloudLoginOrOnPremLogin, RequireNonAPIKeyCloudLoginOrOnPremLogin:
 			return cfg.IsCloudLogin()
-		case RequireNonAPIKeyCloudLoginOrOnPremLogin:
-			return cfg.IsCloudLogin()
-		case RequireOnPremLogin:
-			return false
 		}
 	}
 	return false

--- a/internal/pkg/cmd/run_requirements_test.go
+++ b/internal/pkg/cmd/run_requirements_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	orgv1 "github.com/confluentinc/cc-structs/kafka/org/v1"
+
 	v1 "github.com/confluentinc/cli/internal/pkg/config/v1"
 	testserver "github.com/confluentinc/cli/test/test-server"
 )
@@ -116,7 +117,7 @@ func TestErrIfMissingRunRequirement_Error(t *testing.T) {
 		{RequireNonAPIKeyCloudLoginOrOnPremLogin, apiKeyCloudCfg, v1.RequireNonAPIKeyCloudLoginOrOnPremLoginErr},
 		{RequireNonAPIKeyCloudLoginOrOnPremLogin, apiKeyCloudCfg, v1.RequireNonAPIKeyCloudLoginOrOnPremLoginErr},
 		{RequireOnPremLogin, cloudCfg(regularOrgContextState), v1.RequireOnPremLoginErr},
-		{RequireUpdatesEnabled, updatesDisabledCfg, requireUpdatesEnabledErr},
+		{RequireUpdatesEnabled, updatesDisabledCfg, v1.RequireUpdatesEnabledErr},
 	} {
 		cmd := &cobra.Command{Annotations: map[string]string{RunRequirement: test.req}}
 		err := ErrIfMissingRunRequirement(cmd, test.cfg)

--- a/internal/pkg/config/v1/config.go
+++ b/internal/pkg/config/v1/config.go
@@ -54,9 +54,17 @@ var (
 		"you must log in to Confluent Cloud with a username and password or log in to Confluent Platform to use this command",
 		"Log in with \"confluent login\" or \"confluent login --url <mds-url>\".\n"+signupSuggestion,
 	)
+	RequireNonCloudLogin = errors.NewErrorWithSuggestions(
+		"you must log out of Confluent Cloud to use this command",
+		"Log out with \"confluent logout\".\n",
+	)
 	RequireOnPremLoginErr = errors.NewErrorWithSuggestions(
 		"you must log in to Confluent Platform to use this command",
 		`Log in with "confluent login --url <mds-url>".`,
+	)
+	RequireUpdatesEnabledErr = errors.NewErrorWithSuggestions(
+		"you must enable updates to use this command",
+		"WARNING: To guarantee compatibility, enabling updates is not recommended for Confluent Platform users.\n"+`In ~/.confluent/config.json, set "disable_updates": false`,
 	)
 )
 
@@ -572,6 +580,20 @@ func (c *Config) CheckIsNonAPIKeyCloudLoginOrOnPremLogin() error {
 		return RequireNonAPIKeyCloudLoginOrOnPremLoginErr
 	}
 
+	return nil
+}
+
+func (c *Config) CheckIsNonCloudLogin() error {
+	if c.isCloud() {
+		return RequireNonCloudLogin
+	}
+	return nil
+}
+
+func (c *Config) CheckAreUpdatesEnabled() error {
+	if c.DisableUpdates {
+		return RequireUpdatesEnabledErr
+	}
 	return nil
 }
 

--- a/test/fixtures/output/help/no-context-windows.golden
+++ b/test/fixtures/output/help/no-context-windows.golden
@@ -12,6 +12,7 @@ Available Commands:
   login           Log in to Confluent Cloud or Confluent Platform.
   logout          Log out of Confluent Cloud or Confluent Platform.
   prompt          Add Confluent CLI context to your terminal prompt.
+  secret          Manage secrets for Confluent Platform.
   shell           Start an interactive shell.
   update          Update the Confluent CLI.
   version         Show version of the Confluent CLI.

--- a/test/fixtures/output/help/no-context.golden
+++ b/test/fixtures/output/help/no-context.golden
@@ -13,6 +13,7 @@ Available Commands:
   login           Log in to Confluent Cloud or Confluent Platform.
   logout          Log out of Confluent Cloud or Confluent Platform.
   prompt          Add Confluent CLI context to your terminal prompt.
+  secret          Manage secrets for Confluent Platform.
   shell           Start an interactive shell.
   update          Update the Confluent CLI.
   version         Show version of the Confluent CLI.


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok

What
----
In other words, only allow `confluent secret` to be used if not logged in to Confluent Cloud. This is a recurring request: `confluent secret` shouldn't require login, but at the same time we want to hide it from Confluent Cloud users.

References
----------
https://confluent.slack.com/archives/CM80GTNUQ/p1656981267820799

Test & Review
-------------
Updated unit/integration tests. Manually tested as well.