### PR TITLE
Do not set `name` field in cluster update when it's not specified

### DIFF
--- a/internal/cmd/kafka/command_cluster_update.go
+++ b/internal/cmd/kafka/command_cluster_update.go
@@ -85,7 +85,6 @@ func (c *clusterCommand) update(cmd *cobra.Command, args []string, prompt form.P
 			return err
 		}
 		update.Spec.Config = &cmkv2.CmkV2ClusterSpecUpdateConfigOneOf{CmkV2Dedicated: &cmkv2.CmkV2Dedicated{Kind: "Dedicated", Cku: updatedCku}}
-
 	}
 
 	updatedCluster, err := c.V2Client.UpdateKafkaCluster(clusterID, update)
@@ -106,7 +105,7 @@ func (c *clusterCommand) validateResize(cmd *cobra.Command, cku int32, currentCl
 		return 0, errors.New(errors.ClusterResizeNotSupportedErrorMsg)
 	}
 	// Durability Checks
-	if *currentCluster.GetSpec().Availability == highAvailability && cku <= 1 {
+	if currentCluster.Spec.GetAvailability() == highAvailability && cku <= 1 {
 		return 0, errors.New(errors.CKUMoreThanOneErrorMsg)
 	}
 	if cku == 0 {

--- a/internal/cmd/kafka/command_cluster_update.go
+++ b/internal/cmd/kafka/command_cluster_update.go
@@ -34,7 +34,7 @@ func (c *clusterCommand) newUpdateCommand(cfg *v1.Config) *cobra.Command {
 	}
 
 	cmd.Flags().String("name", "", "Name of the Kafka cluster.")
-	cmd.Flags().Int("cku", 0, "Number of Confluent Kafka Units (non-negative). For Kafka clusters of type 'dedicated' only. When shrinking a cluster, you can reduce capacity one CKU at a time.")
+	cmd.Flags().Int32("cku", 0, "Number of Confluent Kafka Units (non-negative). For Kafka clusters of type 'dedicated' only. When shrinking a cluster, you can reduce capacity one CKU at a time.")
 	pcmd.AddContextFlag(cmd, c.CLICommand)
 	if cfg.IsCloudLogin() {
 		pcmd.AddEnvironmentFlag(cmd, c.AuthenticatedCLICommand)
@@ -50,6 +50,11 @@ func (c *clusterCommand) update(cmd *cobra.Command, args []string, prompt form.P
 	}
 
 	clusterID := args[0]
+	currentCluster, _, err := c.V2Client.DescribeKafkaCluster(clusterID, c.EnvironmentId())
+	if err != nil {
+		return errors.NewErrorWithSuggestions(fmt.Sprintf(errors.KafkaClusterNotFoundErrorMsg, clusterID), errors.ChooseRightEnvironmentSuggestions)
+	}
+
 	update := cmkv2.CmkV2ClusterUpdate{
 		Id: cmkv2.PtrString(clusterID),
 		Spec: &cmkv2.CmkV2ClusterSpecUpdate{
@@ -57,10 +62,6 @@ func (c *clusterCommand) update(cmd *cobra.Command, args []string, prompt form.P
 				Id: c.EnvironmentId(),
 			},
 		},
-	}
-	currentCluster, _, err := c.V2Client.DescribeKafkaCluster(clusterID, c.EnvironmentId())
-	if err != nil {
-		return errors.NewErrorWithSuggestions(fmt.Sprintf(errors.KafkaClusterNotFoundErrorMsg, clusterID), errors.ChooseRightEnvironmentSuggestions)
 	}
 
 	if cmd.Flags().Changed("name") {
@@ -72,16 +73,20 @@ func (c *clusterCommand) update(cmd *cobra.Command, args []string, prompt form.P
 			return errors.New(errors.NonEmptyNameErrorMsg)
 		}
 		update.Spec.SetDisplayName(name)
-	} else {
-		update.Spec.SetDisplayName(*currentCluster.GetSpec().DisplayName)
 	}
 
-	updatedCku, err := c.validateResize(cmd, &currentCluster, prompt)
-	if err != nil {
-		return err
-	}
-	if updatedCku != -1 {
-		update.Spec.Config = &cmkv2.CmkV2ClusterSpecUpdateConfigOneOf{CmkV2Dedicated: &cmkv2.CmkV2Dedicated{Kind: "Dedicated", Cku: updatedCku}}
+	if cmd.Flags().Changed("cku") {
+		cku, err := cmd.Flags().GetInt32("cku")
+		if err != nil {
+			return err
+		}
+		updatedCku, err := c.validateResize(cmd, cku, &currentCluster, prompt)
+		if err != nil {
+			return err
+		}
+		if updatedCku != -1 {
+			update.Spec.Config = &cmkv2.CmkV2ClusterSpecUpdateConfigOneOf{CmkV2Dedicated: &cmkv2.CmkV2Dedicated{Kind: "Dedicated", Cku: updatedCku}}
+		}
 	}
 
 	updatedCluster, err := c.V2Client.UpdateKafkaCluster(clusterID, update)
@@ -96,52 +101,44 @@ func (c *clusterCommand) update(cmd *cobra.Command, args []string, prompt form.P
 	return c.outputKafkaClusterDescription(cmd, &updatedCluster, true)
 }
 
-func (c *clusterCommand) validateResize(cmd *cobra.Command, currentCluster *cmkv2.CmkV2Cluster, prompt form.Prompt) (int32, error) {
-	// returning -1 when error or unchanged
-	if cmd.Flags().Changed("cku") {
-		cku, err := cmd.Flags().GetInt("cku")
-		if err != nil {
-			return -1, err
-		}
-		// Ensure the cluster is a Dedicated Cluster
-		if currentCluster.GetSpec().Config.CmkV2Dedicated == nil {
-			return -1, errors.New(errors.ClusterResizeNotSupportedErrorMsg)
-		}
-		// Durability Checks
-		if *currentCluster.GetSpec().Availability == highAvailability && cku <= 1 {
-			return -1, errors.New(errors.CKUMoreThanOneErrorMsg)
-		}
-		if cku <= 0 {
-			return -1, errors.New(errors.CKUMoreThanZeroErrorMsg)
-		}
-		// Cluster can't be resized while it's provisioning or being expanded already.
-		// Name _can_ be changed during these times, though.
-		err = isClusterResizeInProgress(currentCluster)
-		if err != nil {
-			return -1, err
-		}
-		//If shrink
-		if int32(cku) < currentCluster.GetSpec().Config.CmkV2Dedicated.Cku {
-			promptMessage := ""
-			// metrics api auth via jwt
-			if err := c.validateKafkaClusterMetrics(currentCluster, true); err != nil {
-				promptMessage += fmt.Sprintf("\n%v\n", err)
-			}
-			if err := c.validateKafkaClusterMetrics(currentCluster, false); err != nil {
-				promptMessage += fmt.Sprintf("\n%v\n", err)
-			}
-			if promptMessage != "" {
-				ok, err := confirmShrink(cmd, prompt, promptMessage)
-				if !ok || err != nil {
-					return -1, err
-				} else {
-					return int32(cku), nil
-				}
-			}
-		}
-		return int32(cku), nil
+func (c *clusterCommand) validateResize(cmd *cobra.Command, cku int32, currentCluster *cmkv2.CmkV2Cluster, prompt form.Prompt) (int32, error) {
+	// Ensure the cluster is a Dedicated Cluster
+	if currentCluster.GetSpec().Config.CmkV2Dedicated == nil {
+		return -1, errors.New(errors.ClusterResizeNotSupportedErrorMsg)
 	}
-	return -1, nil
+	// Durability Checks
+	if *currentCluster.GetSpec().Availability == highAvailability && cku <= 1 {
+		return -1, errors.New(errors.CKUMoreThanOneErrorMsg)
+	}
+	if cku <= 0 {
+		return -1, errors.New(errors.CKUMoreThanZeroErrorMsg)
+	}
+	// Cluster can't be resized while it's provisioning or being expanded already.
+	// Name _can_ be changed during these times, though.
+	err := isClusterResizeInProgress(currentCluster)
+	if err != nil {
+		return -1, err
+	}
+	//If shrink
+	if cku < currentCluster.GetSpec().Config.CmkV2Dedicated.Cku {
+		promptMessage := ""
+		// metrics api auth via jwt
+		if err := c.validateKafkaClusterMetrics(currentCluster, true); err != nil {
+			promptMessage += fmt.Sprintf("\n%v\n", err)
+		}
+		if err := c.validateKafkaClusterMetrics(currentCluster, false); err != nil {
+			promptMessage += fmt.Sprintf("\n%v\n", err)
+		}
+		if promptMessage != "" {
+			ok, err := confirmShrink(cmd, prompt, promptMessage)
+			if !ok || err != nil {
+				return -1, err
+			} else {
+				return cku, nil
+			}
+		}
+	}
+	return cku, nil
 }
 
 func (c *clusterCommand) validateKafkaClusterMetrics(currentCluster *cmkv2.CmkV2Cluster, isLatestMetric bool) error {

--- a/internal/cmd/kafka/command_cluster_update.go
+++ b/internal/cmd/kafka/command_cluster_update.go
@@ -84,9 +84,8 @@ func (c *clusterCommand) update(cmd *cobra.Command, args []string, prompt form.P
 		if err != nil {
 			return err
 		}
-		if updatedCku != -1 {
-			update.Spec.Config = &cmkv2.CmkV2ClusterSpecUpdateConfigOneOf{CmkV2Dedicated: &cmkv2.CmkV2Dedicated{Kind: "Dedicated", Cku: updatedCku}}
-		}
+		update.Spec.Config = &cmkv2.CmkV2ClusterSpecUpdateConfigOneOf{CmkV2Dedicated: &cmkv2.CmkV2Dedicated{Kind: "Dedicated", Cku: updatedCku}}
+
 	}
 
 	updatedCluster, err := c.V2Client.UpdateKafkaCluster(clusterID, update)
@@ -119,7 +118,7 @@ func (c *clusterCommand) validateResize(cmd *cobra.Command, cku int32, currentCl
 	if err != nil {
 		return 0, err
 	}
-	//If shrink
+	// If shrink
 	if cku < currentCluster.GetSpec().Config.CmkV2Dedicated.Cku {
 		promptMessage := ""
 		// metrics api auth via jwt

--- a/test/test-server/cmk_handlers.go
+++ b/test/test-server/cmk_handlers.go
@@ -240,7 +240,10 @@ func handleCmkKafkaDedicatedClusterExpansion(t *testing.T) http.HandlerFunc {
 			err := json.NewDecoder(r.Body).Decode(&req)
 			require.NoError(t, err)
 			req.Id = cmkv2.PtrString("lkc-update-dedicated-expand")
-			cluster := getCmkDedicatedDescribeCluster(*req.Id, *req.Spec.DisplayName, req.Spec.Config.CmkV2Dedicated.Cku)
+			if req.Spec.GetDisplayName() == "" { // keep the name unchanged when not specified in request
+				req.Spec.SetDisplayName("lkc-update-dedicated-expand")
+			}
+			cluster := getCmkDedicatedDescribeCluster(req.GetId(), req.Spec.GetDisplayName(), req.Spec.Config.CmkV2Dedicated.Cku)
 			cluster.Status.Cku = cmkv2.PtrInt32(1)
 			err = json.NewEncoder(w).Encode(cluster)
 			require.NoError(t, err)
@@ -263,7 +266,10 @@ func handleCmkKafkaDedicatedClusterShrink(t *testing.T) http.HandlerFunc {
 			err := json.NewDecoder(r.Body).Decode(&req)
 			require.NoError(t, err)
 			req.Id = cmkv2.PtrString("lkc-update-dedicated-shrink")
-			cluster := getCmkDedicatedDescribeCluster(*req.Id, *req.Spec.DisplayName, req.Spec.Config.CmkV2Dedicated.Cku)
+			if req.Spec.GetDisplayName() == "" { // keep the name unchanged when not specified in request
+				req.Spec.SetDisplayName("lkc-update-dedicated-shrink")
+			}
+			cluster := getCmkDedicatedDescribeCluster(req.GetId(), req.Spec.GetDisplayName(), req.Spec.Config.CmkV2Dedicated.Cku)
 			cluster.Status.Cku = cmkv2.PtrInt32(2)
 			err = json.NewEncoder(w).Encode(cluster)
 			require.NoError(t, err)


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->
According to docs https://docs.confluent.io/cloud/current/clusters/cluster-api.html#id3 in one request we should only specify the name or the config (cku), although it's possible to update both at the same time. But when the user provides only cku, the display name is set to the new update name field, which is not what the user wants as the name could be different. 
To avoid breaking changes, we still allow updating both name and cku in one line, but in our next major version we might consider only allowing name or cku, to make the command more atomic and match the behavior of other update commands like schema-registry `mode` / `compatibility`

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->
https://confluentinc.atlassian.net/browse/CAPAC-1229

Test & Review
-------------
<!--
Has it been tested? How?
Copy and paste any instructions or steps that can save the reviewer time.
-->

Open Questions / Follow-ups
---------------------------
<!--
Optional: Anything open to discussion for the reviewer, out of scope of this PR, or follow-ups.
-->
