### PR TITLE
[CLI-2061, CLI-2062] Add `--environment` flag to `api-key list`, improve wrong env error

### DIFF
--- a/internal/cmd/api-key/command_list.go
+++ b/internal/cmd/api-key/command_list.go
@@ -48,6 +48,7 @@ func (c *command) newListCommand() *cobra.Command {
 
 	cmd.Flags().String(resourceFlagName, "", `The resource ID to filter by. Use "cloud" to show only Cloud API keys.`)
 	cmd.Flags().Bool("current-user", false, "Show only API keys belonging to current user.")
+	pcmd.AddEnvironmentFlag(cmd, c.AuthenticatedCLICommand)
 	pcmd.AddServiceAccountFlag(cmd, c.AuthenticatedCLICommand)
 	pcmd.AddOutputFlag(cmd)
 

--- a/internal/pkg/dynamic-config/client.go
+++ b/internal/pkg/dynamic-config/client.go
@@ -21,12 +21,12 @@ func (d *DynamicContext) FetchCluster(clusterId string) (*v1.KafkaClusterConfig,
 
 	cluster, httpResp, err := d.V2Client.DescribeKafkaCluster(clusterId, environmentId)
 	if err != nil {
-		return nil, errors.CatchCCloudV2Error(err, httpResp)
+		return nil, errors.CatchKafkaNotFoundError(err, clusterId, httpResp)
 	}
 
 	apiEndpoint, err := getKafkaApiEndpoint(d.Client, clusterId, environmentId)
 	if err != nil {
-		return nil, errors.CatchKafkaNotFoundError(err, clusterId, nil)
+		return nil, err
 	}
 
 	config := &v1.KafkaClusterConfig{


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok

What
----
When using a `--resource` not part of the current environment, the user used to see:
```
Forbidden Access: 403 Forbidden
```

This error has been improved with suggestions:
```
Error: Kafka cluster not found or access forbidden: Forbidden Access: 403 Forbidden

Suggestions:
    Ensure the cluster ID you entered is valid.
    Ensure the cluster you are specifying belongs to the currently selected environment with `confluent kafka cluster list`, `confluent environment list`, and `confluent environment use`.
```

At this point, the user can use `--environment` to choose the right environment.

References
----------
[CLI-2061](https://confluentinc.atlassian.net/browse/CLI-2061)
[CLI-2062](https://confluentinc.atlassian.net/browse/CLI-2062)

Test & Review
-------------
Manually tested, all tests still pass