### PR TITLE
Revert "don't require login for confluent secret (#1365)"

### DIFF
--- a/internal/cmd/command_test.go
+++ b/internal/cmd/command_test.go
@@ -41,8 +41,7 @@ func TestHelp_NoContext(t *testing.T) {
 	require.NoError(t, err)
 
 	commands := []string{
-		"cloud-signup", "completion", "context", "help", "kafka", "local", "login", "logout", "secret", "update",
-		"version",
+		"cloud-signup", "completion", "context", "help", "kafka", "local", "login", "logout", "update", "version",
 	}
 	if runtime.GOOS == "windows" {
 		commands = utils.Remove(commands, "local")

--- a/internal/cmd/secret/command.go
+++ b/internal/cmd/secret/command.go
@@ -17,7 +17,7 @@ func New(prerunner pcmd.PreRunner, flagResolver pcmd.FlagResolver, plugin secret
 	cmd := &cobra.Command{
 		Use:         "secret",
 		Short:       "Manage secrets for Confluent Platform.",
-		Annotations: map[string]string{pcmd.RunRequirement: pcmd.RequireNonCloudLogin},
+		Annotations: map[string]string{pcmd.RunRequirement: pcmd.RequireOnPremLogin},
 	}
 
 	c := &command{

--- a/internal/pkg/cmd/run_requirements_test.go
+++ b/internal/pkg/cmd/run_requirements_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	orgv1 "github.com/confluentinc/cc-structs/kafka/org/v1"
-
 	v1 "github.com/confluentinc/cli/internal/pkg/config/v1"
 	testserver "github.com/confluentinc/cli/test/test-server"
 )
@@ -117,7 +116,7 @@ func TestErrIfMissingRunRequirement_Error(t *testing.T) {
 		{RequireNonAPIKeyCloudLoginOrOnPremLogin, apiKeyCloudCfg, v1.RequireNonAPIKeyCloudLoginOrOnPremLoginErr},
 		{RequireNonAPIKeyCloudLoginOrOnPremLogin, apiKeyCloudCfg, v1.RequireNonAPIKeyCloudLoginOrOnPremLoginErr},
 		{RequireOnPremLogin, cloudCfg(regularOrgContextState), v1.RequireOnPremLoginErr},
-		{RequireUpdatesEnabled, updatesDisabledCfg, v1.RequireUpdatesEnabledErr},
+		{RequireUpdatesEnabled, updatesDisabledCfg, requireUpdatesEnabledErr},
 	} {
 		cmd := &cobra.Command{Annotations: map[string]string{RunRequirement: test.req}}
 		err := ErrIfMissingRunRequirement(cmd, test.cfg)

--- a/internal/pkg/config/v1/config.go
+++ b/internal/pkg/config/v1/config.go
@@ -54,17 +54,9 @@ var (
 		"you must log in to Confluent Cloud with a username and password or log in to Confluent Platform to use this command",
 		"Log in with \"confluent login\" or \"confluent login --url <mds-url>\".\n"+signupSuggestion,
 	)
-	RequireNonCloudLogin = errors.NewErrorWithSuggestions(
-		"you must log out of Confluent Cloud to use this command",
-		"Log out with \"confluent logout\".\n",
-	)
 	RequireOnPremLoginErr = errors.NewErrorWithSuggestions(
 		"you must log in to Confluent Platform to use this command",
 		`Log in with "confluent login --url <mds-url>".`,
-	)
-	RequireUpdatesEnabledErr = errors.NewErrorWithSuggestions(
-		"you must enable updates to use this command",
-		"WARNING: To guarantee compatibility, enabling updates is not recommended for Confluent Platform users.\n"+`In ~/.confluent/config.json, set "disable_updates": false`,
 	)
 )
 
@@ -580,20 +572,6 @@ func (c *Config) CheckIsNonAPIKeyCloudLoginOrOnPremLogin() error {
 		return RequireNonAPIKeyCloudLoginOrOnPremLoginErr
 	}
 
-	return nil
-}
-
-func (c *Config) CheckIsNonCloudLogin() error {
-	if c.isCloud() {
-		return RequireNonCloudLogin
-	}
-	return nil
-}
-
-func (c *Config) CheckAreUpdatesEnabled() error {
-	if c.DisableUpdates {
-		return RequireUpdatesEnabledErr
-	}
 	return nil
 }
 

--- a/test/fixtures/output/help/no-context-windows.golden
+++ b/test/fixtures/output/help/no-context-windows.golden
@@ -12,7 +12,6 @@ Available Commands:
   login           Log in to Confluent Cloud or Confluent Platform.
   logout          Log out of Confluent Cloud or Confluent Platform.
   prompt          Add Confluent CLI context to your terminal prompt.
-  secret          Manage secrets for Confluent Platform.
   shell           Start an interactive shell.
   update          Update the Confluent CLI.
   version         Show version of the Confluent CLI.

--- a/test/fixtures/output/help/no-context.golden
+++ b/test/fixtures/output/help/no-context.golden
@@ -13,7 +13,6 @@ Available Commands:
   login           Log in to Confluent Cloud or Confluent Platform.
   logout          Log out of Confluent Cloud or Confluent Platform.
   prompt          Add Confluent CLI context to your terminal prompt.
-  secret          Manage secrets for Confluent Platform.
   shell           Start an interactive shell.
   update          Update the Confluent CLI.
   version         Show version of the Confluent CLI.


### PR DESCRIPTION
This reverts commit ca1615da68616fec2d4e88dd5d3d7c1b27157980.

Checklist
---------
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok

What
----
https://confluent.slack.com/archives/C010Y0EP5MZ/p1658943020370029