### PR TITLE
[CLI-2130] Remove `full-header` flag in `topic consume` as empty/nil headers are now printed by default

### DIFF
--- a/internal/cmd/kafka/command_topic_consume.go
+++ b/internal/cmd/kafka/command_topic_consume.go
@@ -46,7 +46,6 @@ func newConsumeCommand(prerunner pcmd.PreRunner, clientId string) *cobra.Command
 	cmd.Flags().Int32("partition", -1, "The partition to consume from.")
 	pcmd.AddValueFormatFlag(cmd)
 	cmd.Flags().Bool("print-key", false, "Print key of the message.")
-	cmd.Flags().Bool("full-header", false, "Print complete content of message headers.")
 	cmd.Flags().String("delimiter", "\t", "The delimiter separating each key and value.")
 	cmd.Flags().StringSlice("config", nil, `A comma-separated list of configuration overrides ("key=value") for the consumer client.`)
 	cmd.Flags().String("config-file", "", "The path to the configuration file (in json or avro format) for the consumer client.")
@@ -82,11 +81,6 @@ func (c *hasAPIKeyTopicCommand) consume(cmd *cobra.Command, args []string) error
 	}
 
 	printKey, err := cmd.Flags().GetBool("print-key")
-	if err != nil {
-		return err
-	}
-
-	fullHeader, err := cmd.Flags().GetBool("full-header")
 	if err != nil {
 		return err
 	}
@@ -197,7 +191,7 @@ func (c *hasAPIKeyTopicCommand) consume(cmd *cobra.Command, args []string) error
 		Format:     valueFormat,
 		Out:        cmd.OutOrStdout(),
 		Subject:    subject,
-		Properties: ConsumerProperties{PrintKey: printKey, FullHeader: fullHeader, Delimiter: delimiter, SchemaPath: dir},
+		Properties: ConsumerProperties{PrintKey: printKey, Delimiter: delimiter, SchemaPath: dir},
 	}
 	return runConsumer(cmd, consumer, groupHandler)
 }

--- a/internal/cmd/kafka/command_topic_consume_onprem.go
+++ b/internal/cmd/kafka/command_topic_consume_onprem.go
@@ -43,7 +43,6 @@ func (c *authenticatedTopicCommand) newConsumeCommandOnPrem() *cobra.Command {
 	cmd.Flags().Int32("partition", -1, "The partition to consume from.")
 	pcmd.AddValueFormatFlag(cmd)
 	cmd.Flags().Bool("print-key", false, "Print key of the message.")
-	cmd.Flags().Bool("full-header", false, "Print complete content of message headers.")
 	cmd.Flags().String("delimiter", "\t", "The delimiter separating each key and value.")
 	cmd.Flags().StringSlice("config", nil, `A comma-separated list of configuration overrides ("key=value") for the consumer client.`)
 	cmd.Flags().String("config-file", "", "The path to the configuration file (in json or avro format) for the consumer client.")
@@ -58,11 +57,6 @@ func (c *authenticatedTopicCommand) newConsumeCommandOnPrem() *cobra.Command {
 
 func (c *authenticatedTopicCommand) onPremConsume(cmd *cobra.Command, args []string) error {
 	printKey, err := cmd.Flags().GetBool("print-key")
-	if err != nil {
-		return err
-	}
-
-	fullHeader, err := cmd.Flags().GetBool("full-header")
 	if err != nil {
 		return err
 	}
@@ -165,7 +159,7 @@ func (c *authenticatedTopicCommand) onPremConsume(cmd *cobra.Command, args []str
 		Ctx:        ctx,
 		Format:     valueFormat,
 		Out:        cmd.OutOrStdout(),
-		Properties: ConsumerProperties{PrintKey: printKey, FullHeader: fullHeader, Delimiter: delimiter, SchemaPath: dir},
+		Properties: ConsumerProperties{PrintKey: printKey, Delimiter: delimiter, SchemaPath: dir},
 	}
 	return runConsumer(cmd, consumer, groupHandler)
 }

--- a/internal/cmd/kafka/confluent_kafka.go
+++ b/internal/cmd/kafka/confluent_kafka.go
@@ -44,7 +44,6 @@ var (
 
 type ConsumerProperties struct {
 	Delimiter  string
-	FullHeader bool
 	PrintKey   bool
 	SchemaPath string
 }
@@ -229,11 +228,7 @@ func consumeMessage(e *ckafka.Message, h *GroupHandler) error {
 	}
 
 	if e.Headers != nil {
-		var headers interface{} = e.Headers
-		if h.Properties.FullHeader {
-			headers = getFullHeaders(e.Headers)
-		}
-		_, err = fmt.Fprintf(h.Out, "%% Headers: %v\n", headers)
+		_, err = fmt.Fprintf(h.Out, "%% Headers: %v\n", e.Headers)
 		if err != nil {
 			return err
 		}
@@ -326,22 +321,4 @@ func (h *GroupHandler) RequestSchema(value []byte) (string, map[string]string, e
 	}
 
 	return tempStorePath, referencePathMap, nil
-}
-
-func getFullHeaders(headers []ckafka.Header) []string {
-	headerStrings := make([]string, len(headers))
-	for i, header := range headers {
-		headerStrings[i] = getHeaderString(header)
-	}
-	return headerStrings
-}
-
-func getHeaderString(header ckafka.Header) string {
-	if header.Value == nil {
-		return fmt.Sprintf("%s=nil", header.Key)
-	} else if len(header.Value) == 0 {
-		return fmt.Sprintf("%s=<empty>", header.Key)
-	} else {
-		return fmt.Sprintf("%s=%s", header.Key, string(header.Value))
-	}
 }


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for CP or CCloud functionalities that are already live in prod?
   * yes: ok

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->
Remove this flag because it has no effectiveness on the output. `kafka topic consume` will now always print out headers even if its value is nil or empty, so we don't need to process it anymore.
```
mhe@C02DV0KVMD6T cli % confluent kafka topic consume 2131 -b --value-format jsonschema                
Starting Kafka Consumer. Use Ctrl-C to exit.
{"name":"no header","amount":9.9} // no header
{"name":"second","amount":4.354}
% Headers: [key1="v" key2=<empty> the key=nil] 
{"name":"second","amount":4.354}
% Headers: [the key=nil] // nil value header
```

References
----------
<!--
Copy & paste links to Jira tickets, other PRs, issues, Slack conversations, etc.
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->
https://confluentinc.atlassian.net/browse/CLI-2130

Test & Review
-------------
<!--
Has it been tested? how?
Copy & paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

<!--
Open questions / Follow ups
---------------------------
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->

<!--
Review stakeholders
-------------------
Optional: mention stakeholders or special context that is required to review.
-->
