### PR TITLE
KSQL-9660: CLI was not allowing to set a SR cloud URL for KSQL

### DIFF
--- a/internal/cmd/local/command_services.go
+++ b/internal/cmd/local/command_services.go
@@ -406,7 +406,6 @@ func (c *Command) getConfig(service string) (map[string]string, error) {
 		config["zookeeper.connect"] = fmt.Sprintf("localhost:%d", services["zookeeper"].port)
 	case "ksql-server":
 		config["kafkastore.connection.url"] = fmt.Sprintf("localhost:%d", services["zookeeper"].port)
-		config["ksql.schema.registry.url"] = fmt.Sprintf("http://localhost:%d", services["schema-registry"].port)
 		config["state.dir"] = data
 	case "schema-registry":
 		config["kafkastore.connection.url"] = fmt.Sprintf("localhost:%d", services["zookeeper"].port)

--- a/internal/cmd/local/command_services_test.go
+++ b/internal/cmd/local/command_services_test.go
@@ -58,7 +58,6 @@ func TestGetKafkaRestConfig(t *testing.T) {
 func TestGetKsqlServerConfig(t *testing.T) {
 	want := map[string]string{
 		"kafkastore.connection.url":    "localhost:2181",
-		"ksql.schema.registry.url":     "http://localhost:8081",
 		"state.dir":                    exampleDir,
 		"consumer.interceptor.classes": "io.confluent.monitoring.clients.interceptor.MonitoringConsumerInterceptor",
 		"producer.interceptor.classes": "io.confluent.monitoring.clients.interceptor.MonitoringProducerInterceptor",


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. You may delete or ignore any unused sections.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- <PLACEHOLDER>

New Features
- <PLACEHOLDER>

Bug Fixes
- <PLACEHOLDER>

Checklist
---------
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   yes: ok


What
----
This breaks the local KSQL server if we run it in default mode. Since it does not contain the schema-registry URL. 
This is just a draft PR to showcase the change, needed to allow KSQL to talk to Cloud SR. 
It will need one more change, to check if it is coming from config file then don't override.
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->

References
----------
<!--
Copy & paste links to Jira tickets, other PRs, issues, Slack conversations, etc.
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test & Review
-------------
<!--
Has it been tested? how?
Copy & paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

<!--
Open questions / Follow ups
---------------------------
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->

<!--
Review stakeholders
-------------------
Optional: mention stakeholders or special context that is required to review.
-->
