### PR TITLE
DOCS-22013: Fix variable syntax in examples

### DIFF
--- a/internal/cmd/kafka/command_acl_create.go
+++ b/internal/cmd/kafka/command_acl_create.go
@@ -21,10 +21,10 @@ func (c *aclCommand) newCreateCommand() *cobra.Command {
 		Example: examples.BuildExampleString(
 			examples.Example{
 				Text: "You can specify only one of the following flags per command invocation: `--cluster-scope`, `--consumer-group`, `--topic`, or `--transactional-id`. For example, for a consumer to read a topic, you need to grant \"READ\" and \"DESCRIBE\" both on the `--consumer-group` and the `--topic` resources, issuing two separate commands:",
-				Code: "confluent kafka acl create --allow --service-account sa-55555 --operations READ,DESCRIBE --consumer-group java_example_group_1",
+				Code: "confluent kafka acl create --allow --service-account sa-55555 --operation READ --operation DESCRIBE --consumer-group java_example_group_1",
 			},
 			examples.Example{
-				Code: `confluent kafka acl create --allow --service-account sa-55555 --operations READ,DESCRIBE --topic "*"`,
+				Code: `confluent kafka acl create --allow --service-account sa-55555 --operation READ --operation DESCRIBE --topic "*"`,
 			},
 		),
 	}


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok
   * no: DO NOT MERGE until the required features are live in prod  

What
----
- Fix typo: change "--operations" to "--operation" in examples

References
----------
- Jira: https://confluentinc.atlassian.net/browse/DOCS-22013

Test & Review
-------------
<!--
Has it been tested? How?
Copy and paste any instructions or steps that can save the reviewer time.
-->

Open Questions / Follow-ups
---------------------------
<!--
Optional: Anything open to discussion for the reviewer, out of scope of this PR, or follow-ups.
-->
