### PR TITLE
[RCCA-10729] Resolve display error when creating role bindings with service accounts

### DIFF
--- a/internal/cmd/iam/command_rbac_role_binding.go
+++ b/internal/cmd/iam/command_rbac_role_binding.go
@@ -395,11 +395,11 @@ func (c *roleBindingCommand) displayCCloudCreateAndDeleteOutput(cmd *cobra.Comma
 		if resource != "" {
 			fields = ccloudResourcePatternListFields
 		} else {
-			if user, err := c.V2Client.GetIamUserById(userResourceId); err != nil {
+			user, err := c.V2Client.GetIamUserById(userResourceId)
+			if err != nil {
 				return err
-			} else {
-				out.Email = user.GetEmail()
 			}
+			out.Email = user.GetEmail()
 			fields = []string{"Principal", "Email", "Role"}
 		}
 	}

--- a/internal/cmd/iam/command_rbac_role_binding.go
+++ b/internal/cmd/iam/command_rbac_role_binding.go
@@ -15,7 +15,7 @@ import (
 	v1 "github.com/confluentinc/cli/internal/pkg/config/v1"
 	"github.com/confluentinc/cli/internal/pkg/errors"
 	"github.com/confluentinc/cli/internal/pkg/output"
-	"github.com/confluentinc/cli/internal/pkg/resource"
+	presource "github.com/confluentinc/cli/internal/pkg/resource"
 )
 
 var (

--- a/internal/cmd/iam/command_rbac_role_binding.go
+++ b/internal/cmd/iam/command_rbac_role_binding.go
@@ -15,6 +15,7 @@ import (
 	v1 "github.com/confluentinc/cli/internal/pkg/config/v1"
 	"github.com/confluentinc/cli/internal/pkg/errors"
 	"github.com/confluentinc/cli/internal/pkg/output"
+	"github.com/confluentinc/cli/internal/pkg/resource"
 )
 
 var (
@@ -351,10 +352,7 @@ func (c *roleBindingCommand) validateResourceTypeV1(resourceType string) error {
 
 func (c *roleBindingCommand) displayCCloudCreateAndDeleteOutput(cmd *cobra.Command, roleBinding *mdsv2.IamV2RoleBinding) error {
 	userResourceId := strings.TrimPrefix(roleBinding.GetPrincipal(), "User:")
-	user, err := c.V2Client.GetIamUserById(userResourceId)
-	if err != nil {
-		return err
-	}
+
 	out := &roleBindingOut{
 		Principal: roleBinding.GetPrincipal(),
 		Role:      roleBinding.GetRoleName(),
@@ -363,12 +361,12 @@ func (c *roleBindingCommand) displayCCloudCreateAndDeleteOutput(cmd *cobra.Comma
 	// The err is ignored here since the --prefix flag is not defined by the list subcommand
 	prefix, _ := cmd.Flags().GetBool("prefix")
 
-	resource, err := cmd.Flags().GetString("resource")
+	res, err := cmd.Flags().GetString("resource")
 	if err != nil {
 		return err
 	}
-	if resource != "" {
-		parts := strings.SplitN(resource, ":", 2)
+	if res != "" {
+		parts := strings.SplitN(res, ":", 2)
 		if len(parts) != 2 {
 			return errors.NewErrorWithSuggestions(errors.ResourceFormatErrorMsg, errors.ResourceFormatSuggestions)
 		}
@@ -387,17 +385,21 @@ func (c *roleBindingCommand) displayCCloudCreateAndDeleteOutput(cmd *cobra.Comma
 	}
 
 	var fields []string
-	if err != nil {
-		if resource != "" {
+	if resource.LookupType(userResourceId) == resource.ServiceAccount {
+		if res != "" {
 			fields = resourcePatternListFields
 		} else {
 			fields = []string{"Principal", "Role"}
 		}
 	} else {
-		if resource != "" {
+		if res != "" {
 			fields = ccloudResourcePatternListFields
 		} else {
-			out.Email = user.GetEmail()
+			if user, err := c.V2Client.GetIamUserById(userResourceId); err != nil {
+				return err
+			} else {
+				out.Email = user.GetEmail()
+			}
 			fields = []string{"Principal", "Email", "Role"}
 		}
 	}

--- a/internal/cmd/iam/command_rbac_role_binding.go
+++ b/internal/cmd/iam/command_rbac_role_binding.go
@@ -361,12 +361,12 @@ func (c *roleBindingCommand) displayCCloudCreateAndDeleteOutput(cmd *cobra.Comma
 	// The err is ignored here since the --prefix flag is not defined by the list subcommand
 	prefix, _ := cmd.Flags().GetBool("prefix")
 
-	res, err := cmd.Flags().GetString("resource")
+	resource, err := cmd.Flags().GetString("resource")
 	if err != nil {
 		return err
 	}
-	if res != "" {
-		parts := strings.SplitN(res, ":", 2)
+	if resource != "" {
+		parts := strings.SplitN(resource, ":", 2)
 		if len(parts) != 2 {
 			return errors.NewErrorWithSuggestions(errors.ResourceFormatErrorMsg, errors.ResourceFormatSuggestions)
 		}
@@ -385,14 +385,14 @@ func (c *roleBindingCommand) displayCCloudCreateAndDeleteOutput(cmd *cobra.Comma
 	}
 
 	var fields []string
-	if resource.LookupType(userResourceId) == resource.ServiceAccount {
-		if res != "" {
+	if presource.LookupType(userResourceId) == presource.ServiceAccount {
+		if resource != "" {
 			fields = resourcePatternListFields
 		} else {
 			fields = []string{"Principal", "Role"}
 		}
 	} else {
-		if res != "" {
+		if resource != "" {
 			fields = ccloudResourcePatternListFields
 		} else {
 			if user, err := c.V2Client.GetIamUserById(userResourceId); err != nil {

--- a/test/fixtures/output/iam/rbac/role-binding/create-service-account-developer-read.golden
+++ b/test/fixtures/output/iam/rbac/role-binding/create-service-account-developer-read.golden
@@ -1,0 +1,7 @@
++---------------+---------------+
+| Principal     | User:sa-12345 |
+| Role          | DeveloperRead |
+| Resource Type | Topic         |
+| Name          | payroll       |
+| Pattern Type  | LITERAL       |
++---------------+---------------+

--- a/test/iam_test.go
+++ b/test/iam_test.go
@@ -57,6 +57,7 @@ func (s *CLITestSuite) TestIAMRBACRoleCloud() {
 func (s *CLITestSuite) TestIAMRBACRoleBindingCRUDCloud() {
 	tests := []CLITest{
 		{args: "iam rbac role-binding create --help", fixture: "iam/rbac/role-binding/create-help-cloud.golden"},
+		{args: "iam rbac role-binding create --principal User:sa-12345 --role DeveloperRead --resource Topic:payroll --kafka-cluster lkc-1111aaa --current-environment --cloud-cluster lkc-1111aaa", fixture: "iam/rbac/role-binding/create-service-account-developer-read.golden"},
 		{args: "iam rbac role-binding create --principal User:u-11aaa --role CloudClusterAdmin --current-environment --cloud-cluster lkc-1111aaa"},
 		{args: "iam rbac role-binding create --principal User:u-11aaa --role CloudClusterAdmin --environment a-595 --cloud-cluster lkc-1111aaa"},
 		{args: "iam rbac role-binding create --principal User:u-11aaa --role CloudClusterAdmin", fixture: "iam/rbac/role-binding/missing-cloud-cluster-cloud.golden", wantErrCode: 1},


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
The `displayCCloudCreateAndDeleteOutput` function makes a call to `V2Client.GetIamUserById` for both user id's and service account id's. Before v3, whether or not the error from this call was `nil` was used to determine whether to format the output for service accounts or users. In v3 this error was returned immediately, hence the issue.

I've replaced the check for `err != nil` with a check on the format of the id and moved the `V2Client.GetIamUserById` call so that it should only be called with an actual user id.

References
----------
n/a

Test & Review
-------------
Manual testing using commands of the following forms:
`confluent iam rbac rb create --principal User:sa-12345 --resource Topic:test --role DeveloperRead --kafka-cluster lkc-123abc --environment env-456def --cloud-cluster lkc-123abc`
`confluent iam rbac rb create --principal User:u-67890 --resource Topic:test --role DeveloperRead --kafka-cluster lkc-123abc --environment env-456def --cloud-cluster lkc-123abc`
I also compared with output from v2.38.0.

Added a new integration test with a service account principal, and ran all tests.

Open Questions / Follow-ups
---------------------------
<!--
Optional: Anything open to discussion for the reviewer, out of scope of this PR, or follow-ups.
-->
