### PR TITLE
Use forks for muckrake in jenkinsjob

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -79,16 +79,16 @@ def job = {
                             sh '''#!/usr/bin/env bash
                                 export HASH=$(git rev-parse --short=7 HEAD)
                                 export confluent_s3="https://s3-us-west-2.amazonaws.com"
-                                git clone git@github.com:${CP_FORK}/muckrake.git
+                                git clone git@github.com:confluentinc/muckrake.git
                                 cd muckrake
-                                git remote add upstream git@github.com:confluentinc/muckrake.git
-                                git checkout upstream/7.2.x
+                                git checkout 7.2.x
+                                git remote add userfork git@github.com:${muckrake_remote}/muckrake.git
                                 sed -i "s?\\(confluent-cli-\\(.*\\)=\\)\\(.*\\)?\\1${confluent_s3}/confluent.cloud/confluent-cli-system-test-builds/confluent_SNAPSHOT-${HASH}_linux_amd64\\.tar\\.gz\\"?" ducker/ducker
                                 sed -i "s?get_cli .*?& ${confluent_s3}/confluent.cloud/confluent-cli-system-test-builds/confluent_SNAPSHOT-${HASH}_linux_amd64\\.tar\\.gz?g" vagrant/base-ubuntu.sh
                                 sed -i "s?get_cli .*?& ${confluent_s3}/confluent.cloud/confluent-cli-system-test-builds/confluent_SNAPSHOT-${HASH}_linux_amd64\\.tar\\.gz?g" vagrant/base-redhat.sh
                                 git checkout -b cli_system_test_$HASH
                                 git commit -am "System test configuration for CLI build ${HASH}"
-                                git push -u origin cli_system_test_$HASH
+                                git push -u userfork cli_system_test_$HASH
                             '''
                         }
                     }
@@ -144,7 +144,7 @@ def post = {
                     . ./resources/aws-iam.sh
                     vagrant destroy -f
                     cd ..
-                    git push --delete origin cli_system_test_$HASH
+                    git push --delete userfork cli_system_test_$HASH
                 '''
             }
             withVaultEnv([["aws/prod_cli_team", "key_id", "AWS_ACCESS_KEY_ID"],

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -71,7 +71,7 @@ def job = {
                     ["sonatype/confluent", "user", "SONATYPE_OSSRH_USER"],
                     ["sonatype/confluent", "password", "SONATYPE_OSSRH_PASSWORD"]]) {
                     withEnv([
-                        "GIT_CREDENTIAL=${env.GIT_USER}:${env.GIT_TOKEN}"
+                        "GIT_CREDENTIAL=${env.GIT_USER}:${env.GIT_TOKEN}",
                         "CP_FORK=${env.CHANGE_FORK ?: 'confluentinc'}"
                     ]) {
                         withVaultFile([["gradle/gradle_properties_maven", "gradle_properties_file",

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -72,7 +72,7 @@ def job = {
                     ["sonatype/confluent", "password", "SONATYPE_OSSRH_PASSWORD"]]) {
                     withEnv([
                         "GIT_CREDENTIAL=${env.GIT_USER}:${env.GIT_TOKEN}"
-                        "CP_FORK=${env.CHANGE_FORK ?: muckrake_remote}"
+                        "CP_FORK=${env.CHANGE_FORK ?: 'confluentinc'}"
                     ]) {
                         withVaultFile([["gradle/gradle_properties_maven", "gradle_properties_file",
                             "gradle.properties", "GRADLE_PROPERTIES_FILE"]]) {


### PR DESCRIPTION
Checklist
---------

What
----
update the jenkins job such that when cloning muckrake it pushes to the same branch that vagrant will pull from even if its a different fork.

References
----------
<!--
Copy & paste links to Jira tickets, other PRs, issues, Slack conversations, etc.
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test & Review
-------------
<!--
Has it been tested? how?
Copy & paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

<!--
Open questions / Follow ups
---------------------------
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->

<!--
Review stakeholders
-------------------
Optional: mention stakeholders or special context that is required to review.
-->
