### PR TITLE
Use `master` branch of muckrake

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -78,7 +78,7 @@ def job = {
                                 export confluent_s3="https://s3-us-west-2.amazonaws.com"
                                 git clone git@github.com:confluentinc/muckrake.git
                                 cd muckrake
-                                git checkout 7.2.x
+                                git checkout master
                                 sed -i "s?\\(confluent-cli-\\(.*\\)=\\)\\(.*\\)?\\1${confluent_s3}/confluent.cloud/confluent-cli-system-test-builds/confluent_SNAPSHOT-${HASH}_linux_amd64\\.tar\\.gz\\"?" ducker/ducker
                                 sed -i "s?get_cli .*?& ${confluent_s3}/confluent.cloud/confluent-cli-system-test-builds/confluent_SNAPSHOT-${HASH}_linux_amd64\\.tar\\.gz?g" vagrant/base-ubuntu.sh
                                 sed -i "s?get_cli .*?& ${confluent_s3}/confluent.cloud/confluent-cli-system-test-builds/confluent_SNAPSHOT-${HASH}_linux_amd64\\.tar\\.gz?g" vagrant/base-redhat.sh
@@ -103,7 +103,7 @@ def job = {
                     ["sonatype/confluent", "user", "SONATYPE_OSSRH_USER"],
                     ["sonatype/confluent", "password", "SONATYPE_OSSRH_PASSWORD"]]) {
                     withEnv(["GIT_CREDENTIAL=${env.GIT_USER}:${env.GIT_TOKEN}",
-                        "AWS_KEYPAIR_FILE=${pem_file}", "GIT_BRANCH=7.2.x"]) {
+                        "AWS_KEYPAIR_FILE=${pem_file}", "GIT_BRANCH=master"]) {
                         withVaultFile([["gradle/gradle_properties_maven", "gradle_properties_file",
                             "gradle.properties", "GRADLE_PROPERTIES_FILE"]]) {
                             sh '''#!/usr/bin/env bash


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok

What
----
Just merged https://github.com/confluentinc/muckrake/pull/1755 into `master`, so we need to update the Jenkinsfile accordingly to see this improvement. In the future, we should update this Jenkinsfile to use the last successful build of muckrake so we don't run into build errors (which will be more prevalent now since the `master` branch is less stable).