### PR TITLE
Fix 401 Unauthorized error in `confluent stream-share` commands

### DIFF
--- a/internal/cmd/stream-share/command.go
+++ b/internal/cmd/stream-share/command.go
@@ -29,7 +29,7 @@ func New(cfg *v1.Config, prerunner pcmd.PreRunner) *cobra.Command {
 
 	c := &command{pcmd.NewAuthenticatedCLICommand(cmd, prerunner)}
 
-	c.AddCommand(newProviderCommand(prerunner))
+	c.AddCommand(c.newProviderCommand())
 
 	return c.Command
 }

--- a/internal/cmd/stream-share/command_provider.go
+++ b/internal/cmd/stream-share/command_provider.go
@@ -2,23 +2,15 @@ package streamshare
 
 import (
 	"github.com/spf13/cobra"
-
-	pcmd "github.com/confluentinc/cli/internal/pkg/cmd"
 )
 
-type providerCommand struct {
-	*pcmd.AuthenticatedCLICommand
-}
-
-func newProviderCommand(prerunner pcmd.PreRunner) *cobra.Command {
+func (c *command) newProviderCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "provider",
 		Short: "Manage provider actions.",
 	}
 
-	c := &providerCommand{pcmd.NewAuthenticatedCLICommand(cmd, prerunner)}
+	cmd.AddCommand(c.newProviderShareCommand())
 
-	c.AddCommand(newProviderShareCommand(prerunner))
-
-	return c.Command
+	return cmd
 }

--- a/internal/cmd/stream-share/command_provider_share.go
+++ b/internal/cmd/stream-share/command_provider_share.go
@@ -6,7 +6,6 @@ import (
 	"github.com/spf13/cobra"
 
 	cdxv1 "github.com/confluentinc/ccloud-sdk-go-v2/cdx/v1"
-	pcmd "github.com/confluentinc/cli/internal/pkg/cmd"
 )
 
 var (
@@ -61,26 +60,20 @@ var (
 	}
 )
 
-type providerShareCommand struct {
-	*pcmd.AuthenticatedCLICommand
-}
-
-func newProviderShareCommand(prerunner pcmd.PreRunner) *cobra.Command {
+func (c *command) newProviderShareCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "share",
 		Short: "Manage provider shares.",
 	}
 
-	s := &providerShareCommand{pcmd.NewAuthenticatedCLICommand(cmd, prerunner)}
+	cmd.AddCommand(c.newDeleteCommand())
+	cmd.AddCommand(c.newDescribeCommand())
+	cmd.AddCommand(c.newListCommand())
 
-	s.AddCommand(s.newDeleteCommand())
-	s.AddCommand(s.newDescribeCommand())
-	s.AddCommand(s.newListCommand())
-
-	return s.Command
+	return cmd
 }
 
-func (s *providerShareCommand) buildProviderShare(share cdxv1.CdxV1ProviderShare) *providerShare {
+func (c *command) buildProviderShare(share cdxv1.CdxV1ProviderShare) *providerShare {
 	serviceAccount := share.GetServiceAccount()
 	sharedResource := share.GetSharedResource()
 	element := &providerShare{
@@ -102,20 +95,20 @@ func (s *providerShareCommand) buildProviderShare(share cdxv1.CdxV1ProviderShare
 	return element
 }
 
-func (s *providerShareCommand) validArgs(cmd *cobra.Command, args []string) []string {
+func (c *command) validArgs(cmd *cobra.Command, args []string) []string {
 	if len(args) > 0 {
 		return nil
 	}
 
-	if err := s.PersistentPreRunE(cmd, args); err != nil {
+	if err := c.PersistentPreRunE(cmd, args); err != nil {
 		return nil
 	}
 
-	return s.autocompleteProviderShares()
+	return c.autocompleteProviderShares()
 }
 
-func (s *providerShareCommand) autocompleteProviderShares() []string {
-	providerShares, err := s.V2Client.ListProviderShares("")
+func (c *command) autocompleteProviderShares() []string {
+	providerShares, err := c.V2Client.ListProviderShares("")
 	if err != nil {
 		return nil
 	}

--- a/internal/cmd/stream-share/command_provider_share_delete.go
+++ b/internal/cmd/stream-share/command_provider_share_delete.go
@@ -9,13 +9,13 @@ import (
 	"github.com/confluentinc/cli/internal/pkg/utils"
 )
 
-func (s *providerShareCommand) newDeleteCommand() *cobra.Command {
+func (c *command) newDeleteCommand() *cobra.Command {
 	return &cobra.Command{
 		Use:               "delete <id>",
 		Short:             "Delete a provider share.",
 		Args:              cobra.ExactArgs(1),
-		ValidArgsFunction: pcmd.NewValidArgsFunction(s.validArgs),
-		RunE:              s.delete,
+		ValidArgsFunction: pcmd.NewValidArgsFunction(c.validArgs),
+		RunE:              c.delete,
 		Example: examples.BuildExampleString(
 			examples.Example{
 				Text: `Delete provider share "ss-12345":`,
@@ -25,10 +25,10 @@ func (s *providerShareCommand) newDeleteCommand() *cobra.Command {
 	}
 }
 
-func (s *providerShareCommand) delete(cmd *cobra.Command, args []string) error {
+func (c *command) delete(cmd *cobra.Command, args []string) error {
 	shareId := args[0]
 
-	if _, err := s.V2Client.DeleteProviderShare(shareId); err != nil {
+	if _, err := c.V2Client.DeleteProviderShare(shareId); err != nil {
 		return err
 	}
 

--- a/internal/cmd/stream-share/command_provider_share_describe.go
+++ b/internal/cmd/stream-share/command_provider_share_describe.go
@@ -8,13 +8,13 @@ import (
 	"github.com/confluentinc/cli/internal/pkg/output"
 )
 
-func (s *providerShareCommand) newDescribeCommand() *cobra.Command {
+func (c *command) newDescribeCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "describe <id>",
 		Short:             "Describe a provider share.",
 		Args:              cobra.ExactArgs(1),
-		ValidArgsFunction: pcmd.NewValidArgsFunction(s.validArgs),
-		RunE:              s.describe,
+		ValidArgsFunction: pcmd.NewValidArgsFunction(c.validArgs),
+		RunE:              c.describe,
 		Example: examples.BuildExampleString(
 			examples.Example{
 				Text: `Describe provider share "ss-12345":`,
@@ -28,13 +28,13 @@ func (s *providerShareCommand) newDescribeCommand() *cobra.Command {
 	return cmd
 }
 
-func (s *providerShareCommand) describe(cmd *cobra.Command, args []string) error {
+func (c *command) describe(cmd *cobra.Command, args []string) error {
 	shareId := args[0]
 
-	provideShare, _, err := s.V2Client.DescribeProvideShare(shareId)
+	provideShare, _, err := c.V2Client.DescribeProvideShare(shareId)
 	if err != nil {
 		return err
 	}
 
-	return output.DescribeObject(cmd, s.buildProviderShare(provideShare), providerShareListFields, humanLabelMap, structuredLabelMap)
+	return output.DescribeObject(cmd, c.buildProviderShare(provideShare), providerShareListFields, humanLabelMap, structuredLabelMap)
 }

--- a/internal/cmd/stream-share/command_provider_share_list.go
+++ b/internal/cmd/stream-share/command_provider_share_list.go
@@ -1,18 +1,19 @@
 package streamshare
 
 import (
+	"github.com/spf13/cobra"
+
 	pcmd "github.com/confluentinc/cli/internal/pkg/cmd"
 	"github.com/confluentinc/cli/internal/pkg/examples"
 	"github.com/confluentinc/cli/internal/pkg/output"
-	"github.com/spf13/cobra"
 )
 
-func (s *providerShareCommand) newListCommand() *cobra.Command {
+func (c *command) newListCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List shares for provider.",
 		Args:  cobra.NoArgs,
-		RunE:  s.list,
+		RunE:  c.list,
 		Example: examples.BuildExampleString(
 			examples.Example{
 				Text: "List provider shares:",
@@ -28,13 +29,13 @@ func (s *providerShareCommand) newListCommand() *cobra.Command {
 	return cmd
 }
 
-func (s *providerShareCommand) list(cmd *cobra.Command, _ []string) error {
+func (c *command) list(cmd *cobra.Command, _ []string) error {
 	sharedResource, err := cmd.Flags().GetString("shared-resource")
 	if err != nil {
 		return err
 	}
 
-	providerShares, err := s.V2Client.ListProviderShares(sharedResource)
+	providerShares, err := c.V2Client.ListProviderShares(sharedResource)
 	if err != nil {
 		return err
 	}
@@ -45,7 +46,7 @@ func (s *providerShareCommand) list(cmd *cobra.Command, _ []string) error {
 	}
 
 	for _, share := range providerShares {
-		element := s.buildProviderShare(share)
+		element := c.buildProviderShare(share)
 		outputWriter.AddElement(element)
 	}
 

--- a/internal/pkg/ccloudv2/stream-share.go
+++ b/internal/pkg/ccloudv2/stream-share.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 
 	cdxv1 "github.com/confluentinc/ccloud-sdk-go-v2/cdx/v1"
-	cliv1 "github.com/confluentinc/ccloud-sdk-go-v2/cli/v1"
+
 	plog "github.com/confluentinc/cli/internal/pkg/log"
 )
 
@@ -20,17 +20,17 @@ func newCdxClient(baseURL, userAgent string, isTest bool) *cdxv1.APIClient {
 }
 
 func (c *Client) cdxApiContext() context.Context {
-	return context.WithValue(context.Background(), cliv1.ContextAccessToken, c.AuthToken)
+	return context.WithValue(context.Background(), cdxv1.ContextAccessToken, c.AuthToken)
 }
 
 func (c *Client) DeleteProviderShare(shareId string) (*http.Response, error) {
-	request := c.StreamShareClient.ProviderSharesCdxV1Api.DeleteCdxV1ProviderShare(c.cdxApiContext(), shareId)
-	return c.StreamShareClient.ProviderSharesCdxV1Api.DeleteCdxV1ProviderShareExecute(request)
+	req := c.StreamShareClient.ProviderSharesCdxV1Api.DeleteCdxV1ProviderShare(c.cdxApiContext(), shareId)
+	return c.StreamShareClient.ProviderSharesCdxV1Api.DeleteCdxV1ProviderShareExecute(req)
 }
 
 func (c *Client) DescribeProvideShare(shareId string) (cdxv1.CdxV1ProviderShare, *http.Response, error) {
-	request := c.StreamShareClient.ProviderSharesCdxV1Api.GetCdxV1ProviderShare(c.cdxApiContext(), shareId)
-	return c.StreamShareClient.ProviderSharesCdxV1Api.GetCdxV1ProviderShareExecute(request)
+	req := c.StreamShareClient.ProviderSharesCdxV1Api.GetCdxV1ProviderShare(c.cdxApiContext(), shareId)
+	return c.StreamShareClient.ProviderSharesCdxV1Api.GetCdxV1ProviderShareExecute(req)
 }
 
 func (c *Client) ListProviderShares(sharedResource string) ([]cdxv1.CdxV1ProviderShare, error) {
@@ -57,10 +57,9 @@ func (c *Client) ListProviderShares(sharedResource string) ([]cdxv1.CdxV1Provide
 }
 
 func (c *Client) executeListProviderShares(sharedResource, pageToken string) (cdxv1.CdxV1ProviderShareList, *http.Response, error) {
-	request := c.StreamShareClient.ProviderSharesCdxV1Api.ListCdxV1ProviderShares(c.cdxApiContext()).
-		SharedResource(sharedResource).PageSize(ccloudV2ListPageSize)
+	req := c.StreamShareClient.ProviderSharesCdxV1Api.ListCdxV1ProviderShares(c.cdxApiContext()).SharedResource(sharedResource).PageSize(ccloudV2ListPageSize)
 	if pageToken != "" {
-		request = request.PageToken(pageToken)
+		req = req.PageToken(pageToken)
 	}
-	return c.StreamShareClient.ProviderSharesCdxV1Api.ListCdxV1ProviderSharesExecute(request)
+	return c.StreamShareClient.ProviderSharesCdxV1Api.ListCdxV1ProviderSharesExecute(req)
 }


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok

What
----
Surprised this wasn't caught while testing. All commands returned `Error: 401 Unauthorized` when run. The reason was the `cliv1` package was incorrectly being used to construct the auth token here: https://github.com/confluentinc/cli/blob/ec9a61046a2a91c38dfadb83158934e1ec4ab5ce/internal/pkg/ccloudv2/stream-share.go#L23

Also simplified the command structs, since they all use the same Cloud-based auth

Test & Review
-------------
Manually verified that `401 Unauthorized` is no longer seen and the `Authorization` header is visible