### PR TITLE
restore archiving in gon files

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -97,8 +97,8 @@ builds:
     hooks:
       post:
         - cmd: make download-licenses
-        - cmd: scripts/gon_filepath_editor.sh {{ .Path }} {{ .Target }}
-        - cmd: gon dist/gon_confluent_{{ .Target }}.hcl
+        - cmd: scripts/gon_filepath_editor.sh {{ .Path }} amd64
+        - cmd: gon dist/gon_confluent_amd64.hcl
   - binary: confluent
     id: signed-arm64
     main: cmd/confluent/main.go
@@ -118,8 +118,8 @@ builds:
       - arm64
     hooks:
       post:
-        - cmd: scripts/gon_filepath_editor.sh {{ .Path }} {{ .Target }}
-        - cmd: gon dist/gon_confluent_{{ .Target }}.hcl
+        - cmd: scripts/gon_filepath_editor.sh {{ .Path }} arm64
+        - cmd: gon dist/gon_confluent_arm64.hcl
 
 archives:
   - id: binary

--- a/scripts/gon_confluent_amd64.hcl
+++ b/scripts/gon_confluent_amd64.hcl
@@ -1,0 +1,13 @@
+source = ["path/to/file"]
+bundle_id = "io.confluent.cli.confluent"
+
+apple_id {
+}
+
+sign {
+  application_identity = "Developer ID Application: Confluent, Inc."
+}
+
+zip {
+  output_path = "./dist/confluent_darwin_amd64/confluent_signed.zip"
+}

--- a/scripts/gon_confluent_arm64.hcl
+++ b/scripts/gon_confluent_arm64.hcl
@@ -7,3 +7,7 @@ apple_id {
 sign {
   application_identity = "Developer ID Application: Confluent, Inc."
 }
+
+zip {
+  output_path = "./dist/confluent_darwin_arm64/confluent_signed.zip"
+}

--- a/scripts/gon_filepath_editor.sh
+++ b/scripts/gon_filepath_editor.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 # run sed inside this script to get around difficulties in running it directly inside a post hook
-sed "s|path/to/file|$1|" scripts/gon_confluent.hcl > dist/gon_confluent_$2.hcl
+sed "s|path/to/file|$1|" scripts/gon_confluent_$2.hcl > dist/gon_confluent_$2.hcl


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok  

What
----
Fix an issue preventing Darwin builds from being notarized correctly. The archiving into a zip file in the gon configuration files is necessary, and cannot be removed.

References
----------
N/A

Test & Review
-------------
Manual testing