### PR TITLE
Support CPD requests to ccloud-sdk-go-v2 APIs

### DIFF
--- a/internal/pkg/ccloudv2/client.go
+++ b/internal/pkg/ccloudv2/client.go
@@ -12,6 +12,8 @@ import (
 	metricsv2 "github.com/confluentinc/ccloud-sdk-go-v2/metrics/v2"
 	orgv2 "github.com/confluentinc/ccloud-sdk-go-v2/org/v2"
 	servicequotav1 "github.com/confluentinc/ccloud-sdk-go-v2/service-quota/v1"
+
+	testserver "github.com/confluentinc/cli/test/test-server"
 )
 
 // Client represents a Confluent Cloud Client as defined by ccloud-sdk-go-v2
@@ -33,7 +35,10 @@ type Client struct {
 }
 
 func NewClient(authToken, baseUrl, userAgent string, unsafeTrace, isTest bool) *Client {
-	url := getServerUrl(baseUrl, isTest)
+	url := getServerUrl(baseUrl)
+	if isTest {
+		url = testserver.TestV2CloudURL.String()
+	}
 
 	return &Client{
 		AuthToken: authToken,

--- a/internal/pkg/ccloudv2/utils.go
+++ b/internal/pkg/ccloudv2/utils.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/go-retryablehttp"
 
 	plog "github.com/confluentinc/cli/internal/pkg/log"
+	"github.com/confluentinc/cli/internal/pkg/utils"
 	testserver "github.com/confluentinc/cli/test/test-server"
 )
 
@@ -37,16 +38,19 @@ func newRetryableHttpClient(unsafeTrace bool) *http.Client {
 	return client.StandardClient()
 }
 
-func getServerUrl(baseURL string, isTest bool) string {
-	if isTest {
-		return testserver.TestV2CloudURL.String()
+func getServerUrl(baseURL string) string {
+	u, err := url.Parse(baseURL)
+	if err != nil {
+		return baseURL
 	}
-	if strings.Contains(baseURL, "devel") {
-		return "https://api.devel.cpdev.cloud"
-	} else if strings.Contains(baseURL, "stag") {
-		return "https://api.stag.cpdev.cloud"
+
+	if utils.Contains([]string{"confluent.cloud", "devel.cpdev.cloud", "stag.cpdev.cloud"}, u.Host) {
+		u.Host = "api." + u.Host
+	} else {
+		u.Path = "api"
 	}
-	return "https://api.confluent.cloud"
+
+	return u.String()
 }
 
 func extractPageToken(nextPageUrlString string) (string, error) {

--- a/internal/pkg/ccloudv2/utils_test.go
+++ b/internal/pkg/ccloudv2/utils_test.go
@@ -1,8 +1,10 @@
 package ccloudv2
 
 import (
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestIsCCloudURL_True(t *testing.T) {
@@ -27,5 +29,18 @@ func TestIsCCloudURL_False(t *testing.T) {
 	} {
 		isCCloud := IsCCloudURL(url, false)
 		require.False(t, isCCloud, url+" should return false")
+	}
+}
+
+func TestGetServerUrl(t *testing.T) {
+	m := map[string]string{
+		"https://confluent.cloud":                  "https://api.confluent.cloud",
+		"https://devel.cpdev.cloud":                "https://api.devel.cpdev.cloud",
+		"https://stag.cpdev.cloud":                 "https://api.stag.cpdev.cloud",
+		"https://healthy-fox.gcp.priv.cpdev.cloud": "https://healthy-fox.gcp.priv.cpdev.cloud/api",
+	}
+
+	for baseUrl, serverUrl := range m {
+		assert.Equal(t, serverUrl, getServerUrl(baseUrl))
 	}
 }


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok

What
----
We received two separate requests for CPD support for ccloud-sdk-go-v2 APIs, which until now didn't support CPD URLs. The main three environments can be prefixed with "api.", but CPD must end with "/api".

References
----------
https://confluent.slack.com/archives/C010Y0EP5MZ/p1661359081309459
https://confluent.slack.com/archives/CCWFZLUUD/p1661521120843649

Test & Review
-------------
Unit tested