### PR TITLE
Remove `confluent pipeline` feature flag

### DIFF
--- a/internal/cmd/command.go
+++ b/internal/cmd/command.go
@@ -108,6 +108,7 @@ func NewConfluentCommand(cfg *v1.Config) *cobra.Command {
 	cmd.AddCommand(local.New(prerunner))
 	cmd.AddCommand(login.New(cfg, prerunner, ccloudClientFactory, mdsClientManager, netrcHandler, loginCredentialsManager, loginOrganizationManager, authTokenHandler))
 	cmd.AddCommand(logout.New(cfg, prerunner, netrcHandler))
+	cmd.AddCommand(pipeline.New(prerunner))
 	cmd.AddCommand(plugin.New(cfg, prerunner))
 	cmd.AddCommand(price.New(prerunner))
 	cmd.AddCommand(prompt.New(cfg))
@@ -122,9 +123,6 @@ func NewConfluentCommand(cfg *v1.Config) *cobra.Command {
 	_ = dc.ParseFlagsIntoConfig(cmd)
 	if cfg.IsTest || featureflags.Manager.BoolVariation("cli.cdx", dc.Context(), v1.CliLaunchDarklyClient, true, false) {
 		cmd.AddCommand(streamshare.New(cfg, prerunner))
-	}
-	if cfg.IsTest || featureflags.Manager.BoolVariation("cli.stream_designer", dc.Context(), v1.CliLaunchDarklyClient, true, false) {
-		cmd.AddCommand(pipeline.New(cfg, prerunner))
 	}
 
 	changeDefaults(cmd, cfg)

--- a/internal/cmd/pipeline/command.go
+++ b/internal/cmd/pipeline/command.go
@@ -6,7 +6,6 @@ import (
 	"github.com/spf13/cobra"
 
 	pcmd "github.com/confluentinc/cli/internal/pkg/cmd"
-	v1 "github.com/confluentinc/cli/internal/pkg/config/v1"
 )
 
 type out struct {
@@ -24,7 +23,7 @@ type command struct {
 	prerunner pcmd.PreRunner
 }
 
-func New(cfg *v1.Config, prerunner pcmd.PreRunner) *cobra.Command {
+func New(prerunner pcmd.PreRunner) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:         "pipeline",
 		Short:       "Manage Stream Designer pipelines.",


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok

What
----
This is the only feature-flag-gated feature that's GA. We can remove the feature flag code in v3 to reduce the likelihood that a LaunchDarkly outage makes this flag inaccessible.