### PR TITLE
[RCCA-10621] Pass resource IDs to Kafka REST in `kafka acl` commands

### DIFF
--- a/internal/cmd/kafka/command_acl_create.go
+++ b/internal/cmd/kafka/command_acl_create.go
@@ -4,8 +4,8 @@ import (
 	"github.com/spf13/cobra"
 
 	pacl "github.com/confluentinc/cli/internal/pkg/acl"
-	pcmd "github.com/confluentinc/cli/internal/pkg/cmd"
 	"github.com/confluentinc/cli/internal/pkg/ccstructs"
+	pcmd "github.com/confluentinc/cli/internal/pkg/cmd"
 	"github.com/confluentinc/cli/internal/pkg/examples"
 	"github.com/confluentinc/cli/internal/pkg/kafkarest"
 )
@@ -39,15 +39,6 @@ func (c *aclCommand) newCreateCommand() *cobra.Command {
 func (c *aclCommand) create(cmd *cobra.Command, _ []string) error {
 	acls, err := parse(cmd)
 	if err != nil {
-		return err
-	}
-
-	userIdMap, err := c.mapResourceIdToUserId()
-	if err != nil {
-		return err
-	}
-
-	if err := c.aclResourceIdToNumericId(acls, userIdMap); err != nil {
 		return err
 	}
 

--- a/internal/cmd/kafka/command_acl_delete.go
+++ b/internal/cmd/kafka/command_acl_delete.go
@@ -38,15 +38,6 @@ func (c *aclCommand) delete(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	userIdMap, err := c.mapResourceIdToUserId()
-	if err != nil {
-		return err
-	}
-
-	if err := c.aclResourceIdToNumericId(acls, userIdMap); err != nil {
-		return err
-	}
-
 	var filters []*ccstructs.ACLFilter
 	for _, acl := range acls {
 		validateAddAndDelete(acl)

--- a/internal/cmd/kafka/command_acl_list.go
+++ b/internal/cmd/kafka/command_acl_list.go
@@ -33,15 +33,6 @@ func (c *aclCommand) list(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	userIdMap, err := c.mapResourceIdToUserId()
-	if err != nil {
-		return err
-	}
-
-	if err := c.aclResourceIdToNumericId(acl, userIdMap); err != nil {
-		return err
-	}
-
 	if acl[0].errors != nil {
 		return acl[0].errors
 	}

--- a/internal/cmd/kafka/kafka_api.go
+++ b/internal/cmd/kafka/kafka_api.go
@@ -20,12 +20,10 @@ type ACLConfiguration struct {
 	errors error
 }
 
-func NewACLConfig() *ACLConfiguration {
+func NewACLConfiguration() *ACLConfiguration {
 	return &ACLConfiguration{
 		ACLBinding: &ccstructs.ACLBinding{
-			Entry: &ccstructs.AccessControlEntryConfig{
-				Host: "*",
-			},
+			Entry:   &ccstructs.AccessControlEntryConfig{Host: "*"},
 			Pattern: &ccstructs.ResourcePatternConfig{},
 		},
 	}
@@ -71,7 +69,7 @@ func parse(cmd *cobra.Command) ([]*ACLConfiguration, error) {
 	var aclConfigs []*ACLConfiguration
 
 	if cmd.Name() == "list" {
-		aclConfig := NewACLConfig()
+		aclConfig := NewACLConfiguration()
 		cmd.Flags().Visit(fromArgs(aclConfig))
 		aclConfigs = append(aclConfigs, aclConfig)
 		return aclConfigs, nil
@@ -82,7 +80,7 @@ func parse(cmd *cobra.Command) ([]*ACLConfiguration, error) {
 		return nil, err
 	}
 	for _, operation := range operations {
-		aclConfig := NewACLConfig()
+		aclConfig := NewACLConfiguration()
 		op, err := getACLOperation(operation)
 		if err != nil {
 			return nil, err

--- a/internal/pkg/errors/error_message.go
+++ b/internal/pkg/errors/error_message.go
@@ -72,7 +72,6 @@ const (
 	InvalidOperationValueErrorMsg = "invalid operation value: %s"
 	ExactlyOneSetErrorMsg         = "exactly one of %v must be set"
 	UserIdNotValidErrorMsg        = "can't map user id to a valid service account"
-	PrincipalNotFoundErrorMsg     = `user or service account "%s" not found`
 
 	// iam rbac role commands
 	UnknownRoleErrorMsg    = `unknown role "%s"`

--- a/test/fixtures/output/kafka/40.golden
+++ b/test/fixtures/output/kafka/40.golden
@@ -1,1 +1,1 @@
-Set Kafka cluster "a-595" as the active cluster for environment "a-595".
+Set Kafka cluster "lkc-12345" as the active cluster for environment "a-595".

--- a/test/fixtures/output/kafka/acl/err-numeric-id.golden
+++ b/test/fixtures/output/kafka/acl/err-numeric-id.golden
@@ -1,1 +1,0 @@
-Error: failed to parse principal: numeric IDs are not supported

--- a/test/fixtures/output/kafka/acl/invalid-service-account.golden
+++ b/test/fixtures/output/kafka/acl/invalid-service-account.golden
@@ -1,1 +1,0 @@
-Error: user or service account "sa-54321" not found

--- a/test/kafka_test.go
+++ b/test/kafka_test.go
@@ -54,7 +54,7 @@ func (s *CLITestSuite) TestKafka() {
 		{args: "kafka cluster delete lkc-def973 --force", fixture: "kafka/5.golden"},
 		{args: "kafka cluster delete lkc-def973", preCmdFuncs: []bincover.PreCmdFunc{stdinPipeFunc(strings.NewReader("kafka-cluster\n"))}, fixture: "kafka/5-prompt.golden"},
 
-		{args: "kafka cluster use a-595", fixture: "kafka/40.golden"},
+		{args: "kafka cluster use lkc-12345", fixture: "kafka/40.golden"},
 
 		{args: "kafka region list", fixture: "kafka/14.golden"},
 		{args: "kafka region list -o json", fixture: "kafka/15.golden"},
@@ -86,16 +86,12 @@ func (s *CLITestSuite) TestKafka() {
 		{args: "kafka acl list --cluster lkc-acls", fixture: "kafka/acl/list-cloud.golden"},
 		{args: "kafka acl list --cluster lkc-acls -o json", fixture: "kafka/acl/list-json-cloud.golden"},
 		{args: "kafka acl list --cluster lkc-acls -o yaml", fixture: "kafka/acl/list-yaml-cloud.golden"},
-		{args: "kafka acl list --principal User:12345", fixture: "kafka/acl/err-numeric-id.golden", wantErrCode: 1},
 		{args: "kafka acl create --cluster lkc-acls --allow --service-account 7272 --operations READ,DESCRIBED --topic test-topic", fixture: "kafka/acl/invalid-operation.golden", wantErrCode: 1},
 		{args: "kafka acl create --cluster lkc-acls --allow --service-account sa-12345 --operations READ,DESCRIBE --topic test-topic", fixture: "kafka/acl/create-service-account.golden"},
 		{args: "kafka acl create --cluster lkc-acls --allow --principal User:sa-12345 --operations WRITE,ALTER --topic test-topic", fixture: "kafka/acl/create-principal.golden"},
-		{args: "kafka acl create --cluster lkc-acls --allow --service-account sa-54321 --operations READ,DESCRIBE --topic test-topic", fixture: "kafka/acl/invalid-service-account.golden", wantErrCode: 1},
-		{args: "kafka acl create --principal User:12345 --operations WRITE", fixture: "kafka/acl/err-numeric-id.golden", wantErrCode: 1},
 		{args: "kafka acl delete --cluster lkc-acls --allow --service-account sa-12345 --operations READ,DESCRIBE --topic test-topic --force", fixture: "kafka/acl/delete-cloud.golden"},
 		{args: "kafka acl delete --cluster lkc-acls --allow --service-account sa-12345 --operations READ,DESCRIBE --topic test-topic", preCmdFuncs: []bincover.PreCmdFunc{stdinPipeFunc(strings.NewReader("y\n"))}, fixture: "kafka/acl/delete-cloud-prompt.golden"},
 		{args: "kafka acl delete --cluster lkc-acls --allow --principal User:sa-12345 --operations WRITE,ALTER --topic test-topic --force", fixture: "kafka/acl/delete-cloud.golden"},
-		{args: "kafka acl delete --principal User:12345 --operations WRITE", fixture: "kafka/acl/err-numeric-id.golden", wantErrCode: 1},
 
 		{args: "kafka topic list --cluster lkc-kafka-api-topics", login: "cloud", fixture: "kafka/topic/list-cloud.golden"},
 		{args: "kafka topic list --cluster lkc-topics", fixture: "kafka/topic/list-cloud.golden"},


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
Previously, all principals were being passed to Kafka REST as numeric IDs when creating/listing/deleting a Kafka ACL with `kafka acl`. These should no longer be converted prior to making the request because the backend can handle resource IDs now.

The backend may still respond with numeric IDs (if it can't make the mapping), so I'm keeping the code that maps numeric IDs back to resource IDs so we don't accidentally show numeric IDs to the user.

References
----------
https://confluentinc.atlassian.net/browse/RCCA-10621

Test & Review
-------------
Verified that Kafka ACLs can still be created, listed, and deleted.