### PR TITLE
`iam rbac role-binding` fixes

### DIFF
--- a/internal/cmd/iam/command_rbac_role_binding.go
+++ b/internal/cmd/iam/command_rbac_role_binding.go
@@ -350,7 +350,7 @@ func (c *roleBindingCommand) validateResourceTypeV1(resourceType string) error {
 }
 
 func (c *roleBindingCommand) displayCCloudCreateAndDeleteOutput(cmd *cobra.Command, roleBinding *mdsv2.IamV2RoleBinding) error {
-	userResourceId := strings.TrimLeft(roleBinding.GetPrincipal(), "User:")
+	userResourceId := strings.TrimPrefix(roleBinding.GetPrincipal(), "User:")
 	user, err := c.V2Client.GetIamUserById(userResourceId)
 	if err != nil {
 		return err
@@ -461,7 +461,7 @@ func (c *roleBindingCommand) parseV2RoleBinding(cmd *cobra.Command) (*mdsv2.IamV
 	}
 
 	if strings.HasPrefix(principal, "User:") {
-		principalValue := strings.TrimLeft(principal, "User:")
+		principalValue := strings.TrimPrefix(principal, "User:")
 		if strings.Contains(principalValue, "@") {
 			user, err := c.V2Client.GetIamUserByEmail(principalValue)
 			if err != nil {
@@ -515,7 +515,7 @@ func (c *roleBindingCommand) parseV2RoleBinding(cmd *cobra.Command) (*mdsv2.IamV
 }
 
 func (c *roleBindingCommand) parseV2BaseCrnPattern(cmd *cobra.Command) (string, error) {
-	orgResourceId := c.State.Auth.Organization.GetResourceId()
+	orgResourceId := c.State.Auth.Account.GetOrgResourceId()
 	crnPattern := "crn://confluent.cloud/organization=" + orgResourceId
 
 	if cmd.Flags().Changed("current-environment") {

--- a/test/test-server/ccloud_handlers.go
+++ b/test/test-server/ccloud_handlers.go
@@ -22,7 +22,12 @@ import (
 )
 
 var (
-	environments  = []*ccloudv1.Account{{Id: "a-595", Name: "default"}, {Id: "not-595", Name: "other"}, {Id: "env-123", Name: "env123"}, {Id: SRApiEnvId, Name: "srUpdate"}}
+	environments = []*ccloudv1.Account{
+		{Id: "a-595", Name: "default", OrgResourceId: "abc-123"},
+		{Id: "not-595", Name: "other"},
+		{Id: "env-123", Name: "env123"},
+		{Id: SRApiEnvId, Name: "srUpdate"},
+	}
 	keyIndex      = int32(3)
 	resourceIdMap = map[int32]string{auditLogServiceAccountID: auditLogServiceAccountResourceID, serviceAccountID: serviceAccountResourceID}
 


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
Two bug fixes:
1. It's possible for the `Organization` field to be `nil`. We should be using the `Account` field instead.
2. We need to use `TrimPrefix()` instead of `TrimLeft()`, otherwise principals starting with any of the characters "U", "s", "e", "r", or ":" will be trimmed.