### PR TITLE
Use main branch for build badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Confluent CLI
 
 [![Release](release.svg)](https://github.com/confluentinc/cli/releases/latest)
-[![Build Status](https://confluentinc.semaphoreci.com/badges/cli/branches/master.svg?style=shields&key=f6c470c4-296b-4d7f-b550-0a169f85f767)](https://confluentinc.semaphoreci.com/projects/cli)
+[![Build Status](https://confluentinc.semaphoreci.com/badges/cli/branches/main.svg?style=shields&key=f6c470c4-296b-4d7f-b550-0a169f85f767)](https://confluentinc.semaphoreci.com/projects/cli)
 
 The Confluent CLI lets you manage your Confluent Cloud and Confluent Platform deployments, right from the terminal.
 


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok

What
----
Was wondering why it said "build: unknown". Changed the branch to `main` and it says "build: passed" now.
https://confluentinc.semaphoreci.com/badges/cli/branches/main.svg?style=shields&key=f6c470c4-296b-4d7f-b550-0a169f85f767