### PR TITLE
Fix goreleaser deprecation warnings

### DIFF
--- a/.goreleaser-build.yml
+++ b/.goreleaser-build.yml
@@ -1,7 +1,5 @@
 project_name: confluent
 
-dist: dist
-
 builds:
   - binary: confluent
     main: cmd/confluent/main.go

--- a/.goreleaser-linux-glibc-arm64.yml
+++ b/.goreleaser-linux-glibc-arm64.yml
@@ -1,12 +1,5 @@
 project_name: confluent
 
-dist: dist
-
-before:
-  hooks:
-    # TODO: [CLI-92] we delete the semaphore cache during release to workaround an issue with semaphore and goreleaser
-    - rm -rf $GOPATH/pkg/mod
-
 # NOTE: This will put all builds into the same ./dist folder.  There is no way to configure goreleaser output directories per-build, only per-project.
 # That means that we should probably not rely on the CI's directory layout for publishing binaries to s3 since cloud and rbac will be intermingled.
 builds:

--- a/.goreleaser-linux-glibc.yml
+++ b/.goreleaser-linux-glibc.yml
@@ -1,12 +1,5 @@
 project_name: confluent
 
-dist: dist
-
-before:
-  hooks:
-    # TODO: [CLI-92] we delete the semaphore cache during release to workaround an issue with semaphore and goreleaser
-    - rm -rf $GOPATH/pkg/mod
-
 # NOTE: This will put all builds into the same ./dist folder.  There is no way to configure goreleaser output directories per-build, only per-project.
 # That means that we should probably not rely on the CI's directory layout for publishing binaries to s3 since cloud and rbac will be intermingled.
 builds:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,12 +1,5 @@
 project_name: confluent
 
-dist: dist
-
-# before:
-#   hooks:
-#     # TODO: [CLI-92] we delete the semaphore cache during release to workaround an issue with semaphore and goreleaser
-#     - rm -rf $GOPATH/pkg/mod
-
 # NOTE: This will put all builds into the same ./dist folder.  There is no way to configure goreleaser output directories per-build, only per-project.
 # That means that we should probably not rely on the CI's directory layout for publishing binaries to s3 since cloud and rbac will be intermingled.
 builds:
@@ -139,19 +132,16 @@ archives:
       - LICENSE
       - legal/**/*
     
-release:
-  disable: true
-
-# blobs:
-#   - ids:
-#     - binary
-#     provider: s3
-#     bucket: confluent.cloud
-#     region: us-west-2
-#     folder: "{{.Env.S3FOLDER}}/binaries/{{.Version}}"
-#   - ids:
-#     - archive
-#     provider: s3
-#     bucket: confluent.cloud
-#     region: us-west-2
-#     folder: "{{.Env.S3FOLDER}}/archives/{{.Version}}"
+blobs:
+  - ids:
+    - binary
+    provider: s3
+    bucket: confluent.cloud
+    region: us-west-2
+    folder: "{{.Env.S3FOLDER}}/binaries/{{.Version}}"
+  - ids:
+    - archive
+    provider: s3
+    bucket: confluent.cloud
+    region: us-west-2
+    folder: "{{.Env.S3FOLDER}}/archives/{{.Version}}"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -2,10 +2,10 @@ project_name: confluent
 
 dist: dist
 
-before:
-  hooks:
-    # TODO: [CLI-92] we delete the semaphore cache during release to workaround an issue with semaphore and goreleaser
-    - rm -rf $GOPATH/pkg/mod
+# before:
+#   hooks:
+#     # TODO: [CLI-92] we delete the semaphore cache during release to workaround an issue with semaphore and goreleaser
+#     - rm -rf $GOPATH/pkg/mod
 
 # NOTE: This will put all builds into the same ./dist folder.  There is no way to configure goreleaser output directories per-build, only per-project.
 # That means that we should probably not rely on the CI's directory layout for publishing binaries to s3 since cloud and rbac will be intermingled.
@@ -124,14 +124,13 @@ builds:
 
 archives:
   - id: binary
-    replacements: 
-      linux: alpine
+    name_template: '{{ .ProjectName }}_{{ .Version }}_{{ if eq .Os "linux" }}alpine{{ else }}{{ .Os }}{{ end }}_{{ .Arch }}'
     format: binary
+    rlcp: true
   - id: archive
-    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
-    replacements: 
-      linux: alpine
+    name_template: '{{ .ProjectName }}_{{ .Version }}_{{ if eq .Os "linux" }}alpine{{ else }}{{ .Os }}{{ end }}_{{ .Arch }}'
     format: tar.gz
+    rlcp: true
     format_overrides:
       - goos: windows
         format: zip
@@ -139,17 +138,20 @@ archives:
     files:
       - LICENSE
       - legal/**/*
+    
+release:
+  disable: true
 
-blobs:
-  - ids:
-    - binary
-    provider: s3
-    bucket: confluent.cloud
-    region: us-west-2
-    folder: "{{.Env.S3FOLDER}}/binaries/{{.Version}}"
-  - ids:
-    - archive
-    provider: s3
-    bucket: confluent.cloud
-    region: us-west-2
-    folder: "{{.Env.S3FOLDER}}/archives/{{.Version}}"
+# blobs:
+#   - ids:
+#     - binary
+#     provider: s3
+#     bucket: confluent.cloud
+#     region: us-west-2
+#     folder: "{{.Env.S3FOLDER}}/binaries/{{.Version}}"
+#   - ids:
+#     - archive
+#     provider: s3
+#     bucket: confluent.cloud
+#     region: us-west-2
+#     folder: "{{.Env.S3FOLDER}}/archives/{{.Version}}"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -42,7 +42,7 @@ def job = {
                                 mkdir -p $GOROOT/bin
                                 export PATH=$GOPATH/bin:$GOROOT/bin:$PATH
                                 echo "machine github.com\n\tlogin $GIT_USER\n\tpassword $GIT_TOKEN" > ~/.netrc
-                                go install github.com/goreleaser/goreleaser@v1.14.1
+                                go install github.com/goreleaser/goreleaser@v1.15.2
                                 make build || exit 1
                                 cd dist
                                 dir=confluent_SNAPSHOT-${HASH}_linux_amd64

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ endif
 
 .PHONY: cli-builder
 cli-builder:
-	@TAGS=$(TAGS) CGO_ENABLED=$(CGO_ENABLED) CC=$(CC) CXX=$(CXX) CGO_LDFLAGS=$(CGO_LDFLAGS) VERSION=$(VERSION) GOEXPERIMENT=boringcrypto goreleaser build -f .goreleaser-build.yml --rm-dist --single-target --snapshot
+	@TAGS=$(TAGS) CGO_ENABLED=$(CGO_ENABLED) CC=$(CC) CXX=$(CXX) CGO_LDFLAGS=$(CGO_LDFLAGS) VERSION=$(VERSION) GOEXPERIMENT=boringcrypto goreleaser build -f .goreleaser-build.yml --clean --single-target --snapshot
 
 include ./mk-files/dockerhub.mk
 include ./mk-files/semver.mk
@@ -68,7 +68,7 @@ clean:
 deps:
 	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.51.1 && \
 	go install github.com/google/go-licenses@v1.5.0 && \
-	go install github.com/goreleaser/goreleaser@v1.14.1 && \
+	go install github.com/goreleaser/goreleaser@v1.15.2 && \
 	go install gotest.tools/gotestsum@v1.8.2
 
 show-args:

--- a/debian/patches/standard_build_layout.patch
+++ b/debian/patches/standard_build_layout.patch
@@ -1,5 +1,5 @@
---- cli/Makefile	2023-02-08 21:35:13.253768347 +0000
-+++ debian/Makefile	2023-02-08 21:35:11.813759891 +0000
+--- cli/Makefile	2023-02-10 11:36:31.000000000 -0800
++++ debian/Makefile	2022-12-12 17:29:13.000000000 -0800
 @@ -1,169 +1,130 @@
 -SHELL           := /bin/bash
 -ALL_SRC         := $(shell find . -name "*.go" | grep -v -e vendor)
@@ -41,7 +41,7 @@
 -
 -.PHONY: cli-builder
 -cli-builder:
--	@TAGS=$(TAGS) CGO_ENABLED=$(CGO_ENABLED) CC=$(CC) CXX=$(CXX) CGO_LDFLAGS=$(CGO_LDFLAGS) VERSION=$(VERSION) GOEXPERIMENT=boringcrypto goreleaser build -f .goreleaser-build.yml --rm-dist --single-target --snapshot
+-	@TAGS=$(TAGS) CGO_ENABLED=$(CGO_ENABLED) CC=$(CC) CXX=$(CXX) CGO_LDFLAGS=$(CGO_LDFLAGS) VERSION=$(VERSION) GOEXPERIMENT=boringcrypto goreleaser build -f .goreleaser-build.yml --clean --single-target --snapshot
 -
 -include ./mk-files/dockerhub.mk
 -include ./mk-files/semver.mk
@@ -90,7 +90,7 @@
 -deps:
 -	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.51.1 && \
 -	go install github.com/google/go-licenses@v1.5.0 && \
--	go install github.com/goreleaser/goreleaser@v1.14.1 && \
+-	go install github.com/goreleaser/goreleaser@v1.15.2 && \
 -	go install gotest.tools/gotestsum@v1.8.2
 -
 -show-args:

--- a/mk-files/release.mk
+++ b/mk-files/release.mk
@@ -46,14 +46,14 @@ endef
 # The glibc container doesn't need to publish to S3 so it doesn't need to $(caasenv-authenticate)
 .PHONY: gorelease-linux-glibc
 gorelease-linux-glibc:
-	VERSION=$(VERSION) GOEXPERIMENT=boringcrypto goreleaser release --rm-dist -f .goreleaser-linux-glibc.yml
+	VERSION=$(VERSION) GOEXPERIMENT=boringcrypto goreleaser release --clean -f .goreleaser-linux-glibc.yml
 
 .PHONY: gorelease-linux-glibc-arm64
 gorelease-linux-glibc-arm64:
 ifneq (,$(findstring x86_64,$(shell uname -m)))
-	VERSION=$(VERSION) CGO_ENABLED=1 CC=aarch64-linux-gnu-gcc CXX=aarch64-linux-gnu-g++ GOEXPERIMENT=boringcrypto goreleaser release --rm-dist -f .goreleaser-linux-glibc-arm64.yml
+	VERSION=$(VERSION) CGO_ENABLED=1 CC=aarch64-linux-gnu-gcc CXX=aarch64-linux-gnu-g++ GOEXPERIMENT=boringcrypto goreleaser release --clean -f .goreleaser-linux-glibc-arm64.yml
 else
-	VERSION=$(VERSION) GOEXPERIMENT=boringcrypto goreleaser release --rm-dist -f .goreleaser-linux-glibc-arm64.yml
+	VERSION=$(VERSION) GOEXPERIMENT=boringcrypto goreleaser release --clean -f .goreleaser-linux-glibc-arm64.yml
 endif
 
 # This builds the Darwin, Windows and Linux binaries using goreleaser on the host computer. Goreleaser takes care of uploading the resulting binaries/archives/checksums to S3.
@@ -63,7 +63,7 @@ gorelease:
 	$(eval token := $(shell (grep github.com ~/.netrc -A 2 | grep password || grep github.com ~/.netrc -A 2 | grep login) | head -1 | awk -F' ' '{ print $$2 }'))
 	$(aws-authenticate) && \
 	echo "BUILDING FOR DARWIN, WINDOWS, AND ALPINE LINUX" && \
-	VERSION=$(VERSION) GITHUB_TOKEN=$(token) S3FOLDER=$(S3_STAG_FOLDER_NAME)/confluent-cli GOEXPERIMENT=boringcrypto goreleaser release --rm-dist --timeout 60m -f .goreleaser.yml; \
+	VERSION=$(VERSION) GITHUB_TOKEN=$(token) S3FOLDER=$(S3_STAG_FOLDER_NAME)/confluent-cli GOEXPERIMENT=boringcrypto goreleaser release --clean --timeout 60m -f .goreleaser.yml; \
 	rm -f CLIEVCodeSigningCertificate2.pfx && \
 	echo "BUILDING FOR GLIBC LINUX" && \
 	scripts/build_linux_glibc.sh && \


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
Noticed a few of these during the last release and staying on top of them!
```
DEPRECATED: `archives.replacements` should not be used anymore, check https://goreleaser.com/deprecations#archivesreplacements for more info
DEPRECATED: `archives.rlcp` will be the default soon, check https://goreleaser.com/deprecations#archivesrlcp for more info
```