### PR TITLE
Add diff to `make update-whitelist`

### DIFF
--- a/mk-files/usage.mk
+++ b/mk-files/usage.mk
@@ -21,14 +21,14 @@ update-whitelist:
 	cd $(CC_CLI_SERVICE) && \
 	make db-migrate-up && \
 	git add . && \
-	git commit -m "[ci skip] update whitelist for $(BUMPED_VERSION)" && \
+	git commit -m "update whitelist for $(BUMPED_VERSION)" && \
 	cd db/migrations/ && \
 	a=$$(ls | grep up | tail -n 2 | head -n 1) && \
 	b=$$(ls | grep up | tail -n 1) && \
 	sed -i "" "s/v[0-9]*\.[0-9]*\.[0-9]*/$(BUMPED_VERSION)/" $$a && \
 	body=$$(echo -e "\`\`\`diff\n$$(diff -u $$a $$b)\n\`\`\`") && \
 	git push origin cli-$(BUMPED_VERSION) && \
-	gh pr create -B master --title "[ci skip] Update whitelist for $(BUMPED_VERSION)" --body "$${body}"
+	gh pr create -B master --title "Update whitelist for $(BUMPED_VERSION)" --body "$${body}"
 
 promote:
 	$(eval DIR=$(shell mktemp -d))


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok

What
----
* It's nearly impossible to verify what changes have been made to the whitelist during each release. This PR diffs the last two DB migration files and adds it to the description.
* Added `make db-local-reset` based on our Slack conversation

Test & Review
-------------
Example: https://github.com/confluentinc/cc-cli-service/pull/105