### PR TITLE
added extra check to verify that the cluster is running before deleting the topics

### DIFF
--- a/internal/cmd/ksql/command_delete.go
+++ b/internal/cmd/ksql/command_delete.go
@@ -36,7 +36,7 @@ func (c *ksqlCommand) newDeleteCommand(resource string) *cobra.Command {
 
 func (c *ksqlCommand) delete(cmd *cobra.Command, args []string) error {
 	id := args[0]
-	log.CliLogger.Debugf("Deleting cluster: %v", id)
+	log.CliLogger.Debugf("Deleting ksqlDB cluster \"%v\".\n", id)
 
 	req := &schedv1.KSQLCluster{
 		AccountId: c.EnvironmentId(),


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok

What
----
Deleting ksql clusters that failed to provision was returning an error. This was happening because cluster deletion is trying to delete ksql internal topic by calling an enpoint on the ksql itself. If the cluster is not provisioned this request was failing and the cluster was not deleted

References
----------
https://confluentinc.atlassian.net/browse/KFS-181

Test & Review
-------------
Build the cli locally
<!--
Open questions / Follow ups
---------------------------
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->

<!--
Review stakeholders
-------------------
Optional: mention stakeholders or special context that is required to review.
-->
