### PR TITLE
Fix `environment use` panic when setting environment in config

### DIFF
--- a/internal/cmd/environment/command_use.go
+++ b/internal/cmd/environment/command_use.go
@@ -29,11 +29,11 @@ func (c *command) newUseCommand() *cobra.Command {
 func (c *command) use(cmd *cobra.Command, args []string) error {
 	id := args[0]
 
-	account, err := c.Client.Account.Get(context.Background(), &orgv1.Account{Id: id})
+	environment, err := c.Client.Account.Get(context.Background(), &orgv1.Account{Id: id})
 	if err != nil {
 		return errors.NewErrorWithSuggestions(fmt.Sprintf(errors.EnvNotFoundErrorMsg, id), errors.EnvNotFoundSuggestions)
 	}
-	c.Context.State.Auth.Account = account
+	c.Context.SetEnvironment(environment)
 
 	if err := c.Config.Save(); err != nil {
 		return errors.Wrap(err, errors.EnvSwitchErrorMsg)

--- a/internal/pkg/config/v1/context.go
+++ b/internal/pkg/config/v1/context.go
@@ -154,11 +154,25 @@ func (c *Context) GetPlatformServer() string {
 	return ""
 }
 
+func (c *Context) GetState() *ContextState {
+	if c != nil {
+		return c.State
+	}
+	return nil
+}
+
 func (c *Context) GetAuth() *AuthConfig {
 	if c.State != nil {
 		return c.State.Auth
 	}
 	return nil
+}
+
+func (c *Context) SetAuth(auth *AuthConfig) {
+	if c.GetState() == nil {
+		c.State = new(ContextState)
+	}
+	c.GetState().Auth = auth
 }
 
 func (c *Context) GetUser() *orgv1.User {
@@ -186,16 +200,16 @@ func (c *Context) GetEnvironment() *orgv1.Account {
 	return nil
 }
 
+func (c *Context) SetEnvironment(environment *orgv1.Account) {
+	if c.GetAuth() == nil {
+		c.SetAuth(new(AuthConfig))
+	}
+	c.GetAuth().Account = environment
+}
+
 func (c *Context) GetEnvironments() []*orgv1.Account {
 	if auth := c.GetAuth(); auth != nil {
 		return auth.Accounts
-	}
-	return nil
-}
-
-func (c *Context) GetState() *ContextState {
-	if c != nil {
-		return c.State
 	}
 	return nil
 }


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok

What
----
A user reported a `panic()` after updating to v2.31.0. It's still unclear how their configuration file got into such a state, but it seems related to #1478. I made the code "panic-proof" so that you can still set the environment even if the `auth` field is empty. We can consider "panic-proofing" the rest of our code in a later PR if we like this approach.

References
----------
https://confluent.slack.com/archives/C010Y0EP5MZ/p1667246435290539

Test & Review
-------------
Tests still pass + manually edited configuration file and replicated, then fixed.