### PR TITLE
rename `schema-registry-cluster-id` flag to `schema-registry-cluster`

### DIFF
--- a/internal/cmd/iam/command_rbac_role_binding_create.go
+++ b/internal/cmd/iam/command_rbac_role_binding_create.go
@@ -34,19 +34,19 @@ func (c *roleBindingCommand) newCreateCommand() *cobra.Command {
 			},
 			examples.Example{
 				Text: `Grant the "ResourceOwner" role to principal "User:u-123456" and all subjects for Schema Registry cluster "lsrc-123456" in environment "env-12345":`,
-				Code: "confluent iam rbac role-binding create --principal User:u-123456 --role ResourceOwner --environment env-12345 --schema-registry-cluster-id lsrc-123456 --resource Subject:*",
+				Code: "confluent iam rbac role-binding create --principal User:u-123456 --role ResourceOwner --environment env-12345 --schema-registry-cluster lsrc-123456 --resource Subject:*",
 			},
 			examples.Example{
 				Text: `Grant the "ResourceOwner" role to principal "User:u-123456" and subject "test" for the Schema Registry cluster "lsrc-123456" in the environment "env-12345":`,
-				Code: "confluent iam rbac role-binding create --principal User:u-123456 --role ResourceOwner --environment env-12345 --schema-registry-cluster-id lsrc-123456 --resource Subject:test",
+				Code: "confluent iam rbac role-binding create --principal User:u-123456 --role ResourceOwner --environment env-12345 --schema-registry-cluster lsrc-123456 --resource Subject:test",
 			},
 			examples.Example{
 				Text: `Grant the "ResourceOwner" role to principal "User:u-123456" and all subjects in schema context "schema_context" for Schema Registry cluster "lsrc-123456" in the environment "env-12345":`,
-				Code: "confluent iam rbac role-binding create --principal User:u-123456 --role ResourceOwner --environment env-12345 --schema-registry-cluster-id lsrc-123456 --resource Subject::.schema_context:*",
+				Code: "confluent iam rbac role-binding create --principal User:u-123456 --role ResourceOwner --environment env-12345 --schema-registry-cluster lsrc-123456 --resource Subject::.schema_context:*",
 			},
 			examples.Example{
 				Text: `Grant the "ResourceOwner" role to principal "User:u-123456" and subject "test" in schema context "schema_context" for Schema Registry "lsrc-123456" in the environment "env-12345":`,
-				Code: "confluent iam rbac role-binding create --principal User:u-123456 --role ResourceOwner --environment env-12345 --schema-registry-cluster-id lsrc-123456 --resource Subject::.schema_context:test",
+				Code: "confluent iam rbac role-binding create --principal User:u-123456 --role ResourceOwner --environment env-12345 --schema-registry-cluster lsrc-123456 --resource Subject::.schema_context:test",
 			},
 		)
 	} else {

--- a/test/fixtures/output/iam/rbac/role-binding/create-help-cloud.golden
+++ b/test/fixtures/output/iam/rbac/role-binding/create-help-cloud.golden
@@ -18,19 +18,19 @@ Grant the role "MetricsViewer" to service account "sa-123456":
 
 Grant the "ResourceOwner" role to principal "User:u-123456" and all subjects for Schema Registry cluster "lsrc-123456" in environment "env-12345":
 
-  $ confluent iam rbac role-binding create --principal User:u-123456 --role ResourceOwner --environment env-12345 --schema-registry-cluster-id lsrc-123456 --resource Subject:*
+  $ confluent iam rbac role-binding create --principal User:u-123456 --role ResourceOwner --environment env-12345 --schema-registry-cluster lsrc-123456 --resource Subject:*
 
 Grant the "ResourceOwner" role to principal "User:u-123456" and subject "test" for the Schema Registry cluster "lsrc-123456" in the environment "env-12345":
 
-  $ confluent iam rbac role-binding create --principal User:u-123456 --role ResourceOwner --environment env-12345 --schema-registry-cluster-id lsrc-123456 --resource Subject:test
+  $ confluent iam rbac role-binding create --principal User:u-123456 --role ResourceOwner --environment env-12345 --schema-registry-cluster lsrc-123456 --resource Subject:test
 
 Grant the "ResourceOwner" role to principal "User:u-123456" and all subjects in schema context "schema_context" for Schema Registry cluster "lsrc-123456" in the environment "env-12345":
 
-  $ confluent iam rbac role-binding create --principal User:u-123456 --role ResourceOwner --environment env-12345 --schema-registry-cluster-id lsrc-123456 --resource Subject::.schema_context:*
+  $ confluent iam rbac role-binding create --principal User:u-123456 --role ResourceOwner --environment env-12345 --schema-registry-cluster lsrc-123456 --resource Subject::.schema_context:*
 
 Grant the "ResourceOwner" role to principal "User:u-123456" and subject "test" in schema context "schema_context" for Schema Registry "lsrc-123456" in the environment "env-12345":
 
-  $ confluent iam rbac role-binding create --principal User:u-123456 --role ResourceOwner --environment env-12345 --schema-registry-cluster-id lsrc-123456 --resource Subject::.schema_context:test
+  $ confluent iam rbac role-binding create --principal User:u-123456 --role ResourceOwner --environment env-12345 --schema-registry-cluster lsrc-123456 --resource Subject::.schema_context:test
 
 Flags:
       --role string                      REQUIRED: Role name of the new role binding.


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok

What
----
New examples merged from main still used the old cluster flag naming convention and caused a lint error.

References
----------
n/a

Test & Review
-------------
ran tests
ran `make lint`
