### PR TITLE
[CLI-2306] Fix panic and error in announcements/deprecation framework

### DIFF
--- a/internal/pkg/featureflags/announcements_and_deprecation.go
+++ b/internal/pkg/featureflags/announcements_and_deprecation.go
@@ -36,6 +36,7 @@ func GetAnnouncementsOrDeprecation(resp interface{}) map[string]*Messages {
 
 	list, ok := resp.([]interface{})
 	if !ok {
+		fmt.Println("A")
 		return commandToMessages
 	}
 

--- a/internal/pkg/featureflags/announcements_and_deprecation_test.go
+++ b/internal/pkg/featureflags/announcements_and_deprecation_test.go
@@ -12,24 +12,24 @@ func TestGetAnnouncementsOrDeprecation_BadFormat(t *testing.T) {
 }
 
 func TestGetAnnouncementsOrDeprecation(t *testing.T) {
-	resp := []map[string]string{
-		{
+	resp := []interface{}{
+		map[string]interface{}{
 			"pattern": "command",
 			"message": "0",
 		},
-		{
+		map[string]interface{}{
 			"pattern": "command --flag",
 			"message": "1",
 		},
-		{
+		map[string]interface{}{
 			"pattern": "command-with-dashes",
 			"message": "2",
 		},
-		{
+		map[string]interface{}{
 			"pattern": "--flag-only",
 			"message": "3",
 		},
-		{
+		map[string]interface{}{
 			"pattern": "--multiple --flags",
 			"message": "4",
 		},


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
This bug caused a brief (2 minute) outage in the CLI, since users couldn't log in. This needs to be merged in before the v3 release so we don't run into the same problem during the v4 release.

The framework now supports 1) `commands-with-dashes` and 2) `--flag-only-patterns` (this is what caused the panic)

References
----------
https://confluentinc.atlassian.net/browse/CLI-2306

Test & Review
-------------
Unit tests