### PR TITLE
[MINOR]: Use released version of ccloud-sdk-go-v1-public

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/confluentinc/cc-structs/kafka/scheduler v0.1267.0
 	github.com/confluentinc/cc-structs/kafka/util v0.1096.0
 	github.com/confluentinc/ccloud-sdk-go-v1 v0.0.108
-	github.com/confluentinc/ccloud-sdk-go-v1-public v0.0.0-20221129200057-fcec26d70dbc
+	github.com/confluentinc/ccloud-sdk-go-v1-public v0.0.0-20221201012806-05d56fd583cf
 	github.com/confluentinc/ccloud-sdk-go-v2/apikeys v0.4.0
 	github.com/confluentinc/ccloud-sdk-go-v2/cdx v0.0.4
 	github.com/confluentinc/ccloud-sdk-go-v2/cli v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -633,8 +633,8 @@ github.com/confluentinc/cc-utils v0.240.0/go.mod h1:l5vuobVLiwFY9S+M7aLwHzFBc354
 github.com/confluentinc/cc-utils/idgen v0.203.0/go.mod h1:vKsrR9u7tqRE/9MP1sQn0bqNrDQSVbNe0qbqSU/xWYc=
 github.com/confluentinc/ccloud-sdk-go-v1 v0.0.108 h1:XVbx4yuLLM2jPjepdvmOY1X1y8ti7GcTBUZmuXGHjHs=
 github.com/confluentinc/ccloud-sdk-go-v1 v0.0.108/go.mod h1:AAVdbxtQfR0gJkrADk+cyA3u8fTxsofg6l73n901nWo=
-github.com/confluentinc/ccloud-sdk-go-v1-public v0.0.0-20221129200057-fcec26d70dbc h1:SM5PQXSkLNgLqqy6vyTDFAl6hA2l3uUjSUTi3duDh84=
-github.com/confluentinc/ccloud-sdk-go-v1-public v0.0.0-20221129200057-fcec26d70dbc/go.mod h1:WqkVs0zqDRTBPUpU3azJVTxA0w3mejPgmqNs1K7T3pw=
+github.com/confluentinc/ccloud-sdk-go-v1-public v0.0.0-20221201012806-05d56fd583cf h1:5XlMvgPj5se/Ots105D7SizLxOkzH4QLvhJPDRuqvc4=
+github.com/confluentinc/ccloud-sdk-go-v1-public v0.0.0-20221201012806-05d56fd583cf/go.mod h1:KtqKCUuccBTr/ziC5wJRLL2wIFLNURZLgQzT1ibWpEU=
 github.com/confluentinc/ccloud-sdk-go-v2-internal/networking v0.0.5/go.mod h1:b0fKj4FlWseVcd8CsjXUdvvDtAGHu8nDUJjPykqWInQ=
 github.com/confluentinc/ccloud-sdk-go-v2-internal/networking v0.0.7/go.mod h1:b0fKj4FlWseVcd8CsjXUdvvDtAGHu8nDUJjPykqWInQ=
 github.com/confluentinc/ccloud-sdk-go-v2/apikeys v0.4.0 h1:8fWyLwMuy8ec0MVF5Avd54UvbIxhDFhZzanHBVwgxdw=


### PR DESCRIPTION
Ran 
```
go get github.com/confluentinc/ccloud-sdk-go-v1-public@auth/v0.1.0
go mod tidy
```
So that it uses the latest released version https://github.com/confluentinc/ccloud-sdk-go-v1-public/releases/tag/auth%2Fv0.1.0.