### PR TITLE
Fix `kafka link list` panic

### DIFF
--- a/internal/cmd/kafka/command_link_list.go
+++ b/internal/cmd/kafka/command_link_list.go
@@ -82,8 +82,8 @@ func (c *linkCommand) list(cmd *cobra.Command, _ []string) error {
 
 	list := output.NewList(cmd)
 	for _, data := range listLinksRespDataList.Data {
-		if includeTopics && len(*data.TopicsNames) > 0 {
-			for _, topic := range *data.TopicsNames {
+		if includeTopics && len(data.GetTopicsNames()) > 0 {
+			for _, topic := range data.GetTopicsNames() {
 				list.Add(newLink(data, topic))
 			}
 		} else {


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
Avoid panic due to a `nil` pointer dereference.

References
----------
https://confluent.slack.com/archives/C010Y0EP5MZ/p1675803783662019