### PR TITLE
Increase goreleaser timeout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,16 +141,6 @@ endef
 fmt:
 	@goimports -e -l -local github.com/confluentinc/cli/ -w $(ALL_SRC)
 
-.PHONY: release-ci
-release-ci:
-ifneq ($(SEMAPHORE_GIT_PR_BRANCH),)
-	true
-else ifeq ($(SEMAPHORE_GIT_BRANCH),master)
-	make release
-else
-	true
-endif
-
 .PHONY: lint
 lint:
 	make lint-go

--- a/debian/patches/standard_build_layout.patch
+++ b/debian/patches/standard_build_layout.patch
@@ -1,6 +1,6 @@
---- cli/Makefile	2022-09-27 16:09:05.000000000 -0700
-+++ debian/Makefile	2022-09-01 10:34:50.000000000 -0700
-@@ -1,221 +1,130 @@
+--- cli/Makefile	2022-10-03 16:53:23.000000000 -0700
++++ debian/Makefile	2022-07-12 14:17:45.000000000 -0700
+@@ -1,211 +1,130 @@
 -SHELL           := /bin/bash
 -ALL_SRC         := $(shell find . -name "*.go" | grep -v -e vendor)
 -GIT_REMOTE_NAME ?= origin
@@ -72,6 +72,16 @@
 +ifndef VERSION
 +	VERSION=$(CLI_VERSION)
 +endif
++
++export PACKAGE_TITLE=cli
++export FULL_PACKAGE_TITLE=confluent-$(PACKAGE_TITLE)
++export PACKAGE_NAME=$(FULL_PACKAGE_TITLE)-$(VERSION)
++
++# Defaults that are likely to vary by platform. These are cleanly separated so
++# it should be easy to maintain altered values on platform-specific branches
++# when the values aren't overridden by the script invoking the Makefile
++
++APPLY_PATCHES?=yes
  
 -.PHONY: generate
 -generate:
@@ -148,29 +158,6 @@
 -fmt:
 -	@goimports -e -l -local github.com/confluentinc/cli/ -w $(ALL_SRC)
 -
--.PHONY: release-ci
--release-ci:
--ifneq ($(SEMAPHORE_GIT_PR_BRANCH),)
--	true
--else ifeq ($(SEMAPHORE_GIT_BRANCH),master)
--	make release
--else
--	true
-+export PACKAGE_TITLE=cli
-+export FULL_PACKAGE_TITLE=confluent-$(PACKAGE_TITLE)
-+export PACKAGE_NAME=$(FULL_PACKAGE_TITLE)-$(VERSION)
-+
-+# Defaults that are likely to vary by platform. These are cleanly separated so
-+# it should be easy to maintain altered values on platform-specific branches
-+# when the values aren't overridden by the script invoking the Makefile
-+
-+APPLY_PATCHES?=yes
-+
-+# DESTDIR may be overridden by e.g. debian packaging
-+ifeq ($(DESTDIR),)
-+DESTDIR=$(CURDIR)/BUILD/
- endif
- 
 -.PHONY: lint
 -lint:
 -	make lint-go
@@ -216,6 +203,11 @@
 -	@GOPRIVATE=github.com/confluentinc gotestsum --junitfile unit-test-report.xml -- -v -race -coverpkg=$$(go list ./... | grep -v test | grep -v mock | tr '\n' ',' | sed 's/,$$//g') -coverprofile=unit_coverage.txt $$(go list ./... | grep -v vendor | grep -v test) -ldflags '-buildmode=exe'
 -  endif
 -	@grep -h -v "mode: atomic" unit_coverage.txt >> coverage.txt
++# DESTDIR may be overridden by e.g. debian packaging
++ifeq ($(DESTDIR),)
++DESTDIR=$(CURDIR)/BUILD/
++endif
++
 +ifeq ($(PACKAGE_TYPE),archive)
 +PREFIX=$(PACKAGE_NAME)
 +SYSCONFDIR=$(PREFIX)/etc/$(PACKAGE_TITLE)

--- a/mk-files/release-notes.mk
+++ b/mk-files/release-notes.mk
@@ -38,7 +38,6 @@ clone-and-setup-docs-repos:
 
 .PHONY: build-release-notes
 build-release-notes:
-	@echo Previous Release Version: v$(CLEAN_VERSION)
 	@GO11MODULE=on go run -ldflags '-X main.releaseVersion=$(BUMPED_VERSION) -X main.releaseNotesPath=$(CONFLUENT_DOCS_DIR)' cmd/release-notes/release/main.go
 
 .PHONY: publish-release-notes-to-docs-repos

--- a/mk-files/release.mk
+++ b/mk-files/release.mk
@@ -62,7 +62,7 @@ gorelease:
 	$(aws-authenticate) && \
 	echo "BUILDING FOR DARWIN, WINDOWS, AND ALPINE LINUX" && \
 	GO111MODULE=off go get -u github.com/inconshreveable/mousetrap && \
-	GOPRIVATE=github.com/confluentinc VERSION=$(VERSION) HOSTNAME="$(HOSTNAME)" GITHUB_TOKEN=$(token) S3FOLDER=$(S3_STAG_FOLDER_NAME)/confluent-cli goreleaser release --rm-dist -f .goreleaser.yml; \
+	GOPRIVATE=github.com/confluentinc VERSION=$(VERSION) HOSTNAME="$(HOSTNAME)" GITHUB_TOKEN=$(token) S3FOLDER=$(S3_STAG_FOLDER_NAME)/confluent-cli goreleaser release --rm-dist --timeout 60m -f .goreleaser.yml; \
 	echo "BUILDING FOR GLIBC LINUX" && \
 	./build_linux_glibc.sh && \
 	aws s3 cp dist/confluent_$(VERSION)_linux_amd64.tar.gz $(S3_STAG_PATH)/confluent-cli/archives/$(VERSION_NO_V)/confluent_$(VERSION)_linux_amd64.tar.gz && \


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok

What
----
* Increase the timeout from 30m to 60m (was timing out on my slow wifi)
* Delete unused `make` target
* Remove debug message that gives me a heart attack during every release (since it reports the previous version instead of the current version)