### PR TITLE
Print warning that command reference is auto-generated

### DIFF
--- a/internal/pkg/docs/doc_page.go
+++ b/internal/pkg/docs/doc_page.go
@@ -27,6 +27,7 @@ func printDocPage(tabs []Tab, depth int) []string {
 	cmd := tabs[0].Command
 
 	return flatten([][]string{
+		printComments(),
 		printHeader(cmd, false),
 		printTitle(cmd, "-"),
 		printWarnings(cmd, depth),

--- a/internal/pkg/docs/doc_page_test.go
+++ b/internal/pkg/docs/doc_page_test.go
@@ -56,6 +56,9 @@ func TestPrintDocPage(t *testing.T) {
 	}
 
 	expected := []string{
+		"..",
+		"   WARNING: This documentation is auto-generated from the confluentinc/cli repository and should not be manually edited.",
+		"",
 		".. _a_b:",
 		"",
 		"a b",

--- a/internal/pkg/docs/index_page.go
+++ b/internal/pkg/docs/index_page.go
@@ -38,6 +38,7 @@ func printRootIndexPage(tabs []Tab) []string {
 	cmd := tabs[0].Command
 
 	return flatten([][]string{
+		printComments(),
 		printHeader(cmd, false),
 		printTitle(cmd, "="),
 		printInlineScript(),
@@ -49,6 +50,7 @@ func printIndexPage(tabs []Tab, isOverview bool) []string {
 	cmd := tabs[0].Command
 
 	rows := [][]string{
+		printComments(),
 		printHeader(cmd, isOverview),
 		printTitle(cmd, "="),
 		printTabbedSection("Description", printDescription, tabs),
@@ -69,6 +71,14 @@ func flatten(arrs [][]string) []string {
 		flatArr = append(flatArr, arr...)
 	}
 	return flatArr
+}
+
+func printComments() []string {
+	return []string{
+		"..",
+		tab + "WARNING: This documentation is auto-generated from the confluentinc/cli repository and should not be manually edited.",
+		"",
+	}
 }
 
 func printHeader(cmd *cobra.Command, isOverview bool) []string {

--- a/internal/pkg/docs/index_page_test.go
+++ b/internal/pkg/docs/index_page_test.go
@@ -27,6 +27,9 @@ func TestPrintIndexPage(t *testing.T) {
 	}
 
 	expected := []string{
+		"..",
+		"   WARNING: This documentation is auto-generated from the confluentinc/cli repository and should not be manually edited.",
+		"",
 		".. _command_a:",
 		"",
 		"command a",
@@ -95,6 +98,9 @@ func TestPrintRootIndexPage(t *testing.T) {
 	}
 
 	expected := []string{
+		"..",
+		"   WARNING: This documentation is auto-generated from the confluentinc/cli repository and should not be manually edited.",
+		"",
 		".. _command_a:",
 		"",
 		"command a",
@@ -124,6 +130,16 @@ func TestFlatten(t *testing.T) {
 	}
 
 	require.Equal(t, []string{"a", "b", "c", "d"}, flatten(arrs))
+}
+
+func TestPrintComments(t *testing.T) {
+	expected := []string{
+		"..",
+		"   WARNING: This documentation is auto-generated from the confluentinc/cli repository and should not be manually edited.",
+		"",
+	}
+
+	require.Equal(t, expected, printComments())
 }
 
 func TestPrintHeader(t *testing.T) {


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok

What
----
It's common for uninitiated docs team members to attempt to edit our auto-generated docs. We should warn them against this with a comment at the top of every auto-generated file.

Test & Review
-------------
Tested with a draft docs PR here: https://github.com/confluentinc/docs-confluent-cli/pull/482