### PR TITLE
restore license line in goreleaser files

### DIFF
--- a/.goreleaser-linux-glibc-arm64.yml
+++ b/.goreleaser-linux-glibc-arm64.yml
@@ -39,4 +39,5 @@ archives:
         format: zip
     wrap_in_directory: "{{ .ProjectName }}"
     files:
+      - LICENSE
       - legal/**/*

--- a/.goreleaser-linux-glibc.yml
+++ b/.goreleaser-linux-glibc.yml
@@ -39,4 +39,5 @@ archives:
         format: zip
     wrap_in_directory: "{{ .ProjectName }}"
     files:
+      - LICENSE
       - legal/**/*

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -134,6 +134,7 @@ archives:
         format: zip
     wrap_in_directory: "{{ .ProjectName }}"
     files:
+      - LICENSE
       - legal/**/*
 
 blobs:


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok

What
----
Restore bundling of the LICENSE file in the archives built by the goreleaser files

References
----------


Test & Review
-------------
Built the glibc versions, unzipped one of the tar.gz files and confirmed that the LICENSE file is there