### PR TITLE
Disable plugins by default on Windows

### DIFF
--- a/internal/pkg/config/load/load_latest.go
+++ b/internal/pkg/config/load/load_latest.go
@@ -1,6 +1,8 @@
 package load
 
 import (
+	"runtime"
+
 	"github.com/confluentinc/cli/internal/pkg/config"
 	v1 "github.com/confluentinc/cli/internal/pkg/config/v1"
 )
@@ -35,6 +37,12 @@ func loadLatestNoErr(latestCfg *v1.Config, cfgIndex int) (config.Config, error) 
 func migrateToLatest(cfg config.Config) *v1.Config {
 	switch cfg := cfg.(type) {
 	case *v1.Config:
+		// On Windows, plugin search is prohibitively slow for users with a long $PATH, so plugins should be disabled by default.
+		if runtime.GOOS == "windows" && !cfg.HasDisabledPlugins {
+			cfg.DisablePlugins = true
+			cfg.HasDisabledPlugins = true
+			_ = cfg.Save()
+		}
 		return cfg
 	default:
 		return nil

--- a/internal/pkg/config/load/load_latest.go
+++ b/internal/pkg/config/load/load_latest.go
@@ -38,9 +38,9 @@ func migrateToLatest(cfg config.Config) *v1.Config {
 	switch cfg := cfg.(type) {
 	case *v1.Config:
 		// On Windows, plugin search is prohibitively slow for users with a long $PATH, so plugins should be disabled by default.
-		if runtime.GOOS == "windows" && !cfg.HasDisabledPlugins {
+		if runtime.GOOS == "windows" && !cfg.DisablePluginsOnce {
 			cfg.DisablePlugins = true
-			cfg.HasDisabledPlugins = true
+			cfg.DisablePluginsOnce = true
 			_ = cfg.Save()
 		}
 		return cfg

--- a/internal/pkg/config/v1/config.go
+++ b/internal/pkg/config/v1/config.go
@@ -78,6 +78,7 @@ type Config struct {
 	DisableUpdateCheck  bool                        `json:"disable_update_check"`
 	DisableUpdates      bool                        `json:"disable_updates"`
 	DisablePlugins      bool                        `json:"disable_plugins"`
+	DisablePluginsOnce  bool                        `json:"disable_plugins_once,omitempty"`
 	DisableFeatureFlags bool                        `json:"disable_feature_flags"`
 	NoBrowser           bool                        `json:"no_browser"`
 	Platforms           map[string]*Platform        `json:"platforms,omitempty"`


### PR DESCRIPTION
Release Notes
-------------
Breaking Changes
- Disable plugins by default on Windows, but allow manual re-enablement in ~/.confluent/config.json

Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
Plugin search can be prohibitively slow on Windows. Users with a long `$PATH` often report search times of around 20s, even when running `confluent version`. This is unacceptable UX, so plugins should be disabled by default on Windows. A user can enable them in ~/.confluent/config.json and they won't be disabled again in the lifetime of the configuration file.

Test & Review
-------------
Removed the `runtime.OS == "windows"` condition and tested manually.