### PR TITLE
[CLI-962] add `--use` flag in `api-key create` to automatically use the created api-key for the provided resource

### DIFF
--- a/internal/cmd/api-key/command_create.go
+++ b/internal/cmd/api-key/command_create.go
@@ -50,6 +50,7 @@ func (c *command) newCreateCommand() *cobra.Command {
 
 	cmd.Flags().String(resourceFlagName, "", `The resource ID. Use "cloud" to create a Cloud API key.`)
 	cmd.Flags().String("description", "", "Description of API key.")
+	cmd.Flags().Bool("use", false, "automatically use this apikey for the provided resource.")
 	pcmd.AddContextFlag(cmd, c.CLICommand)
 	pcmd.AddEnvironmentFlag(cmd, c.AuthenticatedCLICommand)
 	pcmd.AddServiceAccountFlag(cmd, c.AuthenticatedCLICommand)
@@ -131,6 +132,21 @@ func (c *command) create(cmd *cobra.Command, _ []string) error {
 		if err := c.keystore.StoreAPIKey(userKey, clusterId); err != nil {
 			return errors.Wrap(err, errors.UnableToStoreAPIKeyErrorMsg)
 		}
+	}
+
+	use, err := cmd.Flags().GetBool("use")
+	if err != nil {
+		return err
+	}
+	if use {
+		if resourceType != resource.KafkaCluster {
+			return errors.Wrap(errors.New(errors.NonKafkaNotImplementedErrorMsg), "--use flag ineffective")
+		}
+		err = c.Context.UseAPIKey(userKey.Key, clusterId)
+		if err != nil {
+			return errors.NewWrapErrorWithSuggestions(err, errors.APIKeyUseFailedErrorMsg, fmt.Sprintf(errors.APIKeyUseFailedSuggestions, userKey.Key))
+		}
+		utils.Printf(cmd, errors.UseAPIKeyMsg, userKey.Key, clusterId)
 	}
 
 	return nil

--- a/internal/cmd/api-key/command_create.go
+++ b/internal/cmd/api-key/command_create.go
@@ -50,7 +50,7 @@ func (c *command) newCreateCommand() *cobra.Command {
 
 	cmd.Flags().String(resourceFlagName, "", `The resource ID. Use "cloud" to create a Cloud API key.`)
 	cmd.Flags().String("description", "", "Description of API key.")
-	cmd.Flags().Bool("use", false, "automatically use this apikey for the provided resource.")
+	cmd.Flags().Bool("use", false, "Use the created apikey for the provided resource.")
 	pcmd.AddContextFlag(cmd, c.CLICommand)
 	pcmd.AddEnvironmentFlag(cmd, c.AuthenticatedCLICommand)
 	pcmd.AddServiceAccountFlag(cmd, c.AuthenticatedCLICommand)
@@ -140,7 +140,7 @@ func (c *command) create(cmd *cobra.Command, _ []string) error {
 	}
 	if use {
 		if resourceType != resource.KafkaCluster {
-			return errors.Wrap(errors.New(errors.NonKafkaNotImplementedErrorMsg), "--use flag ineffective")
+			return errors.Wrap(errors.New(errors.NonKafkaNotImplementedErrorMsg), `"--use" set but ineffective`)
 		}
 		err = c.Context.UseAPIKey(userKey.Key, clusterId)
 		if err != nil {

--- a/internal/cmd/api-key/command_create.go
+++ b/internal/cmd/api-key/command_create.go
@@ -140,7 +140,7 @@ func (c *command) create(cmd *cobra.Command, _ []string) error {
 	}
 	if use {
 		if resourceType != resource.KafkaCluster {
-			return errors.Wrap(errors.New(errors.NonKafkaNotImplementedErrorMsg), `"--use" set but ineffective`)
+			return errors.Wrap(errors.New(errors.NonKafkaNotImplementedErrorMsg), "`--use` set but ineffective")
 		}
 		err = c.Context.UseAPIKey(userKey.Key, clusterId)
 		if err != nil {

--- a/internal/cmd/api-key/command_create.go
+++ b/internal/cmd/api-key/command_create.go
@@ -50,7 +50,7 @@ func (c *command) newCreateCommand() *cobra.Command {
 
 	cmd.Flags().String(resourceFlagName, "", `The resource ID. Use "cloud" to create a Cloud API key.`)
 	cmd.Flags().String("description", "", "Description of API key.")
-	cmd.Flags().Bool("use", false, "Use the created apikey for the provided resource.")
+	cmd.Flags().Bool("use", false, "Use the created API key for the provided resource.")
 	pcmd.AddContextFlag(cmd, c.CLICommand)
 	pcmd.AddEnvironmentFlag(cmd, c.AuthenticatedCLICommand)
 	pcmd.AddServiceAccountFlag(cmd, c.AuthenticatedCLICommand)

--- a/internal/pkg/errors/error_message.go
+++ b/internal/pkg/errors/error_message.go
@@ -15,7 +15,7 @@ const (
 	// api-key commands
 	BadServiceAccountIDErrorMsg         = `failed to parse service account id: ensure service account id begins with "sa-"`
 	UnableToStoreAPIKeyErrorMsg         = "unable to store API key locally"
-	NonKafkaNotImplementedErrorMsg      = "command not yet available for non-Kafka cluster resources"
+	NonKafkaNotImplementedErrorMsg      = "functionality not yet available for non-Kafka cluster resources"
 	RefuseToOverrideSecretErrorMsg      = `refusing to overwrite existing secret for API Key "%s"`
 	RefuseToOverrideSecretSuggestions   = "If you would like to override the existing secret stored for API key \"%s\", use `--force` flag."
 	APIKeyUseFailedErrorMsg             = "unable to set active API key"

--- a/test/api_key_test.go
+++ b/test/api_key_test.go
@@ -110,7 +110,7 @@ func (s *CLITestSuite) TestAPIKey() {
 		{args: "api-key create --description yaml-output --resource lkc-other1 -o yaml", fixture: "api-key/46.golden"},
 
 		// create api-key and use for the resource
-		{args: "api-key create --description my-cool-app --resource lkc-cool1 --use", fixture: "api-key/60.golden"}, // MYKEY4
+		{args: "api-key create --description my-cool-app --resource lkc-cool1 --use", fixture: "api-key/60.golden"}, // MYKEY16
 
 		// store: error handling
 		{name: "error if storing unknown API key", args: "api-key store UNKNOWN @test/fixtures/input/api-key/UIAPISECRET100.txt --resource lkc-cool1", fixture: "api-key/47.golden"},

--- a/test/api_key_test.go
+++ b/test/api_key_test.go
@@ -109,6 +109,9 @@ func (s *CLITestSuite) TestAPIKey() {
 		{args: "api-key create --description json-output --resource lkc-other1 -o json", fixture: "api-key/45.golden"},
 		{args: "api-key create --description yaml-output --resource lkc-other1 -o yaml", fixture: "api-key/46.golden"},
 
+		// create api-key and use for the resource
+		{args: "api-key create --description my-cool-app --resource lkc-cool1 --use", fixture: "api-key/60.golden"}, // MYKEY4
+
 		// store: error handling
 		{name: "error if storing unknown API key", args: "api-key store UNKNOWN @test/fixtures/input/api-key/UIAPISECRET100.txt --resource lkc-cool1", fixture: "api-key/47.golden"},
 		{name: "error if storing API key with existing secret", args: "api-key store UIAPIKEY100 NEWSECRET --resource lkc-cool1", fixture: "api-key/48.golden"},

--- a/test/cli_test.go
+++ b/test/cli_test.go
@@ -159,7 +159,7 @@ func (s *CLITestSuite) runIntegrationTest(tt CLITest) {
 		}
 
 		if tt.authKafka != "" {
-			output := runCommand(t, testBin, []string{}, "api-key create --use --resource "+tt.useKafka, 0, "")
+			output := runCommand(t, testBin, []string{}, fmt.Sprintf("api-key create --resource %s --use", tt.useKafka), 0, "")
 			if *debug {
 				fmt.Println(output)
 			}

--- a/test/cli_test.go
+++ b/test/cli_test.go
@@ -159,13 +159,7 @@ func (s *CLITestSuite) runIntegrationTest(tt CLITest) {
 		}
 
 		if tt.authKafka != "" {
-			output := runCommand(t, testBin, []string{}, "api-key create --resource "+tt.useKafka, 0, "")
-			if *debug {
-				fmt.Println(output)
-			}
-			// HACK: we don't have scriptable output yet so we parse it from the table
-			key := strings.TrimSpace(strings.Split(strings.Split(output, "\n")[3], "|")[2])
-			output = runCommand(t, testBin, []string{}, fmt.Sprintf("api-key use %s --resource %s", key, tt.useKafka), 0, "")
+			output := runCommand(t, testBin, []string{}, "api-key create --use --resource "+tt.useKafka, 0, "")
 			if *debug {
 				fmt.Println(output)
 			}

--- a/test/fixtures/output/api-key/29.golden
+++ b/test/fixtures/output/api-key/29.golden
@@ -1,1 +1,1 @@
-Error: command not yet available for non-Kafka cluster resources
+Error: functionality not yet available for non-Kafka cluster resources

--- a/test/fixtures/output/api-key/54.golden
+++ b/test/fixtures/output/api-key/54.golden
@@ -14,6 +14,7 @@ Create an API key for cluster "lkc-123456" and service account "sa-123456":
 Flags:
       --resource string          REQUIRED: The resource ID. Use "cloud" to create a Cloud API key.
       --description string       Description of API key.
+      --use                      Use the created API key for the provided resource.
       --context string           CLI context name.
       --environment string       Environment ID.
       --service-account string   Service account ID.

--- a/test/fixtures/output/api-key/60.golden
+++ b/test/fixtures/output/api-key/60.golden
@@ -1,0 +1,7 @@
+It may take a couple of minutes for the API key to be ready.
+Save the API key and secret. The secret is not retrievable later.
++------------+------------+
+| API Key    | MYKEY16    |
+| API Secret | MYSECRET16 |
++------------+------------+
+Set API Key "MYKEY16" as the active API key for "lkc-cool1".


### PR DESCRIPTION
Release Notes
-------------
New Features
- Add the ``--use`` flag to ``confluent api-key create`` to select the API key after it has been created

Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->
new flag ``--use`` in ``confluent api-key create`` which will use the created API key for the provided resource after successfully creating the key.
If the resource provided is not a kafka cluster, print out error that ``use`` was not effective.

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->
https://confluentinc.atlassian.net/browse/CLI-962

Test & Review
-------------
<!--
Has it been tested? How?
Copy and paste any instructions or steps that can save the reviewer time.
-->


Open Questions / Follow-ups
---------------------------
<!--
Optional: Anything open to discussion for the reviewer, out of scope of this PR, or follow-ups.
-->
