### PR TITLE
[CLI-1920] Revert using ccloud-sdk-go-v2 for `kafka acl`

### DIFF
--- a/internal/cmd/kafka/command_acl_create.go
+++ b/internal/cmd/kafka/command_acl_create.go
@@ -81,8 +81,8 @@ func (c *aclCommand) create(cmd *cobra.Command, _ []string) error {
 
 		kafkaRestExists := true
 		for i, binding := range bindings {
-			data := getCreateAclRequestData(binding)
-			httpResp, err := kafkaREST.CloudClient.CreateKafkaAcls(kafkaClusterConfig.ID, data)
+			opts := aclBindingToClustersClusterIdAclsPostOpts(binding)
+			httpResp, err := kafkaREST.Client.ACLV3Api.CreateKafkaAcls(kafkaREST.Context, kafkaClusterConfig.ID, &opts)
 			if err != nil && httpResp == nil {
 				if i == 0 {
 					// assume Kafka REST is not available, fallback to KafkaAPI
@@ -91,7 +91,7 @@ func (c *aclCommand) create(cmd *cobra.Command, _ []string) error {
 				}
 				// i > 0: unlikely
 				_ = aclutil.PrintACLsWithResourceIdMap(cmd, bindings[:i], os.Stdout, resourceIdMap)
-				return kafkaRestError(kafkaREST.CloudClient.GetKafkaRestUrl(), err, httpResp)
+				return kafkaRestError(kafkaREST.Client.GetConfig().BasePath, err, httpResp)
 			}
 
 			if err != nil {
@@ -99,7 +99,7 @@ func (c *aclCommand) create(cmd *cobra.Command, _ []string) error {
 					// unlikely
 					_ = aclutil.PrintACLsWithResourceIdMap(cmd, bindings[:i], os.Stdout, resourceIdMap)
 				}
-				return kafkaRestError(kafkaREST.CloudClient.GetKafkaRestUrl(), err, httpResp)
+				return kafkaRestError(kafkaREST.Client.GetConfig().BasePath, err, httpResp)
 			}
 
 			if httpResp != nil && httpResp.StatusCode != http.StatusCreated {

--- a/internal/cmd/kafka/command_acl_delete.go
+++ b/internal/cmd/kafka/command_acl_delete.go
@@ -65,7 +65,8 @@ func (c *aclCommand) delete(cmd *cobra.Command, _ []string) error {
 		kafkaRestExists := true
 		matchingBindingCount := 0
 		for i, filter := range filters {
-			deleteResp, httpResp, err := kafkaREST.CloudClient.DeleteKafkaAcls(kafkaClusterConfig.ID, filter)
+			opts := aclFilterToClustersClusterIdAclsDeleteOpts(filter)
+			deleteResp, httpResp, err := kafkaREST.Client.ACLV3Api.DeleteKafkaAcls(kafkaREST.Context, kafkaClusterConfig.ID, &opts)
 			if err != nil && httpResp == nil {
 				if i == 0 {
 					// Kafka REST is not available, fallback to KafkaAPI
@@ -74,7 +75,7 @@ func (c *aclCommand) delete(cmd *cobra.Command, _ []string) error {
 				}
 				// i > 0: unlikely
 				printAclsDeleted(cmd, matchingBindingCount)
-				return kafkaRestError(kafkaREST.CloudClient.GetKafkaRestUrl(), err, httpResp)
+				return kafkaRestError(kafkaREST.Client.GetConfig().BasePath, err, httpResp)
 			}
 
 			if err != nil {
@@ -82,7 +83,7 @@ func (c *aclCommand) delete(cmd *cobra.Command, _ []string) error {
 					// unlikely
 					printAclsDeleted(cmd, matchingBindingCount)
 				}
-				return kafkaRestError(kafkaREST.CloudClient.GetKafkaRestUrl(), err, httpResp)
+				return kafkaRestError(kafkaREST.Client.GetConfig().BasePath, err, httpResp)
 			}
 
 			if httpResp.StatusCode == http.StatusOK {

--- a/internal/cmd/kafka/command_acl_list.go
+++ b/internal/cmd/kafka/command_acl_list.go
@@ -64,10 +64,11 @@ func (c *aclCommand) list(cmd *cobra.Command, _ []string) error {
 			return err
 		}
 
-		aclGetResp, httpResp, err := kafkaREST.CloudClient.GetKafkaAcls(kafkaClusterConfig.ID, acl[0].ACLBinding)
+		opts := aclBindingToClustersClusterIdAclsGetOpts(acl[0].ACLBinding)
+		aclGetResp, httpResp, err := kafkaREST.Client.ACLV3Api.GetKafkaAcls(kafkaREST.Context, kafkaClusterConfig.ID, &opts)
 		if err != nil && httpResp != nil {
 			// Kafka REST is available, but an error occurred
-			return kafkaRestError(kafkaREST.CloudClient.GetKafkaRestUrl(), err, httpResp)
+			return kafkaRestError(kafkaREST.Client.GetConfig().BasePath, err, httpResp)
 		}
 		if err == nil && httpResp != nil {
 			if httpResp.StatusCode != http.StatusOK {

--- a/internal/cmd/kafka/kafka_rest.go
+++ b/internal/cmd/kafka/kafka_rest.go
@@ -92,3 +92,61 @@ func aclBindingToClustersClusterIdAclsGetOpts(acl *schedv1.ACLBinding) kafkarest
 
 	return opts
 }
+
+// Converts ACLBinding to Kafka REST ClustersClusterIdAclsPostOpts
+func aclBindingToClustersClusterIdAclsPostOpts(acl *schedv1.ACLBinding) kafkarestv3.CreateKafkaAclsOpts {
+	var aclRequestData kafkarestv3.CreateAclRequestData
+
+	if acl.Pattern.ResourceType != schedv1.ResourceTypes_UNKNOWN {
+		aclRequestData.ResourceType = kafkarestv3.AclResourceType(acl.Pattern.ResourceType.String())
+	}
+
+	if acl.Pattern.PatternType != schedv1.PatternTypes_UNKNOWN {
+		aclRequestData.PatternType = acl.Pattern.PatternType.String()
+	}
+
+	aclRequestData.ResourceName = acl.Pattern.Name
+	aclRequestData.Principal = acl.Entry.Principal
+	aclRequestData.Host = acl.Entry.Host
+
+	if acl.Entry.Operation != schedv1.ACLOperations_UNKNOWN {
+		aclRequestData.Operation = acl.Entry.Operation.String()
+	}
+
+	if acl.Entry.PermissionType != schedv1.ACLPermissionTypes_UNKNOWN {
+		aclRequestData.Permission = acl.Entry.PermissionType.String()
+	}
+
+	var opts kafkarestv3.CreateKafkaAclsOpts
+	opts.CreateAclRequestData = optional.NewInterface(aclRequestData)
+
+	return opts
+}
+
+// Converts ACLFilter to Kafka REST ClustersClusterIdAclsDeleteOpts
+func aclFilterToClustersClusterIdAclsDeleteOpts(acl *schedv1.ACLFilter) kafkarestv3.DeleteKafkaAclsOpts {
+	var opts kafkarestv3.DeleteKafkaAclsOpts
+
+	if acl.PatternFilter.ResourceType != schedv1.ResourceTypes_UNKNOWN {
+		opts.ResourceType = optional.NewInterface(kafkarestv3.AclResourceType(acl.PatternFilter.ResourceType.String()))
+	}
+
+	opts.ResourceName = optional.NewString(acl.PatternFilter.Name)
+
+	if acl.PatternFilter.PatternType != schedv1.PatternTypes_UNKNOWN {
+		opts.PatternType = optional.NewString(acl.PatternFilter.PatternType.String())
+	}
+
+	opts.Principal = optional.NewString(acl.EntryFilter.Principal)
+	opts.Host = optional.NewString(acl.EntryFilter.Host)
+
+	if acl.EntryFilter.Operation != schedv1.ACLOperations_UNKNOWN {
+		opts.Operation = optional.NewString(acl.EntryFilter.Operation.String())
+	}
+
+	if acl.EntryFilter.PermissionType != schedv1.ACLPermissionTypes_UNKNOWN {
+		opts.Permission = optional.NewString(acl.EntryFilter.PermissionType.String())
+	}
+
+	return opts
+}

--- a/internal/pkg/acl/acl.go
+++ b/internal/pkg/acl/acl.go
@@ -13,8 +13,7 @@ import (
 	"github.com/spf13/pflag"
 
 	schedv1 "github.com/confluentinc/cc-structs/kafka/scheduler/v1"
-	cckafkarestv3 "github.com/confluentinc/ccloud-sdk-go-v2/kafkarest/v3"
-	cpkafkarestv3 "github.com/confluentinc/kafka-rest-sdk-go/kafkarestv3"
+	"github.com/confluentinc/kafka-rest-sdk-go/kafkarestv3"
 
 	pcmd "github.com/confluentinc/cli/internal/pkg/cmd"
 	"github.com/confluentinc/cli/internal/pkg/errors"
@@ -30,7 +29,7 @@ var (
 )
 
 type AclRequestDataWithError struct {
-	ResourceType cpkafkarestv3.AclResourceType
+	ResourceType kafkarestv3.AclResourceType
 	ResourceName string
 	PatternType  string
 	Principal    string
@@ -40,7 +39,7 @@ type AclRequestDataWithError struct {
 	Errors       error
 }
 
-func PrintACLsFromKafkaRestResponse(cmd *cobra.Command, aclGetResp []cpkafkarestv3.AclData, writer io.Writer, listFields, humanLabels, structuredLabels []string) error {
+func PrintACLsFromKafkaRestResponse(cmd *cobra.Command, aclGetResp []kafkarestv3.AclData, writer io.Writer, listFields, humanLabels, structuredLabels []string) error {
 	// non list commands which do not have -o flags also uses this function, need to set default
 	_, err := cmd.Flags().GetString(output.FlagName)
 	if err != nil {
@@ -211,8 +210,8 @@ func setAclRequestResourcePattern(conf *AclRequestDataWithError, n, v string) {
 	if conf.ResourceType != "" {
 		// A resourceType has already been set with a previous flag
 		conf.Errors = multierror.Append(conf.Errors, fmt.Errorf("exactly one of %v must be set",
-			convertToFlags(cpkafkarestv3.ACLRESOURCETYPE_TOPIC, cpkafkarestv3.ACLRESOURCETYPE_GROUP,
-				cpkafkarestv3.ACLRESOURCETYPE_CLUSTER, cpkafkarestv3.ACLRESOURCETYPE_TRANSACTIONAL_ID)))
+			convertToFlags(kafkarestv3.ACLRESOURCETYPE_TOPIC, kafkarestv3.ACLRESOURCETYPE_GROUP,
+				kafkarestv3.ACLRESOURCETYPE_CLUSTER, kafkarestv3.ACLRESOURCETYPE_TRANSACTIONAL_ID)))
 		return
 	}
 
@@ -221,11 +220,11 @@ func setAclRequestResourcePattern(conf *AclRequestDataWithError, n, v string) {
 	n = strings.ReplaceAll(n, "-", "_")
 
 	enumUtils := utils.EnumUtils{}
-	enumUtils.Init(cpkafkarestv3.ACLRESOURCETYPE_TOPIC, cpkafkarestv3.ACLRESOURCETYPE_GROUP,
-		cpkafkarestv3.ACLRESOURCETYPE_CLUSTER, cpkafkarestv3.ACLRESOURCETYPE_TRANSACTIONAL_ID)
-	conf.ResourceType = enumUtils[n].(cpkafkarestv3.AclResourceType)
+	enumUtils.Init(kafkarestv3.ACLRESOURCETYPE_TOPIC, kafkarestv3.ACLRESOURCETYPE_GROUP,
+		kafkarestv3.ACLRESOURCETYPE_CLUSTER, kafkarestv3.ACLRESOURCETYPE_TRANSACTIONAL_ID)
+	conf.ResourceType = enumUtils[n].(kafkarestv3.AclResourceType)
 
-	if conf.ResourceType == cpkafkarestv3.ACLRESOURCETYPE_CLUSTER {
+	if conf.ResourceType == kafkarestv3.ACLRESOURCETYPE_CLUSTER {
 		conf.PatternType = "LITERAL"
 	}
 	conf.ResourceName = v
@@ -236,10 +235,10 @@ func convertToFlags(operations ...interface{}) string {
 
 	for _, v := range operations {
 		// clean the resources that don't map directly to flag name
-		if v == cpkafkarestv3.ACLRESOURCETYPE_GROUP {
+		if v == kafkarestv3.ACLRESOURCETYPE_GROUP {
 			v = "consumer-group"
 		}
-		if v == cpkafkarestv3.ACLRESOURCETYPE_CLUSTER {
+		if v == kafkarestv3.ACLRESOURCETYPE_CLUSTER {
 			v = "cluster-scope"
 		}
 		s := fmt.Sprintf("%v", v)
@@ -265,15 +264,15 @@ func ValidateCreateDeleteAclRequestData(aclConfiguration *AclRequestDataWithErro
 
 	if aclConfiguration.ResourceType == "" {
 		aclConfiguration.Errors = multierror.Append(aclConfiguration.Errors, errors.Errorf(errors.MustSetResourceTypeErrorMsg,
-			convertToFlags(cpkafkarestv3.ACLRESOURCETYPE_TOPIC, cpkafkarestv3.ACLRESOURCETYPE_GROUP,
-				cpkafkarestv3.ACLRESOURCETYPE_CLUSTER, cpkafkarestv3.ACLRESOURCETYPE_TRANSACTIONAL_ID)))
+			convertToFlags(kafkarestv3.ACLRESOURCETYPE_TOPIC, kafkarestv3.ACLRESOURCETYPE_GROUP,
+				kafkarestv3.ACLRESOURCETYPE_CLUSTER, kafkarestv3.ACLRESOURCETYPE_TRANSACTIONAL_ID)))
 	}
 	return aclConfiguration
 }
 
-func AclRequestToCreateAclRequest(acl *AclRequestDataWithError) *cpkafkarestv3.CreateKafkaAclsOpts {
-	return &cpkafkarestv3.CreateKafkaAclsOpts{
-		CreateAclRequestData: optional.NewInterface(cpkafkarestv3.CreateAclRequestData{
+func AclRequestToCreateAclRequest(acl *AclRequestDataWithError) *kafkarestv3.CreateKafkaAclsOpts {
+	return &kafkarestv3.CreateKafkaAclsOpts{
+		CreateAclRequestData: optional.NewInterface(kafkarestv3.CreateAclRequestData{
 			ResourceType: acl.ResourceType,
 			ResourceName: acl.ResourceName,
 			PatternType:  acl.PatternType,
@@ -287,8 +286,8 @@ func AclRequestToCreateAclRequest(acl *AclRequestDataWithError) *cpkafkarestv3.C
 
 // Functions for converting AclRequestDataWithError into structs for create, delete, and list requests
 
-func AclRequestToListAclRequest(acl *AclRequestDataWithError) *cpkafkarestv3.GetKafkaAclsOpts {
-	opts := &cpkafkarestv3.GetKafkaAclsOpts{}
+func AclRequestToListAclRequest(acl *AclRequestDataWithError) *kafkarestv3.GetKafkaAclsOpts {
+	opts := &kafkarestv3.GetKafkaAclsOpts{}
 	if acl.ResourceType != "" {
 		opts.ResourceType = optional.NewInterface(acl.ResourceType)
 	}
@@ -313,8 +312,8 @@ func AclRequestToListAclRequest(acl *AclRequestDataWithError) *cpkafkarestv3.Get
 	return opts
 }
 
-func AclRequestToDeleteAclRequest(acl *AclRequestDataWithError) *cpkafkarestv3.DeleteKafkaAclsOpts {
-	return &cpkafkarestv3.DeleteKafkaAclsOpts{
+func AclRequestToDeleteAclRequest(acl *AclRequestDataWithError) *kafkarestv3.DeleteKafkaAclsOpts {
+	return &kafkarestv3.DeleteKafkaAclsOpts{
 		ResourceType: optional.NewInterface(acl.ResourceType),
 		ResourceName: optional.NewString(acl.ResourceName),
 		PatternType:  optional.NewString(acl.PatternType),
@@ -325,8 +324,8 @@ func AclRequestToDeleteAclRequest(acl *AclRequestDataWithError) *cpkafkarestv3.D
 	}
 }
 
-func CreateAclRequestDataToAclData(data *AclRequestDataWithError) cpkafkarestv3.AclData {
-	return cpkafkarestv3.AclData{
+func CreateAclRequestDataToAclData(data *AclRequestDataWithError) kafkarestv3.AclData {
+	return kafkarestv3.AclData{
 		ResourceType: data.ResourceType,
 		ResourceName: data.ResourceName,
 		PatternType:  data.PatternType,
@@ -337,7 +336,7 @@ func CreateAclRequestDataToAclData(data *AclRequestDataWithError) cpkafkarestv3.
 	}
 }
 
-func PrintACLsFromKafkaRestResponseWithResourceIdMap(cmd *cobra.Command, aclGetResp cckafkarestv3.AclDataList, writer io.Writer, idMap map[int32]string) error {
+func PrintACLsFromKafkaRestResponseWithResourceIdMap(cmd *cobra.Command, aclGetResp kafkarestv3.AclDataList, writer io.Writer, idMap map[int32]string) error {
 	// non list commands which do not have -o flags also uses this function, need to set default
 	_, err := cmd.Flags().GetString(output.FlagName)
 	if err != nil {


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok

What
----
We're seeing 404s here since the host URL is incorrect. The fix seems like a decent amount of work, so I'd rather revert for the time being until I have time to redo this.

References
----------
https://confluent.slack.com/archives/C9Y6NAM6X/p1661175001157989

Test & Review
-------------
Manually tested that functionality is back to normal.