### PR TITLE
[CIAM-1796] Dataplane roles get 403 when listing api keys

### DIFF
--- a/internal/cmd/api-key/command.go
+++ b/internal/cmd/api-key/command.go
@@ -104,6 +104,9 @@ func (c *command) getAllUsers() ([]*ccloudv1.User, error) {
 	}
 	users = append(users, adminUsers...)
 
+	currentUser := c.State.Auth.User
+	users = append(users, currentUser)
+
 	return users, nil
 }
 

--- a/internal/cmd/api-key/command.go
+++ b/internal/cmd/api-key/command.go
@@ -89,9 +89,13 @@ func (c *command) getAllUsers() ([]*ccloudv1.User, error) {
 	if auditLog := v1.GetAuditLog(c.Context.Context); auditLog != nil {
 		serviceAccount, err := c.Client.User.GetServiceAccount(context.Background(), auditLog.GetServiceAccountId())
 		if err != nil {
-			return nil, err
+			// ignore 403s so we can still get other users
+			if !strings.Contains(err.Error(), "Forbidden Access") {
+				return nil, err
+			}
+		} else {
+			users = append(users, serviceAccount)
 		}
-		users = append(users, serviceAccount)
 	}
 
 	adminUsers, err := c.Client.User.List(context.Background())

--- a/internal/cmd/api-key/command_list.go
+++ b/internal/cmd/api-key/command_list.go
@@ -180,9 +180,9 @@ func (c *command) getEmail(resourceId string, resourceIdToUserIdMap map[string]i
 		return user.Email
 	}
 
-	// check if api key is owned by current user
-	if c.State.Auth.User.ResourceId == resourceId {
-		return c.State.Auth.User.Email
+	// Check if API key is owned by the current user
+	if user := c.State.Auth.User; user.ResourceId == resourceId {
+		return user.GetEmail()
 	}
 
 	return "<deactivated user>"

--- a/internal/cmd/api-key/command_list.go
+++ b/internal/cmd/api-key/command_list.go
@@ -180,11 +180,6 @@ func (c *command) getEmail(resourceId string, resourceIdToUserIdMap map[string]i
 		return user.Email
 	}
 
-	// Check if API key is owned by the current user
-	if user := c.State.Auth.User; user.ResourceId == resourceId {
-		return user.GetEmail()
-	}
-
 	return "<deactivated user>"
 }
 

--- a/internal/cmd/api-key/command_list.go
+++ b/internal/cmd/api-key/command_list.go
@@ -180,6 +180,11 @@ func (c *command) getEmail(resourceId string, resourceIdToUserIdMap map[string]i
 		return user.Email
 	}
 
+	// check if api key is owned by current user
+	if c.State.Auth.User.ResourceId == resourceId {
+		return c.State.Auth.User.Email
+	}
+
 	return "<deactivated user>"
 }
 

--- a/internal/cmd/api-key/command_test.go
+++ b/internal/cmd/api-key/command_test.go
@@ -263,7 +263,7 @@ func (suite *APITestSuite) SetupTest() {
 					Id:          myServiceAccountId,
 					ResourceId:  myUserResourceId,
 					ServiceName: myAccountName,
-					Email:       "csreesangkom@confluent.io",
+					Email:       "cli-mock-email@confluent.io",
 				},
 				{
 					Id:         auditLogServiceAccountId,
@@ -389,7 +389,7 @@ func (suite *APITestSuite) TestListEmails() {
 	req.True(suite.apiKeysMock.ListIamV2ApiKeysExecuteCalled())
 	req.Contains(out, "<auditlog service account>")
 	req.Contains(out, "<service account>")
-	req.Contains(out, "csreesangkom@confluent.io")
+	req.Contains(out, "cli-mock-email@confluent.io")
 }
 
 func (suite *APITestSuite) TestStoreApiKeyForce() {

--- a/test/test-server/ccloud_handlers.go
+++ b/test/test-server/ccloud_handlers.go
@@ -96,9 +96,9 @@ func (c *CloudRouter) HandleMe(t *testing.T, isAuditLogEnabled bool) http.Handle
 		b, err := ccloudv1.MarshalJSONToBytes(&ccloudv1.GetMeReply{
 			User: &ccloudv1.User{
 				Id:         23,
-				Email:      "cody@confluent.io",
-				FirstName:  "Cody",
-				ResourceId: "u-11aaa",
+				Email:      "mhe@confluent.io",
+				FirstName:  "Muwei",
+				ResourceId: "u-44ddd",
 			},
 			Accounts:     environments,
 			Organization: org,


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
users with DeveloperRead/Write/Manage roles get a 403 Forbidden when trying to call `confluent api-key list`. 

```
> confluent -vvvv api-key list
2022-03-02T22:41:32.196-0800 [DEBUG] UserService.GetServiceAccounts request: GET https://devel.cpdev.cloud/api/service_accounts
2022-03-02T22:41:32.495-0800 [DEBUG] UserService.GetServiceAccounts response: 200 OK X-Request-Id:37073471e5fa8cad325d32274d5b9d4b Body: {"users":[],"page_info":{"page_size":0,"page_token":""},"error":null} request: GET https://devel.cpdev.cloud/api/service_accounts
2022-03-02T22:41:32.495-0800 [DEBUG] UserService.List request: GET https://devel.cpdev.cloud/api/users
2022-03-02T22:41:32.564-0800 [DEBUG] UserService.List response: 200 OK X-Request-Id:cb4ce9263e8a1335457c805a7ba2a9c6 Body: {"users":[],"error":null,"page_info":{"page_size":0,"page_token":""}} request: GET https://devel.cpdev.cloud/api/users
2022-03-02T22:41:32.564-0800 [DEBUG] UserService.GetServiceAccounts request: GET https://devel.cpdev.cloud/api/service_accounts
2022-03-02T22:41:32.625-0800 [DEBUG] UserService.GetServiceAccounts response: 200 OK X-Request-Id:00a1f2522c2cd77abc2e6778b7060e15 Body: {"users":[],"page_info":{"page_size":0,"page_token":""},"error":null} request: GET https://devel.cpdev.cloud/api/service_accounts
2022-03-02T22:41:32.625-0800 [DEBUG] UserService.GetServiceAccount request: GET https://devel.cpdev.cloud/api/service_accounts/641233
2022-03-02T22:41:32.685-0800 [DEBUG] UserService.GetServiceAccount response: 403 Forbidden X-Request-Id:7492ea1de571ab86408e85cc4a0368b6 Body: {"error":{"code":403,"message":"Forbidden Access"}}
 request: GET https://devel.cpdev.cloud/api/service_accounts/641233
Error: CCloud backend error: 1 error occurred:
	* error getting service account: Forbidden Access
```
This seems to be happening because Developer* roles do not have permission to read a specific service account. When looking through the logic in the api-key list command, this api call is happening because audit logs is enabled and is therefore trying to access the Audit Logs service account.

This PR adds some logic to ignore the 403 from this specific audit logs SA check, so that dataplane roles can still list other api keys that they have access to.

Also, while testing I noticed that when listing api keys it showed <deactivated user> when it was the user's own api key, so added logic for that (similar to https://github.com/confluentinc/cli/pull/1212, not sure when this logic was removed).

References
----------
https://confluentinc.atlassian.net/browse/CIAM-1796

Test & Review
-------------
Manually tested in stag with DeveloperRead role, who should be able to see their own api keys from `confluent api-key list` command. 
```
> ./confluent api-key list
  Current |       Key        | Description |  Owner   |             Owner Email              | Resource Type |  Resource  |       Created
----------+------------------+-------------+----------+--------------------------------------+---------------+------------+-----------------------
          | JIFBUDBBAVCLZBKU |             | u-q5jv87 | lfan+bugbash3_catalogds@confluent.io | kafka         | lkc-y6582j | 2023-02-05T18:35:07Z
```

Open Questions / Follow-ups
---------------------------
<!--
Optional: Anything open to discussion for the reviewer, out of scope of this PR, or follow-ups.
-->
