### PR TITLE
Update whitelist without service redeploy

### DIFF
--- a/mk-files/usage.mk
+++ b/mk-files/usage.mk
@@ -35,6 +35,7 @@ update-db:
 	source ~/git/go/src/github.com/confluentinc/cc-dotfiles/caas.sh && \
 	git clone git@github.com:confluentinc/cc-cli-service.git $(CC_CLI_SERVICE) && \
 	cd $(CC_CLI_SERVICE) && \
+	git checkout -b cli-$(BUMPED_VERSION) && \
 	sed -i "" "s|db.url: .*|db.url: postgres://cc_cli_service@127.0.0.1:8432/cli?sslmode=require|" config.yaml && \
 	for pair in stag,237597620434 devel,037803949979 prod,050879227952; do \
 		IFS="," read env arn <<< $$pair; \
@@ -42,7 +43,11 @@ update-db:
 		cctunnel -e $$env -b cli -i read-write; \
 		make db-migrate-up; \
 		kill -9 $$(lsof -i 4:8432 | awk 'NR > 1 { print $$2 };'); \
-	done
+	done && \
+	git add db/schema.sql && \
+	git commit -m "update db for $(BUMPED_VERSION)" && \
+	git push origin cli-$(BUMPED_VERSION) && \
+	gh pr create -B master --title "Update DB for $(BUMPED_VERSION)" --body ""
 
 promote:
 	$(eval DIR=$(shell mktemp -d))
@@ -50,13 +55,13 @@ promote:
 	
 	git clone git@github.com:confluentinc/cc-cli-service.git $(CC_CLI_SERVICE) && \
 	cd $(CC_CLI_SERVICE) && \
-	git checkout -b promote-$(BUMPED_VERSION) && \
+	git checkout -b promote && \
 	export VAULT_ADDR=https://vault.cireops.gcp.internal.confluent.cloud; vault login -method=oidc -path=okta/ && \
 	halctl --context prod --vault-oidc-role halyard-prod --vault-token "$$(cat ~/.vault-token)" --vault-login-path "auth/app/prod/login" release service environment version list cc-cli-service stag | sed -n 's/\*.*\(0.[0-9]*.0\).*/\1/p' > $(DIR)/version.txt && \
 	for env in devel prod; do \
 		halctl --context prod --vault-oidc-role halyard-prod --vault-token "$$(cat ~/.vault-token)" --vault-login-path "auth/app/prod/login" release service environment version list cc-cli-service $${env} | grep $$(cat $(DIR)/version.txt) | grep -o -E '[0-9]+' | head -1 > $(DIR)/$${env}.txt; \
 		sed -i '' "s/installedVersion: \"[0-9]*\"/installedVersion: \"$$(cat $(DIR)/$${env}.txt)\"/" .deployed-versions/$${env}.yaml; \
 	done && \
-	git commit -am "promote devel to $$(cat $(DIR)/devel.txt) and promote prod to $$(cat $(DIR)/prod.txt) for $(BUMPED_VERSION)" && \
-	git push origin promote-$(BUMPED_VERSION) && \
-	gh pr create -B master --title "Promote devel and prod for $(BUMPED_VERSION)" --body ""
+	git commit -am "promote devel to $$(cat $(DIR)/devel.txt) and promote prod to $$(cat $(DIR)/prod.txt)" && \
+	git push origin promote && \
+	gh pr create -B master --title "Promote devel and prod" --body ""


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok

What
----
Currently, updating the whitelist takes two steps:
1. Creating a migration, getting a PR approval, and merging
2. Waiting for the migration to be deployed in stag, then promoting to devel/prod

This whole process takes about 30-45 minutes. We'd like to improve this by:
1. Using `[ci skip]`, so the PR doesn't kick off a deployment in stag
2. Manually running the migration through `cctunnel`

Each target will take just a few seconds to run!

Test & Review
-------------
Manual testing