### PR TITLE
[RCCA-8880] Strip trailing slash from CCloud URLs

### DIFF
--- a/internal/pkg/ccloudv2/utils.go
+++ b/internal/pkg/ccloudv2/utils.go
@@ -46,6 +46,7 @@ func getServerUrl(baseURL string) string {
 
 	if utils.Contains([]string{"confluent.cloud", "devel.cpdev.cloud", "stag.cpdev.cloud"}, u.Host) {
 		u.Host = "api." + u.Host
+		u.Path = ""
 	} else {
 		u.Path = "api"
 	}

--- a/internal/pkg/ccloudv2/utils_test.go
+++ b/internal/pkg/ccloudv2/utils_test.go
@@ -37,6 +37,7 @@ func TestGetServerUrl(t *testing.T) {
 		"https://confluent.cloud":                  "https://api.confluent.cloud",
 		"https://devel.cpdev.cloud":                "https://api.devel.cpdev.cloud",
 		"https://stag.cpdev.cloud":                 "https://api.stag.cpdev.cloud",
+		"https://stag.cpdev.cloud/":                "https://api.stag.cpdev.cloud",
 		"https://healthy-fox.gcp.priv.cpdev.cloud": "https://healthy-fox.gcp.priv.cpdev.cloud/api",
 	}
 


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok

What
----
Users who logged in with `confluent login --url https://stag.cpdev.cloud/` (note the trailing slash) were making calls to invalid URLs such as `POST //iam/v2/service-accounts`. Now, we remove the trailing slash if prod/stag/devel, or set the path to "api" if CPD.

References
----------
https://confluent.slack.com/archives/C9Y6NAM6X/p1663229396504689

Test & Review
-------------
Unit tested, manually tested