### PR TITLE
Allow adding orgs to OAuth feature flag

### DIFF
--- a/internal/cmd/iam/command.go
+++ b/internal/cmd/iam/command.go
@@ -5,7 +5,6 @@ import (
 
 	pcmd "github.com/confluentinc/cli/internal/pkg/cmd"
 	v1 "github.com/confluentinc/cli/internal/pkg/config/v1"
-	"github.com/confluentinc/cli/internal/pkg/featureflags"
 )
 
 type command struct {
@@ -36,10 +35,8 @@ func New(cfg *v1.Config, prerunner pcmd.PreRunner) *cobra.Command {
 	}
 
 	c.AddCommand(newACLCommand(c.prerunner))
-	if cfg.IsTest || featureflags.Manager.BoolVariation("cli.identity-provider", c.Context, v1.CliLaunchDarklyClient, true, false) {
-		c.AddCommand(newPoolCommand(c.prerunner))
-		c.AddCommand(newProviderCommand(c.prerunner))
-	}
+	c.AddCommand(newPoolCommand(cfg, c.prerunner))
+	c.AddCommand(newProviderCommand(cfg, c.prerunner))
 	c.AddCommand(newRBACCommand(cfg, c.prerunner))
 	c.AddCommand(newServiceAccountCommand(c.prerunner))
 	c.AddCommand(newUserCommand(c.prerunner))

--- a/internal/cmd/iam/command_pool.go
+++ b/internal/cmd/iam/command_pool.go
@@ -4,6 +4,9 @@ import (
 	"github.com/spf13/cobra"
 
 	pcmd "github.com/confluentinc/cli/internal/pkg/cmd"
+	v1 "github.com/confluentinc/cli/internal/pkg/config/v1"
+	dynamicconfig "github.com/confluentinc/cli/internal/pkg/dynamic-config"
+	launchdarkly "github.com/confluentinc/cli/internal/pkg/featureflags"
 )
 
 type identityPoolCommand struct {
@@ -18,7 +21,7 @@ type identityPool struct {
 	Filter        string
 }
 
-func newPoolCommand(prerunner pcmd.PreRunner) *cobra.Command {
+func newPoolCommand(cfg *v1.Config, prerunner pcmd.PreRunner) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:         "pool",
 		Short:       "Manage identity pools.",
@@ -26,6 +29,10 @@ func newPoolCommand(prerunner pcmd.PreRunner) *cobra.Command {
 	}
 
 	c := &identityPoolCommand{pcmd.NewAuthenticatedCLICommand(cmd, prerunner)}
+
+	dc := dynamicconfig.New(cfg, nil, nil)
+	_ = dc.ParseFlagsIntoConfig(cmd)
+	c.Hidden = !(cfg.IsTest || launchdarkly.Manager.BoolVariation("cli.identity-provider", dc.Context(), v1.CliLaunchDarklyClient, true, false))
 
 	cmd.AddCommand(c.newCreateCommand())
 	cmd.AddCommand(c.newDeleteCommand())
@@ -44,7 +51,7 @@ func (c *identityPoolCommand) validArgs(cmd *cobra.Command, args []string) []str
 	if err := c.PersistentPreRunE(cmd, args); err != nil {
 		return nil
 	}
-	
+
 	provider, _ := cmd.Flags().GetString("provider")
 	return pcmd.AutocompleteIdentityPools(c.V2Client, provider)
 }

--- a/internal/cmd/iam/command_provider.go
+++ b/internal/cmd/iam/command_provider.go
@@ -4,6 +4,9 @@ import (
 	"github.com/spf13/cobra"
 
 	pcmd "github.com/confluentinc/cli/internal/pkg/cmd"
+	v1 "github.com/confluentinc/cli/internal/pkg/config/v1"
+	dynamicconfig "github.com/confluentinc/cli/internal/pkg/dynamic-config"
+	launchdarkly "github.com/confluentinc/cli/internal/pkg/featureflags"
 )
 
 var providerListFields = []string{"Id", "Name", "Description", "IssuerUri", "JwksUri"}
@@ -20,7 +23,7 @@ type identityProvider struct {
 	JwksUri     string
 }
 
-func newProviderCommand(prerunner pcmd.PreRunner) *cobra.Command {
+func newProviderCommand(cfg *v1.Config, prerunner pcmd.PreRunner) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:         "provider",
 		Short:       "Manage identity providers.",
@@ -28,6 +31,10 @@ func newProviderCommand(prerunner pcmd.PreRunner) *cobra.Command {
 	}
 
 	c := &identityProviderCommand{pcmd.NewAuthenticatedCLICommand(cmd, prerunner)}
+
+	dc := dynamicconfig.New(cfg, nil, nil)
+	_ = dc.ParseFlagsIntoConfig(cmd)
+	c.Hidden = !(cfg.IsTest || launchdarkly.Manager.BoolVariation("cli.identity-provider", dc.Context(), v1.CliLaunchDarklyClient, true, false))
 
 	cmd.AddCommand(c.newCreateCommand())
 	cmd.AddCommand(c.newDeleteCommand())


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok

What
----
The `iam pool` and `iam provider` commands previously were not able to compare the logged-in user's org to the enabled orgs in the feature flag. This is because it was run before the prerun function. We need to use a dynamic config here to enable this. (Copied from the `confluent kafka quota` commands, who recently had a successful LA where they incrementally added orgs)

References
----------
https://confluent.slack.com/archives/CG6BW233L/p1664429867581189