### PR TITLE
Revert "Add linux/arm64 to Confluent Platform packaging (#1527)"

### DIFF
--- a/debian/Makefile
+++ b/debian/Makefile
@@ -56,7 +56,7 @@ install: apply-patches
 	chmod 755 $(DESTDIR)$(BINPATH)/confluent
 
 	cd $(DESTDIR)$(LIBPATH) ; \
-	for dir in darwin_amd64 darwin_arm64 linux_amd64 linux_arm64 windows_amd64; do \
+	for dir in darwin_amd64 darwin_arm64 linux_amd64 windows_amd64; do \
 		mkdir -p $${dir} ; \
 		ext=""; if [[ $${dir} =~ windows_.+ ]]; then ext=".exe"; fi ; \
 		filepath=$${dir}/confluent$${ext} ; \

--- a/debian/patches/standard_build_layout.patch
+++ b/debian/patches/standard_build_layout.patch
@@ -1,5 +1,5 @@
---- cli/Makefile	2022-11-16 08:33:45.000000000 -0800
-+++ debian/Makefile	2022-11-16 14:23:05.000000000 -0800
+--- cli/Makefile	2022-10-19 00:13:05.000000000 -0700
++++ debian/Makefile	2022-07-12 14:17:45.000000000 -0700
 @@ -1,208 +1,130 @@
 -SHELL           := /bin/bash
 -ALL_SRC         := $(shell find . -name "*.go" | grep -v -e vendor)
@@ -252,7 +252,7 @@
 +	chmod 755 $(DESTDIR)$(BINPATH)/confluent
 +
 +	cd $(DESTDIR)$(LIBPATH) ; \
-+	for dir in darwin_amd64 darwin_arm64 linux_amd64 linux_arm64 windows_amd64; do \
++	for dir in darwin_amd64 darwin_arm64 linux_amd64 windows_amd64; do \
 +		mkdir -p $${dir} ; \
 +		ext=""; if [[ $${dir} =~ windows_.+ ]]; then ext=".exe"; fi ; \
 +		filepath=$${dir}/confluent$${ext} ; \


### PR DESCRIPTION
This reverts commit b9f665823676195053ce21666d17bf60dafed4a3.

Checklist
---------
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok

What
----
Debian packaging failed. We'll wait until Confluent Platform supports linux/arm64 to add this back. https://confluent.slack.com/archives/C010Y0EP5MZ/p1668797797678259