### PR TITLE
Add timeout to integration test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -194,7 +194,7 @@ endif
 .PHONY: int-test
 int-test:
 ifdef CI
-	@INTEG_COVER=on gotestsum --junitfile integration-test-report.xml --timeout 10m -- -v $$(go list ./... | grep test)
+	@INTEG_COVER=on gotestsum --junitfile integration-test-report.xml -- -v -timeout 10m $$(go list ./... | grep test)
 	@grep -h -v "mode: atomic" integ_coverage.txt >> coverage.txt
 else
 	@GOPRIVATE=github.com/confluentinc go test -v -race $$(go list ./... | grep test) $(INT_TEST_ARGS) -timeout 45m

--- a/debian/patches/standard_build_layout.patch
+++ b/debian/patches/standard_build_layout.patch
@@ -1,4 +1,4 @@
---- cli/Makefile	2023-01-03 12:03:46.000000000 -0600
+--- cli/Makefile	2023-01-03 12:15:48.000000000 -0600
 +++ debian/Makefile	2022-12-12 19:29:13.000000000 -0600
 @@ -1,208 +1,130 @@
 -SHELL           := /bin/bash
@@ -233,7 +233,7 @@
 -.PHONY: int-test
 -int-test:
 -ifdef CI
--	@INTEG_COVER=on gotestsum --junitfile integration-test-report.xml --timeout 10m -- -v $$(go list ./... | grep test)
+-	@INTEG_COVER=on gotestsum --junitfile integration-test-report.xml -- -v -timeout 10m $$(go list ./... | grep test)
 -	@grep -h -v "mode: atomic" integ_coverage.txt >> coverage.txt
 +BINPATH=$(PREFIX)/bin
 +LIBPATH=$(PREFIX)/libexec/$(PACKAGE_TITLE)


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok

What
----
We've seen a few flaky integration test failures on Linux, where all tests say "(unknown)" for their completion time. Since the integration tests appear to `gotestsum` as a single test, it's possible that they're timing out (the total time in [this example job](https://semaphore.ci.confluent.io/jobs/b00ee77d-07b9-4f7f-9f43-6d63242538b8) is 239.9s, which is very close to 4m). Furthermore, the `gosumtest` source code shows that "unknown" is returned if there's a timeout: https://github.com/gotestyourself/gotestsum/blob/10c2a47f9b99c8b49cbea60d12a6c76af0678d50/testjson/summary.go#L118. We started seeing this after downgrading to s1-prod-ubuntu20-04-amd64-1 which is a slower machine than we were using previously.