### PR TITLE
Add sleep statement to update db script

### DIFF
--- a/mk-files/usage.mk
+++ b/mk-files/usage.mk
@@ -41,6 +41,7 @@ update-db:
 		IFS="," read env arn <<< "$$pair"; \
 		eval $$(gimme-aws-creds --output-format export --roles arn:aws:iam::$${arn}:role/administrator); \
 		cctunnel -e $$env -b cli -i read-write; \
+		sleep 3; \
 		make db-migrate-up; \
 		kill -9 $$(lsof -i 4:8432 | awk 'NR > 1 { print $$2 };'); \
 	done && \


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
cctunnel returns control to the user before it's actually done. Adding a sleep statement before the next command in this script to try and prevent the connection refused errors I keep getting when I do the releases.

3 seconds is probably longer than necessary, but seems alright for a first try.