### PR TITLE
[CLI-1757] only get service accounts and users once, in kafka acl commands

### DIFF
--- a/internal/cmd/kafka/command_acl.go
+++ b/internal/cmd/kafka/command_acl.go
@@ -1,7 +1,6 @@
 package kafka
 
 import (
-	"context"
 	"fmt"
 	"strconv"
 	"strings"
@@ -140,48 +139,20 @@ func parsePrincipal(principal string) (string, error) {
 	return id, nil
 }
 
-func (c *aclCommand) mapUserIdToResourceId(users []*ccloud.User) ([]*ccloud.User, map[int32]string, error) {
-	if users == nil {
-		serviceAccounts, err := c.Client.User.GetServiceAccounts(context.Background())
-		if err != nil {
-			return nil, nil, err
-		}
-
-		adminUsers, err := c.Client.User.List(context.Background())
-		if err != nil {
-			return nil, nil, err
-		}
-
-		users = append(serviceAccounts, adminUsers...)
-	}
-
+func (c *aclCommand) mapUserIdToResourceId(users []*ccloud.User) (map[int32]string, error) {
 	idMap := make(map[int32]string)
 	for _, sa := range users {
 		idMap[sa.Id] = sa.ResourceId
 	}
-	return users, idMap, nil
+	return idMap, nil
 }
 
-func (c *aclCommand) mapResourceIdToUserId(users []*ccloud.User) ([]*ccloud.User, map[string]int32, error) {
-	if users == nil {
-		serviceAccounts, err := c.Client.User.GetServiceAccounts(context.Background())
-		if err != nil {
-			return nil, nil, err
-		}
-
-		adminUsers, err := c.Client.User.List(context.Background())
-		if err != nil {
-			return nil, nil, err
-		}
-
-		users = append(serviceAccounts, adminUsers...)
-	}
-
+func (c *aclCommand) mapResourceIdToUserId(users []*ccloud.User) (map[string]int32, error) {
 	idMap := make(map[string]int32)
 	for _, sa := range users {
 		idMap[sa.ResourceId] = sa.Id
 	}
-	return users, idMap, nil
+	return idMap, nil
 }
 
 func (c *aclCommand) provisioningClusterCheck(cmd *cobra.Command, lkc string) error {

--- a/internal/cmd/kafka/command_acl_create.go
+++ b/internal/cmd/kafka/command_acl_create.go
@@ -1,6 +1,7 @@
 package kafka
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/spf13/cobra"
@@ -55,7 +56,19 @@ func (c *aclCommand) create(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	users, userIdMap, err := c.mapResourceIdToUserId(nil)
+	serviceAccounts, err := c.Client.User.GetServiceAccounts(context.Background())
+	if err != nil {
+		return err
+	}
+
+	adminUsers, err := c.Client.User.List(context.Background())
+	if err != nil {
+		return err
+	}
+
+	users := append(serviceAccounts, adminUsers...)
+
+	userIdMap, err := c.mapResourceIdToUserId(users)
 	if err != nil {
 		return err
 	}
@@ -64,7 +77,7 @@ func (c *aclCommand) create(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	_, resourceIdMap, err := c.mapUserIdToResourceId(users)
+	resourceIdMap, err := c.mapUserIdToResourceId(users)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/kafka/command_acl_create.go
+++ b/internal/cmd/kafka/command_acl_create.go
@@ -1,7 +1,6 @@
 package kafka
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/spf13/cobra"
@@ -56,31 +55,18 @@ func (c *aclCommand) create(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	serviceAccounts, err := c.Client.User.GetServiceAccounts(context.Background())
+	users, err := c.getAllUsers()
 	if err != nil {
 		return err
 	}
 
-	adminUsers, err := c.Client.User.List(context.Background())
-	if err != nil {
-		return err
-	}
-
-	users := append(serviceAccounts, adminUsers...)
-
-	userIdMap, err := c.mapResourceIdToUserId(users)
-	if err != nil {
-		return err
-	}
+	userIdMap := c.mapResourceIdToUserId(users)
 
 	if err := c.aclResourceIdToNumericId(acls, userIdMap); err != nil {
 		return err
 	}
 
-	resourceIdMap, err := c.mapUserIdToResourceId(users)
-	if err != nil {
-		return err
-	}
+	resourceIdMap := c.mapUserIdToResourceId(users)
 
 	var bindings []*ccstructs.ACLBinding
 	for _, acl := range acls {

--- a/internal/cmd/kafka/command_acl_create.go
+++ b/internal/cmd/kafka/command_acl_create.go
@@ -55,7 +55,7 @@ func (c *aclCommand) create(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	userIdMap, err := c.mapResourceIdToUserId()
+	users, userIdMap, err := c.mapResourceIdToUserId(nil)
 	if err != nil {
 		return err
 	}
@@ -64,7 +64,7 @@ func (c *aclCommand) create(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	resourceIdMap, err := c.mapUserIdToResourceId()
+	_, resourceIdMap, err := c.mapUserIdToResourceId(users)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/kafka/command_acl_delete.go
+++ b/internal/cmd/kafka/command_acl_delete.go
@@ -49,7 +49,7 @@ func (c *aclCommand) delete(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	userIdMap, err := c.mapResourceIdToUserId()
+	_, userIdMap, err := c.mapResourceIdToUserId(nil)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/kafka/command_acl_delete.go
+++ b/internal/cmd/kafka/command_acl_delete.go
@@ -1,7 +1,6 @@
 package kafka
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/spf13/cobra"
@@ -50,22 +49,12 @@ func (c *aclCommand) delete(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	serviceAccounts, err := c.Client.User.GetServiceAccounts(context.Background())
+	users, err := c.getAllUsers()
 	if err != nil {
 		return err
 	}
 
-	adminUsers, err := c.Client.User.List(context.Background())
-	if err != nil {
-		return err
-	}
-
-	users := append(serviceAccounts, adminUsers...)
-
-	userIdMap, err := c.mapResourceIdToUserId(users)
-	if err != nil {
-		return err
-	}
+	userIdMap := c.mapResourceIdToUserId(users)
 
 	if err := c.aclResourceIdToNumericId(acls, userIdMap); err != nil {
 		return err

--- a/internal/cmd/kafka/command_acl_delete.go
+++ b/internal/cmd/kafka/command_acl_delete.go
@@ -1,6 +1,7 @@
 package kafka
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/spf13/cobra"
@@ -49,7 +50,19 @@ func (c *aclCommand) delete(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	_, userIdMap, err := c.mapResourceIdToUserId(nil)
+	serviceAccounts, err := c.Client.User.GetServiceAccounts(context.Background())
+	if err != nil {
+		return err
+	}
+
+	adminUsers, err := c.Client.User.List(context.Background())
+	if err != nil {
+		return err
+	}
+
+	users := append(serviceAccounts, adminUsers...)
+
+	userIdMap, err := c.mapResourceIdToUserId(users)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/kafka/command_acl_list.go
+++ b/internal/cmd/kafka/command_acl_list.go
@@ -37,7 +37,7 @@ func (c *aclCommand) list(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	userIdMap, err := c.mapResourceIdToUserId()
+	users, userIdMap, err := c.mapResourceIdToUserId(nil)
 	if err != nil {
 		return err
 	}
@@ -50,7 +50,7 @@ func (c *aclCommand) list(cmd *cobra.Command, _ []string) error {
 		return acl[0].errors
 	}
 
-	resourceIdMap, err := c.mapUserIdToResourceId()
+	_, resourceIdMap, err := c.mapUserIdToResourceId(users)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/kafka/command_acl_list.go
+++ b/internal/cmd/kafka/command_acl_list.go
@@ -1,8 +1,6 @@
 package kafka
 
 import (
-	"context"
-
 	"github.com/spf13/cobra"
 
 	aclutil "github.com/confluentinc/cli/internal/pkg/acl"
@@ -39,22 +37,12 @@ func (c *aclCommand) list(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	serviceAccounts, err := c.Client.User.GetServiceAccounts(context.Background())
+	users, err := c.getAllUsers()
 	if err != nil {
 		return err
 	}
 
-	adminUsers, err := c.Client.User.List(context.Background())
-	if err != nil {
-		return err
-	}
-
-	users := append(serviceAccounts, adminUsers...)
-
-	userIdMap, err := c.mapResourceIdToUserId(users)
-	if err != nil {
-		return err
-	}
+	userIdMap := c.mapResourceIdToUserId(users)
 
 	if err := c.aclResourceIdToNumericId(acl, userIdMap); err != nil {
 		return err
@@ -64,10 +52,7 @@ func (c *aclCommand) list(cmd *cobra.Command, _ []string) error {
 		return acl[0].errors
 	}
 
-	resourceIdMap, err := c.mapUserIdToResourceId(users)
-	if err != nil {
-		return err
-	}
+	resourceIdMap := c.mapUserIdToResourceId(users)
 
 	kafkaClusterConfig, err := c.Context.GetKafkaClusterForCommand()
 	if err != nil {

--- a/internal/cmd/kafka/command_acl_list.go
+++ b/internal/cmd/kafka/command_acl_list.go
@@ -1,6 +1,8 @@
 package kafka
 
 import (
+	"context"
+
 	"github.com/spf13/cobra"
 
 	aclutil "github.com/confluentinc/cli/internal/pkg/acl"
@@ -37,7 +39,19 @@ func (c *aclCommand) list(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	users, userIdMap, err := c.mapResourceIdToUserId(nil)
+	serviceAccounts, err := c.Client.User.GetServiceAccounts(context.Background())
+	if err != nil {
+		return err
+	}
+
+	adminUsers, err := c.Client.User.List(context.Background())
+	if err != nil {
+		return err
+	}
+
+	users := append(serviceAccounts, adminUsers...)
+
+	userIdMap, err := c.mapResourceIdToUserId(users)
 	if err != nil {
 		return err
 	}
@@ -50,7 +64,7 @@ func (c *aclCommand) list(cmd *cobra.Command, _ []string) error {
 		return acl[0].errors
 	}
 
-	_, resourceIdMap, err := c.mapUserIdToResourceId(users)
+	resourceIdMap, err := c.mapUserIdToResourceId(users)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. You may delete or ignore any unused sections.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- <PLACEHOLDER>

New Features
- <PLACEHOLDER>

Bug Fixes
- <PLACEHOLDER>

Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->
only get service accounts and users once, in kafka acl commands, if users are already got, pass it on to next call.

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
<!--
Has it been tested? How?
Copy and paste any instructions or steps that can save the reviewer time.
-->
```
mhe@C02DV0KVMD6T cli % confluent kafka acl list -vvv
2023-02-28T13:20:38.937-0800 [DEBUG] Searching `$PATH` for plugins. Plugins can be disabled in /Users/mhe/.confluent/config.json.

2023-02-28T13:20:39.307-0800 [DEBUG] UserService.GetServiceAccounts request: GET https://confluent.cloud/api/service_accounts
2023-02-28T13:20:39.613-0800 [DEBUG] UserService.GetServiceAccounts response: 200 OK X-Request-Id:60382d3c0de95e8b100a1f8eb6f664e4 Body: {"users":[{"id":618212,"email":"57547-sa-2@serviceaccounts.confluent.cloud","first_name":"","last_name":"","deactivated":false,"verified":"1970-01-01T00:00:00Z","created":"2022-04-19T20:49:50.655621Z","modified":"2022-04-19T20:49:50.655621Z","service_name":"sa-2","service_description":"hello","service_account":true,"preferences":{},"internal":false,"resource_id":"sa-nv87wz","deactivated_at":null,"social_connection":"","auth_type":"AUTH_TYPE_UNKNOWN"},{"id":1031339,"email":"57547-ksql.lksqlc-j33wym@serviceaccounts.confluent.cloud","first_name":"","last_name":"","deactivated":false,"verified":"1970-01-01T00:00:00Z","created":"2022-12-06T21:28:37.587147Z","modified":"2022-12-06T21:28:37.587147Z","service_name":"KSQL.lksqlc-j33wym","service_description":"SA for KSQL w/ ID lksqlc-j33wym and Name tester2","service_account":true,"preferences":{},"internal":false,"resource_id":"sa-5m211z","deactivated_at":null,"social_connection":"","auth_type":"AUTH_TYPE_UNKNOWN"},{"id":1115274,"email":"57547-test-account@serviceaccounts.confluent.cloud","first_name":"","last_name":"","deactivated":false,"verified":"1970-01-01T00:00:00Z","created":"2023-01-20T18:01:52.048401Z","modified":"2023-01-20T18:01:52.048401Z","service_name":"test-account","service_description":"sa","service_account":true,"preferences":{},"internal":false,"resource_id":"sa-zp5qx0","deactivated_at":null,"social_connection":"","auth_type":"AUTH_TYPE_UNKNOWN"},{"id":1168710,"email":"57547-hello@serviceaccounts.confluent.cloud","first_name":"","last_name":"","deactivated":false,"verified":"1970-01-01T00:00:00Z","created":"2023-02-15T23:28:51.900318Z","modified":"2023-02-15T23:28:51.900318Z","service_name":"hello","service_description":"trying","service_account":true,"preferences":{},"internal":false,"resource_id":"sa-55w02z","deactivated_at":null,"social_connection":"","auth_type":"AUTH_TYPE_UNKNOWN"},{"id":1170527,"email":"57547-demoserviceaccount@serviceaccounts.confluent.cloud","first_name":"","last_name":"","deactivated":false,"verified":"1970-01-01T00:00:00Z","created":"2023-02-16T17:37:48.120023Z","modified":"2023-02-16T17:37:48.120023Z","service_name":"DemoServiceAccount","service_description":"This is a demo service account.","service_account":true,"preferences":{},"internal":false,"resource_id":"sa-1n9ykj","deactivated_at":null,"social_connection":"","auth_type":"AUTH_TYPE_UNKNOWN"}],"page_info":{"page_size":0,"page_token":""},"error":null} request: GET https://confluent.cloud/api/service_accounts
2023-02-28T13:20:39.614-0800 [DEBUG] UserService.List request: GET https://confluent.cloud/api/users
2023-02-28T13:20:39.684-0800 [DEBUG] UserService.List response: 200 OK X-Request-Id:e4e95775db2e0507b09bf3b17b8d5bbf Body: {"users":[{"id":222045,"email":"mhe@confluent.io","first_name":"Muwei","last_name":"He","deactivated":false,"verified":"2021-04-28T20:42:34.233043Z","created":"2021-04-28T20:42:16.002626Z","modified":"2023-01-24T00:00:17.777761Z","service_name":"","service_description":"","service_account":false,"preferences":{"ContentfulAnnouncement_1bNdXQcWRrxk6NTXGv1ZwX":"COMPLETE","ContentfulAnnouncement_5ZmlnMShtNKJhWihFLOohr":"COMPLETE","ContentfulAnnouncement_dYhQIQYjVr5c691IKq4Ez":"COMPLETE","accountsWithStreamGovernancePackageUpsellSeen":"{\"env-5z5w8\":true,\"env-2mdy1\":true}","branchPageShown":"COMPLETE","gettingStarted":"SKIPPED","gettingStarted_accountId":"env-5z5w8","gettingStarted_clusterId":"","gettingStarted_lastCompleteStep":"clusterCreate","guidedLearning":"CLOSED","hasDismissedGlobalAnnouncement-a1299b47dcf2337bbdd9ad27b85f42046f0fb1edc8529940ec68516bd33eb9b2":"true","hasFinishedWelcomeSurvey":"true","ksqlGettingStarted":"IN_PROGRESS","ksqlGettingStarted_accountId":"env-2mdy1","ksqlGettingStarted_clusterId":"","ksqlGettingStarted_ksqlClusterId":"lksqlc-dowpky","ksqlGettingStarted_lastCompleteStep":"ksqlCreate","ksqlGettingStarted_source":"ksql-cta","showWelcomePageStatus":"COMPLETE","streamDesignerFlow":"STARTED","userReportedKafkaFamiliarity":"aware","userReportedObjective":"learn","userReportedRole":"developer"},"internal":false,"resource_id":"u-e02dw5","deactivated_at":null,"social_connection":"","auth_type":"AUTH_TYPE_LOCAL"},{"id":623926,"email":"mhe+apple@confluent.io","first_name":"Muwei","last_name":"Cinder","deactivated":false,"verified":"1970-01-01T00:00:00Z","created":"2022-04-22T21:37:47.055572Z","modified":"2022-04-22T21:40:56.566582Z","service_name":"","service_description":"","service_account":false,"preferences":{},"internal":false,"resource_id":"u-j5pzoq","deactivated_at":null,"social_connection":"","auth_type":"AUTH_TYPE_LOCAL"}],"error":null,"page_info":{"page_size":0,"page_token":""}} request: GET https://confluent.cloud/api/users
```

Open Questions / Follow-ups
---------------------------
<!--
Optional: Anything open to discussion for the reviewer, out of scope of this PR, or follow-ups.
-->
