### PR TITLE
Stop installing Chocolatey dependencies

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -80,7 +80,7 @@ blocks:
             # Set up Git
             - export "GOPRIVATE=github.com/confluentinc"
             - git config --global url."git@github.com:".insteadOf "https://github.com/"
-              
+
             # Run tests
             - make deps
             - ulimit -n 2048


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok

What
----
Thanks to @cchristous, we no longer need to install `base64` and `make` with Chocolatey. This should shave a few seconds off of our build times!