### PR TITLE
[CLI-2188] Add missing metric KafkaRestProduce in `confluent price list`

### DIFF
--- a/internal/cmd/price/command_list.go
+++ b/internal/cmd/price/command_list.go
@@ -28,7 +28,7 @@ var (
 		"KafkaNetworkWrite":     "Kafka write",
 		"KafkaNumCKUs":          "CKU price",
 		"KafkaPartition":        "Kafka partition",
-		"KafkaRestProduce":      "Kafka Rest Produce",
+		"KafkaRestProduce":      "Kafka REST produce",
 		"KafkaStorage":          "Kafka storage",
 		"ClusterLinkingBase":    "Cluster linking base",
 		"ClusterLinkingPerLink": "Cluster linking per-link",


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->
https://confluentinc.atlassian.net/browse/CLI-2188
This metric name was missing from the map, so now metric name was showing in human output. 

References
----------
<!--
Copy & paste links to Jira tickets, other PRs, issues, Slack conversations, etc.
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test & Review
-------------
<!--
Has it been tested? how?
Copy & paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

<!--
Open questions / Follow ups
---------------------------
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->

<!--
Review stakeholders
-------------------
Optional: mention stakeholders or special context that is required to review.
-->
