### PR TITLE
[CLI-2262] Check for empty flag values in `price list`

### DIFF
--- a/test/cli_test.go
+++ b/test/cli_test.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/shlex"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
@@ -219,11 +220,14 @@ func (s *CLITestSuite) validateTestOutput(tt CLITest, t *testing.T, output strin
 	}
 }
 
-func runCommand(t *testing.T, binaryName string, env []string, args string, wantErrCode int, input string) string {
+func runCommand(t *testing.T, binaryName string, env []string, argString string, wantErrCode int, input string) string {
 	dir, err := os.Getwd()
 	require.NoError(t, err)
 
-	cmd := exec.Command(filepath.Join(dir, binaryName), strings.Split(args, " ")...)
+	args, err := shlex.Split(argString)
+	require.NoError(t, err)
+
+	cmd := exec.Command(filepath.Join(dir, binaryName), args...)
 	cmd.Env = append(os.Environ(), env...)
 	cmd.Stdin = strings.NewReader(input)
 

--- a/test/fixtures/output/iam/identity-pool/create.golden
+++ b/test/fixtures/output/iam/identity-pool/create.golden
@@ -1,7 +1,7 @@
-+----------------+-------------------------------------------+
-| ID             | pool-55555                                |
-| Name           | testPool                                  |
-| Description    | new-description                           |
-| Identity Claim | sub                                       |
-| Filter         | claims.iss="https://company.provider.com" |
-+----------------+-------------------------------------------+
++----------------+-----------------------------------------+
+| ID             | pool-55555                              |
+| Name           | testPool                                |
+| Description    | new-description                         |
+| Identity Claim | sub                                     |
+| Filter         | claims.iss=https://company.provider.com |
++----------------+-----------------------------------------+

--- a/test/fixtures/output/iam/identity-pool/update.golden
+++ b/test/fixtures/output/iam/identity-pool/update.golden
@@ -1,7 +1,7 @@
-+----------------+---------------------------------------------------+
-| ID             | op-55555                                          |
-| Name           | newer-name                                        |
-| Description    | more-descriptive                                  |
-| Identity Claim | new-sub                                           |
-| Filter         | claims.iss="https://new-company.new-provider.com" |
-+----------------+---------------------------------------------------+
++----------------+-------------------------------------------------+
+| ID             | op-55555                                        |
+| Name           | newer-name                                      |
+| Description    | more-descriptive                                |
+| Identity Claim | new-sub                                         |
+| Filter         | claims.iss=https://new-company.new-provider.com |
++----------------+-------------------------------------------------+

--- a/test/fixtures/output/price/list-empty-flag.golden
+++ b/test/fixtures/output/price/list-empty-flag.golden
@@ -1,0 +1,1 @@
+Error: `--region` must not be empty

--- a/test/iam_test.go
+++ b/test/iam_test.go
@@ -326,7 +326,7 @@ func (s *CLITestSuite) TestIAMProviderList() {
 
 func (s *CLITestSuite) TestIAMPoolCreate() {
 	tests := []CLITest{
-		{args: "iam pool create testPool --provider op-12345 --description new-description --identity-claim sub --filter claims.iss=\"https://company.provider.com\"", fixture: "iam/identity-pool/create.golden"},
+		{args: `iam pool create testPool --provider op-12345 --description new-description --identity-claim sub --filter "claims.iss=https://company.provider.com"`, fixture: "iam/identity-pool/create.golden"},
 	}
 
 	for _, test := range tests {
@@ -361,7 +361,7 @@ func (s *CLITestSuite) TestIAMPoolDescribe() {
 
 func (s *CLITestSuite) TestIAMPoolUpdate() {
 	tests := []CLITest{
-		{args: "iam pool update pool-12345 --provider op-12345 --name newer-name --description more-descriptive --identity-claim new-sub --filter claims.iss=\"https://new-company.new-provider.com\"", fixture: "iam/identity-pool/update.golden"},
+		{args: `iam pool update pool-12345 --provider op-12345 --name newer-name --description more-descriptive --identity-claim new-sub --filter "claims.iss=https://new-company.new-provider.com"`, fixture: "iam/identity-pool/update.golden"},
 	}
 
 	for _, test := range tests {

--- a/test/pipeline_test.go
+++ b/test/pipeline_test.go
@@ -7,7 +7,7 @@ import (
 	"runtime"
 )
 
-func (s *CLITestSuite) TestSDPipeline() {
+func (s *CLITestSuite) TestPipeline() {
 	_, callerFileName, _, ok := runtime.Caller(0)
 	if !ok {
 		s.T().Fatalf("problems recovering caller information")
@@ -26,7 +26,7 @@ func (s *CLITestSuite) TestSDPipeline() {
 		{args: "pipeline create --name testPipeline --ksql-cluster lksqlc-12345", fixture: "pipeline/create.golden"},
 		{args: "pipeline create --name testPipeline --ksql-cluster lksqlc-12345 --description testDescription", fixture: "pipeline/create.golden"},
 		{args: fmt.Sprintf("pipeline create --name testPipeline --ksql-cluster lksqlc-12345 --description testDescription --sql-file %s", testPipelineSourceCode), fixture: "pipeline/create.golden"},
-		{args: "pipeline create --name testPipeline --ksql-cluster lksqlc-12345 --description testDescription --secret name1=value1 --secret name2=value-with,and= --secret name3=value-with\"and' --secret a_really_really_really_really_really_really_really_really_really_really_really_really_long_secret_name_but_not_exceeding_128_yet=value", fixture: "pipeline/create-with-secret-names.golden"},
+		{args: `pipeline create --name testPipeline --ksql-cluster lksqlc-12345 --description testDescription --secret name1=value1 --secret name2=value-with,and= --secret name3=value-with\"and\' --secret a_really_really_really_really_really_really_really_really_really_really_really_really_long_secret_name_but_not_exceeding_128_yet=value`, fixture: "pipeline/create-with-secret-names.golden"},
 		// secret value with space (e.g. name="some value") also works but cannot be integration tested, due to cli_test.runCommand() is splitting these args by space character
 		{args: "pipeline delete --help", fixture: "pipeline/delete-help.golden"},
 		{args: "pipeline delete pipe-12345 --force", fixture: "pipeline/delete.golden"},
@@ -43,7 +43,7 @@ func (s *CLITestSuite) TestSDPipeline() {
 		{args: "pipeline update pipeline-12345 --activation-privilege=true", fixture: "pipeline/update-activation-privilege.golden"},
 		{args: "pipeline update pipeline-12345 --activation-privilege=false", fixture: "pipeline/update.golden"},
 		{args: fmt.Sprintf("pipeline update pipeline-12345 --sql-file %s", testPipelineSourceCode), fixture: "pipeline/update.golden"},
-		{args: "pipeline update pipeline-12345 --secret name1=value-with,and= --secret name2=value-with\"and' --secret name3=", fixture: "pipeline/update-with-secret-names.golden"},
+		{args: `pipeline update pipeline-12345 --secret name1=value-with,and= --secret name2=value-with\"and\' --secret name3=`, fixture: "pipeline/update-with-secret-names.golden"},
 	}
 
 	for _, tt := range tests {

--- a/test/price_test.go
+++ b/test/price_test.go
@@ -9,14 +9,9 @@ const (
 
 func (s *CLITestSuite) TestPriceList() {
 	tests := []CLITest{
-		{
-			args:    fmt.Sprintf("price list --cloud %s --region %s", exampleCloud, exampleRegion),
-			fixture: "price/list.golden",
-		},
-		{
-			args:    fmt.Sprintf("price list --cloud %s --region %s -o json", exampleCloud, exampleRegion),
-			fixture: "price/list-json.golden",
-		},
+		{args: fmt.Sprintf("price list --cloud %s --region %s", exampleCloud, exampleRegion), fixture: "price/list.golden"},
+		{args: fmt.Sprintf("price list --cloud %s --region %s -o json", exampleCloud, exampleRegion), fixture: "price/list-json.golden"},
+		{args: fmt.Sprintf(`price list --cloud %s --region ""`, exampleCloud), fixture: "price/list-empty-flag.golden", wantErrCode: 1},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Release Notes
-------------
Bug Fixes
- Prevent empty values from being passed to flags in ``confluent price list``

Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
`confluent price list --cloud "" --region ""` used to be accepted. Empty values should not be accepted, so now we error.

Used the shlex package to parse integration test commands in a similar manner to bash/zsh (now you can pass multi-word arguments in quotes)

References
----------
https://confluentinc.atlassian.net/browse/CLI-2262

Test & Review
-------------
Added an integration test and fixed other integration tests after switching to shlex.