### PR TITLE
KFS-362 Fix deleteTopics usage in `confluent ksql cluster delete` cmd

### DIFF
--- a/internal/cmd/ksql/command_cluster_delete.go
+++ b/internal/cmd/ksql/command_cluster_delete.go
@@ -54,8 +54,8 @@ func (c *ksqlCommand) delete(cmd *cobra.Command, args []string) error {
 	// the topics.
 	if cluster.Status == schedv1.ClusterStatus_UP {
 		provisioningFailed, err := c.checkProvisioningFailed(cluster)
-		if !provisioningFailed && err != nil {
-			if err := c.deleteTopics(req); err != nil {
+		if !provisioningFailed && err == nil {
+			if err := c.deleteTopics(cluster.GetId(), cluster.GetEndpoint()); err != nil {
 				return err
 			}
 		}
@@ -69,21 +69,21 @@ func (c *ksqlCommand) delete(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func (c *ksqlCommand) deleteTopics(cluster *schedv1.KSQLCluster) error {
+func (c *ksqlCommand) deleteTopics(clusterId, endpoint string) error {
 	ctx := c.Config.Context()
 	state, err := ctx.AuthenticatedState()
 	if err != nil {
 		return err
 	}
 
-	bearerToken, err := pauth.GetBearerToken(state, ctx.Platform.Server, cluster.Id)
+	bearerToken, err := pauth.GetBearerToken(state, ctx.Platform.Server, clusterId)
 	if err != nil {
 		return err
 	}
 
 	ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: bearerToken})
-	client := sling.New().Client(oauth2.NewClient(context.Background(), ts)).Base(cluster.Endpoint)
-	request := map[string][]string{"deleteTopicList": []string{".*"}}
+	client := sling.New().Client(oauth2.NewClient(context.Background(), ts)).Base(endpoint)
+	request := map[string][]string{"deleteTopicList": {".*"}}
 	response, err := client.Post("/ksql/terminate").BodyJSON(&request).ReceiveSuccess(nil)
 	//this returns a 503
 	if err != nil {
@@ -95,7 +95,7 @@ func (c *ksqlCommand) deleteTopics(cluster *schedv1.KSQLCluster) error {
 		if err != nil {
 			return err
 		}
-		return errors.Errorf(errors.KsqlDBTerminateClusterErrorMsg, cluster.Id, string(body))
+		return errors.Errorf(errors.KsqlDBTerminateClusterErrorMsg, clusterId, string(body))
 	}
 	return nil
 }


### PR DESCRIPTION
Fixes two issues:
- We were calling `c.deleteTopics(req)`, but `req.Endpoint` is `nil`.
- We had ```go if !provisioningFailed && err != nil { } ``` which is always false.

Checklist
---------
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->
These fixes were already applied to the v3 branch. Pulling them into main in this PR

References
----------
<!--
Copy & paste links to Jira tickets, other PRs, issues, Slack conversations, etc.
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->
#1371 
