### PR TITLE
Performance improvements

### DIFF
--- a/internal/pkg/ccloudv2/cli.go
+++ b/internal/pkg/ccloudv2/cli.go
@@ -2,28 +2,32 @@ package ccloudv2
 
 import (
 	"context"
+	"net/http"
+	"time"
 
 	cliv1 "github.com/confluentinc/ccloud-sdk-go-v2/cli/v1"
 	"github.com/confluentinc/cli/internal/pkg/errors"
 )
 
 func newCliClient(url, userAgent string, unsafeTrace bool) *cliv1.APIClient {
-	// We do not use a retryable HTTP client so the CLI does not hang if there is a problem with the usage service.
-
 	cfg := cliv1.NewConfiguration()
 	cfg.Debug = unsafeTrace
 	cfg.Servers = cliv1.ServerConfigurations{{URL: url}}
 	cfg.UserAgent = userAgent
 
+	// We do not use a retryable HTTP client so the CLI does not hang if there is a problem with the usage service.
+	cfg.HTTPClient = http.DefaultClient
+	cfg.HTTPClient.Timeout = time.Second
+
 	return cliv1.NewAPIClient(cfg)
 }
 
-func (c *Client) cliApiContext(ctx context.Context) context.Context {
+func (c *Client) cliApiContext() context.Context {
 	return context.WithValue(context.Background(), cliv1.ContextAccessToken, c.AuthToken)
 }
 
-func (c *Client) CreateCliUsage(ctx context.Context, usage cliv1.CliV1Usage) error {
-	req := c.CliClient.UsagesCliV1Api.CreateCliV1Usage(c.cliApiContext(ctx)).CliV1Usage(usage)
+func (c *Client) CreateCliUsage(usage cliv1.CliV1Usage) error {
+	req := c.CliClient.UsagesCliV1Api.CreateCliV1Usage(c.cliApiContext()).CliV1Usage(usage)
 	r, err := c.CliClient.UsagesCliV1Api.CreateCliV1UsageExecute(req)
 	return errors.CatchCCloudV2Error(err, r)
 }

--- a/internal/pkg/ccloudv2/cli.go
+++ b/internal/pkg/ccloudv2/cli.go
@@ -18,12 +18,12 @@ func newCliClient(url, userAgent string, unsafeTrace bool) *cliv1.APIClient {
 	return cliv1.NewAPIClient(cfg)
 }
 
-func (c *Client) cliApiContext() context.Context {
+func (c *Client) cliApiContext(ctx context.Context) context.Context {
 	return context.WithValue(context.Background(), cliv1.ContextAccessToken, c.AuthToken)
 }
 
-func (c *Client) CreateCliUsage(usage cliv1.CliV1Usage) error {
-	req := c.CliClient.UsagesCliV1Api.CreateCliV1Usage(c.cliApiContext()).CliV1Usage(usage)
+func (c *Client) CreateCliUsage(ctx context.Context, usage cliv1.CliV1Usage) error {
+	req := c.CliClient.UsagesCliV1Api.CreateCliV1Usage(c.cliApiContext(ctx)).CliV1Usage(usage)
 	r, err := c.CliClient.UsagesCliV1Api.CreateCliV1UsageExecute(req)
 	return errors.CatchCCloudV2Error(err, r)
 }

--- a/internal/pkg/ccloudv2/cli.go
+++ b/internal/pkg/ccloudv2/cli.go
@@ -2,9 +2,9 @@ package ccloudv2
 
 import (
 	"context"
-	"net/http"
 
 	cliv1 "github.com/confluentinc/ccloud-sdk-go-v2/cli/v1"
+	"github.com/confluentinc/cli/internal/pkg/errors"
 )
 
 func newCliClient(url, userAgent string, unsafeTrace bool) *cliv1.APIClient {
@@ -22,7 +22,8 @@ func (c *Client) cliApiContext() context.Context {
 	return context.WithValue(context.Background(), cliv1.ContextAccessToken, c.AuthToken)
 }
 
-func (c *Client) CreateCliUsage(usage cliv1.CliV1Usage) (*http.Response, error) {
+func (c *Client) CreateCliUsage(usage cliv1.CliV1Usage) error {
 	req := c.CliClient.UsagesCliV1Api.CreateCliV1Usage(c.cliApiContext()).CliV1Usage(usage)
-	return c.CliClient.UsagesCliV1Api.CreateCliV1UsageExecute(req)
+	r, err := c.CliClient.UsagesCliV1Api.CreateCliV1UsageExecute(req)
+	return errors.CatchCCloudV2Error(err, r)
 }

--- a/internal/pkg/ccloudv2/cli.go
+++ b/internal/pkg/ccloudv2/cli.go
@@ -17,7 +17,7 @@ func newCliClient(url, userAgent string, unsafeTrace bool) *cliv1.APIClient {
 
 	// We do not use a retryable HTTP client so the CLI does not hang if there is a problem with the usage service.
 	cfg.HTTPClient = http.DefaultClient
-	cfg.HTTPClient.Timeout = time.Second
+	cfg.HTTPClient.Timeout = 5 * time.Second
 
 	return cliv1.NewAPIClient(cfg)
 }

--- a/internal/pkg/plugin/plugin.go
+++ b/internal/pkg/plugin/plugin.go
@@ -17,6 +17,8 @@ import (
 	pversion "github.com/confluentinc/cli/internal/pkg/version"
 )
 
+var pluginRegex = regexp.MustCompile(`^confluent(-[a-z][0-9_a-z]*)+$`)
+
 type pluginInfo struct {
 	args     []string
 	name     string
@@ -25,20 +27,23 @@ type pluginInfo struct {
 
 // SearchPath goes through the files in the user's $PATH and checks if they are plugins
 func SearchPath(cfg *v1.Config) map[string][]string {
-	log.CliLogger.Debugf("Recursively searching $PATH for plugins. Plugins can be disabled in %s.\n", cfg.GetFilename())
+	log.CliLogger.Debugf("Searching `$PATH` for plugins. Plugins can be disabled in %s.\n", cfg.GetFilename())
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		home = ""
+	}
 
 	plugins := make(map[string][]string)
 	for _, dir := range filepath.SplitList(os.Getenv("PATH")) {
 		entries, err := os.ReadDir(dir)
 		if err != nil {
-			log.CliLogger.Warnf("unable to read directory from $PATH: %s", dir)
+			log.CliLogger.Warnf("unable to read directory from `$PATH`: %s", dir)
 			continue
 		}
 
-		if home, err := os.UserHomeDir(); err == nil {
-			if strings.HasPrefix(dir, home) {
-				dir = filepath.Join("~", strings.TrimPrefix(dir, home))
-			}
+		if home != "" && strings.HasPrefix(dir, home) {
+			dir = filepath.Join("~", strings.TrimPrefix(dir, home))
 		}
 
 		for _, entry := range entries {
@@ -60,7 +65,7 @@ func pluginFromEntry(entry os.DirEntry) string {
 	name := entry.Name()
 	name = strings.TrimSuffix(name, filepath.Ext(name))
 
-	if !regexp.MustCompile(`^confluent(-[a-z][0-9_a-z]*)+$`).MatchString(name) {
+	if !pluginRegex.MatchString(name) {
 		return ""
 	}
 

--- a/internal/pkg/usage/usage.go
+++ b/internal/pkg/usage/usage.go
@@ -1,7 +1,9 @@
 package usage
 
 import (
+	"context"
 	"runtime"
+	"time"
 
 	cliv1 "github.com/confluentinc/ccloud-sdk-go-v2/cli/v1"
 	"github.com/spf13/cobra"
@@ -36,10 +38,10 @@ func (u *Usage) Collect(cmd *cobra.Command, _ []string) {
 
 // Report sends usage data to cc-cli-usage-service.
 func (u *Usage) Report(client *ccloudv2.Client) {
-	// ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-	// defer cancel()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Microsecond)
+	defer cancel()
 
-	if err := client.CreateCliUsage(cliv1.CliV1Usage(*u)); err != nil {
+	if err := client.CreateCliUsage(ctx, cliv1.CliV1Usage(*u)); err != nil {
 		log.CliLogger.Warnf("Failed to report CLI usage: %v", err)
 	}
 }

--- a/internal/pkg/usage/usage.go
+++ b/internal/pkg/usage/usage.go
@@ -1,9 +1,7 @@
 package usage
 
 import (
-	"context"
 	"runtime"
-	"time"
 
 	cliv1 "github.com/confluentinc/ccloud-sdk-go-v2/cli/v1"
 	"github.com/spf13/cobra"
@@ -38,10 +36,7 @@ func (u *Usage) Collect(cmd *cobra.Command, _ []string) {
 
 // Report sends usage data to cc-cli-usage-service.
 func (u *Usage) Report(client *ccloudv2.Client) {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Microsecond)
-	defer cancel()
-
-	if err := client.CreateCliUsage(ctx, cliv1.CliV1Usage(*u)); err != nil {
+	if err := client.CreateCliUsage(cliv1.CliV1Usage(*u)); err != nil {
 		log.CliLogger.Warnf("Failed to report CLI usage: %v", err)
 	}
 }

--- a/internal/pkg/usage/usage.go
+++ b/internal/pkg/usage/usage.go
@@ -36,7 +36,10 @@ func (u *Usage) Collect(cmd *cobra.Command, _ []string) {
 
 // Report sends usage data to cc-cli-usage-service.
 func (u *Usage) Report(client *ccloudv2.Client) {
-	if _, err := client.CreateCliUsage(cliv1.CliV1Usage(*u)); err != nil {
+	// ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	// defer cancel()
+
+	if err := client.CreateCliUsage(cliv1.CliV1Usage(*u)); err != nil {
 		log.CliLogger.Warnf("Failed to report CLI usage: %v", err)
 	}
 }


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
* Moved a few expensive operations outside of loops for plugin search.
* Limited usage service calls to 5s. If there is a service outage, this is much better than the original timeout of 30s.

References
----------
* https://confluent.slack.com/archives/C010Y0EP5MZ/p1675957387604929
* https://confluent.slack.com/archives/C010Y0EP5MZ/p1675878574713979

Test & Review
-------------
Set the timeout to 1ms and observed the following error:
```
2023-02-09T14:18:54.580-0800 [WARN]  Failed to report CLI usage: Post "https://api.confluent.cloud/cli/v1/usages": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
```