### PR TITLE
[FF-7973] CLI should not require user-login to produce/consume using an API key

### DIFF
--- a/internal/pkg/dynamic-config/dynamic_context.go
+++ b/internal/pkg/dynamic-config/dynamic_context.go
@@ -115,6 +115,9 @@ func (d *DynamicContext) GetKafkaClusterForCommand() (*v1.KafkaClusterConfig, er
 
 func (d *DynamicContext) FindKafkaCluster(clusterId string) (*v1.KafkaClusterConfig, error) {
 	if config := d.KafkaClusterContext.GetKafkaClusterConfig(clusterId); config != nil {
+		if clusterId == "anonymous-id" {
+			return config, nil
+		}
 		const week = 7 * 24 * time.Hour
 		if time.Now().Before(config.LastUpdate.Add(week)) {
 			return config, nil


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   yes

What
----
Fixed bug preventing producing/consuming from cluster when using an API key/secret by adding an additional check for an anonymous cluster being used in a context, as the check below it only sees if the config file has been updated less than a week ago.

References
----------
https://confluentinc.atlassian.net/browse/FF-7973

Test & Review
-------------


<!--
Open questions / Follow ups
---------------------------
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->

<!--
Review stakeholders
-------------------
Optional: mention stakeholders or special context that is required to review.
-->
