### PR TITLE
Update backup code for kafka cluster describe

### DIFF
--- a/internal/cmd/kafka/command_cluster_describe.go
+++ b/internal/cmd/kafka/command_cluster_describe.go
@@ -14,6 +14,7 @@ import (
 	pcmd "github.com/confluentinc/cli/internal/pkg/cmd"
 	v1 "github.com/confluentinc/cli/internal/pkg/config/v1"
 	"github.com/confluentinc/cli/internal/pkg/ccloudv2"
+	dynamicconfig "github.com/confluentinc/cli/internal/pkg/dynamic-config"
 	"github.com/confluentinc/cli/internal/pkg/errors"
 	"github.com/confluentinc/cli/internal/pkg/kafkarest"
 	"github.com/confluentinc/cli/internal/pkg/output"
@@ -260,7 +261,10 @@ func (c *clusterCommand) getTopicCountForKafkaCluster(cluster *cmkv2.CmkV2Cluste
 	}
 
 	// Kafka REST is not available, fall back to KafkaAPI, to be deprecated
-	req := &schedv1.KafkaCluster{AccountId: c.EnvironmentId(), Id: lkc}
+	req, err := dynamicconfig.KafkaCluster(c.Context)
+	if err != nil {
+		return 0, err
+	}
 	resp, err := c.Client.Kafka.ListTopics(context.Background(), req)
 	return len(resp), err
 }


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok

What
----
Any scenario where Kafka REST was unavailable led to an `unsupported protocol scheme ""` error. The cause is that the request had an empty `api_endpoint` field, and therefore an empty protocol scheme.

This is a short-term fix for some users & customers who don't have kafka REST available for one reason or another.

References
----------
https://confluentinc.atlassian.net/browse/CLI-2082
This is related to this ticket, but it's unclear from the linked discussions whether this will really resolve the issue for all users seeing this error. I mean that, while they won't see this error, they might still see other errors. So I'm keeping this ticket open for now to see what happens.

Test & Review
-------------
I commented out the kafka REST block and checked that the command works w/ the backup code.

Open questions / Follow ups
---------------------------
See References section above.