### PR TITLE
KGLOBAL-2382: Print mirror topic name instead of source topic name after mirror topic creation

### DIFF
--- a/internal/cmd/kafka/command_mirror_create.go
+++ b/internal/cmd/kafka/command_mirror_create.go
@@ -112,6 +112,6 @@ func (c *mirrorCommand) create(cmd *cobra.Command, args []string) error {
 		return kafkarest.NewError(kafkaREST.CloudClient.GetUrl(), err, httpResp)
 	}
 
-	utils.Printf(cmd, errors.CreatedResourceMsg, resource.MirrorTopic, sourceTopicName)
+	utils.Printf(cmd, errors.CreatedResourceMsg, resource.MirrorTopic, mirrorTopicName)
 	return nil
 }


### PR DESCRIPTION
### JIRA
https://confluentinc.atlassian.net/browse/KGLOBAL-2382

### Details
This is a small fix to print the mirror topic name, not the source topic name, after a mirror topic is created. They can be different if the link has a prefix. This is causing some QE tests to fail, such as https://confluentinc.semaphoreci.com/jobs/3080896d-ed39-45dc-856e-bd942dccb871. I'm a bit confused how the tests were passing before tbh. My guess from looking at a few runs is the prefix was not set in those runs.

Checklist
---------
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
yes

What
----
See above

References
----------
n/a

Test & Review
-------------
I ran `make test` and also manually built the CLI and tested the change by creating a mirror topic.
Before:
```
agrant@C02GN0121PG2 cli % lconfluent kafka mirror create prefix-2topic-2 --link my-link-2 --source-topic topic-2
Created mirror topic "topic-2".
```
After:
```
agrant@C02GN0121PG2 cli % lconfluent kafka mirror create prefix-2topic-3 --link my-link-2 --source-topic topic-3
Created mirror topic "prefix-2topic-3".
```

<!--
Open questions / Follow ups
---------------------------
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->

<!--
Review stakeholders
-------------------
Optional: mention stakeholders or special context that is required to review.
-->
