### PR TITLE
[DGS-3096] AsyncAPI: Reset Channel Details for every topic

### DIFF
--- a/internal/cmd/asyncapi/command_export.go
+++ b/internal/cmd/asyncapi/command_export.go
@@ -283,17 +283,9 @@ func (c *command) getBindings(cluster *schedv1.KafkaCluster, topicDescription *s
 			}
 		}
 	}
-	partitions := 0
-	replicas := 0
-	if topicDescription.GetPartitions() != nil {
-		partitions = len(topicDescription.GetPartitions())
-	}
-	if partitions > 0 {
-		replicas = len(topicDescription.GetPartitions()[0].Replicas)
-	}
 	var channelBindings interface{} = confluentBinding{
-		Partitions: partitions,
-		Replicas:   replicas,
+		Partitions: len(topicDescription.GetPartitions()),
+		Replicas:   len(topicDescription.GetPartitions()[0].Replicas),
 		Configs: Configs{
 			CleanupPolicy:                  cleanupPolicy,
 			DeleteRetentionMs:              deleteRetentionMsValue,
@@ -321,7 +313,7 @@ func (c *command) getBindings(cluster *schedv1.KafkaCluster, topicDescription *s
 		messageBinding:   messageBindings,
 		operationBinding: operationBindings,
 	}
-	if deleteRetentionMsValue != -1 && cleanupPolicy != "" && partitions > 0 && replicas > 0 {
+	if deleteRetentionMsValue != -1 && cleanupPolicy != "" {
 		bindings.channelBindings = spec.ChannelBindingsObject{Kafka: &channelBindings}
 	}
 	return bindings, nil

--- a/internal/cmd/asyncapi/command_export_test.go
+++ b/internal/cmd/asyncapi/command_export_test.go
@@ -217,19 +217,6 @@ func newCmd() (*command, error) {
 							},
 						},
 					},
-					{
-						Name: "topic2",
-						Config: []*schedv1.TopicConfigEntry{
-							{
-								Name:  "cleanup.policy",
-								Value: "delete",
-							},
-							{
-								Name:  "delete.retention.ms",
-								Value: "86400000",
-							},
-						},
-					},
 				}, nil
 			},
 			ListTopicConfigFunc: func(ctx context.Context, cluster *schedv1.KafkaCluster, topic *schedv1.Topic) (*schedv1.TopicConfig, error) {
@@ -305,10 +292,8 @@ func TestGetBindings(t *testing.T) {
 	c, err := newCmd()
 	require.NoError(t, err)
 	topics, _ := c.Client.Kafka.ListTopics(*new(context.Context), new(schedv1.KafkaCluster))
-	for _, topic := range topics {
-		_, err = c.getBindings(details.cluster, topic)
-		require.NoError(t, err)
-	}
+	_, err = c.getBindings(details.cluster, topics[0])
+	require.NoError(t, err)
 }
 
 func TestGetTags(t *testing.T) {


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
 Yes

What
----
Resetting the channel details for every topic (channel), so that no information from previous topic is used in the current topic. This will prevent errors like [this](https://github.com/confluentinc/cli/pull/1557) and [this](https://github.com/confluentinc/cli/pull/1535)


References
----------
<!--
Copy & paste links to Jira tickets, other PRs, issues, Slack conversations, etc.
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test & Review
-------------
<!--
Has it been tested? how?
Copy & paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

<!--
Open questions / Follow ups
---------------------------
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->

<!--
Review stakeholders
-------------------
Optional: mention stakeholders or special context that is required to review.
-->
