### PR TITLE
Fix panic for `confluent api-key create` on 10+ kSQL API keys

### DIFF
--- a/internal/cmd/api-key/command_create.go
+++ b/internal/cmd/api-key/command_create.go
@@ -146,16 +146,20 @@ func (c *command) createV1(ownerResourceId, clusterId, resourceType, description
 	if err != nil {
 		return nil, err
 	}
-
 	if resourceType != resource.Cloud {
 		key.LogicalClusters = []*schedv1.ApiKey_Cluster{{Id: clusterId, Type: resourceType}}
 	}
+
 	schedv1ApiKey, err := c.Client.APIKey.Create(context.Background(), key)
+	if err != nil {
+		return nil, c.catchServiceAccountNotValidError(err, nil, clusterId, ownerResourceId)
+	}
+
 	displayKey := &v1.APIKeyPair{
 		Key:    schedv1ApiKey.Key,
 		Secret: schedv1ApiKey.Secret,
 	}
-	return displayKey, c.catchServiceAccountNotValidError(err, nil, clusterId, ownerResourceId)
+	return displayKey, nil
 }
 
 func (c *command) completeKeyUserId(key *schedv1.ApiKey) (*schedv1.ApiKey, error) {


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok

What
----
When more than 10 kSQL API keys are created, the backend returns a `nil` API key and an error. We were trying to use the `nil` API key instead of catching the error.

References
----------
https://confluent.slack.com/archives/C9Y6NAM6X/p1658200714836689

Test & Review
-------------
Manually tested with 10+ kSQL API keys. Before:
```
% confluent api-key create --resource lksqlc-v753kp
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x55c300a]

goroutine 1 [running]:
github.com/confluentinc/cli/internal/cmd/api-key.(*command).createV1(0xc00047c8a0, {0x0, 0x0}, {0xc000a22f40, 0x61531e4}, {0x614f3f9, 0x4}, {0x0, 0x0})
        go/src/github.com/confluentinc/cli/internal/cmd/api-key/command_create.go:155 +0x2ca
github.com/confluentinc/cli/internal/cmd/api-key.(*command).create(0xc00047c8a0, 0x20, {0x7a03760, 0xc000a9e0a0, 0x0})
        go/src/github.com/confluentinc/cli/internal/cmd/api-key/command_create.go:77 +0x1a9
github.com/confluentinc/cli/internal/pkg/cmd.Chain.func1(0xc0007114e0, {0xc000744060, 0x0, 0x2})
        go/src/github.com/confluentinc/cli/internal/pkg/cmd/cobra.go:24 +0x83
github.com/confluentinc/cli/internal/pkg/cmd.CatchErrors.func1(0xc000207400, {0xc000744060, 0x0, 0x2})
        go/src/github.com/confluentinc/cli/internal/pkg/cmd/cobra.go:12 +0x69
github.com/spf13/cobra.(*Command).execute(0xc000207400, {0xc000744040, 0x2, 0x2})
        go/1.17.6/pkg/mod/github.com/spf13/cobra@v1.3.0/command.go:856 +0x60e
github.com/spf13/cobra.(*Command).ExecuteC(0xc0000d0a00)
        go/1.17.6/pkg/mod/github.com/spf13/cobra@v1.3.0/command.go:974 +0x3bc
github.com/spf13/cobra.(*Command).Execute(...)
        go/1.17.6/pkg/mod/github.com/spf13/cobra@v1.3.0/command.go:902
github.com/confluentinc/cli/internal/cmd.Execute(0xc0000d0a00, 0xc0004b6400, 0xc0004b6980, 0x0)
        go/src/github.com/confluentinc/cli/internal/cmd/command.go:127 +0x1b4
main.main()
        go/src/github.com/confluentinc/cli/cmd/confluent/main.go:37 +0x265
```

After:
```
% confluent api-key create --resource lksqlc-v753kp
Error: Confluent Cloud backend error: error creating api key: Your Api Keys per User is currently limited to 10
```