### PR TITLE
[CLI-1886] Fix for 401 response when attempting to shrink a cluster in devel using CLI

### DIFF
--- a/internal/pkg/ccloudv2/client.go
+++ b/internal/pkg/ccloudv2/client.go
@@ -41,7 +41,7 @@ func NewClient(authToken, baseURL, userAgent string, isTest bool) *Client {
 		IamClient:              newIamClient(baseURL, userAgent, isTest),
 		IdentityProviderClient: newIdentityProviderClient(baseURL, userAgent, isTest),
 		KafkaRestClient:        newKafkaRestClient(baseURL, userAgent, isTest),
-		MetricsClient:          newMetricsClient(userAgent, isTest),
+		MetricsClient:          newMetricsClient(baseURL, userAgent, isTest),
 		OrgClient:              newOrgClient(baseURL, userAgent, isTest),
 		ServiceQuotaClient:     newServiceQuotaClient(baseURL, userAgent, isTest),
 	}

--- a/internal/pkg/ccloudv2/metrics.go
+++ b/internal/pkg/ccloudv2/metrics.go
@@ -21,11 +21,11 @@ type responseDataPoint struct {
 	Value     float32   `json:"value"`
 }
 
-func newMetricsClient(userAgent string, isTest bool) *metricsv2.APIClient {
+func newMetricsClient(baseURL, userAgent string, isTest bool) *metricsv2.APIClient {
 	cfg := metricsv2.NewConfiguration()
 	cfg.Debug = plog.CliLogger.Level >= plog.DEBUG
 	cfg.HTTPClient = newRetryableHttpClient()
-	cfg.Servers = metricsv2.ServerConfigurations{{URL: getMetricsServerUrl(isTest)}}
+	cfg.Servers = metricsv2.ServerConfigurations{{URL: getMetricsServerUrl(baseURL, isTest)}}
 	cfg.UserAgent = userAgent
 
 	return metricsv2.NewAPIClient(cfg)

--- a/internal/pkg/ccloudv2/utils.go
+++ b/internal/pkg/ccloudv2/utils.go
@@ -54,9 +54,14 @@ func getServerUrl(baseURL string, isTest bool) string {
 	return "https://api.confluent.cloud"
 }
 
-func getMetricsServerUrl(isTest bool) string {
+func getMetricsServerUrl(baseURL string, isTest bool) string {
 	if isTest {
 		return testserver.TestV2CloudURL.String()
+	}
+	if strings.Contains(baseURL, "devel") {
+		return "https://devel-sandbox-api.telemetry.aws.confluent.cloud"
+	} else if strings.Contains(baseURL, "stag") {
+		return "https://stag-sandbox-api.telemetry.aws.confluent.cloud"
 	}
 	return "https://api.telemetry.confluent.cloud"
 }


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   N/A

What
----
Modified `getMetricsServerURL` to include paths for `devel` and `stag` instead of hardcoding the `prod` metrics api url. This allows for calls to the metrics api when using the CLI client against dev. Used the logic from the adjacent function `getServerUrl`.

This resolves 401 errors resulting from requests being sent to the wrong metrics server when using the CLI with devel.

The `devel` and `stag` url's currently redirect to the same place, but will be split in the future. 

References
----------
https://confluentinc.atlassian.net/browse/CLI-1886

Test & Review
-------------
Tested by logging in with `--url https://devel.cpdev.cloud` and then running `kafka cluster update lkc-nkgp8d --cku 1`.

Before:
```
Error: cluster shrink validation error: 
Looking at metrics in the last 15 min window: 
 could not retrieve partition count metrics to validate request to shrink cluster, please try again in a few minutes: 401 Unauthorized 
 could not retrieve cluster load metrics to validate request to shrink cluster, please try again in a few minutes: 401 Unauthorized
```

After:
```
+----------------------+------------------------------------------------------------+
| ID                   | lkc-nkgp8d                                                 |
| Name                 | Shrink-test-CLI-1886                                       |
| Type                 | DEDICATED                                                  |
| Ingress              |                                                        100 |
| Egress               |                                                        300 |
| Storage              | Infinite                                                   |
| Provider             | aws                                                        |
| Availability         | single-zone                                                |
| Region               | us-west-2                                                  |
| Status               | SHRINKING                                                  |
| Endpoint             | SASL_SSL://pkc-q28y5m.us-west-2.aws.devel.cpdev.cloud:9092 |
| API Endpoint         | https://pkac-gqk0xm.us-west-2.aws.devel.cpdev.cloud        |
| REST Endpoint        | https://pkc-q28y5m.us-west-2.aws.devel.cpdev.cloud:443     |
| Cluster Size         |                                                          2 |
| Pending Cluster Size |                                                          1 |
+----------------------+------------------------------------------------------------+
```

Also logged in with the default url (`https://confluent.cloud`), provisioned a dedicated cluster, and ran the same command `kafka cluster update lkc-q2wr0p --cku 1`:
```
+----------------------+---------------------------------------------------------+
| ID                   | lkc-q2wr0p                                              |
| Name                 | Shrink-Test                                             |
| Type                 | DEDICATED                                               |
| Ingress              |                                                     100 |
| Egress               |                                                     300 |
| Storage              | Infinite                                                |
| Provider             | aws                                                     |
| Availability         | single-zone                                             |
| Region               | us-west-2                                               |
| Status               | SHRINKING                                               |
| Endpoint             | SASL_SSL://pkc-jzzj8.us-west-2.aws.confluent.cloud:9092 |
| API Endpoint         | https://pkac-255x1.us-west-2.aws.confluent.cloud        |
| REST Endpoint        | https://pkc-jzzj8.us-west-2.aws.confluent.cloud:443     |
| Cluster Size         |                                                       2 |
| Pending Cluster Size |                                                       1 |
+----------------------+---------------------------------------------------------+
```