### PR TITLE
AsyncAPI Fix for Protobuf message logging

### DIFF
--- a/internal/cmd/asyncapi/account_details.go
+++ b/internal/cmd/asyncapi/account_details.go
@@ -130,7 +130,9 @@ func (d *accountDetails) buildMessageEntity() *spec.MessageEntity {
 	if d.channelDetails.example != nil {
 		(*spec.MessageEntity).WithExamples(entityProducer, spec.MessageOneOf1OneOf1ExamplesItems{Payload: &d.channelDetails.example})
 	}
-	(*spec.MessageEntity).WithBindings(entityProducer, d.channelDetails.bindings.messageBinding)
+	if d.channelDetails.bindings != nil {
+		(*spec.MessageEntity).WithBindings(entityProducer, d.channelDetails.bindings.messageBinding)
+	}
 	(*spec.MessageEntity).WithPayload(entityProducer, d.channelDetails.unmarshalledSchema)
 	return entityProducer
 }

--- a/internal/cmd/asyncapi/command_export.go
+++ b/internal/cmd/asyncapi/command_export.go
@@ -118,7 +118,7 @@ func (c *command) export(cmd *cobra.Command, _ []string) (err error) {
 					currentSubject: subject,
 				}
 				err := c.getChannelDetails(accountDetails, flags)
-				if err.Error() == "protobuf" {
+				if err != nil && err.Error() == "protobuf" {
 					continue
 				}
 				if err != nil {

--- a/internal/cmd/asyncapi/command_export.go
+++ b/internal/cmd/asyncapi/command_export.go
@@ -118,6 +118,9 @@ func (c *command) export(cmd *cobra.Command, _ []string) (err error) {
 					currentSubject: subject,
 				}
 				err := c.getChannelDetails(accountDetails, flags)
+				if err.Error() == "protobuf" {
+					continue
+				}
 				if err != nil {
 					return err
 				}
@@ -154,8 +157,8 @@ func (c *command) getChannelDetails(details *accountDetails, flags *flags) error
 	utils.Printf(c.Command, "Adding operation: %s\n", details.channelDetails.currentTopic.GetTopicName())
 	err := details.getSchemaDetails()
 	if details.channelDetails.contentType == "PROTOBUF" {
-		log.CliLogger.Log("Protobuf is not supported.")
-		return nil
+		log.CliLogger.Info("Protobuf is not supported.")
+		return fmt.Errorf("protobuf")
 	}
 	if err != nil {
 		return fmt.Errorf("failed to get schema details: %v", err)


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. You may delete or ignore any unused sections.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- <PLACEHOLDER>

New Features
- <PLACEHOLDER>

Bug Fixes
- <PLACEHOLDER>
- Fixes logging for the Protobuf case
- Ensures that in case of Protobuf, further functions are not called for that channel (subject).

Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes
  

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->
- In case of a Protobuf schema, that subject should be skipped. Ensuring that other functions are not called in such a case.
- Switching to log.Clilogger.Info() method instead of using log.Clilogger.log()
- Adding a unit test for the protobuf case

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->
https://confluent.slack.com/archives/C010Y0EP5MZ/p1676912651486499

Test & Review
-------------
<!--
Has it been tested? How?
Copy and paste any instructions or steps that can save the reviewer time.
-->

Open Questions / Follow-ups
---------------------------
<!--
Optional: Anything open to discussion for the reviewer, out of scope of this PR, or follow-ups.
-->
