### PR TITLE
Fix usage format for N args

### DIFF
--- a/internal/cmd/kafka/command_mirror_failover.go
+++ b/internal/cmd/kafka/command_mirror_failover.go
@@ -13,7 +13,7 @@ import (
 
 func (c *mirrorCommand) newFailoverCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "failover <destination-topic-1> <destination-topic-2> ... <destination-topic-N> --link my-link",
+		Use:   "failover <destination-topic-1> [destination-topic-2] ... [destination-topic-N] --link my-link",
 		Short: "Failover mirror topics.",
 		Args:  cobra.MinimumNArgs(1),
 		RunE:  c.failover,

--- a/internal/cmd/kafka/command_mirror_pause.go
+++ b/internal/cmd/kafka/command_mirror_pause.go
@@ -13,7 +13,7 @@ import (
 
 func (c *mirrorCommand) newPauseCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "pause <destination-topic-1> <destination-topic-2> ... <destination-topic-N> --link my-link",
+		Use:   "pause <destination-topic-1> [destination-topic-2] ... [destination-topic-N] --link my-link",
 		Short: "Pause mirror topics.",
 		Args:  cobra.MinimumNArgs(1),
 		RunE:  c.pause,

--- a/internal/cmd/kafka/command_mirror_promote.go
+++ b/internal/cmd/kafka/command_mirror_promote.go
@@ -13,7 +13,7 @@ import (
 
 func (c *mirrorCommand) newPromoteCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "promote <destination-topic-1> <destination-topic-2> ... <destination-topic-N> --link my-link",
+		Use:   "promote <destination-topic-1> [destination-topic-2] ... [destination-topic-N] --link my-link",
 		Short: "Promote mirror topics.",
 		RunE:  c.promote,
 		Args:  cobra.MinimumNArgs(1),

--- a/internal/cmd/kafka/command_mirror_resume.go
+++ b/internal/cmd/kafka/command_mirror_resume.go
@@ -16,7 +16,7 @@ import (
 
 func (c *mirrorCommand) newResumeCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "resume <destination-topic-1> <destination-topic-2> ... <destination-topic-N>",
+		Use:   "resume <destination-topic-1> [destination-topic-2] ... [destination-topic-N]",
 		Short: "Resume mirror topics.",
 		Args:  cobra.MinimumNArgs(1),
 		RunE:  c.resume,

--- a/internal/cmd/ksql/command_cluster_configureacls.go
+++ b/internal/cmd/ksql/command_cluster_configureacls.go
@@ -21,7 +21,7 @@ import (
 
 func (c *ksqlCommand) newConfigureAclsCommand(resource string) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:               "configure-acls <id> TOPICS...",
+		Use:               "configure-acls <id> [topic-1] [topic-2] ... [topic-N]",
 		Short:             fmt.Sprintf("Configure ACLs for a ksqlDB %s.", resource),
 		Args:              cobra.MinimumNArgs(1),
 		ValidArgsFunction: pcmd.NewValidArgsFunction(c.validArgs),

--- a/test/fixtures/output/ksql/app/configure-acls-help.golden
+++ b/test/fixtures/output/ksql/app/configure-acls-help.golden
@@ -1,7 +1,7 @@
 DEPRECATED: Configure ACLs for a ksqlDB app.
 
 Usage:
-  confluent ksql app configure-acls <id> TOPICS... [flags]
+  confluent ksql app configure-acls <id> [topic-1] [topic-2] ... [topic-N] [flags]
 
 Flags:
       --dry-run              If specified, print the ACLs that will be set and exit.

--- a/test/fixtures/output/ksql/cluster/configure-acls-help.golden
+++ b/test/fixtures/output/ksql/cluster/configure-acls-help.golden
@@ -1,7 +1,7 @@
 Configure ACLs for a ksqlDB cluster.
 
 Usage:
-  confluent ksql cluster configure-acls <id> TOPICS... [flags]
+  confluent ksql cluster configure-acls <id> [topic-1] [topic-2] ... [topic-N] [flags]
 
 Flags:
       --dry-run              If specified, print the ACLs that will be set and exit.


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok

What
----
Required args should use `<>` and optional args should use `[]`. Also standardize the format for 1-N args.