### PR TITLE
[CLI-1431] Add non-root user to Dockerfile so users don't have to run as root with container

### DIFF
--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -1,4 +1,21 @@
-FROM alpine:latest
+FROM amd64/alpine:latest
+
+ENV USER=confluent
+ENV UID=2358
+ENV GID=2358
+
+RUN addgroup \
+    --gid $GID \
+    --system \
+    $USER
+
+RUN adduser \
+    --disabled-password \
+    --gecos "" \
+    --ingroup "$USER" \
+    --no-create-home \
+    --uid "$UID" \
+    "$USER"
 
 RUN apk update --no-cache && \
     apk add --no-cache curl && \
@@ -13,3 +30,5 @@ RUN chmod +x /bin/confluent
 RUN ln -s /bin/confluent /confluent
 
 RUN mkdir /etc/bash_completion.d && confluent completion bash > /etc/bash_completion.d/confluent
+
+USER $USER


### PR DESCRIPTION
Also fixed a small gotcha that would have broken the release process on M1 Macs (forcing the Dockerfile to use alpine/amd64 instead of allowing alpine/arm64).
