### PR TITLE
[CLI-2190] Resolve panic that can occur during auto-login without a role or environment

### DIFF
--- a/internal/pkg/cmd/prerunner.go
+++ b/internal/pkg/cmd/prerunner.go
@@ -326,8 +326,8 @@ func (r *PreRun) Authenticated(command *AuthenticatedCLICommand) func(cmd *cobra
 		}
 
 		if command.Context.GetEnvironment() == nil {
-			noEnvSuggestions := errors.ComposeSuggestionsMessage("This issue may occur if this user has no role bindings. Contact an Organization Admin to create a role binding for this user.")
-			_, _ = utils.ErrPrint("WARNING: This command requires an environment; no environments found.\n" + noEnvSuggestions + "\n")
+			noEnvSuggestions := errors.ComposeSuggestionsMessage("This issue may occur if this user has no valid role bindings. Contact an Organization Admin to create a role binding for this user.")
+			utils.ErrPrint(cmd, "WARNING: This command requires an environment; no environments found.\n" + noEnvSuggestions + "\n")
 		}
 
 		unsafeTrace, err := cmd.Flags().GetBool("unsafe-trace")


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok

What
----
A panic occurs in `ccloudAutoLogin` if a user account has no environments associated with it, which can happen when that user has no role-bindings. This PR makes two changes:
- Switch from direct access to using Get methods to prevent the panic
- Add an error if the environment is still nil after setting the context.

References
----------
https://confluentinc.atlassian.net/browse/CLI-2190

Test & Review
-------------
Ran tests
Manual testing:
- I Invited myself as a new user to my org and checked that running commands which require Authentication does not panic, and instead returns the new error
- Checked that basic functionality still works: login/logout, help, update, version.
- Checked that a user with an environment, but without an _active_ environment, can still run commands without the new error.
