### PR TITLE
[CLI-2067] Use `$PATHEXT` to find executable plugins on Windows

### DIFF
--- a/internal/pkg/plugin/plugin.go
+++ b/internal/pkg/plugin/plugin.go
@@ -74,18 +74,16 @@ func pluginFromEntry(entry os.DirEntry) string {
 
 func isExecutable(entry fs.DirEntry) bool {
 	if runtime.GOOS == "windows" {
-		return isExecutableWindows(entry.Name())
+		extension := strings.ToUpper(filepath.Ext(entry.Name()))
+		return utils.Contains(filepath.SplitList(os.Getenv("PATHEXT")), extension)
 	}
+
 	fileInfo, err := entry.Info()
 	if err != nil {
 		return false
 	}
-	return !fileInfo.Mode().IsDir() && fileInfo.Mode()&0111 != 0
-}
 
-func isExecutableWindows(name string) bool {
-	ext := strings.ToLower(filepath.Ext(name))
-	return utils.Contains([]string{".bat", ".cmd", ".com", ".exe", ".ps1"}, ext)
+	return !fileInfo.Mode().IsDir() && fileInfo.Mode()&0111 != 0
 }
 
 // FindPlugin determines if the arguments passed in are meant for a plugin

--- a/internal/pkg/plugin/plugin_test.go
+++ b/internal/pkg/plugin/plugin_test.go
@@ -23,9 +23,11 @@ func TestIsExec_Dir(t *testing.T) {
 
 func TestIsExec_Executable(t *testing.T) {
 	if runtime.GOOS == "windows" {
-		require.True(t, isExecutableWindows("hello.exe"))
+		assert.False(t, isExecutable(&mock.FileInfo{NameVal: "hello.nonexe"}))
+		assert.True(t, isExecutable(&mock.FileInfo{NameVal: "hello.exe"}))
 	} else {
-		require.True(t, isExecutable(&mock.FileInfo{ModeVal: fs.ModePerm}))
+		assert.False(t, isExecutable(&mock.FileInfo{ModeVal: fs.ModeDir}))
+		assert.True(t, isExecutable(&mock.FileInfo{ModeVal: fs.ModePerm}))
 	}
 }
 


### PR DESCRIPTION
Release Notes
-------------
Bug Fixes
- Use ``$PATHEXT`` to correctly determine if a plugin is executable on Windows

Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
Before, the list of valid plugin extensions was hardcoded (and was missing several extension types!) Windows relies on `$PATHEXT` to determine which file extensions are executable, so we should too.

References
----------
https://confluentinc.atlassian.net/browse/CLI-2067

Test & Review
-------------
Unit tests