### PR TITLE
Use `--unsafe-trace` across all SDKs

### DIFF
--- a/internal/cmd/kafka/command_clientconfig_create.go
+++ b/internal/cmd/kafka/command_clientconfig_create.go
@@ -261,8 +261,13 @@ func (c *createCommand) setSchemaRegistryCluster(cmd *cobra.Command, configFile 
 		return configFile, nil
 	}
 
+	unsafeTrace, err := cmd.Flags().GetBool("unsafe-trace")
+	if err != nil {
+		return "", err
+	}
+
 	// validate that the key pair matches with the cluster
-	if err := c.validateSchemaRegistryCredentials(srCluster); err != nil {
+	if err := c.validateSchemaRegistryCredentials(srCluster, unsafeTrace); err != nil {
 		return "", err
 	}
 
@@ -319,7 +324,7 @@ func (c *createCommand) validateKafkaCredentials(kafkaCluster *v1.KafkaClusterCo
 	return nil
 }
 
-func (c *createCommand) validateSchemaRegistryCredentials(srCluster *v1.SchemaRegistryCluster) error {
+func (c *createCommand) validateSchemaRegistryCredentials(srCluster *v1.SchemaRegistryCluster, unsafeTrace bool) error {
 	srConfig := srsdk.NewConfiguration()
 
 	// set BasePath of srConfig
@@ -334,6 +339,7 @@ func (c *createCommand) validateSchemaRegistryCredentials(srCluster *v1.SchemaRe
 	srCtx := context.WithValue(context.Background(), srsdk.ContextBasicAuth, *srAuth)
 
 	srConfig.UserAgent = c.Version.UserAgent
+	srConfig.Debug = unsafeTrace
 	srClient := srsdk.NewAPIClient(srConfig)
 
 	// Test credentials

--- a/internal/cmd/login/command.go
+++ b/internal/cmd/login/command.go
@@ -18,10 +18,10 @@ import (
 	pcmd "github.com/confluentinc/cli/internal/pkg/cmd"
 	v1 "github.com/confluentinc/cli/internal/pkg/config/v1"
 	"github.com/confluentinc/cli/internal/pkg/errors"
+	"github.com/confluentinc/cli/internal/pkg/examples"
 	"github.com/confluentinc/cli/internal/pkg/log"
 	"github.com/confluentinc/cli/internal/pkg/netrc"
 	"github.com/confluentinc/cli/internal/pkg/utils"
-	"github.com/confluentinc/cli/internal/pkg/examples"
 )
 
 type command struct {
@@ -254,7 +254,12 @@ func (c *command) loginMDS(cmd *cobra.Command, url string) error {
 		}
 	}
 
-	client, err := c.mdsClientManager.GetMDSClient(url, caCertPath)
+	unsafeTrace, err := cmd.Flags().GetBool("unsafe-trace")
+	if err != nil {
+		return err
+	}
+
+	client, err := c.mdsClientManager.GetMDSClient(url, caCertPath, unsafeTrace)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/login/command_test.go
+++ b/internal/cmd/login/command_test.go
@@ -730,7 +730,7 @@ func getNewLoginCommandForSelfSignedCertTest(req *require.Assertions, cfg *v1.Co
 		},
 	}
 	mdsClientManager := &cliMock.MockMDSClientManager{
-		GetMDSClientFunc: func(url string, caCertPath string) (client *mds.APIClient, e error) {
+		GetMDSClientFunc: func(_, caCertPath string, _ bool) (*mds.APIClient, error) {
 			// ensure the right caCertPath is used
 			req.Contains(caCertPath, expectedCaCertPath)
 			mdsClient.GetConfig().HTTPClient, err = utils.SelfSignedCertClient(certReader, tls.Certificate{})
@@ -741,6 +741,7 @@ func getNewLoginCommandForSelfSignedCertTest(req *require.Assertions, cfg *v1.Co
 		},
 	}
 	loginCmd := New(cfg, prerunner, nil, mdsClientManager, mockNetrcHandler, mockLoginCredentialsManager, mockLoginOrganizationManager, mockAuthTokenHandler, true)
+	loginCmd.Flags().Bool("unsafe-trace", false, "")
 	loginCmd.PersistentFlags().CountP("verbose", "v", "Increase output verbosity")
 
 	return loginCmd
@@ -936,12 +937,13 @@ func newLoginCmd(auth *sdkMock.Auth, user *sdkMock.User, isCloud bool, req *requ
 		},
 	}
 	mdsClientManager := &cliMock.MockMDSClientManager{
-		GetMDSClientFunc: func(url string, caCertPath string) (client *mds.APIClient, e error) {
+		GetMDSClientFunc: func(_, _ string, _ bool) (*mds.APIClient, error) {
 			return mdsClient, nil
 		},
 	}
 	prerunner := cliMock.NewPreRunnerMock(ccloudClientFactory.AnonHTTPClientFactory(ccloudURL), nil, mdsClient, nil, cfg)
 	loginCmd := New(cfg, prerunner, ccloudClientFactory, mdsClientManager, netrcHandler, loginCredentialsManager, loginOrganizationManager, authTokenHandler, true)
+	loginCmd.Flags().Bool("unsafe-trace", false, "")
 	return loginCmd, cfg
 }
 

--- a/internal/cmd/logout/command_test.go
+++ b/internal/cmd/logout/command_test.go
@@ -191,7 +191,7 @@ func newLoginCmd(auth *sdkMock.Auth, user *sdkMock.User, isCloud bool, req *requ
 		},
 	}
 	mdsClientManager := &cliMock.MockMDSClientManager{
-		GetMDSClientFunc: func(url string, caCertPath string) (client *mds.APIClient, e error) {
+		GetMDSClientFunc: func(_, _ string, _ bool) (*mds.APIClient, error) {
 			return mdsClient, nil
 		},
 	}

--- a/internal/cmd/schema-registry/credentials.go
+++ b/internal/cmd/schema-registry/credentials.go
@@ -64,7 +64,13 @@ func GetSrApiClientWithToken(cmd *cobra.Command, ver *version.Version, mdsToken 
 
 func GetSchemaRegistryClientWithApiKey(cmd *cobra.Command, cfg *dynamicconfig.DynamicConfig, ver *version.Version, srAPIKey, srAPISecret string) (*srsdk.APIClient, context.Context, error) {
 	srConfig := srsdk.NewConfiguration()
-	srConfig.Debug = log.CliLogger.Level >= log.DEBUG
+
+	unsafeTrace, err := cmd.Flags().GetBool("unsafe-trace")
+	if err != nil {
+		return nil, nil, err
+	}
+
+	srConfig.Debug = unsafeTrace
 
 	ctx := cfg.Context()
 
@@ -182,6 +188,13 @@ func getSchemaRegistryClientWithToken(cmd *cobra.Command, ver *version.Version, 
 
 	srConfig.BasePath = endpoint
 	srConfig.UserAgent = ver.UserAgent
+
+	unsafeTrace, err := cmd.Flags().GetBool("unsafe-trace")
+	if err != nil {
+		return nil, nil, err
+	}
+
+	srConfig.Debug = unsafeTrace
 	srConfig.HTTPClient, err = utils.GetCAClient(caCertPath)
 	if err != nil {
 		return nil, nil, err

--- a/internal/pkg/auth/mds_client.go
+++ b/internal/pkg/auth/mds_client.go
@@ -10,14 +10,14 @@ import (
 
 // Made it an interface so that we can inject MDS client for testing through GetMDSClient
 type MDSClientManager interface {
-	GetMDSClient(url string, caCertPath string) (*mds.APIClient, error)
+	GetMDSClient(url, caCertPath string, unsafeTrace bool) (*mds.APIClient, error)
 }
 
 type MDSClientManagerImpl struct{}
 
-func (m *MDSClientManagerImpl) GetMDSClient(url, caCertPath string) (*mds.APIClient, error) {
+func (m *MDSClientManagerImpl) GetMDSClient(url, caCertPath string, unsafeTrace bool) (*mds.APIClient, error) {
 	mdsConfig := mds.NewConfiguration()
-	mdsConfig.Debug = log.CliLogger.Level == log.DEBUG || log.CliLogger.Level == log.TRACE
+	mdsConfig.Debug = unsafeTrace
 
 	if caCertPath != "" {
 		log.CliLogger.Debugf("CA certificate path was specified.  Note, the set of supported ciphers for the CLI can be found at https://golang.org/pkg/crypto/tls/#pkg-constants")

--- a/internal/pkg/cmd/prerunner_test.go
+++ b/internal/pkg/cmd/prerunner_test.go
@@ -104,7 +104,7 @@ func getPreRunBase() *pcmd.PreRun {
 			},
 		},
 		MDSClientManager: &cliMock.MockMDSClientManager{
-			GetMDSClientFunc: func(url, caCertPath string) (client *mds.APIClient, e error) {
+			GetMDSClientFunc: func(_, _ string, _ bool) (*mds.APIClient, error) {
 				return &mds.APIClient{}, nil
 			},
 		},

--- a/mock/auth_mds_client.go
+++ b/mock/auth_mds_client.go
@@ -13,18 +13,19 @@ import (
 // MockMDSClientManager is a mock of MDSClientManager interface
 type MockMDSClientManager struct {
 	lockGetMDSClient sync.Mutex
-	GetMDSClientFunc func(url, caCertPath string) (*github_com_confluentinc_mds_sdk_go_mdsv1.APIClient, error)
+	GetMDSClientFunc func(url, caCertPath string, unsafeTrace bool) (*github_com_confluentinc_mds_sdk_go_mdsv1.APIClient, error)
 
 	calls struct {
 		GetMDSClient []struct {
-			Url        string
-			CaCertPath string
+			Url         string
+			CaCertPath  string
+			UnsafeTrace bool
 		}
 	}
 }
 
 // GetMDSClient mocks base method by wrapping the associated func.
-func (m *MockMDSClientManager) GetMDSClient(url, caCertPath string) (*github_com_confluentinc_mds_sdk_go_mdsv1.APIClient, error) {
+func (m *MockMDSClientManager) GetMDSClient(url, caCertPath string, unsafeTrace bool) (*github_com_confluentinc_mds_sdk_go_mdsv1.APIClient, error) {
 	m.lockGetMDSClient.Lock()
 	defer m.lockGetMDSClient.Unlock()
 
@@ -33,16 +34,18 @@ func (m *MockMDSClientManager) GetMDSClient(url, caCertPath string) (*github_com
 	}
 
 	call := struct {
-		Url        string
-		CaCertPath string
+		Url         string
+		CaCertPath  string
+		UnsafeTrace bool
 	}{
-		Url:        url,
-		CaCertPath: caCertPath,
+		Url:         url,
+		CaCertPath:  caCertPath,
+		UnsafeTrace: unsafeTrace,
 	}
 
 	m.calls.GetMDSClient = append(m.calls.GetMDSClient, call)
 
-	return m.GetMDSClientFunc(url, caCertPath)
+	return m.GetMDSClientFunc(url, caCertPath, unsafeTrace)
 }
 
 // GetMDSClientCalled returns true if GetMDSClient was called at least once.
@@ -55,8 +58,9 @@ func (m *MockMDSClientManager) GetMDSClientCalled() bool {
 
 // GetMDSClientCalls returns the calls made to GetMDSClient.
 func (m *MockMDSClientManager) GetMDSClientCalls() []struct {
-	Url        string
-	CaCertPath string
+	Url         string
+	CaCertPath  string
+	UnsafeTrace bool
 } {
 	m.lockGetMDSClient.Lock()
 	defer m.lockGetMDSClient.Unlock()


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok

What
----
I only connected `--unsafe-trace` to ccloud-sdk-go-v2 and the retryable HTTP client 🤦‍♂️
This PR connects the global flag to all of our SDKs.

References
----------
List of SDKs: https://confluent.slack.com/archives/C03Q5LDR4TG/p1658433236647359

Test & Review
-------------
Test cases still pass, manual verification.