### PR TITLE
[CLI-1088] Interrupt password prompt on Ctrl+C

### DIFF
--- a/internal/pkg/form/prompt.go
+++ b/internal/pkg/form/prompt.go
@@ -4,9 +4,11 @@ package form
 
 import (
 	"bufio"
+	"fmt"
 	"io"
 	"os"
 	"strings"
+	"syscall"
 
 	"github.com/havoc-io/gopass"
 )
@@ -47,6 +49,10 @@ func (p *RealPrompt) ReadLineMasked() (string, error) {
 	}
 
 	pwd, err := gopass.GetPasswdMasked()
+	if err != nil && err.Error() == "interrupted" {
+		_, _ = fmt.Fprint(p.Out, "^C")
+		_ = syscall.Kill(syscall.Getpid(), syscall.SIGINT)
+	}
 	return string(pwd), err
 }
 


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok

What
----
When Ctrl+C was pressed during a password prompt (masked input), the prompt would return `""` for the password, which resulted in a failed login. Instead, interrupt the process and print "^C".

References
----------
[CLI-1088](https://confluentinc.atlassian.net/browse/CLI-1088)

Test & Review
-------------
```
% confluent login
Enter your Confluent Cloud credentials:
Email: bstrauch@confluent.io
Password: 
^C
```