### PR TITLE
Add `defer` statements to flaky `secret` tests

### DIFF
--- a/internal/pkg/secret/encryption_engine_test.go
+++ b/internal/pkg/secret/encryption_engine_test.go
@@ -1,1 +1,0 @@
-package secret


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok

What
----
Due to cost concerns, the MacOS Semaphore CI machines don't reset their state between jobs- and the `confluent secret` unit tests don't guarantee that resources are cleaned up... Another lesson in why you should always use `defer` statements.

Also removed an unused test file and added missing `t.Run()` syntax so we can use a `defer` inside a `for` loop.

References
----------
Example failure: https://confluentinc.semaphoreci.com/jobs/c6c5725a-ee33-44ee-af18-a4b3680809c3

Test & Review
-------------
Verified that tests pass and always clean up resources