### PR TITLE
Update docker images for glibc builds to use go 1.19.5 and goreleaser 1.14.1

### DIFF
--- a/dockerfiles/Dockerfile_linux_glibc
+++ b/dockerfiles/Dockerfile_linux_glibc
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 050879227952.dkr.ecr.us-west-1.amazonaws.com/confluentinc/cli-centos-base-amd64:2.0
+FROM --platform=linux/amd64 050879227952.dkr.ecr.us-west-1.amazonaws.com/confluentinc/cli-centos-base-amd64:3.0
 
 COPY . /go/src/github.com/confluentinc/cli/
 

--- a/dockerfiles/Dockerfile_linux_glibc_arm64_from_amd64
+++ b/dockerfiles/Dockerfile_linux_glibc_arm64_from_amd64
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 050879227952.dkr.ecr.us-west-1.amazonaws.com/confluentinc/cli-ubuntu-base-arm64:latest
+FROM --platform=linux/amd64 050879227952.dkr.ecr.us-west-1.amazonaws.com/confluentinc/cli-ubuntu-base-arm64:2.0
 
 COPY . /go/src/github.com/confluentinc/cli/
 


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
What it says in the title.

References
----------
N/A

Test & Review
-------------
Ran the glibc build script w/ the new docker images and successfully built.
