### PR TITLE
Chown /etc so cli can read/write /etc/machine-id on Alpine for encryption

### DIFF
--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -26,6 +26,7 @@ RUN curl -L --http1.1 https://cnfl.io/cli | sh -s -- -b /bin
 
 RUN chmod +x /bin/confluent
 RUN chown $USER:$USER /bin/confluent
+RUN chown $USER:$USER /etc
 
 # This symbolic link exists for backwards compatibility reasons
 RUN ln -s /bin/confluent /confluent


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- PLACEHOLDER

New Features
- PLACEHOLDER

Bug Fixes
- Fix ``cipher: message authentication failed`` issue on Alpine image

Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->
got multiple reports saying alpine image is not working because of `cipher authentication error`. Because `/etc` was a read-only dir and cli generates/reads machine id on `/etc/machine-id`, encryption was failing because no actual machine id is being used. chown this dir to solve the read/write issue.

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
<!--
Has it been tested? How?
Copy and paste any instructions or steps that can save the reviewer time.
-->
Tested alpine image that commands and `--save` are working.

Open Questions / Follow-ups
---------------------------
<!--
Optional: Anything open to discussion for the reviewer, out of scope of this PR, or follow-ups.
-->
