### PR TITLE
Hide `stream-share` command reference

### DIFF
--- a/cmd/docs/main.go
+++ b/cmd/docs/main.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"os"
+	"path/filepath"
+	"regexp"
 
 	orgv1 "github.com/confluentinc/cc-structs/kafka/org/v1"
 
@@ -48,7 +50,28 @@ func main() {
 		panic(err)
 	}
 
+	removeDocumentation()
+
 	if err := os.Setenv("HOME", currentHOME); err != nil {
+		panic(err)
+	}
+}
+
+// removeDocumentation hides documentation for unreleased features
+func removeDocumentation() {
+	out, err := os.ReadFile(filepath.Join("docs", "index.rst"))
+	if err != nil {
+		panic(err)
+	}
+
+	re := regexp.MustCompile(`\s{3}stream-share/index\n`)
+	out = re.ReplaceAll(out, []byte(""))
+
+	if err := os.WriteFile(filepath.Join("docs", "index.rst"), out, 0644); err != nil {
+		panic(err)
+	}
+
+	if err := os.RemoveAll(filepath.Join("docs", "stream-share")); err != nil {
 		panic(err)
 	}
 }


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok

What
----
The `stream-share` commands are hidden behind a feature flag, and the Stream Sharing team does not want them to be visible in the command reference documentation. Unfortunately there's no way to use feature flags within our documentation, so we'll have to remove the commands manually for now.

References
-----------
https://confluent.slack.com/archives/C010Y0EP5MZ/p1668109573453219