### PR TITLE
[CLI-2101] Prevent panic when the parsing environment flag into the context

### DIFF
--- a/internal/pkg/config/v1/context.go
+++ b/internal/pkg/config/v1/context.go
@@ -214,6 +214,13 @@ func (c *Context) GetEnvironments() []*ccloudv1.Account {
 	return nil
 }
 
+func (c *Context) SetEnvironments(environments []*ccloudv1.Account) {
+	if c.GetAuth() == nil {
+		c.SetAuth(new(AuthConfig))
+	}
+	c.GetAuth().Accounts = environments
+}
+
 func (c *Context) GetAuthToken() string {
 	if state := c.GetState(); state != nil {
 		return state.AuthToken

--- a/internal/pkg/dynamic-config/dynamic_context.go
+++ b/internal/pkg/dynamic-config/dynamic_context.go
@@ -39,7 +39,7 @@ func (d *DynamicContext) ParseFlagsIntoContext(cmd *cobra.Command, client *cclou
 		}
 
 		// If environment ID is not found in config, make api call and check against those accounts
-		if !d.verifyEnvironmentId(environment, d.State.Auth.Accounts) {
+		if !d.verifyEnvironmentId(environment, d.GetEnvironments()) {
 			if client == nil {
 				return fmt.Errorf(errors.EnvironmentNotFoundErrorMsg, environment, d.Name)
 			}
@@ -50,7 +50,7 @@ func (d *DynamicContext) ParseFlagsIntoContext(cmd *cobra.Command, client *cclou
 			}
 
 			if d.verifyEnvironmentId(environment, accounts) {
-				d.State.Auth.Accounts = accounts
+				d.SetEnvironments(accounts)
 				_ = d.Save()
 			} else {
 				return fmt.Errorf(errors.EnvironmentNotFoundErrorMsg, environment, d.Name)


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. You may delete or ignore any unused sections.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- <PLACEHOLDER>

New Features
- <PLACEHOLDER>

Bug Fixes
- Prevent a panic that could occur when using commands with the ``--environment`` flag

Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
If `State` or `Auth` are unexpectedly nil, trying to get `c.State.Auth.Accounts` will panic. This PR replaces the direct access with `Get` functions that check for both a non-nil state and auth.

References
----------
n/a

Test & Review
-------------
All tests pass.
Checked that commands using `--environment` flag still work correctly, and that everything works if you delete the the environment list from the config file (although I'll note that this is true even before this PR, so it's unclear why exactly this issue occurred in the first place).

Open Questions / Follow-ups
---------------------------
<!--
Optional: Anything open to discussion for the reviewer, out of scope of this PR, or follow-ups.
-->
