### PR TITLE
Fix `confluent local` panic

### DIFF
--- a/internal/cmd/local/command_services.go
+++ b/internal/cmd/local/command_services.go
@@ -362,12 +362,13 @@ func (c *Command) getConfig(service string) (map[string]string, error) {
 			return map[string]string{}, err
 		}
 
-		path := local.ExtractConfig(data)["plugin.path"].(string)
-		full, err := c.ch.GetFile("share", "java")
-		if err != nil {
-			return map[string]string{}, err
+		if path, ok := local.ExtractConfig(data)["plugin.path"].(string); ok {
+			full, err := c.ch.GetFile("share", "java")
+			if err != nil {
+				return map[string]string{}, err
+			}
+			config["plugin.path"] = strings.ReplaceAll(path, "share/java", full)
 		}
-		config["plugin.path"] = strings.ReplaceAll(path, "share/java", full)
 
 		matches, err := c.ch.FindFile("share/java/kafka-connect-replicator/replicator-rest-extension-*.jar")
 		if err != nil {


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok

What
----
Fix panic when "plugin.path" is not specified. This value is not required by connect so it can be safely ignored.

References
----------
https://confluent.slack.com/archives/C9Y6NAM6X/p1658842480998709

Test & Review
-------------
Manually reproduced and verified that the panic is gone.