### PR TITLE
Remove `make deps`

### DIFF
--- a/.goreleaser-linux-glibc-arm64.yml
+++ b/.goreleaser-linux-glibc-arm64.yml
@@ -1,7 +1,5 @@
 project_name: confluent
 
-# NOTE: This will put all builds into the same ./dist folder.  There is no way to configure goreleaser output directories per-build, only per-project.
-# That means that we should probably not rely on the CI's directory layout for publishing binaries to s3 since cloud and rbac will be intermingled.
 builds:
   - binary: confluent
     main: cmd/confluent/main.go

--- a/.goreleaser-linux-glibc.yml
+++ b/.goreleaser-linux-glibc.yml
@@ -1,7 +1,5 @@
 project_name: confluent
 
-# NOTE: This will put all builds into the same ./dist folder.  There is no way to configure goreleaser output directories per-build, only per-project.
-# That means that we should probably not rely on the CI's directory layout for publishing binaries to s3 since cloud and rbac will be intermingled.
 builds:
   - binary: confluent
     main: cmd/confluent/main.go

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,7 +1,5 @@
 project_name: confluent
 
-# NOTE: This will put all builds into the same ./dist folder.  There is no way to configure goreleaser output directories per-build, only per-project.
-# That means that we should probably not rely on the CI's directory layout for publishing binaries to s3 since cloud and rbac will be intermingled.
 builds:
   - binary: confluent
     id: confluent-alpine-amd64

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -30,9 +30,7 @@ blocks:
             # Run tests
             - make generate-packaging-patch
             - diff -w -u <(git cat-file --filters HEAD:debian/patches/standard_build_layout.patch | awk "{if (NR>3) {print}}") <(cat debian/patches/standard_build_layout.patch | awk "{if (NR>3) {print}}")
-            - go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.51.1
             - make lint
-            - go install gotest.tools/gotestsum@v1.8.2
             - make test
             - make test-installer
 
@@ -61,7 +59,6 @@ blocks:
             - export PATH=$PATH:$(go env GOPATH)/bin
 
             # Run tests
-            - go install gotest.tools/gotestsum@v1.8.2
             - make test
 
 after_pipeline:

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -42,7 +42,6 @@ def job = {
                                 mkdir -p $GOROOT/bin
                                 export PATH=$GOPATH/bin:$GOROOT/bin:$PATH
                                 echo "machine github.com\n\tlogin $GIT_USER\n\tpassword $GIT_TOKEN" > ~/.netrc
-                                go install github.com/goreleaser/goreleaser@v1.15.2
                                 make build || exit 1
                                 cd dist
                                 dir=confluent_SNAPSHOT-${HASH}_linux_amd64

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
-SHELL           := /bin/bash
-ALL_SRC         := $(shell find . -name "*.go" | grep -v -e vendor)
+SHELL              := /bin/bash
+ALL_SRC            := $(shell find . -name "*.go" | grep -v -e vendor)
+GORELEASER_VERSION := v1.15.2
+
 GIT_REMOTE_NAME ?= origin
 MAIN_BRANCH     ?= main
 RELEASE_BRANCH  ?= main
@@ -38,7 +40,8 @@ endif
 
 .PHONY: cli-builder
 cli-builder:
-	@TAGS=$(TAGS) CGO_ENABLED=$(CGO_ENABLED) CC=$(CC) CXX=$(CXX) CGO_LDFLAGS=$(CGO_LDFLAGS) VERSION=$(VERSION) GOEXPERIMENT=boringcrypto goreleaser build -f .goreleaser-build.yml --clean --single-target --snapshot
+	go install github.com/goreleaser/goreleaser@$(GORELEASER_VERSION) && \
+	TAGS=$(TAGS) CGO_ENABLED=$(CGO_ENABLED) CC=$(CC) CXX=$(CXX) CGO_LDFLAGS=$(CGO_LDFLAGS) VERSION=$(VERSION) GOEXPERIMENT=boringcrypto goreleaser build -f .goreleaser-build.yml --clean --single-target --snapshot
 
 include ./mk-files/dockerhub.mk
 include ./mk-files/semver.mk
@@ -63,13 +66,6 @@ clean:
 	@for dir in bin dist docs legal release-notes; do \
 		[ -d $$dir ] && rm -r $$dir || true ; \
 	done
-
-.PHONY: deps
-deps:
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.51.1 && \
-	go install github.com/google/go-licenses@v1.5.0 && \
-	go install github.com/goreleaser/goreleaser@v1.15.2 && \
-	go install gotest.tools/gotestsum@v1.8.2
 
 show-args:
 	@echo "VERSION: $(VERSION)"
@@ -127,12 +123,13 @@ lint:
 
 .PHONY: lint-go
 lint-go:
-	@golangci-lint run --timeout=10m
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.51.1 && \
+	golangci-lint run --timeout=10m && \
 	@echo "✅  golangci-lint"
 
 .PHONY: lint-cli
 lint-cli: cmd/lint/en_US.aff cmd/lint/en_US.dic
-	@go run cmd/lint/main.go -aff-file $(word 1,$^) -dic-file $(word 2,$^) $(ARGS)
+	go run cmd/lint/main.go -aff-file $(word 1,$^) -dic-file $(word 2,$^) $(ARGS) && \
 	@echo "✅  cmd/lint/main.go"
 
 cmd/lint/en_US.aff:
@@ -141,13 +138,10 @@ cmd/lint/en_US.aff:
 cmd/lint/en_US.dic:
 	curl -s "https://chromium.googlesource.com/chromium/deps/hunspell_dictionaries/+/master/en_US.dic?format=TEXT" | base64 -D > $@
 
-.PHONY: lint-licenses
-lint-licenses:
-	go-licenses check ./...
-
 .PHONY: unit-test
 unit-test:
 ifdef CI
+	go install gotest.tools/gotestsum@v1.8.2 && \
 	gotestsum --junitfile unit-test-report.xml -- -v -race $$(go list ./... | grep -v test)
 else
 	go test -v -race $$(go list ./... | grep -v test) $(UNIT_TEST_ARGS)
@@ -156,6 +150,7 @@ endif
 .PHONY: int-test
 int-test:
 ifdef CI
+	go install gotest.tools/gotestsum@v1.8.2 && \
 	gotestsum --junitfile integration-test-report.xml -- -v -race $$(go list ./... | grep test)
 else
 	go test -v -race $$(go list ./... | grep test) $(INT_TEST_ARGS)

--- a/Makefile
+++ b/Makefile
@@ -124,12 +124,12 @@ lint:
 .PHONY: lint-go
 lint-go:
 	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.51.1 && \
-	golangci-lint run --timeout=10m && \
+	golangci-lint run --timeout=10m
 	@echo "✅  golangci-lint"
 
 .PHONY: lint-cli
 lint-cli: cmd/lint/en_US.aff cmd/lint/en_US.dic
-	go run cmd/lint/main.go -aff-file $(word 1,$^) -dic-file $(word 2,$^) $(ARGS) && \
+	go run cmd/lint/main.go -aff-file $(word 1,$^) -dic-file $(word 2,$^) $(ARGS)
 	@echo "✅  cmd/lint/main.go"
 
 cmd/lint/en_US.aff:

--- a/README.md
+++ b/README.md
@@ -74,7 +74,6 @@ To install the CLI from a tarball:
 
 ### Building from Source
 
-    make deps
     make build
     dist/confluent_$(go env GOOS)_$(go env GOARCH)/confluent -h
 

--- a/debian/patches/standard_build_layout.patch
+++ b/debian/patches/standard_build_layout.patch
@@ -1,8 +1,10 @@
---- cli/Makefile	2023-02-10 11:36:31.000000000 -0800
+--- cli/Makefile	2023-02-13 17:44:54.000000000 -0800
 +++ debian/Makefile	2022-12-12 17:29:13.000000000 -0800
-@@ -1,169 +1,130 @@
--SHELL           := /bin/bash
--ALL_SRC         := $(shell find . -name "*.go" | grep -v -e vendor)
+@@ -1,164 +1,130 @@
+-SHELL              := /bin/bash
+-ALL_SRC            := $(shell find . -name "*.go" | grep -v -e vendor)
+-GORELEASER_VERSION := v1.15.2
+-
 -GIT_REMOTE_NAME ?= origin
 -MAIN_BRANCH     ?= main
 -RELEASE_BRANCH  ?= main
@@ -41,7 +43,8 @@
 -
 -.PHONY: cli-builder
 -cli-builder:
--	@TAGS=$(TAGS) CGO_ENABLED=$(CGO_ENABLED) CC=$(CC) CXX=$(CXX) CGO_LDFLAGS=$(CGO_LDFLAGS) VERSION=$(VERSION) GOEXPERIMENT=boringcrypto goreleaser build -f .goreleaser-build.yml --clean --single-target --snapshot
+-	go install github.com/goreleaser/goreleaser@$(GORELEASER_VERSION) && \
+-	TAGS=$(TAGS) CGO_ENABLED=$(CGO_ENABLED) CC=$(CC) CXX=$(CXX) CGO_LDFLAGS=$(CGO_LDFLAGS) VERSION=$(VERSION) GOEXPERIMENT=boringcrypto goreleaser build -f .goreleaser-build.yml --clean --single-target --snapshot
 -
 -include ./mk-files/dockerhub.mk
 -include ./mk-files/semver.mk
@@ -70,7 +73,9 @@
 +ifndef VERSION
 +	VERSION=$(CLI_VERSION)
 +endif
-+
+ 
+-show-args:
+-	@echo "VERSION: $(VERSION)"
 +export PACKAGE_TITLE=cli
 +export FULL_PACKAGE_TITLE=confluent-$(PACKAGE_TITLE)
 +export PACKAGE_NAME=$(FULL_PACKAGE_TITLE)-$(VERSION)
@@ -86,16 +91,6 @@
 +DESTDIR=$(CURDIR)/BUILD/
 +endif
  
--.PHONY: deps
--deps:
--	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.51.1 && \
--	go install github.com/google/go-licenses@v1.5.0 && \
--	go install github.com/goreleaser/goreleaser@v1.15.2 && \
--	go install gotest.tools/gotestsum@v1.8.2
--
--show-args:
--	@echo "VERSION: $(VERSION)"
--
 -.PHONY: build-integ-nonrace
 -build-integ-nonrace:
 -	go test ./cmd/confluent -ldflags="-s -w \
@@ -149,12 +144,13 @@
 -
 -.PHONY: lint-go
 -lint-go:
--	@golangci-lint run --timeout=10m
+-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.51.1 && \
+-	golangci-lint run --timeout=10m
 -	@echo "✅  golangci-lint"
 -
 -.PHONY: lint-cli
 -lint-cli: cmd/lint/en_US.aff cmd/lint/en_US.dic
--	@go run cmd/lint/main.go -aff-file $(word 1,$^) -dic-file $(word 2,$^) $(ARGS)
+-	go run cmd/lint/main.go -aff-file $(word 1,$^) -dic-file $(word 2,$^) $(ARGS)
 -	@echo "✅  cmd/lint/main.go"
 -
 -cmd/lint/en_US.aff:
@@ -163,13 +159,10 @@
 -cmd/lint/en_US.dic:
 -	curl -s "https://chromium.googlesource.com/chromium/deps/hunspell_dictionaries/+/master/en_US.dic?format=TEXT" | base64 -D > $@
 -
--.PHONY: lint-licenses
--lint-licenses:
--	go-licenses check ./...
--
 -.PHONY: unit-test
 -unit-test:
 -ifdef CI
+-	go install gotest.tools/gotestsum@v1.8.2 && \
 -	gotestsum --junitfile unit-test-report.xml -- -v -race $$(go list ./... | grep -v test)
 +ifeq ($(PACKAGE_TYPE),archive)
 +PREFIX=$(PACKAGE_NAME)
@@ -178,8 +171,13 @@
 -	go test -v -race $$(go list ./... | grep -v test) $(UNIT_TEST_ARGS)
 +PREFIX=/usr
 +SYSCONFDIR=/etc/$(PACKAGE_TITLE)
-+endif
-+
+ endif
+ 
+-.PHONY: int-test
+-int-test:
+-ifdef CI
+-	go install gotest.tools/gotestsum@v1.8.2 && \
+-	gotestsum --junitfile integration-test-report.xml -- -v -race $$(go list ./... | grep test)
 +all: install
 +
 +archive: install
@@ -231,12 +229,8 @@
 +ifneq ($(PACKAGE_TYPE),deb)
 +	git reset --hard HEAD
 +	git status --ignored --porcelain | cut -d ' ' -f 2 | xargs rm -rf
- endif
- 
--.PHONY: int-test
--int-test:
--ifdef CI
--	gotestsum --junitfile integration-test-report.xml -- -v -race $$(go list ./... | grep test)
++endif
++
 +RPM_VERSION=$(shell echo $(VERSION) | sed -e 's/-alpha[0-9]*//' -e 's/-beta[0-9]*//' -e 's/-rc[0-9]*//' -e 's/-SNAPSHOT//' -e 's/-cp[0-9]*//' -e 's/-hotfix[0-9]*//' -e 's/-[0-9]*//')
 +
 +# Get any -alpha, -beta (preview), -rc (release candidate), -SNAPSHOT (nightly), -cp (confluent patch), -hotfix piece that we need to put into the Release part of

--- a/mk-files/release.mk
+++ b/mk-files/release.mk
@@ -46,13 +46,16 @@ endef
 # The glibc container doesn't need to publish to S3 so it doesn't need to $(caasenv-authenticate)
 .PHONY: gorelease-linux-glibc
 gorelease-linux-glibc:
+	go install github.com/goreleaser/goreleaser@$(GORELEASER_VERSION) && \
 	VERSION=$(VERSION) GOEXPERIMENT=boringcrypto goreleaser release --clean -f .goreleaser-linux-glibc.yml
 
 .PHONY: gorelease-linux-glibc-arm64
 gorelease-linux-glibc-arm64:
 ifneq (,$(findstring x86_64,$(shell uname -m)))
+	go install github.com/goreleaser/goreleaser@$(GORELEASER_VERSION) && \
 	VERSION=$(VERSION) CGO_ENABLED=1 CC=aarch64-linux-gnu-gcc CXX=aarch64-linux-gnu-g++ GOEXPERIMENT=boringcrypto goreleaser release --clean -f .goreleaser-linux-glibc-arm64.yml
 else
+	go install github.com/goreleaser/goreleaser@$(GORELEASER_VERSION) && \
 	VERSION=$(VERSION) GOEXPERIMENT=boringcrypto goreleaser release --clean -f .goreleaser-linux-glibc-arm64.yml
 endif
 
@@ -63,6 +66,7 @@ gorelease:
 	$(eval token := $(shell (grep github.com ~/.netrc -A 2 | grep password || grep github.com ~/.netrc -A 2 | grep login) | head -1 | awk -F' ' '{ print $$2 }'))
 	$(aws-authenticate) && \
 	echo "BUILDING FOR DARWIN, WINDOWS, AND ALPINE LINUX" && \
+	go install github.com/goreleaser/goreleaser@$(GORELEASER_VERSION) && \
 	VERSION=$(VERSION) GITHUB_TOKEN=$(token) S3FOLDER=$(S3_STAG_FOLDER_NAME)/confluent-cli GOEXPERIMENT=boringcrypto goreleaser release --clean --timeout 60m -f .goreleaser.yml; \
 	rm -f CLIEVCodeSigningCertificate2.pfx && \
 	echo "BUILDING FOR GLIBC LINUX" && \
@@ -135,6 +139,7 @@ endef
 
 .PHONY: download-licenses
 download-licenses:
+	go install github.com/google/go-licenses@v1.5.0 && \
 	go-licenses save ./... --save_path legal/licenses --force || true
 
 .PHONY: publish-installer


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
`go install` is essentially a no-op when a package is already installed (it's much more performant now than it was in certain older versions of Go). We can move the `go install` commands closer to where they're needed to simplify the setup process (and make our tests that only use some of the dependencies faster)

Test & Review
-------------
Manually executed targets to make sure they still work as intended.