### PR TITLE
Check for 204 in `ksql cluster configure-acls`

### DIFF
--- a/internal/cmd/ksql/command_cluster_configureacls.go
+++ b/internal/cmd/ksql/command_cluster_configureacls.go
@@ -84,7 +84,7 @@ func (c *ksqlCommand) configureACLs(cmd *cobra.Command, args []string) error {
 			return kafkarest.NewError(kafkaREST.CloudClient.GetUrl(), err, httpResp)
 		}
 		if err == nil && httpResp != nil {
-			if httpResp.StatusCode != http.StatusCreated {
+			if httpResp.StatusCode != http.StatusNoContent {
 				msg := fmt.Sprintf(errors.KafkaRestUnexpectedStatusErrorMsg, httpResp.Request.URL, httpResp.StatusCode)
 				return errors.NewErrorWithSuggestions(msg, errors.InternalServerErrorSuggestions)
 			}


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok

What
----
When implementing #1447, I was looking at the Kafka REST API spec, which said this endpoint returns a 201. It actually returns a 204, so I updated the spec and this command.

https://confluent.slack.com/archives/C010Y0EP5MZ/p1668001914694509

Test & Review
-------------
Manually verified