### PR TITLE
Remove duplicated page token code

### DIFF
--- a/internal/pkg/ccloudv2/api-keys.go
+++ b/internal/pkg/ccloudv2/api-keys.go
@@ -72,7 +72,7 @@ func (c *Client) ListApiKeys(owner, resource string) ([]apikeysv2.IamV2ApiKey, e
 		}
 		list = append(list, page.GetData()...)
 
-		pageToken, done, err = extractApiKeysNextPageToken(page.GetMetadata().Next)
+		pageToken, done, err = extractNextPageToken(page.GetMetadata().Next)
 		if err != nil {
 			return nil, err
 		}
@@ -86,13 +86,4 @@ func (c *Client) executeListApiKeys(owner, resource, pageToken string) (apikeysv
 		req = req.PageToken(pageToken)
 	}
 	return c.ApiKeysClient.APIKeysIamV2Api.ListIamV2ApiKeysExecute(req)
-}
-
-func extractApiKeysNextPageToken(nextPageUrlStringNullable apikeysv2.NullableString) (string, bool, error) {
-	if !nextPageUrlStringNullable.IsSet() {
-		return "", true, nil
-	}
-	nextPageUrlString := *nextPageUrlStringNullable.Get()
-	pageToken, err := extractPageToken(nextPageUrlString)
-	return pageToken, false, err
 }

--- a/internal/pkg/ccloudv2/byok.go
+++ b/internal/pkg/ccloudv2/byok.go
@@ -49,7 +49,7 @@ func (c *Client) ListByokKeys(provider string, state string) ([]byokv1.ByokV1Key
 		}
 		list = append(list, page.GetData()...)
 
-		pageToken, done, err = extractByokNextPageToken(page.GetMetadata().Next)
+		pageToken, done, err = extractNextPageToken(page.GetMetadata().Next)
 		if err != nil {
 			return nil, err
 		}
@@ -70,16 +70,4 @@ func (c *Client) executeListByokKeys(pageToken string, provider string, state st
 	}
 	req = req.PageSize(ccloudV2ListPageSize)
 	return c.ByokClient.KeysByokV1Api.ListByokV1KeysExecute(req)
-}
-
-func extractByokNextPageToken(nextPageUrlStringNullable byokv1.NullableString) (string, bool, error) {
-	if !nextPageUrlStringNullable.IsSet() {
-		return "", true, nil
-	}
-	nextPageUrlString := *nextPageUrlStringNullable.Get()
-	if nextPageUrlString == "" {
-		return "", true, nil
-	}
-	pageToken, err := extractPageToken(nextPageUrlString)
-	return pageToken, false, err
 }

--- a/internal/pkg/ccloudv2/cdx.go
+++ b/internal/pkg/ccloudv2/cdx.go
@@ -71,7 +71,7 @@ func (c *Client) ListProviderShares(sharedResource string) ([]cdxv1.CdxV1Provide
 		}
 		list = append(list, page.GetData()...)
 
-		pageToken, done, err = extractCdxNextPageToken(page.GetMetadata().Next)
+		pageToken, done, err = extractNextPageToken(page.GetMetadata().Next)
 		if err != nil {
 			return nil, err
 		}
@@ -92,7 +92,7 @@ func (c *Client) ListConsumerShares(sharedResource string) ([]cdxv1.CdxV1Consume
 		}
 		list = append(list, page.GetData()...)
 
-		pageToken, done, err = extractCdxNextPageToken(page.GetMetadata().Next)
+		pageToken, done, err = extractNextPageToken(page.GetMetadata().Next)
 		if err != nil {
 			return nil, err
 		}
@@ -113,7 +113,7 @@ func (c *Client) ListConsumerSharedResources(streamShareId string) ([]cdxv1.CdxV
 		}
 		list = append(list, page.GetData()...)
 
-		pageToken, done, err = extractCdxNextPageToken(page.GetMetadata().Next)
+		pageToken, done, err = extractNextPageToken(page.GetMetadata().Next)
 		if err != nil {
 			return nil, err
 		}
@@ -146,15 +146,6 @@ func (c *Client) executeListProviderShares(sharedResource, pageToken string) (cd
 		req = req.PageToken(pageToken)
 	}
 	return c.CdxClient.ProviderSharesCdxV1Api.ListCdxV1ProviderSharesExecute(req)
-}
-
-func extractCdxNextPageToken(nextPageUrlStringNullable cdxv1.NullableString) (string, bool, error) {
-	if !nextPageUrlStringNullable.IsSet() {
-		return "", true, nil
-	}
-	nextPageUrlString := *nextPageUrlStringNullable.Get()
-	pageToken, err := extractPageToken(nextPageUrlString)
-	return pageToken, false, err
 }
 
 func (c *Client) RedeemSharedToken(token, awsAccountId, azureSubscriptionId, gcpProjectId string) (cdxv1.CdxV1RedeemTokenResponse, error) {

--- a/internal/pkg/ccloudv2/cmk.go
+++ b/internal/pkg/ccloudv2/cmk.go
@@ -57,7 +57,7 @@ func (c *Client) ListKafkaClusters(environment string) ([]cmkv2.CmkV2Cluster, er
 		}
 		list = append(list, page.GetData()...)
 
-		pageToken, done, err = extractCmkNextPageToken(page.GetMetadata().Next)
+		pageToken, done, err = extractNextPageToken(page.GetMetadata().Next)
 		if err != nil {
 			return nil, err
 		}
@@ -71,13 +71,4 @@ func (c *Client) executeListClusters(pageToken, environment string) (cmkv2.CmkV2
 		req = req.PageToken(pageToken)
 	}
 	return c.CmkClient.ClustersCmkV2Api.ListCmkV2ClustersExecute(req)
-}
-
-func extractCmkNextPageToken(nextPageUrlStringNullable cmkv2.NullableString) (string, bool, error) {
-	if !nextPageUrlStringNullable.IsSet() {
-		return "", true, nil
-	}
-	nextPageUrlString := *nextPageUrlStringNullable.Get()
-	pageToken, err := extractPageToken(nextPageUrlString)
-	return pageToken, false, err
 }

--- a/internal/pkg/ccloudv2/iam.go
+++ b/internal/pkg/ccloudv2/iam.go
@@ -58,7 +58,7 @@ func (c *Client) ListIamServiceAccounts() ([]iamv2.IamV2ServiceAccount, error) {
 		}
 		list = append(list, page.GetData()...)
 
-		pageToken, done, err = extractIamNextPageToken(page.GetMetadata().Next)
+		pageToken, done, err = extractNextPageToken(page.GetMetadata().Next)
 		if err != nil {
 			return nil, err
 		}
@@ -120,7 +120,7 @@ func (c *Client) ListIamUsers() ([]iamv2.IamV2User, error) {
 		}
 		list = append(list, page.GetData()...)
 
-		pageToken, done, err = extractIamNextPageToken(page.GetMetadata().Next)
+		pageToken, done, err = extractNextPageToken(page.GetMetadata().Next)
 		if err != nil {
 			return nil, err
 		}
@@ -168,7 +168,7 @@ func (c *Client) ListIamInvitations() ([]iamv2.IamV2Invitation, error) {
 		}
 		list = append(list, page.GetData()...)
 
-		pageToken, done, err = extractIamNextPageToken(page.GetMetadata().Next)
+		pageToken, done, err = extractNextPageToken(page.GetMetadata().Next)
 		if err != nil {
 			return nil, err
 		}
@@ -182,13 +182,4 @@ func (c *Client) executeListInvitations(pageToken string) (iamv2.IamV2Invitation
 		req = req.PageToken(pageToken)
 	}
 	return c.IamClient.InvitationsIamV2Api.ListIamV2InvitationsExecute(req)
-}
-
-func extractIamNextPageToken(nextPageUrlStringNullable iamv2.NullableString) (string, bool, error) {
-	if !nextPageUrlStringNullable.IsSet() {
-		return "", true, nil
-	}
-	nextPageUrlString := *nextPageUrlStringNullable.Get()
-	pageToken, err := extractPageToken(nextPageUrlString)
-	return pageToken, false, err
 }

--- a/internal/pkg/ccloudv2/identity-provider.go
+++ b/internal/pkg/ccloudv2/identity-provider.go
@@ -62,7 +62,7 @@ func (c *Client) ListIdentityProviders() ([]identityproviderv2.IamV2IdentityProv
 		}
 		list = append(list, page.GetData()...)
 
-		pageToken, done, err = extractIdentityProviderNextPageToken(page.GetMetadata().Next)
+		pageToken, done, err = extractNextPageToken(page.GetMetadata().Next)
 		if err != nil {
 			return nil, err
 		}
@@ -114,7 +114,7 @@ func (c *Client) ListIdentityPools(providerId string) ([]identityproviderv2.IamV
 		}
 		list = append(list, page.GetData()...)
 
-		pageToken, done, err = extractIdentityProviderNextPageToken(page.GetMetadata().Next)
+		pageToken, done, err = extractNextPageToken(page.GetMetadata().Next)
 		if err != nil {
 			return nil, err
 		}
@@ -128,13 +128,4 @@ func (c *Client) executeListIdentityPools(providerID string, pageToken string) (
 		req = req.PageToken(pageToken)
 	}
 	return c.IdentityProviderClient.IdentityPoolsIamV2Api.ListIamV2IdentityPoolsExecute(req)
-}
-
-func extractIdentityProviderNextPageToken(nextPageUrlStringNullable identityproviderv2.NullableString) (string, bool, error) {
-	if !nextPageUrlStringNullable.IsSet() {
-		return "", true, nil
-	}
-	nextPageUrlString := *nextPageUrlStringNullable.Get()
-	pageToken, err := extractPageToken(nextPageUrlString)
-	return pageToken, false, err
 }

--- a/internal/pkg/ccloudv2/kafka-quota.go
+++ b/internal/pkg/ccloudv2/kafka-quota.go
@@ -36,7 +36,7 @@ func (c *Client) ListKafkaQuotas(clusterId, envId string) ([]kafkaquotasv1.Kafka
 		list = append(list, page.GetData()...)
 
 		// nextPageUrlStringNullable is nil for the last page
-		pageToken, done, err = extractKafkaQuotasNextPagePageToken(page.GetMetadata().Next)
+		pageToken, done, err = extractNextPageToken(page.GetMetadata().Next)
 		if err != nil {
 			return nil, err
 		}
@@ -76,17 +76,4 @@ func (c *Client) DeleteKafkaQuota(quotaId string) error {
 	req := c.KafkaQuotasClient.ClientQuotasKafkaQuotasV1Api.DeleteKafkaQuotasV1ClientQuota(c.quotaContext(), quotaId)
 	httpResp, err := req.Execute()
 	return errors.CatchCCloudV2Error(err, httpResp)
-}
-
-func extractKafkaQuotasNextPagePageToken(nextPageUrlStringNullable kafkaquotasv1.NullableString) (string, bool, error) {
-	if nextPageUrlStringNullable.IsSet() {
-		nextPageUrlString := *nextPageUrlStringNullable.Get()
-		pageToken, err := extractPageToken(nextPageUrlString)
-		if err != nil {
-			return "", true, nil
-		}
-		return pageToken, false, err
-	} else {
-		return "", true, nil
-	}
 }

--- a/internal/pkg/ccloudv2/org.go
+++ b/internal/pkg/ccloudv2/org.go
@@ -54,7 +54,7 @@ func (c *Client) ListOrgEnvironments() ([]orgv2.OrgV2Environment, error) {
 		}
 		list = append(list, page.GetData()...)
 
-		pageToken, done, err = extractOrgNextPageToken(page.GetMetadata().Next)
+		pageToken, done, err = extractNextPageToken(page.GetMetadata().Next)
 		if err != nil {
 			return nil, err
 		}
@@ -92,7 +92,7 @@ func (c *Client) ListOrgOrganizations() ([]orgv2.OrgV2Organization, error) {
 		}
 		list = append(list, page.GetData()...)
 
-		pageToken, done, err = extractOrgNextPageToken(page.GetMetadata().Next)
+		pageToken, done, err = extractNextPageToken(page.GetMetadata().Next)
 		if err != nil {
 			return nil, err
 		}
@@ -106,13 +106,4 @@ func (c *Client) executeListOrganizations(pageToken string) (orgv2.OrgV2Organiza
 		req = req.PageToken(pageToken)
 	}
 	return c.OrgClient.OrganizationsOrgV2Api.ListOrgV2OrganizationsExecute(req)
-}
-
-func extractOrgNextPageToken(nextPageUrlStringNullable orgv2.NullableString) (string, bool, error) {
-	if !nextPageUrlStringNullable.IsSet() {
-		return "", true, nil
-	}
-	nextPageUrlString := *nextPageUrlStringNullable.Get()
-	pageToken, err := extractPageToken(nextPageUrlString)
-	return pageToken, false, err
 }

--- a/internal/pkg/ccloudv2/service-quota.go
+++ b/internal/pkg/ccloudv2/service-quota.go
@@ -34,7 +34,7 @@ func (c *Client) ListServiceQuotas(quotaScope, kafkaCluster, environment, networ
 		}
 		list = append(list, page.GetData()...)
 
-		pageToken, done, err = extractServiceQuotaNextPageToken(page.GetMetadata().Next)
+		pageToken, done, err = extractNextPageToken(page.GetMetadata().Next)
 		if err != nil {
 			return nil, err
 		}
@@ -48,13 +48,4 @@ func (c *Client) executeListAppliedQuotas(pageToken, quotaScope, kafkaCluster, e
 		req = req.PageToken(pageToken)
 	}
 	return c.ServiceQuotaClient.AppliedQuotasServiceQuotaV1Api.ListServiceQuotaV1AppliedQuotasExecute(req)
-}
-
-func extractServiceQuotaNextPageToken(nextPageUrlStringNullable servicequotav1.NullableString) (string, bool, error) {
-	if !nextPageUrlStringNullable.IsSet() {
-		return "", true, nil
-	}
-	nextPageUrlString := *nextPageUrlStringNullable.Get()
-	pageToken, err := extractPageToken(nextPageUrlString)
-	return pageToken, false, err
 }

--- a/internal/pkg/ccloudv2/stream-designer.go
+++ b/internal/pkg/ccloudv2/stream-designer.go
@@ -34,7 +34,7 @@ func (c *Client) ListPipelines(envId, clusterId string) ([]streamdesignerv1.SdV1
 		}
 		list = append(list, page.GetData()...)
 
-		pageToken, done, err = extractSdNextPageToken(page.GetMetadata().Next)
+		pageToken, done, err = extractNextPageToken(page.GetMetadata().Next)
 		if err != nil {
 			return nil, err
 		}
@@ -94,13 +94,4 @@ func (c *Client) UpdateSdPipeline(envId, clusterId, id string, update streamdesi
 
 	resp, httpResp, err := c.StreamDesignerClient.PipelinesSdV1Api.UpdateSdV1PipelineExecute(req)
 	return resp, errors.CatchCCloudV2Error(err, httpResp)
-}
-
-func extractSdNextPageToken(nextPageUrlStringNullable streamdesignerv1.NullableString) (string, bool, error) {
-	if !nextPageUrlStringNullable.IsSet() {
-		return "", true, nil
-	}
-	nextPageUrlString := *nextPageUrlStringNullable.Get()
-	pageToken, err := extractPageToken(nextPageUrlString)
-	return pageToken, false, err
 }

--- a/internal/pkg/ccloudv2/utils.go
+++ b/internal/pkg/ccloudv2/utils.go
@@ -19,6 +19,11 @@ const (
 	ccloudV2ListPageSize    = 100
 )
 
+type NullableString interface {
+	Get() *string
+	IsSet() bool
+}
+
 var Hostnames = []string{"confluent.cloud", "cpdev.cloud"}
 
 func IsCCloudURL(url string, isTest bool) bool {
@@ -72,4 +77,16 @@ func extractPageToken(nextPageUrlString string) (string, error) {
 		return "", fmt.Errorf(`could not parse the value for query parameter "%s" from %s`, pageTokenQueryParameter, nextPageUrlString)
 	}
 	return pageToken, nil
+}
+
+func extractNextPageToken(nextPageUrl NullableString) (string, bool, error) {
+	if !nextPageUrl.IsSet() {
+		return "", true, nil
+	}
+	nextPageUrlString := *nextPageUrl.Get()
+	if nextPageUrlString == "" {
+		return "", true, nil
+	}
+	pageToken, err := extractPageToken(nextPageUrlString)
+	return pageToken, false, err
 }


### PR DESCRIPTION
Release Notes
--------------
Bug Fixes
- Correctly propagate backend errors in ``confluent kafka quota list``

Checklist
---------
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok

What
----
Identical utility functions to extract next page tokens for list commands had identical code but different arguments because each v2 API in `ccloud-sdk-go-v2` defines its own `NullableString` struct.

This PR defines an interface w/ the two NullableString methods that we call (there are other methods, but we don't need them) so that we can unify all of these into one function.

Targeting `v3` instead of `main` because `v3` has more usages of this pattern (in `mds`) than `main`.

References
----------
n/a

Test & Review
-------------
Ran tests.
Manually changed the page size from 100 to 5, created 12 api-keys and verified with `--unsafe-trace` that three GET calls are made with the api-keys divided between their responses (thanks Brian for the suggestion)
