### PR TITLE
Add ECR login to build_linux_glibc.sh script

### DIFF
--- a/build_linux_glibc.sh
+++ b/build_linux_glibc.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+aws ecr get-login-password --region us-west-1 | docker login --username AWS --password-stdin 050879227952.dkr.ecr.us-west-1.amazonaws.com
+
 go mod vendor
 #amd64
 docker build . -f ./dockerfiles/Dockerfile_linux_glibc -t cli-linux-glibc-builder-image


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok

What
----
When the Docker images haven't been downloaded and cached locally, you need to run this locally. It won't do anything if you're already logged in, so we should always try it.