### PR TITLE
Add aliases to index page command reference

### DIFF
--- a/internal/pkg/docs/doc_page.go
+++ b/internal/pkg/docs/doc_page.go
@@ -74,7 +74,7 @@ func printSphinxBlock(key, val string, args map[string]string) []string {
 }
 
 func printDescriptionAndUsage(cmd *cobra.Command) ([]string, bool) {
-	// We need to manually add the -h flag, so the the usage line gets suffixed with "[flags]".
+	// We need to manually add the -h flag so the usage line is suffixed with "[flags]".
 	cmd.InitDefaultHelpFlag()
 
 	rows := []string{

--- a/internal/pkg/docs/index_page.go
+++ b/internal/pkg/docs/index_page.go
@@ -53,6 +53,7 @@ func printIndexPage(tabs []Tab, isOverview bool) []string {
 		printComments(),
 		printHeader(cmd, isOverview),
 		printTitle(cmd, "="),
+		printSection("Aliases", printAliases(cmd)),
 		printTabbedSection("Description", printDescription, tabs),
 	}
 
@@ -157,6 +158,21 @@ func printLink(cmd *cobra.Command) string {
 		return path.Join(cmd.Name(), "index")
 	} else {
 		return printRef(cmd, false)
+	}
+}
+
+func printAliases(cmd *cobra.Command) []string {
+	if len(cmd.Aliases) == 0 {
+		return []string{}
+	}
+
+	aliases := append([]string{cmd.Name()}, cmd.Aliases...)
+
+	return []string{
+		"::",
+		"",
+		fmt.Sprintf("  %s", strings.Join(aliases, ", ")),
+		"",
 	}
 }
 

--- a/internal/pkg/docs/index_page_test.go
+++ b/internal/pkg/docs/index_page_test.go
@@ -12,8 +12,8 @@ var doNothingFunc = func(_ *cobra.Command, _ []string) {}
 func TestPrintIndexPage(t *testing.T) {
 	cmd := &cobra.Command{Use: "command"}
 
-	a1 := &cobra.Command{Use: "a", Short: "Description 1."}
-	a2 := &cobra.Command{Use: "a", Short: "Description 2."}
+	a1 := &cobra.Command{Use: "a", Short: "Description 1.", Aliases: []string{"alias"}}
+	a2 := &cobra.Command{Use: "a", Short: "Description 2.", Aliases: []string{"alias"}}
 
 	cmd.AddCommand(a1)
 	cmd.AddCommand(a2)
@@ -34,6 +34,13 @@ func TestPrintIndexPage(t *testing.T) {
 		"",
 		"command a",
 		"=========",
+		"",
+		"Aliases",
+		"~~~~~~~",
+		"",
+		"::",
+		"",
+		"  a, alias",
 		"",
 		"Description",
 		"~~~~~~~~~~~",
@@ -230,6 +237,56 @@ func TestPrintLink(t *testing.T) {
 
 	require.Equal(t, "a/index", printLink(a))
 	require.Equal(t, "a_b", printLink(b))
+}
+
+func TestPrintAliases_Empty(t *testing.T) {
+	cmd := new(cobra.Command)
+	require.Empty(t, printAliases(cmd))
+}
+
+func TestPrintAliases(t *testing.T) {
+	cmd := &cobra.Command{
+		Use:     "long-command",
+		Aliases: []string{"lc"},
+	}
+
+	expected := []string{
+		"::",
+		"",
+		"  long-command, lc",
+		"",
+	}
+
+	require.Equal(t, expected, printAliases(cmd))
+}
+
+func TestPrintDescription_Root(t *testing.T) {
+	cmd := &cobra.Command{Use: "command"}
+
+	expected := []string{
+		"The available |confluent| CLI commands are documented here.",
+		"",
+	}
+
+	actual, ok := printDescription(cmd)
+	require.True(t, ok)
+	require.Equal(t, expected, actual)
+}
+
+func TestPrintDescription(t *testing.T) {
+	a := &cobra.Command{Use: "a"}
+	b := &cobra.Command{Use: "b", Short: "Description."}
+
+	a.AddCommand(b)
+
+	expected := []string{
+		"Description.",
+		"",
+	}
+
+	actual, ok := printDescription(b)
+	require.True(t, ok)
+	require.Equal(t, expected, actual)
 }
 
 func TestPrintLongestDescription_Short(t *testing.T) {

--- a/internal/pkg/docs/tab.go
+++ b/internal/pkg/docs/tab.go
@@ -58,6 +58,10 @@ func printTabbedSection(title string, printSectionFunc func(*cobra.Command) ([]s
 }
 
 func printSection(title string, section []string) []string {
+	if len(section) == 0 {
+		return []string{}
+	}
+
 	head := []string{
 		title,
 		strings.Repeat("~", len(title)),


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok

What
----
Commands such as `confluent audit-log` can be written as `confluent al`. Add a new section to all index pages with aliases in the command reference.

Bonus: Added a few missing unit tests for `printDescription()`.

References
----------
[DOCS-18111](https://confluentinc.atlassian.net/browse/DOCS-18111)

Test & Review
-------------
Unit tests, manually generated and verified