### PR TITLE
Hide identity provider errors in `iam rbac role-binding list`

### DIFF
--- a/internal/cmd/iam/command_rbac_role_binding_list.go
+++ b/internal/cmd/iam/command_rbac_role_binding_list.go
@@ -242,13 +242,13 @@ func (c *roleBindingCommand) listMyRoleBindings(cmd *cobra.Command, options *rol
 func (c *roleBindingCommand) getPoolToNameMap() (map[string]string, error) {
 	providers, err := c.V2Client.ListIdentityProviders()
 	if err != nil {
-		return nil, err
+		return map[string]string{}, err
 	}
 	poolToName := make(map[string]string)
 	for _, provider := range providers {
 		pools, err := c.V2Client.ListIdentityPools(*provider.Id)
 		if err != nil {
-			return nil, err
+			return map[string]string{}, err
 		}
 		for _, pool := range pools {
 			poolToName["User:"+*pool.Id] = *pool.DisplayName


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok

What
----
These endpoints will not be available to all users until Identity Providers goes GA. For now, suppress errors and return an empty map.

References
----------
https://confluent.slack.com/archives/C041P4P0WM7