### PR TITLE
Default to 6 partitions for Kafka API

### DIFF
--- a/internal/cmd/kafka/command_topic_create.go
+++ b/internal/cmd/kafka/command_topic_create.go
@@ -152,6 +152,7 @@ func (c *authenticatedTopicCommand) create(cmd *cobra.Command, args []string) er
 			Name:              topicName,
 			Configs:           configMap,
 			ReplicationFactor: 3,
+			NumPartitions:     6,
 		},
 		Validate: dryRun,
 	}


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok

What
----
The Kafka REST backend will choose the number of partitions, but Kafka API will not. Default to 6 if it's not specified.

Reverts https://github.com/confluentinc/cli/pull/1487