### PR TITLE
Various example and flag text updates

### DIFF
--- a/internal/cmd/iam/acl_utils.go
+++ b/internal/cmd/iam/acl_utils.go
@@ -26,12 +26,7 @@ func aclFlags() *pflag.FlagSet {
 	flgSet := pflag.NewFlagSet("acl-config", pflag.ExitOnError)
 	flgSet.String("kafka-cluster", "", "Kafka cluster ID for scope of ACL commands.")
 	flgSet.String("principal", "", "Principal for this operation with User: or Group: prefix.")
-	flgSet.String("operation", "", fmt.Sprintf("Set ACL Operation to: (%s).",
-		acl.ConvertToLower(mds.ACLOPERATION_ALL, mds.ACLOPERATION_ALTER, mds.ACLOPERATION_ALTER_CONFIGS,
-			mds.ACLOPERATION_CLUSTER_ACTION, mds.ACLOPERATION_CREATE, mds.ACLOPERATION_DELETE,
-			mds.ACLOPERATION_DESCRIBE, mds.ACLOPERATION_DESCRIBE_CONFIGS,
-			mds.ACLOPERATION_IDEMPOTENT_WRITE, mds.ACLOPERATION_READ,
-			mds.ACLOPERATION_WRITE)))
+	flgSet.String("operation", "", fmt.Sprintf("Set ACL Operation to: (%s).", acl.ConvertToLower(acl.AclOperations)))
 	flgSet.String("host", "*", "Set host for access. Only IP addresses are supported.")
 	flgSet.Bool("allow", false, "ACL permission to allow access.")
 	flgSet.Bool("deny", false, "ACL permission to restrict access to resource.")

--- a/internal/cmd/iam/acl_utils.go
+++ b/internal/cmd/iam/acl_utils.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/confluentinc/cli/internal/pkg/acl"
 	"github.com/confluentinc/cli/internal/pkg/utils"
 
 	"github.com/hashicorp/go-multierror"
@@ -26,7 +27,7 @@ func aclFlags() *pflag.FlagSet {
 	flgSet.String("kafka-cluster", "", "Kafka cluster ID for scope of ACL commands.")
 	flgSet.String("principal", "", "Principal for this operation with User: or Group: prefix.")
 	flgSet.String("operation", "", fmt.Sprintf("Set ACL Operation to: (%s).",
-		convertToFlags(mds.ACLOPERATION_ALL, mds.ACLOPERATION_READ, mds.ACLOPERATION_WRITE,
+		acl.ConvertToLower(mds.ACLOPERATION_ALL, mds.ACLOPERATION_READ, mds.ACLOPERATION_WRITE,
 			mds.ACLOPERATION_CREATE, mds.ACLOPERATION_DELETE, mds.ACLOPERATION_ALTER,
 			mds.ACLOPERATION_DESCRIBE, mds.ACLOPERATION_CLUSTER_ACTION,
 			mds.ACLOPERATION_DESCRIBE_CONFIGS, mds.ACLOPERATION_ALTER_CONFIGS,
@@ -156,9 +157,8 @@ func convertToFlags(operations ...any) string {
 		if v == mds.ACLRESOURCETYPE_CLUSTER {
 			v = "cluster-scope"
 		}
-		s := fmt.Sprint(v)
-		s = strings.ReplaceAll(s, "_", "-")
-		ops = append(ops, strings.ToLower(s))
+		s := strings.ToLower(strings.ReplaceAll(fmt.Sprint(v), "_", "-"))
+		ops = append(ops, fmt.Sprintf("`--%s`", s))
 	}
 
 	sort.Strings(ops)

--- a/internal/cmd/iam/acl_utils.go
+++ b/internal/cmd/iam/acl_utils.go
@@ -148,9 +148,9 @@ func setResourcePattern(conf *ACLConfiguration, n string, v string) {
 }
 
 func convertToFlags(operations ...any) string {
-	var ops []string
+	ops := make([]string, len(operations))
 
-	for _, v := range operations {
+	for i, v := range operations {
 		if v == mds.ACLRESOURCETYPE_GROUP {
 			v = "consumer-group"
 		}
@@ -158,7 +158,7 @@ func convertToFlags(operations ...any) string {
 			v = "cluster-scope"
 		}
 		s := strings.ToLower(strings.ReplaceAll(fmt.Sprint(v), "_", "-"))
-		ops = append(ops, fmt.Sprintf("`--%s`", s))
+		ops[i] = fmt.Sprintf("`--%s`", s)
 	}
 
 	sort.Strings(ops)

--- a/internal/cmd/iam/acl_utils.go
+++ b/internal/cmd/iam/acl_utils.go
@@ -27,11 +27,11 @@ func aclFlags() *pflag.FlagSet {
 	flgSet.String("kafka-cluster", "", "Kafka cluster ID for scope of ACL commands.")
 	flgSet.String("principal", "", "Principal for this operation with User: or Group: prefix.")
 	flgSet.String("operation", "", fmt.Sprintf("Set ACL Operation to: (%s).",
-		acl.ConvertToLower(mds.ACLOPERATION_ALL, mds.ACLOPERATION_READ, mds.ACLOPERATION_WRITE,
-			mds.ACLOPERATION_CREATE, mds.ACLOPERATION_DELETE, mds.ACLOPERATION_ALTER,
-			mds.ACLOPERATION_DESCRIBE, mds.ACLOPERATION_CLUSTER_ACTION,
-			mds.ACLOPERATION_DESCRIBE_CONFIGS, mds.ACLOPERATION_ALTER_CONFIGS,
-			mds.ACLOPERATION_IDEMPOTENT_WRITE)))
+		acl.ConvertToLower(mds.ACLOPERATION_ALL, mds.ACLOPERATION_ALTER, mds.ACLOPERATION_ALTER_CONFIGS,
+			mds.ACLOPERATION_CLUSTER_ACTION, mds.ACLOPERATION_CREATE, mds.ACLOPERATION_DELETE,
+			mds.ACLOPERATION_DESCRIBE, mds.ACLOPERATION_DESCRIBE_CONFIGS,
+			mds.ACLOPERATION_IDEMPOTENT_WRITE, mds.ACLOPERATION_READ,
+			mds.ACLOPERATION_WRITE)))
 	flgSet.String("host", "*", "Set host for access. Only IP addresses are supported.")
 	flgSet.Bool("allow", false, "ACL permission to allow access.")
 	flgSet.Bool("deny", false, "ACL permission to restrict access to resource.")

--- a/internal/cmd/iam/command_acl_create.go
+++ b/internal/cmd/iam/command_acl_create.go
@@ -19,16 +19,16 @@ func (c *aclCommand) newCreateCommand() *cobra.Command {
 		RunE:  c.create,
 		Example: examples.BuildExampleString(
 			examples.Example{
-				Text: "Create an ACL that grants the specified user READ permission to the specified consumer group in the specified Kafka cluster:",
-				Code: "confluent iam acl create --allow --principal User:User1 --operation READ --consumer-group java_example_group_1 --kafka-cluster <kafka-cluster-id>",
+				Text: `Create an ACL that grants the specified user "read" permission to the specified consumer group in the specified Kafka cluster:`,
+				Code: "confluent iam acl create --allow --principal User:User1 --operation read --consumer-group java_example_group_1 --kafka-cluster <kafka-cluster-id>",
 			},
 			examples.Example{
-				Text: "Create an ACL that grants the specified user WRITE permission on all topics in the specified Kafka cluster:",
-				Code: "confluent iam acl create --allow --principal User:User1 --operation WRITE --topic '*' --kafka-cluster <kafka-cluster-id>",
+				Text: `Create an ACL that grants the specified user "write" permission on all topics in the specified Kafka cluster:`,
+				Code: "confluent iam acl create --allow --principal User:User1 --operation write --topic '*' --kafka-cluster <kafka-cluster-id>",
 			},
 			examples.Example{
-				Text: "Create an ACL that assigns a group READ access to all topics that use the specified prefix in the specified Kafka cluster:",
-				Code: "confluent iam acl create --allow --principal Group:Finance --operation READ --topic financial --prefix --kafka-cluster <kafka-cluster-id>",
+				Text: `Create an ACL that assigns a group "read" access to all topics that use the specified prefix in the specified Kafka cluster:`,
+				Code: "confluent iam acl create --allow --principal Group:Finance --operation read --topic financial --prefix --kafka-cluster <kafka-cluster-id>",
 			},
 		),
 	}

--- a/internal/cmd/iam/command_acl_list.go
+++ b/internal/cmd/iam/command_acl_list.go
@@ -20,7 +20,7 @@ func (c *aclCommand) newListCommand() *cobra.Command {
 				Code: "confluent iam acl list --kafka-cluster <kafka-cluster-id>",
 			},
 			examples.Example{
-				Text: "List all the ACLs for the specified cluster that include allow permissions for the user Jane:",
+				Text: `List all the ACLs for the specified cluster that include "allow" permissions for the user Jane:`,
 				Code: "confluent iam acl list --kafka-cluster <kafka-cluster-id> --allow --principal User:Jane",
 			},
 		),

--- a/internal/cmd/iam/command_acl_test.go
+++ b/internal/cmd/iam/command_acl_test.go
@@ -366,7 +366,7 @@ func (suite *ACLTestSuite) TestMdsMultipleResourceACL() {
 
 	err := cmd.Execute()
 	assert.NotNil(suite.T(), err)
-	expect := fmt.Sprintf(errors.ExactlyOneSetErrorMsg, "cluster-scope, consumer-group, topic, transactional-id")
+	expect := fmt.Sprintf(errors.ExactlyOneSetErrorMsg, "`--cluster-scope`, `--consumer-group`, `--topic`, `--transactional-id`")
 	assert.Contains(suite.T(), err.Error(), expect)
 }
 

--- a/internal/cmd/iam/command_rbac_role_binding_list.go
+++ b/internal/cmd/iam/command_rbac_role_binding_list.go
@@ -37,7 +37,7 @@ func (c *roleBindingCommand) newListCommand() *cobra.Command {
 	if c.cfg.IsCloudLogin() {
 		cmd.Example = examples.BuildExampleString(
 			examples.Example{
-				Text: "List the role bindings for current user:",
+				Text: "List the role bindings for the current user:",
 				Code: "confluent iam rbac role-binding list --current-user",
 			},
 			examples.Example{
@@ -51,6 +51,14 @@ func (c *roleBindingCommand) newListCommand() *cobra.Command {
 			examples.Example{
 				Text: `List the role bindings for user "u-123456" with role "CloudClusterAdmin":`,
 				Code: "confluent iam rbac role-binding list --principal User:u-123456 --role CloudClusterAdmin --environment env-12345 --cloud-cluster lkc-123456",
+			},
+			examples.Example{
+				Text: `List the role bindings for user "u-123456" for all scopes:`,
+				Code: "confluent iam rbac role-binding list --principal User:u-123456 --inclusive",
+			},
+			examples.Example{
+				Text: "List the role bindings for the current user at the environment scope and its nested scopes:",
+				Code: "confluent iam rbac role-binding list --current-user --environment env-12345 --inclusive",
 			},
 		)
 	} else {

--- a/internal/cmd/kafka/command_acl_create.go
+++ b/internal/cmd/kafka/command_acl_create.go
@@ -20,11 +20,11 @@ func (c *aclCommand) newCreateCommand() *cobra.Command {
 		RunE:  c.create,
 		Example: examples.BuildExampleString(
 			examples.Example{
-				Text: "You can specify only one of the following flags per command invocation: `--cluster-scope`, `--consumer-group`, `--topic`, or `--transactional-id`. For example, for a consumer to read a topic, you need to grant \"READ\" and \"DESCRIBE\" both on the `--consumer-group` and the `--topic` resources, issuing two separate commands:",
-				Code: "confluent kafka acl create --allow --service-account sa-55555 --operations READ,DESCRIBE --consumer-group java_example_group_1",
+				Text: "You can specify only one of the following flags per command invocation: `--cluster-scope`, `--consumer-group`, `--topic`, or `--transactional-id`. For example, for a consumer to read a topic, you need to grant \"read\" and \"describe\" both on the `--consumer-group` and the `--topic` resources, issuing two separate commands:",
+				Code: "confluent kafka acl create --allow --service-account sa-55555 --operations read,describe --consumer-group java_example_group_1",
 			},
 			examples.Example{
-				Code: `confluent kafka acl create --allow --service-account sa-55555 --operations READ,DESCRIBE --topic "*"`,
+				Code: `confluent kafka acl create --allow --service-account sa-55555 --operations read,describe --topic "*"`,
 			},
 		),
 	}

--- a/internal/cmd/kafka/command_acl_create_onprem.go
+++ b/internal/cmd/kafka/command_acl_create_onprem.go
@@ -18,25 +18,25 @@ func (c *aclCommand) newCreateCommandOnPrem() *cobra.Command {
 		RunE:  c.createOnPrem,
 		Example: examples.BuildExampleString(
 			examples.Example{
-				Text: "You can specify only one of the following flags per command invocation: `--cluster-scope`, `--consumer-group`, `--topic`, or `--transactional-id`. For example, for a consumer to read a topic, you need to grant \"READ\" and \"DESCRIBE\" both on the `--consumer-group` and the `--topic` resources, issuing two separate commands:",
-				Code: "confluent kafka acl create --allow --principal User:Jane --operation READ --operation DESCRIBE --consumer-group java_example_group_1",
+				Text: "You can specify only one of the following flags per command invocation: `--cluster-scope`, `--consumer-group`, `--topic`, or `--transactional-id`. For example, for a consumer to read a topic, you need to grant \"read\" and \"describe\" both on the `--consumer-group` and the `--topic` resources, issuing two separate commands:",
+				Code: "confluent kafka acl create --allow --principal User:Jane --operation read --operation describe --consumer-group java_example_group_1",
 			},
 			examples.Example{
-				Code: `confluent kafka acl create --allow --principal User:Jane --operation READ --operation DESCRIBE --topic "*"`,
+				Code: `confluent kafka acl create --allow --principal User:Jane --operation read --operation describe --topic "*"`,
 			},
 			examples.Example{
 				Text: "You can run the previous example without logging in if you provide the embedded Kafka REST Proxy endpoint with the `--url` flag.",
-				Code: "confluent kafka acl create --url http://localhost:8090/kafka --allow --principal User:Jane --operation READ --operation DESCRIBE --consumer-group java_example_group_1",
+				Code: "confluent kafka acl create --url http://localhost:8090/kafka --allow --principal User:Jane --operation read --operation describe --consumer-group java_example_group_1",
 			},
 			examples.Example{
-				Code: `confluent kafka acl create --url http://localhost:8090/kafka --allow --principal User:Jane --operation READ --operation DESCRIBE --topic "*"`,
+				Code: `confluent kafka acl create --url http://localhost:8090/kafka --allow --principal User:Jane --operation read --operation describe --topic "*"`,
 			},
 			examples.Example{
 				Text: "You can also run the example above without logging in if you provide the Kafka REST proxy endpoint with the `--url` flag.",
-				Code: "confluent kafka acl create --url http://localhost:8082 --allow --principal User:Jane --operation READ --operation DESCRIBE --consumer-group java_example_group_1",
+				Code: "confluent kafka acl create --url http://localhost:8082 --allow --principal User:Jane --operation read --operation describe --consumer-group java_example_group_1",
 			},
 			examples.Example{
-				Code: `confluent kafka acl create --url http://localhost:8082 --allow --principal User:Jane --operation READ --operation DESCRIBE --topic "*"`,
+				Code: `confluent kafka acl create --url http://localhost:8082 --allow --principal User:Jane --operation read --operation describe --topic "*"`,
 			},			
 		),
 	}

--- a/internal/cmd/kafka/command_acl_delete_onprem.go
+++ b/internal/cmd/kafka/command_acl_delete_onprem.go
@@ -19,16 +19,16 @@ func (c *aclCommand) newDeleteCommandOnPrem() *cobra.Command {
 		RunE:  c.deleteOnPrem,
 		Example: examples.BuildExampleString(
 			examples.Example{
-				Text: "Delete all READ access ACLs for the specified user (providing embedded Kafka REST Proxy endpoint).",
-				Code: `confluent kafka acl delete --url http://localhost:8090/kafka --operation READ --allow --topic Test --principal User:Jane --host "*"`,
+				Text: `Delete all "read" access ACLs for the specified user (providing embedded Kafka REST Proxy endpoint).`,
+				Code: `confluent kafka acl delete --url http://localhost:8090/kafka --operation read --allow --topic Test --principal User:Jane --host "*"`,
 			},
 			examples.Example{
-				Text: "Delete all READ access ACLs for the specified user (providing Kafka REST Proxy endpoint).",
-				Code: `confluent kafka acl delete --url http://localhost:8082 --operation READ --allow --topic Test --principal User:Jane --host "*"`,
+				Text: `Delete all "read" access ACLs for the specified user (providing Kafka REST Proxy endpoint).`,
+				Code: `confluent kafka acl delete --url http://localhost:8082 --operation read --allow --topic Test --principal User:Jane --host "*"`,
 			},
 			examples.Example{
-				Text: "Delete all READ access ACLs for the specified user.",
-				Code: `confluent kafka acl delete --operation READ --allow --topic Test --principal User:Jane --host "*"`,
+				Text: `Delete all "read" access ACLs for the specified user.`,
+				Code: `confluent kafka acl delete --operation read --allow --topic Test --principal User:Jane --host "*"`,
 			},
 		),
 	}

--- a/internal/pkg/acl/acl.go
+++ b/internal/pkg/acl/acl.go
@@ -187,9 +187,9 @@ func setAclRequestResourcePattern(conf *AclRequestDataWithError, n, v string) {
 }
 
 func convertToFlags(operations ...any) string {
-	var ops []string
+	ops := make([]string, len(operations))
 
-	for _, v := range operations {
+	for i, v := range operations {
 		// clean the resources that don't map directly to flag name
 		if v == cpkafkarestv3.ACLRESOURCETYPE_GROUP {
 			v = "consumer-group"
@@ -198,7 +198,7 @@ func convertToFlags(operations ...any) string {
 			v = "cluster-scope"
 		}
 		s := strings.ToLower(strings.ReplaceAll(fmt.Sprint(v), "_", "-"))
-		ops = append(ops, fmt.Sprintf("`--%s`", s))
+		ops[i] = fmt.Sprintf("`--%s`", s)
 	}
 
 	sort.Strings(ops)
@@ -208,13 +208,12 @@ func convertToFlags(operations ...any) string {
 func ConvertToLower(operations ...any) string {
 	ops := make([]string, len(operations))
 
-	for _, v := range operations {
-		s := strings.ToLower(strings.ReplaceAll(fmt.Sprint(v), "_", "-"))
-		ops = append(ops, s)
+	for i, v := range operations {
+		ops[i] = strings.ReplaceAll(fmt.Sprint(v), "_", "-")
 	}
 
 	sort.Strings(ops)
-	return strings.Join(ops, ", ")
+	return strings.ToLower(strings.Join(ops, ", "))
 }
 
 func ValidateCreateDeleteAclRequestData(aclConfiguration *AclRequestDataWithError) *AclRequestDataWithError {

--- a/internal/pkg/acl/acl.go
+++ b/internal/pkg/acl/acl.go
@@ -206,7 +206,7 @@ func convertToFlags(operations ...any) string {
 }
 
 func ConvertToLower(operations ...any) string {
-	var ops []string
+	ops := make([]string, len(operations))
 
 	for _, v := range operations {
 		s := strings.ToLower(strings.ReplaceAll(fmt.Sprint(v), "_", "-"))

--- a/internal/pkg/acl/acl.go
+++ b/internal/pkg/acl/acl.go
@@ -205,6 +205,18 @@ func convertToFlags(operations ...any) string {
 	return strings.Join(ops, ", ")
 }
 
+func ConvertToLower(operations ...any) string {
+	var ops []string
+
+	for _, v := range operations {
+		s := strings.ToLower(strings.ReplaceAll(fmt.Sprint(v), "_", "-"))
+		ops = append(ops, s)
+	}
+
+	sort.Strings(ops)
+	return strings.Join(ops, ", ")
+}
+
 func ValidateCreateDeleteAclRequestData(aclConfiguration *AclRequestDataWithError) *AclRequestDataWithError {
 	// delete is deliberately less powerful in the cli than in the API to prevent accidental
 	// deletion of too many acls at once. Expectation is that multi delete will be done via

--- a/internal/pkg/acl/acl.go
+++ b/internal/pkg/acl/acl.go
@@ -24,11 +24,19 @@ import (
 
 var listFields = []string{"Principal", "Permission", "Operation", "ResourceType", "ResourceName", "PatternType"}
 
-var AclOperations = []mds.AclOperation{mds.ACLOPERATION_ALL, mds.ACLOPERATION_ALTER, mds.ACLOPERATION_ALTER_CONFIGS,
-	mds.ACLOPERATION_CLUSTER_ACTION, mds.ACLOPERATION_CREATE, mds.ACLOPERATION_DELETE,
-	mds.ACLOPERATION_DESCRIBE, mds.ACLOPERATION_DESCRIBE_CONFIGS,
-	mds.ACLOPERATION_IDEMPOTENT_WRITE, mds.ACLOPERATION_READ,
-	mds.ACLOPERATION_WRITE}
+var AclOperations = []mds.AclOperation{
+	mds.ACLOPERATION_ALL,
+	mds.ACLOPERATION_ALTER,
+	mds.ACLOPERATION_ALTER_CONFIGS,
+	mds.ACLOPERATION_CLUSTER_ACTION,
+	mds.ACLOPERATION_CREATE,
+	mds.ACLOPERATION_DELETE,
+	mds.ACLOPERATION_DESCRIBE,
+	mds.ACLOPERATION_DESCRIBE_CONFIGS,
+	mds.ACLOPERATION_IDEMPOTENT_WRITE,
+	mds.ACLOPERATION_READ,
+	mds.ACLOPERATION_WRITE,
+}
 
 type out struct {
 	Principal    string `human:"Principal" serialized:"principal"`

--- a/internal/pkg/acl/acl.go
+++ b/internal/pkg/acl/acl.go
@@ -79,7 +79,7 @@ func PrintACLs(cmd *cobra.Command, acls []*ccstructs.ACLBinding) error {
 func AclFlags() *pflag.FlagSet {
 	flgSet := pflag.NewFlagSet("acl-config", pflag.ExitOnError)
 	flgSet.String("principal", "", "Principal for this operation with User: or Group: prefix.")
-	flgSet.String("operation", "", fmt.Sprintf("Set ACL Operation to: (%s).", convertToFlags("ALL", "READ", "WRITE", "CREATE", "DELETE", "ALTER", "DESCRIBE", "CLUSTER_ACTION", "DESCRIBE_CONFIGS", "ALTER_CONFIGS", "IDEMPOTENT_WRITE")))
+	flgSet.String("operation", "", fmt.Sprintf("Set ACL Operation to: (%s).", ConvertToLower("ALL", "READ", "WRITE", "CREATE", "DELETE", "ALTER", "DESCRIBE", "CLUSTER_ACTION", "DESCRIBE_CONFIGS", "ALTER_CONFIGS", "IDEMPOTENT_WRITE")))
 	flgSet.String("host", "*", "Set host for access. Only IP addresses are supported.")
 	flgSet.Bool("allow", false, "ACL permission to allow access.")
 	flgSet.Bool("deny", false, "ACL permission to restrict access to resource.")

--- a/internal/pkg/acl/acl.go
+++ b/internal/pkg/acl/acl.go
@@ -13,6 +13,7 @@ import (
 
 	cckafkarestv3 "github.com/confluentinc/ccloud-sdk-go-v2/kafkarest/v3"
 	cpkafkarestv3 "github.com/confluentinc/kafka-rest-sdk-go/kafkarestv3"
+	mds "github.com/confluentinc/mds-sdk-go-public/mdsv1"
 
 	"github.com/confluentinc/cli/internal/pkg/ccstructs"
 	"github.com/confluentinc/cli/internal/pkg/errors"
@@ -22,6 +23,12 @@ import (
 )
 
 var listFields = []string{"Principal", "Permission", "Operation", "ResourceType", "ResourceName", "PatternType"}
+
+var AclOperations = []mds.AclOperation{mds.ACLOPERATION_ALL, mds.ACLOPERATION_ALTER, mds.ACLOPERATION_ALTER_CONFIGS,
+	mds.ACLOPERATION_CLUSTER_ACTION, mds.ACLOPERATION_CREATE, mds.ACLOPERATION_DELETE,
+	mds.ACLOPERATION_DESCRIBE, mds.ACLOPERATION_DESCRIBE_CONFIGS,
+	mds.ACLOPERATION_IDEMPOTENT_WRITE, mds.ACLOPERATION_READ,
+	mds.ACLOPERATION_WRITE}
 
 type out struct {
 	Principal    string `human:"Principal" serialized:"principal"`
@@ -79,7 +86,7 @@ func PrintACLs(cmd *cobra.Command, acls []*ccstructs.ACLBinding) error {
 func AclFlags() *pflag.FlagSet {
 	flgSet := pflag.NewFlagSet("acl-config", pflag.ExitOnError)
 	flgSet.String("principal", "", "Principal for this operation with User: or Group: prefix.")
-	flgSet.String("operation", "", fmt.Sprintf("Set ACL Operation to: (%s).", ConvertToLower("ALL", "ALTER", "ALTER_CONFIGS", "CLUSTER_ACTION", "CREATE", "DELETE", "DESCRIBE", "DESCRIBE_CONFIGS", "IDEMPOTENT_WRITE", "READ", "WRITE")))
+	flgSet.String("operation", "", fmt.Sprintf("Set ACL Operation to: (%s).", ConvertToLower(AclOperations)))
 	flgSet.String("host", "*", "Set host for access. Only IP addresses are supported.")
 	flgSet.Bool("allow", false, "ACL permission to allow access.")
 	flgSet.Bool("deny", false, "ACL permission to restrict access to resource.")
@@ -205,7 +212,7 @@ func convertToFlags(operations ...any) string {
 	return strings.Join(ops, ", ")
 }
 
-func ConvertToLower(operations ...any) string {
+func ConvertToLower[T any](operations []T) string {
 	ops := make([]string, len(operations))
 
 	for i, v := range operations {

--- a/internal/pkg/acl/acl.go
+++ b/internal/pkg/acl/acl.go
@@ -79,7 +79,7 @@ func PrintACLs(cmd *cobra.Command, acls []*ccstructs.ACLBinding) error {
 func AclFlags() *pflag.FlagSet {
 	flgSet := pflag.NewFlagSet("acl-config", pflag.ExitOnError)
 	flgSet.String("principal", "", "Principal for this operation with User: or Group: prefix.")
-	flgSet.String("operation", "", fmt.Sprintf("Set ACL Operation to: (%s).", ConvertToLower("ALL", "READ", "WRITE", "CREATE", "DELETE", "ALTER", "DESCRIBE", "CLUSTER_ACTION", "DESCRIBE_CONFIGS", "ALTER_CONFIGS", "IDEMPOTENT_WRITE")))
+	flgSet.String("operation", "", fmt.Sprintf("Set ACL Operation to: (%s).", ConvertToLower("ALL", "ALTER", "ALTER_CONFIGS", "CLUSTER_ACTION", "CREATE", "DELETE", "DESCRIBE", "DESCRIBE_CONFIGS", "IDEMPOTENT_WRITE", "READ", "WRITE")))
 	flgSet.String("host", "*", "Set host for access. Only IP addresses are supported.")
 	flgSet.Bool("allow", false, "ACL permission to allow access.")
 	flgSet.Bool("deny", false, "ACL permission to restrict access to resource.")
@@ -212,7 +212,6 @@ func ConvertToLower(operations ...any) string {
 		ops[i] = strings.ReplaceAll(fmt.Sprint(v), "_", "-")
 	}
 
-	sort.Strings(ops)
 	return strings.ToLower(strings.Join(ops, ", "))
 }
 

--- a/internal/pkg/acl/acl_test.go
+++ b/internal/pkg/acl/acl_test.go
@@ -20,7 +20,7 @@ func TestParseAclRequest(t *testing.T) {
 		expectedAcl AclRequestDataWithError
 	}{
 		{
-			args: []string{"--operation", "READ", "--principal", "User:Alice", "--cluster-scope", "--host", "127.0.0.1", "--allow"},
+			args: []string{"--operation", "read", "--principal", "User:Alice", "--cluster-scope", "--host", "127.0.0.1", "--allow"},
 			expectedAcl: AclRequestDataWithError{
 				ResourceType: kafkarestv3.ACLRESOURCETYPE_CLUSTER,
 				ResourceName: "kafka-cluster",
@@ -54,7 +54,7 @@ func TestParseAclRequest(t *testing.T) {
 			},
 		},
 		{
-			args: []string{"--operation", "READ", "--principal", "User:Alice", "--transactional-id", "123", "--allow", "--deny"},
+			args: []string{"--operation", "read", "--principal", "User:Alice", "--transactional-id", "123", "--allow", "--deny"},
 			expectedAcl: AclRequestDataWithError{
 				Errors: multierror.Append(errors.Errorf(errMsgs.OnlySetAllowOrDenyErrorMsg)),
 			},

--- a/test/fixtures/output/iam/acl/create-help.golden
+++ b/test/fixtures/output/iam/acl/create-help.golden
@@ -4,17 +4,17 @@ Usage:
   confluent iam acl create [flags]
 
 Examples:
-Create an ACL that grants the specified user READ permission to the specified consumer group in the specified Kafka cluster:
+Create an ACL that grants the specified user "read" permission to the specified consumer group in the specified Kafka cluster:
 
-  $ confluent iam acl create --allow --principal User:User1 --operation READ --consumer-group java_example_group_1 --kafka-cluster <kafka-cluster-id>
+  $ confluent iam acl create --allow --principal User:User1 --operation read --consumer-group java_example_group_1 --kafka-cluster <kafka-cluster-id>
 
-Create an ACL that grants the specified user WRITE permission on all topics in the specified Kafka cluster:
+Create an ACL that grants the specified user "write" permission on all topics in the specified Kafka cluster:
 
-  $ confluent iam acl create --allow --principal User:User1 --operation WRITE --topic '*' --kafka-cluster <kafka-cluster-id>
+  $ confluent iam acl create --allow --principal User:User1 --operation write --topic '*' --kafka-cluster <kafka-cluster-id>
 
-Create an ACL that assigns a group READ access to all topics that use the specified prefix in the specified Kafka cluster:
+Create an ACL that assigns a group "read" access to all topics that use the specified prefix in the specified Kafka cluster:
 
-  $ confluent iam acl create --allow --principal Group:Finance --operation READ --topic financial --prefix --kafka-cluster <kafka-cluster-id>
+  $ confluent iam acl create --allow --principal Group:Finance --operation read --topic financial --prefix --kafka-cluster <kafka-cluster-id>
 
 Flags:
       --kafka-cluster string      REQUIRED: Kafka cluster ID for scope of ACL commands.

--- a/test/fixtures/output/iam/acl/list-help.golden
+++ b/test/fixtures/output/iam/acl/list-help.golden
@@ -8,7 +8,7 @@ List all the ACLs for the specified Kafka cluster:
 
   $ confluent iam acl list --kafka-cluster <kafka-cluster-id>
 
-List all the ACLs for the specified cluster that include allow permissions for the user Jane:
+List all the ACLs for the specified cluster that include "allow" permissions for the user Jane:
 
   $ confluent iam acl list --kafka-cluster <kafka-cluster-id> --allow --principal User:Jane
 

--- a/test/fixtures/output/iam/rbac/role-binding/list-failure-help-cloud.golden
+++ b/test/fixtures/output/iam/rbac/role-binding/list-failure-help-cloud.golden
@@ -3,7 +3,7 @@ Usage:
   confluent iam rbac role-binding list [flags]
 
 Examples:
-List the role bindings for current user:
+List the role bindings for the current user:
 
   $ confluent iam rbac role-binding list --current-user
 
@@ -18,6 +18,14 @@ List the role bindings for principals with role "CloudClusterAdmin":
 List the role bindings for user "u-123456" with role "CloudClusterAdmin":
 
   $ confluent iam rbac role-binding list --principal User:u-123456 --role CloudClusterAdmin --environment env-12345 --cloud-cluster lkc-123456
+
+List the role bindings for user "u-123456" for all scopes:
+
+  $ confluent iam rbac role-binding list --principal User:u-123456 --inclusive
+
+List the role bindings for the current user at the environment scope and its nested scopes:
+
+  $ confluent iam rbac role-binding list --current-user --environment env-12345 --inclusive
 
 Flags:
       --principal string                 Principal whose role bindings should be listed.

--- a/test/fixtures/output/iam/rbac/role-binding/list-help-cloud.golden
+++ b/test/fixtures/output/iam/rbac/role-binding/list-help-cloud.golden
@@ -4,7 +4,7 @@ Usage:
   confluent iam rbac role-binding list [flags]
 
 Examples:
-List the role bindings for current user:
+List the role bindings for the current user:
 
   $ confluent iam rbac role-binding list --current-user
 
@@ -19,6 +19,14 @@ List the role bindings for principals with role "CloudClusterAdmin":
 List the role bindings for user "u-123456" with role "CloudClusterAdmin":
 
   $ confluent iam rbac role-binding list --principal User:u-123456 --role CloudClusterAdmin --environment env-12345 --cloud-cluster lkc-123456
+
+List the role bindings for user "u-123456" for all scopes:
+
+  $ confluent iam rbac role-binding list --principal User:u-123456 --inclusive
+
+List the role bindings for the current user at the environment scope and its nested scopes:
+
+  $ confluent iam rbac role-binding list --current-user --environment env-12345 --inclusive
 
 Flags:
       --principal string                 Principal whose role bindings should be listed.

--- a/test/fixtures/output/kafka/acl/create-help.golden
+++ b/test/fixtures/output/kafka/acl/create-help.golden
@@ -1,0 +1,32 @@
+Create a Kafka ACL.
+
+Usage:
+  confluent kafka acl create [flags]
+
+Examples:
+You can specify only one of the following flags per command invocation: `--cluster-scope`, `--consumer-group`, `--topic`, or `--transactional-id`. For example, for a consumer to read a topic, you need to grant "read" and "describe" both on the `--consumer-group` and the `--topic` resources, issuing two separate commands:
+
+  $ confluent kafka acl create --allow --service-account sa-55555 --operations read,describe --consumer-group java_example_group_1
+
+  $ confluent kafka acl create --allow --service-account sa-55555 --operations read,describe --topic "*"
+
+Flags:
+      --operations strings        REQUIRED: A comma-separated list of ACL operations: (alter, alter-configs, cluster-action, create, delete, describe, describe-configs, idempotent-write, read, write).
+      --principal string          Principal for this operation, prefixed with "User:".
+      --service-account string    The service account ID.
+      --allow                     Access to the resource is allowed.
+      --deny                      Access to the resource is denied.
+      --cluster-scope             Modify ACLs for the cluster.
+      --topic string              Modify ACLs for the specified topic resource.
+      --consumer-group string     Modify ACLs for the specified consumer group resource.
+      --transactional-id string   Modify ACLs for the specified TransactionalID resource.
+      --prefix                    When this flag is set, the specified resource name is interpreted as a prefix.
+      --cluster string            Kafka cluster ID.
+      --context string            CLI context name.
+      --environment string        Environment ID.
+  -o, --output string             Specify the output format as "human", "json", or "yaml". (default "human")
+
+Global Flags:
+  -h, --help            Show help for this command.
+      --unsafe-trace    Equivalent to -vvvv, but also log HTTP requests and responses which may contain plaintext secrets.
+  -v, --verbose count   Increase verbosity (-v for warn, -vv for info, -vvv for debug, -vvvv for trace).

--- a/test/fixtures/output/kafka/acl/onprem-create-help.golden
+++ b/test/fixtures/output/kafka/acl/onprem-create-help.golden
@@ -1,0 +1,48 @@
+Create a Kafka ACL.
+
+Usage:
+  confluent kafka acl create [flags]
+
+Examples:
+You can specify only one of the following flags per command invocation: `--cluster-scope`, `--consumer-group`, `--topic`, or `--transactional-id`. For example, for a consumer to read a topic, you need to grant "read" and "describe" both on the `--consumer-group` and the `--topic` resources, issuing two separate commands:
+
+  $ confluent kafka acl create --allow --principal User:Jane --operation read --operation describe --consumer-group java_example_group_1
+
+  $ confluent kafka acl create --allow --principal User:Jane --operation read --operation describe --topic "*"
+
+You can run the previous example without logging in if you provide the embedded Kafka REST Proxy endpoint with the `--url` flag.
+
+  $ confluent kafka acl create --url http://localhost:8090/kafka --allow --principal User:Jane --operation read --operation describe --consumer-group java_example_group_1
+
+  $ confluent kafka acl create --url http://localhost:8090/kafka --allow --principal User:Jane --operation read --operation describe --topic "*"
+
+You can also run the example above without logging in if you provide the Kafka REST proxy endpoint with the `--url` flag.
+
+  $ confluent kafka acl create --url http://localhost:8082 --allow --principal User:Jane --operation read --operation describe --consumer-group java_example_group_1
+
+  $ confluent kafka acl create --url http://localhost:8082 --allow --principal User:Jane --operation read --operation describe --topic "*"
+
+Flags:
+      --principal string          REQUIRED: Principal for this operation with User: or Group: prefix.
+      --operation string          REQUIRED: Set ACL Operation to: (all, alter, alter-configs, cluster-action, create, delete, describe, describe-configs, idempotent-write, read, write).
+      --host string               Set host for access. Only IP addresses are supported. (default "*")
+      --allow                     ACL permission to allow access.
+      --deny                      ACL permission to restrict access to resource.
+      --cluster-scope             Set the cluster resource. With this option the ACL grants access to the provided operations on the Kafka cluster itself.
+      --consumer-group string     Set the Consumer Group resource.
+      --transactional-id string   Set the TransactionalID resource.
+      --topic string              Set the topic resource. With this option the ACL grants the provided operations on the topics that start with that prefix, depending on whether the --prefix option was also passed.
+      --prefix                    Set to match all resource names prefixed with this value.
+      --url string                Base URL of REST Proxy Endpoint of Kafka Cluster (include /kafka for embedded Rest Proxy). Must set flag or CONFLUENT_REST_URL.
+      --ca-cert-path string       Path to a PEM-encoded CA to verify the Confluent REST Proxy.
+      --client-cert-path string   Path to client cert to be verified by Confluent REST Proxy, include for mTLS authentication.
+      --client-key-path string    Path to client private key, include for mTLS authentication.
+      --no-authentication         Include if requests should be made without authentication headers, and user will not be prompted for credentials.
+      --prompt                    Bypass use of available login credentials and prompt for Kafka Rest credentials.
+      --context string            CLI context name.
+  -o, --output string             Specify the output format as "human", "json", or "yaml". (default "human")
+
+Global Flags:
+  -h, --help            Show help for this command.
+      --unsafe-trace    Equivalent to -vvvv, but also log HTTP requests and responses which may contain plaintext secrets.
+  -v, --verbose count   Increase verbosity (-v for warn, -vv for info, -vvv for debug, -vvvv for trace).

--- a/test/fixtures/output/kafka/acl/onprem-list-help.golden
+++ b/test/fixtures/output/kafka/acl/onprem-list-help.golden
@@ -1,0 +1,42 @@
+List Kafka ACLs.
+
+Usage:
+  confluent kafka acl list [flags]
+
+Examples:
+List all the local ACLs for the Kafka cluster (providing embedded Kafka REST Proxy endpoint).
+
+  $ confluent kafka acl list --url http://localhost:8090/kafka
+
+List all the local ACLs for the Kafka cluster (providing Kafka REST Proxy endpoint).
+
+  $ confluent kafka acl list --url http://localhost:8082
+
+List all the ACLs for the Kafka cluster that include allow permissions for the user "Jane":
+
+  $ confluent kafka acl list --allow --principal User:Jane
+
+Flags:
+      --url string                Base URL of REST Proxy Endpoint of Kafka Cluster (include /kafka for embedded Rest Proxy). Must set flag or CONFLUENT_REST_URL.
+      --ca-cert-path string       Path to a PEM-encoded CA to verify the Confluent REST Proxy.
+      --client-cert-path string   Path to client cert to be verified by Confluent REST Proxy, include for mTLS authentication.
+      --client-key-path string    Path to client private key, include for mTLS authentication.
+      --no-authentication         Include if requests should be made without authentication headers, and user will not be prompted for credentials.
+      --prompt                    Bypass use of available login credentials and prompt for Kafka Rest credentials.
+      --principal string          Principal for this operation with User: or Group: prefix.
+      --operation string          Set ACL Operation to: (all, alter, alter-configs, cluster-action, create, delete, describe, describe-configs, idempotent-write, read, write).
+      --host string               Set host for access. Only IP addresses are supported. (default "*")
+      --allow                     ACL permission to allow access.
+      --deny                      ACL permission to restrict access to resource.
+      --cluster-scope             Set the cluster resource. With this option the ACL grants access to the provided operations on the Kafka cluster itself.
+      --consumer-group string     Set the Consumer Group resource.
+      --transactional-id string   Set the TransactionalID resource.
+      --topic string              Set the topic resource. With this option the ACL grants the provided operations on the topics that start with that prefix, depending on whether the --prefix option was also passed.
+      --prefix                    Set to match all resource names prefixed with this value.
+      --context string            CLI context name.
+  -o, --output string             Specify the output format as "human", "json", or "yaml". (default "human")
+
+Global Flags:
+  -h, --help            Show help for this command.
+      --unsafe-trace    Equivalent to -vvvv, but also log HTTP requests and responses which may contain plaintext secrets.
+  -v, --verbose count   Increase verbosity (-v for warn, -vv for info, -vvv for debug, -vvvv for trace).

--- a/test/kafka_test.go
+++ b/test/kafka_test.go
@@ -157,6 +157,18 @@ func (s *CLITestSuite) TestKafka() {
 		tt.workflow = true
 		s.runIntegrationTest(tt)
 	}
+
+	tests = []CLITest{
+		{args: "kafka acl create -h", fixture: "kafka/acl/onprem-create-help.golden"},
+		{args: "kafka acl list -h", fixture: "kafka/acl/onprem-list-help.golden"},
+	}
+
+	resetConfiguration(s.T(), false)
+
+	for _, tt := range tests {
+		tt.login = "platform"
+		s.runIntegrationTest(tt)
+	}
 }
 
 func (s *CLITestSuite) TestKafkaClusterCreate_GcpByok() {

--- a/test/kafka_test.go
+++ b/test/kafka_test.go
@@ -87,15 +87,16 @@ func (s *CLITestSuite) TestKafka() {
 		{args: "kafka acl list --cluster lkc-acls -o json", fixture: "kafka/acl/list-json-cloud.golden"},
 		{args: "kafka acl list --cluster lkc-acls -o yaml", fixture: "kafka/acl/list-yaml-cloud.golden"},
 		{args: "kafka acl list --principal User:12345", fixture: "kafka/acl/err-numeric-id.golden", wantErrCode: 1},
-		{args: "kafka acl create --cluster lkc-acls --allow --service-account 7272 --operations READ,DESCRIBED --topic test-topic", fixture: "kafka/acl/invalid-operation.golden", wantErrCode: 1},
-		{args: "kafka acl create --cluster lkc-acls --allow --service-account sa-12345 --operations READ,DESCRIBE --topic test-topic", fixture: "kafka/acl/create-service-account.golden"},
-		{args: "kafka acl create --cluster lkc-acls --allow --principal User:sa-12345 --operations WRITE,ALTER --topic test-topic", fixture: "kafka/acl/create-principal.golden"},
-		{args: "kafka acl create --cluster lkc-acls --allow --service-account sa-54321 --operations READ,DESCRIBE --topic test-topic", fixture: "kafka/acl/invalid-service-account.golden", wantErrCode: 1},
-		{args: "kafka acl create --principal User:12345 --operations WRITE", fixture: "kafka/acl/err-numeric-id.golden", wantErrCode: 1},
-		{args: "kafka acl delete --cluster lkc-acls --allow --service-account sa-12345 --operations READ,DESCRIBE --topic test-topic --force", fixture: "kafka/acl/delete-cloud.golden"},
-		{args: "kafka acl delete --cluster lkc-acls --allow --service-account sa-12345 --operations READ,DESCRIBE --topic test-topic", preCmdFuncs: []bincover.PreCmdFunc{stdinPipeFunc(strings.NewReader("y\n"))}, fixture: "kafka/acl/delete-cloud-prompt.golden"},
-		{args: "kafka acl delete --cluster lkc-acls --allow --principal User:sa-12345 --operations WRITE,ALTER --topic test-topic --force", fixture: "kafka/acl/delete-cloud.golden"},
-		{args: "kafka acl delete --principal User:12345 --operations WRITE", fixture: "kafka/acl/err-numeric-id.golden", wantErrCode: 1},
+		{args: "kafka acl create -h", fixture: "kafka/acl/create-help.golden"},
+		{args: "kafka acl create --cluster lkc-acls --allow --service-account 7272 --operations read,described --topic test-topic", fixture: "kafka/acl/invalid-operation.golden", wantErrCode: 1},
+		{args: "kafka acl create --cluster lkc-acls --allow --service-account sa-12345 --operations read,describe --topic test-topic", fixture: "kafka/acl/create-service-account.golden"},
+		{args: "kafka acl create --cluster lkc-acls --allow --principal User:sa-12345 --operations write,alter --topic test-topic", fixture: "kafka/acl/create-principal.golden"},
+		{args: "kafka acl create --cluster lkc-acls --allow --service-account sa-54321 --operations read,describe --topic test-topic", fixture: "kafka/acl/invalid-service-account.golden", wantErrCode: 1},
+		{args: "kafka acl create --principal User:12345 --operations write", fixture: "kafka/acl/err-numeric-id.golden", wantErrCode: 1},
+		{args: "kafka acl delete --cluster lkc-acls --allow --service-account sa-12345 --operations read,describe --topic test-topic --force", fixture: "kafka/acl/delete-cloud.golden"},
+		{args: "kafka acl delete --cluster lkc-acls --allow --service-account sa-12345 --operations read,describe --topic test-topic", preCmdFuncs: []bincover.PreCmdFunc{stdinPipeFunc(strings.NewReader("y\n"))}, fixture: "kafka/acl/delete-cloud-prompt.golden"},
+		{args: "kafka acl delete --cluster lkc-acls --allow --principal User:sa-12345 --operations write,alter --topic test-topic --force", fixture: "kafka/acl/delete-cloud.golden"},
+		{args: "kafka acl delete --principal User:12345 --operations write", fixture: "kafka/acl/err-numeric-id.golden", wantErrCode: 1},
 
 		{args: "kafka topic list --cluster lkc-kafka-api-topics", login: "cloud", fixture: "kafka/topic/list-cloud.golden"},
 		{args: "kafka topic list --cluster lkc-topics", fixture: "kafka/topic/list-cloud.golden"},
@@ -483,10 +484,10 @@ func (s *CLITestSuite) TestKafkaAcl() {
 		// error case: bad operation, specified more than one resource type, allow/deny not set
 		{args: fmt.Sprintf("kafka acl delete --principal User:Alice --host '*' --operation fake --topic Test --consumer-group Group:Test --url %s --no-authentication", kafkaRestURL), name: "bad operation, conflicting resource type, no allow/deny specified errors", fixture: "kafka/acl/delete-errors.golden", wantErrCode: 1},
 		// success cases
-		{args: fmt.Sprintf("kafka acl delete --cluster-scope --principal User:Alice --host '*' --operation READ --principal User:Alice --allow --url %s --no-authentication --force", kafkaRestURL), name: "acl delete output human", fixture: "kafka/acl/delete.golden"},
-		{args: fmt.Sprintf("kafka acl delete --cluster-scope --principal User:Alice --host '*' --operation READ --principal User:Alice --allow --url %s --no-authentication", kafkaRestURL), preCmdFuncs: []bincover.PreCmdFunc{stdinPipeFunc(strings.NewReader("y\n"))}, name: "acl delete output human", fixture: "kafka/acl/delete-prompt.golden"},
-		{args: fmt.Sprintf("kafka acl delete --cluster-scope --principal User:Alice --host '*' --operation READ --principal User:Alice --allow -o json --url %s --no-authentication --force", kafkaRestURL), name: "acl delete output json", fixture: "kafka/acl/delete-json.golden"},
-		{args: fmt.Sprintf("kafka acl delete --cluster-scope --principal User:Alice --host '*' --operation READ --principal User:Alice --allow -o yaml --url %s --no-authentication --force", kafkaRestURL), name: "acl delete output yaml", fixture: "kafka/acl/delete-yaml.golden"},
+		{args: fmt.Sprintf("kafka acl delete --cluster-scope --principal User:Alice --host '*' --operation read --principal User:Alice --allow --url %s --no-authentication --force", kafkaRestURL), name: "acl delete output human", fixture: "kafka/acl/delete.golden"},
+		{args: fmt.Sprintf("kafka acl delete --cluster-scope --principal User:Alice --host '*' --operation read --principal User:Alice --allow --url %s --no-authentication", kafkaRestURL), preCmdFuncs: []bincover.PreCmdFunc{stdinPipeFunc(strings.NewReader("y\n"))}, name: "acl delete output human", fixture: "kafka/acl/delete-prompt.golden"},
+		{args: fmt.Sprintf("kafka acl delete --cluster-scope --principal User:Alice --host '*' --operation read --principal User:Alice --allow -o json --url %s --no-authentication --force", kafkaRestURL), name: "acl delete output json", fixture: "kafka/acl/delete-json.golden"},
+		{args: fmt.Sprintf("kafka acl delete --cluster-scope --principal User:Alice --host '*' --operation read --principal User:Alice --allow -o yaml --url %s --no-authentication --force", kafkaRestURL), name: "acl delete output yaml", fixture: "kafka/acl/delete-yaml.golden"},
 	}
 
 	for _, clitest := range tests {


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
Updates to examples and flag strings.
- operations like "read" and "describe" for ACL commands are now lowercase in the example strings and the `--help` output. This is not a breaking change; only the text has been updated and the code continues to accept lower or upper case.
- Added new examples to `confluent iam rbac role-binding list` to highlight the `--inclusive` flag.
- Added more integration tests for help text.

References
----------
n/a

Test & Review
-------------
Ran all tests

Open Questions / Follow-ups
---------------------------
Should we update the description of the `confluent iam rbac role-binding list` command to explain which combinations of flags correspond to which scopes? For example, the `--environment` and `--cloud-cluster` flags together will display role bindings at the Cloud Cluster scope.
