### PR TITLE
Add `-r` flag to `xattr` for Windows signing

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -57,7 +57,7 @@ builds:
     hooks:
       pre:
         - cmd: az keyvault secret download --file CLIEVCodeSigningCertificate2.pfx --name CLIEVCodeSigningCertificate2 --subscription cc-prod --vault-name CLICodeSigningKeyVault --encoding base64
-        - cmd: xattr -d com.apple.quarantine ./lib/osslsigncode
+        - cmd: xattr -dr com.apple.quarantine ./lib/osslsigncode
       post:
         - cmd: ./lib/osslsigncode sign -n "Confluent CLI" -i "https://confluent.io" -pkcs12 CLIEVCodeSigningCertificate2.pfx -in dist/confluent-windows-amd64_windows_amd64/confluent.exe -out dist/confluent-windows-amd64_windows_amd64/confluent.exe
         - cmd: rm CLIEVCodeSigningCertificate2.pfx


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok

What
----
`-r` is required to sign the whole repository, recursively (as opposed to only signing the top level files in the directory)

Test & Review
-------------
Tested manually