### PR TITLE
Remove `stream-share` from overview.rst

### DIFF
--- a/cmd/docs/main.go
+++ b/cmd/docs/main.go
@@ -50,28 +50,36 @@ func main() {
 		panic(err)
 	}
 
-	removeDocumentation()
+	removeUnreleasedDocs()
 
 	if err := os.Setenv("HOME", currentHOME); err != nil {
 		panic(err)
 	}
 }
 
-// removeDocumentation hides documentation for unreleased features
-func removeDocumentation() {
-	out, err := os.ReadFile(filepath.Join("docs", "index.rst"))
-	if err != nil {
+// removeUnreleasedDocs hides documentation for unreleased features
+func removeUnreleasedDocs() {
+	if err := removeLineFromFile(`\s{3}stream-share/index\n`, filepath.Join("docs", "index.rst")); err != nil {
 		panic(err)
 	}
 
-	re := regexp.MustCompile(`\s{3}stream-share/index\n`)
-	out = re.ReplaceAll(out, []byte(""))
-
-	if err := os.WriteFile(filepath.Join("docs", "index.rst"), out, 0644); err != nil {
+	if err := removeLineFromFile("\\s{7}:ref:`confluent_stream-share`\\s+.+\\s+\n", filepath.Join("docs", "overview.rst")); err != nil {
 		panic(err)
 	}
 
 	if err := os.RemoveAll(filepath.Join("docs", "stream-share")); err != nil {
 		panic(err)
 	}
+}
+
+func removeLineFromFile(line, file string) error {
+	out, err := os.ReadFile(file)
+	if err != nil {
+		return err
+	}
+
+	re := regexp.MustCompile(line)
+	out = re.ReplaceAll(out, []byte(""))
+
+	return os.WriteFile(file, out, 0644)
 }


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok

What
----
A stray reference to the hidden stream-share command reference pages broke the docs build during the last release. This cleans up that reference from the overview.rst page.