### PR TITLE
Parallelize unit tests with `tparallel` and `paralleltests`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ lint: lint-go lint-cli
 .PHONY: lint-go
 lint-go:
 	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.51.1 && \
-	golangci-lint run --enable dupword,misspell,prealloc,usestdlibvars,whitespace --timeout=10m
+	golangci-lint run --enable dupword,misspell,paralleltest,prealloc,tparallel,usestdlibvars,whitespace --timeout=10m
 	@echo "✅  golangci-lint"
 
 .PHONY: lint-cli

--- a/debian/patches/standard_build_layout.patch
+++ b/debian/patches/standard_build_layout.patch
@@ -1,4 +1,4 @@
---- cli/Makefile	2023-03-08 10:19:27.000000000 -0800
+--- cli/Makefile	2023-03-08 17:47:32.000000000 -0800
 +++ debian/Makefile	2022-12-12 17:29:13.000000000 -0800
 @@ -1,128 +1,130 @@
 -SHELL              := /bin/bash
@@ -96,7 +96,7 @@
 -.PHONY: lint-go
 -lint-go:
 -	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.51.1 && \
--	golangci-lint run --enable dupword,misspell,prealloc,usestdlibvars,whitespace --timeout=10m
+-	golangci-lint run --enable dupword,misspell,paralleltest,prealloc,tparallel,usestdlibvars,whitespace --timeout=10m
 -	@echo "✅  golangci-lint"
 -
 -.PHONY: lint-cli

--- a/internal/cmd/admin/command_promo_list_test.go
+++ b/internal/cmd/admin/command_promo_list_test.go
@@ -8,14 +8,20 @@ import (
 )
 
 func TestFormatBalance(t *testing.T) {
+	t.Parallel()
+
 	require.Equal(t, "$0.00/1.00 USD", formatBalance(0, 10000))
 }
 
 func TestConvertToUSD(t *testing.T) {
+	t.Parallel()
+
 	require.Equal(t, 1.23, ConvertToUSD(12300))
 }
 
 func TestFormatExpiration(t *testing.T) {
+	t.Parallel()
+
 	date := time.Date(2021, time.June, 16, 0, 0, 0, 0, time.Local)
 	require.Equal(t, "Jun 16, 2021", formatExpiration(date.Unix()))
 }

--- a/internal/cmd/api-key/command_test.go
+++ b/internal/cmd/api-key/command_test.go
@@ -465,5 +465,6 @@ func (suite *APITestSuite) TestStoreApiKeyPromptUserForKeyAndSecret() {
 }
 
 func TestApiTestSuite(t *testing.T) {
+	t.Parallel()
 	suite.Run(t, new(APITestSuite))
 }

--- a/internal/cmd/asyncapi/command_export_test.go
+++ b/internal/cmd/asyncapi/command_export_test.go
@@ -204,6 +204,8 @@ func newCmd() (*command, error) {
 }
 
 func TestGetTopicDescription(t *testing.T) {
+	t.Parallel()
+
 	c, err := newCmd()
 	require.NoError(t, err)
 
@@ -242,6 +244,8 @@ func TestGetSchemaRegistry(t *testing.T) {
 }
 
 func TestGetSchemaDetails(t *testing.T) {
+	t.Parallel()
+
 	c, err := newCmd()
 	require.NoError(t, err)
 

--- a/internal/cmd/asyncapi/command_export_test.go
+++ b/internal/cmd/asyncapi/command_export_test.go
@@ -227,6 +227,8 @@ func TestGetTopicDescription(t *testing.T) {
 }
 
 func TestGetClusterDetails(t *testing.T) {
+	t.Parallel()
+
 	c, err := newCmd()
 	require.NoError(t, err)
 	flags := &flags{kafkaApiKey: ""}
@@ -235,6 +237,8 @@ func TestGetClusterDetails(t *testing.T) {
 }
 
 func TestGetSchemaRegistry(t *testing.T) {
+	t.Parallel()
+
 	c, err := newCmd()
 	require.NoError(t, err)
 	flags := &flags{schemaRegistryApiKey: "ASYNCAPIKEY", schemaRegistryApiSecret: "ASYNCAPISECRET"}
@@ -268,6 +272,8 @@ func TestGetSchemaDetails(t *testing.T) {
 }
 
 func TestGetChannelDetails(t *testing.T) {
+	t.Parallel()
+
 	c, err := newCmd()
 	require.NoError(t, err)
 
@@ -298,6 +304,8 @@ func TestGetChannelDetails(t *testing.T) {
 }
 
 func TestGetBindings(t *testing.T) {
+	t.Parallel()
+
 	c, err := newCmd()
 	require.NoError(t, err)
 
@@ -315,6 +323,8 @@ func TestGetBindings(t *testing.T) {
 }
 
 func TestGetTags(t *testing.T) {
+	t.Parallel()
+
 	c, err := newCmd()
 	require.NoError(t, err)
 	schema, _, _ := details.srClient.DefaultApi.GetSchemaByVersion(*new(context.Context), "subject1", "1", nil)
@@ -325,10 +335,14 @@ func TestGetTags(t *testing.T) {
 }
 
 func TestGetMessageCompatibility(t *testing.T) {
+	t.Parallel()
+
 	_, err := getMessageCompatibility(details.srClient, *new(context.Context), "subject1")
 	require.NoError(t, err)
 }
 
 func TestMsgName(t *testing.T) {
+	t.Parallel()
+
 	require.Equal(t, "TopicNameMessage", msgName("topic name"))
 }

--- a/internal/cmd/audit-log/command_describe_test.go
+++ b/internal/cmd/audit-log/command_describe_test.go
@@ -15,6 +15,8 @@ import (
 )
 
 func TestAuditLogDescribe(t *testing.T) {
+	t.Parallel()
+
 	cmd := mockAuditLogCommand(true)
 
 	_, err := pcmd.ExecuteCommand(cmd, "describe")
@@ -22,6 +24,8 @@ func TestAuditLogDescribe(t *testing.T) {
 }
 
 func TestAuditLogDescribeUnconfigured(t *testing.T) {
+	t.Parallel()
+
 	cmd := mockAuditLogCommand(false)
 
 	_, err := pcmd.ExecuteCommand(cmd, "describe")

--- a/internal/cmd/audit-log/command_test.go
+++ b/internal/cmd/audit-log/command_test.go
@@ -200,6 +200,7 @@ func (suite *AuditConfigTestSuite) newMockCmd(expect chan MockCall) *cobra.Comma
 }
 
 func TestAuditConfigTestSuite(t *testing.T) {
+	t.Parallel()
 	suite.Run(t, new(AuditConfigTestSuite))
 }
 

--- a/internal/cmd/audit-log/migration_test.go
+++ b/internal/cmd/audit-log/migration_test.go
@@ -14,6 +14,8 @@ import (
 )
 
 func TestAuditLogConfigTranslation(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		clusterConfigs   map[string]string
 		bootstrapServers []string
@@ -224,6 +226,8 @@ func TestAuditLogConfigTranslation(t *testing.T) {
 }
 
 func TestAuditLogConfigTranslationMalformedProperties(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		clusterConfigs   map[string]string
 		bootstrapServers []string
@@ -341,6 +345,8 @@ func TestAuditLogConfigTranslationMalformedProperties(t *testing.T) {
 }
 
 func TestAuditLogConfigTranslationNilCase(t *testing.T) {
+	t.Parallel()
+
 	var null mds.AuditLogConfigSpec
 	val, _ := json.Marshal(null)
 	clusterConfig := map[string]string{"abc": string(val)}

--- a/internal/cmd/byok/command_create_test.go
+++ b/internal/cmd/byok/command_create_test.go
@@ -7,6 +7,8 @@ import (
 )
 
 func TestRemoveKeyVersionFromAzureKeyId(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name     string
 		input    string
@@ -35,7 +37,10 @@ func TestRemoveKeyVersionFromAzureKeyId(t *testing.T) {
 	}
 
 	for _, test := range tests {
+		test := test
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
 			actual := removeKeyVersionFromAzureKeyId(test.input)
 			require.Equal(t, test.expected, actual)
 		})

--- a/internal/cmd/command_test.go
+++ b/internal/cmd/command_test.go
@@ -31,6 +31,8 @@ var (
 )
 
 func TestHelp_NoContext(t *testing.T) {
+	t.Parallel()
+
 	cfg := new(v1.Config)
 
 	out, err := runWithConfig(cfg)
@@ -50,6 +52,8 @@ func TestHelp_NoContext(t *testing.T) {
 }
 
 func TestHelp_CloudSuspendedOrg(t *testing.T) {
+	t.Parallel()
+
 	cfg := &v1.Config{
 		Contexts: map[string]*v1.Context{"cloud": {
 			PlatformName: "confluent.cloud",
@@ -74,6 +78,8 @@ func TestHelp_CloudSuspendedOrg(t *testing.T) {
 }
 
 func TestHelp_CloudEndOfFreeTrialSuspendedOrg(t *testing.T) {
+	t.Parallel()
+
 	cfg := &v1.Config{
 		Contexts: map[string]*v1.Context{"cloud": {
 			PlatformName: "confluent.cloud",
@@ -119,6 +125,8 @@ func TestHelp_CloudEndOfFreeTrialSuspendedOrg(t *testing.T) {
 }
 
 func TestHelp_Cloud(t *testing.T) {
+	t.Parallel()
+
 	cfg := &v1.Config{
 		Contexts: map[string]*v1.Context{"cloud": {
 			PlatformName: "confluent.cloud",
@@ -141,6 +149,8 @@ func TestHelp_Cloud(t *testing.T) {
 }
 
 func TestHelp_CloudWithAPIKey(t *testing.T) {
+	t.Parallel()
+
 	cfg := &v1.Config{
 		Contexts: map[string]*v1.Context{
 			"cloud-with-api-key": {
@@ -166,6 +176,8 @@ func TestHelp_CloudWithAPIKey(t *testing.T) {
 }
 
 func TestHelp_OnPrem(t *testing.T) {
+	t.Parallel()
+
 	cfg := &v1.Config{
 		Contexts:       map[string]*v1.Context{"on-prem": {PlatformName: "https://example.com"}},
 		CurrentContext: "on-prem",

--- a/internal/cmd/completion/completion_test.go
+++ b/internal/cmd/completion/completion_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestCompletion(t *testing.T) {
+	t.Parallel()
+
 	for _, shell := range []string{"bash", "zsh"} {
 		cmd := new(cobra.Command)
 		out, err := completion(cmd, shell)

--- a/internal/cmd/context/command_create_test.go
+++ b/internal/cmd/context/command_create_test.go
@@ -14,6 +14,8 @@ import (
 )
 
 func TestParseStringFlag(t *testing.T) {
+	t.Parallel()
+
 	data := "data"
 
 	cmd := &cobra.Command{}
@@ -36,6 +38,8 @@ func TestParseStringFlag(t *testing.T) {
 }
 
 func TestParseStringFlag_ErrEmpty(t *testing.T) {
+	t.Parallel()
+
 	data := "    "
 
 	cmd := &cobra.Command{}

--- a/internal/cmd/iam/command_acl_test.go
+++ b/internal/cmd/iam/command_acl_test.go
@@ -197,6 +197,7 @@ func (suite *ACLTestSuite) newMockIamCmd(expect chan any, message string) *cobra
 }
 
 func TestAclTestSuite(t *testing.T) {
+	t.Parallel()
 	suite.Run(t, new(ACLTestSuite))
 }
 

--- a/internal/cmd/iam/command_rbac_role_binding_test.go
+++ b/internal/cmd/iam/command_rbac_role_binding_test.go
@@ -24,18 +24,24 @@ func (suite *RoleBindingTestSuite) SetupSuite() {
 }
 
 func TestParseAndValidateResourcePattern_Prefixed(t *testing.T) {
+	t.Parallel()
+
 	pattern, err := parseAndValidateResourcePattern("Topic:test", true)
 	require.NoError(t, err)
 	require.Equal(t, "PREFIXED", pattern.PatternType)
 }
 
 func TestParseAndValidateResourcePattern_Literal(t *testing.T) {
+	t.Parallel()
+
 	pattern, err := parseAndValidateResourcePattern("Topic:a", false)
 	require.NoError(t, err)
 	require.Equal(t, "LITERAL", pattern.PatternType)
 }
 
 func TestParseAndValidateResourcePattern_Topic(t *testing.T) {
+	t.Parallel()
+
 	pattern, err := parseAndValidateResourcePattern("Topic:a", true)
 	require.NoError(t, err)
 	require.Equal(t, "Topic", pattern.ResourceType)
@@ -43,16 +49,21 @@ func TestParseAndValidateResourcePattern_Topic(t *testing.T) {
 }
 
 func TestParseAndValidateResourcePattern_TopicWithColon(t *testing.T) {
+	t.Parallel()
+
 	pattern, err := parseAndValidateResourcePattern("Topic:a:b", true)
 	require.NoError(t, err)
 	require.Equal(t, "a:b", pattern.Name)
 }
 
 func TestParseAndValidateResourcePattern_ErrIncorrectResourceFormat(t *testing.T) {
+	t.Parallel()
+
 	_, err := parseAndValidateResourcePattern("string with no colon", true)
 	require.Error(t, err)
 }
 
 func TestRoleBindingTestSuite(t *testing.T) {
+	t.Parallel()
 	suite.Run(t, new(RoleBindingTestSuite))
 }

--- a/internal/cmd/iam/command_service_account_test.go
+++ b/internal/cmd/iam/command_service_account_test.go
@@ -87,5 +87,6 @@ func (suite *ServiceAccountTestSuite) TestDeleteServiceAccountService() {
 }
 
 func TestServiceAccountTestSuite(t *testing.T) {
+	t.Parallel()
 	suite.Run(t, new(ServiceAccountTestSuite))
 }

--- a/internal/cmd/kafka/command_acl_delete_test.go
+++ b/internal/cmd/kafka/command_acl_delete_test.go
@@ -7,6 +7,8 @@ import (
 )
 
 func TestPrintAclsDeleted(t *testing.T) {
+	t.Parallel()
+
 	assert.Equal(t, "ACL not found. ACL may have been misspelled or already deleted.", printAclsDeleted(0))
 	assert.Equal(t, "Deleted 1 ACL.", printAclsDeleted(1))
 	assert.Equal(t, "Deleted 2 ACLs.", printAclsDeleted(2))

--- a/internal/cmd/kafka/command_acl_test.go
+++ b/internal/cmd/kafka/command_acl_test.go
@@ -7,17 +7,23 @@ import (
 )
 
 func TestParsePrincipal(t *testing.T) {
+	t.Parallel()
+
 	id, err := parsePrincipal("User:u-12345")
 	require.NoError(t, err)
 	require.Equal(t, "u-12345", id)
 }
 
 func TestParsePrincipal_NoPrefix(t *testing.T) {
+	t.Parallel()
+
 	_, err := parsePrincipal("u-12345")
 	require.Error(t, err)
 }
 
 func TestParsePrincipal_NumericId(t *testing.T) {
+	t.Parallel()
+
 	_, err := parsePrincipal("User:12345")
 	require.Error(t, err)
 }

--- a/internal/cmd/kafka/command_clientconfig_test.go
+++ b/internal/cmd/kafka/command_clientconfig_test.go
@@ -7,6 +7,8 @@ import (
 )
 
 func TestCommentAndWarnAboutSr(t *testing.T) {
+	t.Parallel()
+
 	// comments should be at the beginning of the line
 	original := "# Required connection configs for Confluent Cloud Schema Registry\n" +
 		"schema.registry.url=https://{{ SR_ENDPOINT }}\n" +

--- a/internal/cmd/kafka/command_cluster_create_test.go
+++ b/internal/cmd/kafka/command_cluster_create_test.go
@@ -9,11 +9,15 @@ import (
 )
 
 func TestGetKafkaProvisionEstimate_Basic(t *testing.T) {
+	t.Parallel()
+
 	expected := "It may take up to 5 minutes for the Kafka cluster to be ready."
 	require.Equal(t, expected, getKafkaProvisionEstimate(ccstructs.Sku_BASIC))
 }
 
 func TestGetKafkaProvisionEstimate_Dedicated(t *testing.T) {
+	t.Parallel()
+
 	expected := "It may take up to 1 hour for the Kafka cluster to be ready. The organization admin will receive an email once the dedicated cluster is provisioned."
 	require.Equal(t, expected, getKafkaProvisionEstimate(ccstructs.Sku_DEDICATED))
 }

--- a/internal/cmd/kafka/command_cluster_test.go
+++ b/internal/cmd/kafka/command_cluster_test.go
@@ -217,5 +217,6 @@ func (suite *KafkaClusterTestSuite) TestGetLkcForDescribe() {
 }
 
 func TestKafkaClusterTestSuite(t *testing.T) {
+	t.Parallel()
 	suite.Run(t, new(KafkaClusterTestSuite))
 }

--- a/internal/cmd/kafka/kafka_rest_onprem_test.go
+++ b/internal/cmd/kafka/kafka_rest_onprem_test.go
@@ -42,5 +42,6 @@ func (suite *KafkaRestTestSuite) TestSetServerURL() {
 }
 
 func TestKafkaRestTestSuite(t *testing.T) {
+	t.Parallel()
 	suite.Run(t, new(KafkaRestTestSuite))
 }

--- a/internal/cmd/ksql/command_cluster_configureacls_test.go
+++ b/internal/cmd/ksql/command_cluster_configureacls_test.go
@@ -10,6 +10,8 @@ import (
 )
 
 func TestGetCreateAclRequestDataList(t *testing.T) {
+	t.Parallel()
+
 	actual := getCreateAclRequestDataList([]*ccstructs.ACLBinding{{}})
 	expected := kafkarestv3.CreateAclRequestDataList{Data: []kafkarestv3.CreateAclRequestData{{}}}
 	require.Equal(t, expected, actual)

--- a/internal/cmd/ksql/command_test.go
+++ b/internal/cmd/ksql/command_test.go
@@ -175,5 +175,6 @@ func (suite *KSQLTestSuite) TestDeleteKSQL() {
 }
 
 func TestKsqlTestSuite(t *testing.T) {
+	t.Parallel()
 	suite.Run(t, new(KSQLTestSuite))
 }

--- a/internal/cmd/local/command_service_connect_test.go
+++ b/internal/cmd/local/command_service_connect_test.go
@@ -15,6 +15,8 @@ var (
 )
 
 func TestIsJSON(t *testing.T) {
+	t.Parallel()
+
 	req := require.New(t)
 
 	req.True(isJSON([]byte(exampleJSON)))
@@ -22,6 +24,8 @@ func TestIsJSON(t *testing.T) {
 }
 
 func TestFormatJSONResponse(t *testing.T) {
+	t.Parallel()
+
 	req := require.New(t)
 
 	res := &http.Response{
@@ -34,6 +38,8 @@ func TestFormatJSONResponse(t *testing.T) {
 }
 
 func TestFormatEmptyJSONResponse(t *testing.T) {
+	t.Parallel()
+
 	req := require.New(t)
 
 	res := &http.Response{

--- a/internal/cmd/local/command_service_test.go
+++ b/internal/cmd/local/command_service_test.go
@@ -8,6 +8,8 @@ import (
 )
 
 func TestInjectConfigs(t *testing.T) {
+	t.Parallel()
+
 	req := require.New(t)
 
 	data := []byte("replace=old\n# replace=commented-duplicate\n# comment=old\n")
@@ -27,6 +29,8 @@ func TestInjectConfigs(t *testing.T) {
 }
 
 func TestInjectConfigsNoNewline(t *testing.T) {
+	t.Parallel()
+
 	req := require.New(t)
 
 	data := []byte("replace=old\n# replace=commented-duplicate\n# comment=old")
@@ -45,6 +49,8 @@ func TestInjectConfigsNoNewline(t *testing.T) {
 }
 
 func TestSetServiceEnvs(t *testing.T) {
+	t.Parallel()
+
 	req := require.New(t)
 
 	req.NoError(os.Setenv("KAFKA_LOG4J_OPTS", "saveme"))
@@ -57,6 +63,8 @@ func TestSetServiceEnvs(t *testing.T) {
 }
 
 func TestIsValidJavaVersion(t *testing.T) {
+	t.Parallel()
+
 	req := require.New(t)
 
 	var isValid bool

--- a/internal/cmd/local/command_services_test.go
+++ b/internal/cmd/local/command_services_test.go
@@ -15,6 +15,8 @@ const (
 )
 
 func TestGetConnectConfig(t *testing.T) {
+	t.Parallel()
+
 	want := map[string]string{
 		"bootstrap.servers":            "localhost:9092",
 		"plugin.path":                  exampleFile,
@@ -29,13 +31,15 @@ func TestGetConnectConfig(t *testing.T) {
 }
 
 func TestGetControlCenterConfig(t *testing.T) {
-	want := map[string]string{
-		"confluent.controlcenter.data.dir": exampleDir,
-	}
+	t.Parallel()
+
+	want := map[string]string{"confluent.controlcenter.data.dir": exampleDir}
 	testGetConfig(t, "control-center", want)
 }
 
 func TestGetKafkaConfig(t *testing.T) {
+	t.Parallel()
+
 	want := map[string]string{
 		"log.dirs":         exampleDir,
 		"metric.reporters": "io.confluent.metrics.reporter.ConfluentMetricsReporter",
@@ -46,6 +50,8 @@ func TestGetKafkaConfig(t *testing.T) {
 }
 
 func TestGetKafkaRestConfig(t *testing.T) {
+	t.Parallel()
+
 	want := map[string]string{
 		"schema.registry.url":          "http://localhost:8081",
 		"zookeeper.connect":            "localhost:2181",
@@ -56,6 +62,8 @@ func TestGetKafkaRestConfig(t *testing.T) {
 }
 
 func TestGetKsqlServerConfig(t *testing.T) {
+	t.Parallel()
+
 	want := map[string]string{
 		"kafkastore.connection.url":    "localhost:2181",
 		"ksql.schema.registry.url":     "http://localhost:8081",
@@ -67,6 +75,8 @@ func TestGetKsqlServerConfig(t *testing.T) {
 }
 
 func TestGetSchemaRegistryConfig(t *testing.T) {
+	t.Parallel()
+
 	want := map[string]string{
 		"kafkastore.connection.url":    "localhost:2181",
 		"consumer.interceptor.classes": "io.confluent.monitoring.clients.interceptor.MonitoringConsumerInterceptor",
@@ -76,9 +86,9 @@ func TestGetSchemaRegistryConfig(t *testing.T) {
 }
 
 func TestGetZookeeperConfig(t *testing.T) {
-	want := map[string]string{
-		"dataDir": exampleDir,
-	}
+	t.Parallel()
+
+	want := map[string]string{"dataDir": exampleDir}
 	testGetConfig(t, "zookeeper", want)
 }
 
@@ -114,6 +124,8 @@ func testGetConfig(t *testing.T, service string, want map[string]string) {
 }
 
 func TestConfluentPlatformAvailableServices(t *testing.T) {
+	t.Parallel()
+
 	req := require.New(t)
 
 	c := &Command{
@@ -140,6 +152,8 @@ func TestConfluentPlatformAvailableServices(t *testing.T) {
 }
 
 func TestConfluentCommunitySoftwareAvailableServices(t *testing.T) {
+	t.Parallel()
+
 	req := require.New(t)
 
 	c := &Command{

--- a/internal/cmd/login/command_test.go
+++ b/internal/cmd/login/command_test.go
@@ -156,6 +156,8 @@ var (
 )
 
 func TestCredentialsOverride(t *testing.T) {
+	t.Parallel()
+
 	req := require.New(t)
 	auth := &ccloudv1mock.Auth{
 		LoginFunc: func(_ context.Context, _ *ccloudv1.AuthenticateRequest) (*ccloudv1.AuthenticateReply, error) {
@@ -222,6 +224,8 @@ func TestCredentialsOverride(t *testing.T) {
 }
 
 func TestOrgIdOverride(t *testing.T) {
+	t.Parallel()
+
 	req := require.New(t)
 	auth := &ccloudv1mock.Auth{
 		UserFunc: func(ctx context.Context) (*ccloudv1.GetMeReply, error) {
@@ -281,6 +285,8 @@ func TestOrgIdOverride(t *testing.T) {
 }
 
 func TestLoginSuccess(t *testing.T) {
+	t.Parallel()
+
 	req := require.New(t)
 	org2 := false
 	auth := &ccloudv1mock.Auth{
@@ -355,6 +361,8 @@ func TestLoginSuccess(t *testing.T) {
 }
 
 func TestLoginOrderOfPrecedence(t *testing.T) {
+	t.Parallel()
+
 	req := require.New(t)
 	netrcUser := "netrc@confleunt.io"
 	netrcPassword := "netrcpassword"
@@ -412,7 +420,10 @@ func TestLoginOrderOfPrecedence(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			loginCredentialsManager := &climock.LoginCredentialsManager{
 				GetCloudCredentialsFromEnvVarFunc: func(_ string) func() (*pauth.Credentials, error) {
 					return func() (*pauth.Credentials, error) {
@@ -500,6 +511,8 @@ func TestLoginOrderOfPrecedence(t *testing.T) {
 }
 
 func TestPromptLoginFlag(t *testing.T) {
+	t.Parallel()
+
 	req := require.New(t)
 	wrongCreds := &pauth.Credentials{
 		Username: "wrong_user",
@@ -514,13 +527,13 @@ func TestPromptLoginFlag(t *testing.T) {
 			name:    "cloud login prompt flag",
 			isCloud: true,
 		},
-		{
-			name: "on-prem login prompt flag",
-		},
+		{name: "on-prem login prompt flag"},
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			mockLoginCredentialsManager := &climock.LoginCredentialsManager{
 				GetCloudCredentialsFromEnvVarFunc: func(_ string) func() (*pauth.Credentials, error) {
 					return func() (*pauth.Credentials, error) {
@@ -574,6 +587,8 @@ func TestPromptLoginFlag(t *testing.T) {
 }
 
 func TestLoginFail(t *testing.T) {
+	t.Parallel()
+
 	req := require.New(t)
 	mockLoginCredentialsManager := &climock.LoginCredentialsManager{
 		GetCloudCredentialsFromEnvVarFunc: func(_ string) func() (*pauth.Credentials, error) {
@@ -614,7 +629,7 @@ func TestLoginFail(t *testing.T) {
 	req.Equal(new(ccloudv1.InvalidLoginError), err)
 }
 
-func Test_SelfSignedCerts(t *testing.T) {
+func Test_SelfSignedCerts(t *testing.T) { //nolint:paralleltest
 	req := require.New(t)
 	tests := []struct {
 		name                string
@@ -641,7 +656,7 @@ func Test_SelfSignedCerts(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tests {
+	for _, tt := range tests { //nolint:paralleltest
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.setEnv {
 				os.Setenv(pauth.ConfluentPlatformCACertPath, "testcert.pem")
@@ -679,6 +694,8 @@ func Test_SelfSignedCerts(t *testing.T) {
 }
 
 func Test_SelfSignedCertsLegacyContexts(t *testing.T) {
+	t.Parallel()
+
 	originalCaCertPath, _ := filepath.Abs("ogcert.pem")
 
 	req := require.New(t)
@@ -699,7 +716,10 @@ func Test_SelfSignedCertsLegacyContexts(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			legacyContextName := "login-prompt-user@confluent.io-http://localhost:8090"
 			cfg := v1.AuthenticatedConfigMockWithContextName(legacyContextName)
 			cfg.Contexts[legacyContextName].Platform.CaCertPath = originalCaCertPath
@@ -779,7 +799,7 @@ func getNewLoginCommandForSelfSignedCertTest(req *require.Assertions, cfg *v1.Co
 	return loginCmd
 }
 
-func TestLoginWithExistingContext(t *testing.T) {
+func TestLoginWithExistingContext(t *testing.T) { //nolint:paralleltest
 	req := require.New(t)
 	auth := &ccloudv1mock.Auth{
 		LoginFunc: func(_ context.Context, _ *ccloudv1.AuthenticateRequest) (*ccloudv1.AuthenticateReply, error) {
@@ -859,6 +879,8 @@ func TestLoginWithExistingContext(t *testing.T) {
 }
 
 func TestValidateUrl(t *testing.T) {
+	t.Parallel()
+
 	req := require.New(t)
 	suite := []struct {
 		urlIn      string

--- a/internal/cmd/logout/command_test.go
+++ b/internal/cmd/logout/command_test.go
@@ -113,6 +113,8 @@ var (
 )
 
 func TestLogout(t *testing.T) {
+	t.Parallel()
+
 	req := require.New(t)
 	clearCCloudDeprecatedEnvVar(req)
 	cfg := v1.AuthenticatedCloudConfigMock()
@@ -127,6 +129,8 @@ func TestLogout(t *testing.T) {
 }
 
 func TestRemoveNetrcCredentials(t *testing.T) {
+	t.Parallel()
+
 	req := require.New(t)
 	clearCCloudDeprecatedEnvVar(req)
 	cfg := v1.AuthenticatedCloudConfigMock()

--- a/internal/cmd/pipeline/command_create_test.go
+++ b/internal/cmd/pipeline/command_create_test.go
@@ -1,11 +1,14 @@
 package pipeline
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestCreateValidSecretMappings(t *testing.T) {
+	t.Parallel()
+
 	secretMappings, err := createSecretMappings([]string{"name1=value1", "_name2=value2"}, secretMappingWithoutEmptyValue)
 	assert.NoError(t, err)
 	assert.Equal(t, "value1", secretMappings["name1"])
@@ -22,6 +25,8 @@ func TestCreateValidSecretMappings(t *testing.T) {
 }
 
 func TestCreateSecretMappingsWithInvalidName(t *testing.T) {
+	t.Parallel()
+
 	_, err := createSecretMappings([]string{"123invalidName=value"}, secretMappingWithoutEmptyValue)
 	assert.Error(t, err)
 
@@ -30,12 +35,16 @@ func TestCreateSecretMappingsWithInvalidName(t *testing.T) {
 }
 
 func TestCreateSecretMappingsWithLongName(t *testing.T) {
+	t.Parallel()
+
 	secretMappings, err := createSecretMappings([]string{"a_really_really_really_really_really_really_really_really_really_really_really_really_long_secret_name_but_not_exceeding_128_yet=value"}, secretMappingWithoutEmptyValue)
 	assert.NoError(t, err)
 	assert.Equal(t, "value", secretMappings["a_really_really_really_really_really_really_really_really_really_really_really_really_long_secret_name_but_not_exceeding_128_yet"])
 }
 
 func TestCreateSecretMappingsWithEmptyValue(t *testing.T) {
+	t.Parallel()
+
 	// empty secret value is NOT allowed with this regex
 	_, err := createSecretMappings([]string{"name1=value1", "name2="}, secretMappingWithoutEmptyValue)
 	assert.Error(t, err)
@@ -47,6 +56,8 @@ func TestCreateSecretMappingsWithEmptyValue(t *testing.T) {
 }
 
 func TestSecretNamesListWithEmptyInput(t *testing.T) {
+	t.Parallel()
+
 	assert.Equal(t, []string{}, getOrderedSecretNames(nil))
 
 	secretMappings := make(map[string]string)
@@ -54,6 +65,8 @@ func TestSecretNamesListWithEmptyInput(t *testing.T) {
 }
 
 func TestSecretNamesListOrder(t *testing.T) {
+	t.Parallel()
+
 	secretMappings := make(map[string]string)
 
 	secretMappings["name1"] = "value1"

--- a/internal/cmd/pipeline/command_save_test.go
+++ b/internal/cmd/pipeline/command_save_test.go
@@ -8,17 +8,17 @@ import (
 )
 
 func TestGetPath_NoPrefix(t *testing.T) {
+	t.Parallel()
+
 	require.Equal(t, "pipeline.sql", getPath("pipeline.sql"))
 }
 
-func TestGetPath_HomeDir(t *testing.T) {
-	err := os.Setenv("HOME", "home")
-	require.NoError(t, err)
-
+func TestGetPath_HomeDir(t *testing.T) { //nolint:paralleltest
+	t.Setenv("HOME", "home")
 	require.Equal(t, "home/pipeline.sql", getPath("~/pipeline.sql"))
 }
 
-func TestGetPath_HomeDirUnset(t *testing.T) {
+func TestGetPath_HomeDirUnset(t *testing.T) { //nolint:paralleltest
 	err := os.Unsetenv("HOME")
 	require.NoError(t, err)
 

--- a/internal/cmd/price/command_list_test.go
+++ b/internal/cmd/price/command_list_test.go
@@ -28,9 +28,9 @@ const (
 )
 
 func TestRequireFlags(t *testing.T) {
-	var err error
+	t.Parallel()
 
-	_, err = cmd.ExecuteCommand(mockPriceCommand(nil, exampleMetric, exampleUnit), "list", "--cloud", exampleCloud)
+	_, err := cmd.ExecuteCommand(mockPriceCommand(nil, exampleMetric, exampleUnit), "list", "--cloud", exampleCloud)
 	require.Error(t, err)
 
 	_, err = cmd.ExecuteCommand(mockPriceCommand(nil, exampleMetric, exampleUnit), "list", "--region", exampleRegion)
@@ -38,6 +38,8 @@ func TestRequireFlags(t *testing.T) {
 }
 
 func TestList(t *testing.T) {
+	t.Parallel()
+
 	command := mockSingleRowCommand()
 
 	want := strings.Join([]string{
@@ -52,6 +54,8 @@ func TestList(t *testing.T) {
 }
 
 func TestListLegacyClusterTypes(t *testing.T) {
+	t.Parallel()
+
 	command := mockPriceCommand(map[string]float64{
 		strings.Join([]string{exampleCloud, exampleRegion, exampleAvailability, exampleLegacyClusterType, exampleNetworkType}, ":"): examplePrice,
 	}, exampleMetric, exampleUnit)
@@ -68,6 +72,8 @@ func TestListLegacyClusterTypes(t *testing.T) {
 }
 
 func TestOmitLegacyClusterTypes(t *testing.T) {
+	t.Parallel()
+
 	command := mockPriceCommand(map[string]float64{
 		strings.Join([]string{exampleCloud, exampleRegion, exampleAvailability, exampleLegacyClusterType, exampleNetworkType}, ":"): examplePrice,
 	}, exampleMetric, exampleUnit)
@@ -102,6 +108,8 @@ func mockPriceCommand(prices map[string]float64, metricsName, metricsUnit string
 }
 
 func TestFormatPrice(t *testing.T) {
+	t.Parallel()
+
 	require.Equal(t, "$1.00 USD/GB", formatPrice(1, "GB"))
 	require.Equal(t, "$1.20 USD/GB", formatPrice(1.2, "GB"))
 	require.Equal(t, "$1.23 USD/GB", formatPrice(1.23, "GB"))
@@ -109,6 +117,8 @@ func TestFormatPrice(t *testing.T) {
 }
 
 func TestPrice_ClusterLink(t *testing.T) {
+	t.Parallel()
+
 	command := mockPriceCommand(map[string]float64{
 		strings.Join([]string{exampleCloud, exampleRegion, exampleAvailability, exampleClusterType, exampleNetworkType}, ":"): examplePrice,
 	}, "ClusterLinkingBase", "Hour")

--- a/internal/cmd/schema-registry/command_cluster_test.go
+++ b/internal/cmd/schema-registry/command_cluster_test.go
@@ -158,5 +158,6 @@ func (suite *ClusterTestSuite) TestUpdateNoArgs() {
 }
 
 func TestClusterTestSuite(t *testing.T) {
+	t.Parallel()
 	suite.Run(t, new(ClusterTestSuite))
 }

--- a/internal/cmd/schema-registry/command_exporter_describe_test.go
+++ b/internal/cmd/schema-registry/command_exporter_describe_test.go
@@ -7,6 +7,8 @@ import (
 )
 
 func TestConvertMapToString(t *testing.T) {
+	t.Parallel()
+
 	m := map[string]string{"name": "alice", "phone": "xxx-xxx-xxxx", "age": "20"}
 	require.Equal(t, "age=\"20\"\nname=\"alice\"\nphone=\"xxx-xxx-xxxx\"", convertMapToString(m))
 }

--- a/internal/cmd/schema-registry/command_schema_test.go
+++ b/internal/cmd/schema-registry/command_schema_test.go
@@ -200,5 +200,6 @@ func (suite *SchemaTestSuite) TestDescribeBySubjectVersion() {
 }
 
 func TestSchemaSuite(t *testing.T) {
+	t.Parallel()
 	suite.Run(t, new(SchemaTestSuite))
 }

--- a/internal/cmd/schema-registry/command_subject_test.go
+++ b/internal/cmd/schema-registry/command_subject_test.go
@@ -165,5 +165,6 @@ func (suite *SubjectTestSuite) TestSubjectDescribeDeleted() {
 }
 
 func TestSubjectSuite(t *testing.T) {
+	t.Parallel()
 	suite.Run(t, new(SubjectTestSuite))
 }

--- a/internal/cmd/schema-registry/credentials_test.go
+++ b/internal/cmd/schema-registry/credentials_test.go
@@ -10,6 +10,8 @@ import (
 )
 
 func TestSrAuthFound(t *testing.T) {
+	t.Parallel()
+
 	req := require.New(t)
 
 	cfg := climock.AuthenticatedDynamicConfigMock()

--- a/internal/cmd/update/command_test.go
+++ b/internal/cmd/update/command_test.go
@@ -10,6 +10,8 @@ import (
 )
 
 func TestGetReleaseNotes_MultipleReleaseNotes(t *testing.T) {
+	t.Parallel()
+
 	client := &updatemock.Client{
 		GetLatestReleaseNotesFunc: func(_, _ string) (string, []string, error) {
 			notes := []string{

--- a/internal/pkg/acl/acl_test.go
+++ b/internal/pkg/acl/acl_test.go
@@ -15,6 +15,8 @@ import (
 )
 
 func TestParseAclRequest(t *testing.T) {
+	t.Parallel()
+
 	var suite = []struct {
 		args        []string
 		expectedAcl AclRequestDataWithError
@@ -77,6 +79,8 @@ func TestParseAclRequest(t *testing.T) {
 }
 
 func TestValidateCreateDeleteAclRequestData(t *testing.T) {
+	t.Parallel()
+
 	var suite = []struct {
 		initialAcl  AclRequestDataWithError
 		expectedAcl AclRequestDataWithError
@@ -113,6 +117,8 @@ func TestValidateCreateDeleteAclRequestData(t *testing.T) {
 }
 
 func TestGetPrefixAndResourceIdFromPrincipal_Empty(t *testing.T) {
+	t.Parallel()
+
 	prefix, resourceId, err := getPrefixAndResourceIdFromPrincipal("", nil)
 	require.NoError(t, err)
 	require.Equal(t, "", prefix)
@@ -120,11 +126,15 @@ func TestGetPrefixAndResourceIdFromPrincipal_Empty(t *testing.T) {
 }
 
 func TestGetPrefixAndResourceIdFromPrincipal_UnrecognizedFormat(t *testing.T) {
+	t.Parallel()
+
 	_, _, err := getPrefixAndResourceIdFromPrincipal("string with no colon", nil)
 	require.Error(t, err)
 }
 
 func TestGetPrefixAndResourceIdFromPrincipal_ResourceId(t *testing.T) {
+	t.Parallel()
+
 	prefix, resourceId, err := getPrefixAndResourceIdFromPrincipal("User:sa-123456", nil)
 	require.NoError(t, err)
 	require.Equal(t, "User", prefix)
@@ -132,6 +142,8 @@ func TestGetPrefixAndResourceIdFromPrincipal_ResourceId(t *testing.T) {
 }
 
 func TestGetPrefixAndResourceIdFromPrincipal_NumericId(t *testing.T) {
+	t.Parallel()
+
 	prefix, resourceId, err := getPrefixAndResourceIdFromPrincipal("User:123456", map[int32]string{123456: "sa-123456"})
 	require.NoError(t, err)
 	require.Equal(t, "User", prefix)
@@ -139,6 +151,8 @@ func TestGetPrefixAndResourceIdFromPrincipal_NumericId(t *testing.T) {
 }
 
 func TestGetPrefixAndResourceIdFromPrincipal_UserIdNotValid(t *testing.T) {
+	t.Parallel()
+
 	for _, principal := range []string{"User:123456", "User:abcdef"} {
 		_, _, err := getPrefixAndResourceIdFromPrincipal(principal, nil)
 		require.Error(t, err)
@@ -146,6 +160,8 @@ func TestGetPrefixAndResourceIdFromPrincipal_UserIdNotValid(t *testing.T) {
 }
 
 func TestAclBindingToClustersClusterIdAclsPostOpts(t *testing.T) {
+	t.Parallel()
+
 	req := require.New(t)
 
 	binding := &ccstructs.ACLBinding{

--- a/internal/pkg/auth/login_credentials_manager_test.go
+++ b/internal/pkg/auth/login_credentials_manager_test.go
@@ -424,5 +424,6 @@ func (suite *LoginCredentialsManagerTestSuite) clearCPEnvVars() {
 }
 
 func TestLoginCredentialsManager(t *testing.T) {
+	t.Parallel()
 	suite.Run(t, new(LoginCredentialsManagerTestSuite))
 }

--- a/internal/pkg/auth/sso/auth_server_test.go
+++ b/internal/pkg/auth/sso/auth_server_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestServerTimeout(t *testing.T) {
+	t.Parallel()
+
 	state, err := newState("https://devel.cpdev.cloud", false)
 	require.NoError(t, err)
 	server := newServer(state)
@@ -23,7 +25,7 @@ func TestServerTimeout(t *testing.T) {
 	errors.VerifyErrorAndSuggestions(require.New(t), err, errors.BrowserAuthTimedOutErrorMsg, errors.BrowserAuthTimedOutSuggestions)
 }
 
-func TestCallback(t *testing.T) {
+func TestCallback(t *testing.T) { //nolint:paralleltest
 	state, err := newState("https://devel.cpdev.cloud", false)
 	require.NoError(t, err)
 	server := newServer(state)

--- a/internal/pkg/auth/sso/auth_state_test.go
+++ b/internal/pkg/auth/sso/auth_state_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestNewStateDev(t *testing.T) {
+	t.Parallel()
+
 	state, err := newState("https://devel.cpdev.cloud", false)
 	require.NoError(t, err)
 	// randomly generated
@@ -53,6 +55,8 @@ func TestNewStateDev(t *testing.T) {
 }
 
 func TestNewStateDevNoBrowser(t *testing.T) {
+	t.Parallel()
+
 	state, err := newState("https://devel.cpdev.cloud", true)
 	require.NoError(t, err)
 	// randomly generated
@@ -95,6 +99,8 @@ func TestNewStateDevNoBrowser(t *testing.T) {
 }
 
 func TestNewStateProd(t *testing.T) {
+	t.Parallel()
+
 	state, err := newState("https://confluent.cloud", false)
 	require.NoError(t, err)
 	// randomly generated
@@ -115,6 +121,8 @@ func TestNewStateProd(t *testing.T) {
 }
 
 func TestNewStateProdNoBrowser(t *testing.T) {
+	t.Parallel()
+
 	for _, authURL := range []string{"", "https://confluent.cloud"} {
 		state, err := newState(authURL, true)
 		require.NoError(t, err)
@@ -138,6 +146,8 @@ func TestNewStateProdNoBrowser(t *testing.T) {
 }
 
 func TestNewStateInvalidUrl(t *testing.T) {
+	t.Parallel()
+
 	state, err := newState("Invalid url", true)
 	require.Error(t, err)
 	require.Equal(t, err.Error(), "unrecognized auth url: Invalid url")
@@ -145,6 +155,8 @@ func TestNewStateInvalidUrl(t *testing.T) {
 }
 
 func TestGetAuthorizationUrl(t *testing.T) {
+	t.Parallel()
+
 	state, _ := newState("https://devel.cpdev.cloud", false)
 
 	// test get auth code url
@@ -174,6 +186,8 @@ func TestGetAuthorizationUrl(t *testing.T) {
 }
 
 func TestGetOAuthToken(t *testing.T) {
+	t.Parallel()
+
 	mockRefreshToken := "foo"
 
 	state, _ := newState("https://devel.cpdev.cloud", false)
@@ -211,6 +225,8 @@ func TestGetOAuthToken(t *testing.T) {
 }
 
 func TestRefreshOAuthToken(t *testing.T) {
+	t.Parallel()
+
 	mockRefreshToken1 := "foo"
 	mockRefreshToken2 := "bar"
 

--- a/internal/pkg/ccloudv2/utils_test.go
+++ b/internal/pkg/ccloudv2/utils_test.go
@@ -8,6 +8,8 @@ import (
 )
 
 func TestIsCCloudURL_True(t *testing.T) {
+	t.Parallel()
+
 	for _, url := range []string{
 		"confluent.cloud",
 		"https://confluent.cloud",
@@ -22,6 +24,8 @@ func TestIsCCloudURL_True(t *testing.T) {
 }
 
 func TestIsCCloudURL_False(t *testing.T) {
+	t.Parallel()
+
 	for _, url := range []string{
 		"example.com",
 		"example.com:8090",
@@ -33,6 +37,8 @@ func TestIsCCloudURL_False(t *testing.T) {
 }
 
 func TestGetServerUrl(t *testing.T) {
+	t.Parallel()
+
 	m := map[string]string{
 		"https://confluent.cloud":                  "https://api.confluent.cloud",
 		"https://devel.cpdev.cloud":                "https://api.devel.cpdev.cloud",

--- a/internal/pkg/cmd/kafka_rest_test.go
+++ b/internal/pkg/cmd/kafka_rest_test.go
@@ -21,5 +21,6 @@ func (suite *KafkaRestTestSuite) TestInvalidGetBearerToken() {
 }
 
 func TestKafkaRestTestSuite(t *testing.T) {
+	t.Parallel()
 	suite.Run(t, new(KafkaRestTestSuite))
 }

--- a/internal/pkg/cmd/prerunner.go
+++ b/internal/pkg/cmd/prerunner.go
@@ -302,7 +302,7 @@ func (r *PreRun) Authenticated(command *AuthenticatedCLICommand) func(cmd *cobra
 
 		setContextErr := r.setAuthenticatedContext(command)
 		if setContextErr != nil {
-			if _, ok := setContextErr.(*errors.NotLoggedInError); ok { //nolint:gosimple // false positive
+			if _, ok := setContextErr.(*errors.NotLoggedInError); ok {
 				var netrcMachineName string
 				if ctx := command.Config.Context(); ctx != nil {
 					netrcMachineName = ctx.GetNetrcMachineName()
@@ -568,7 +568,7 @@ func (r *PreRun) AuthenticatedWithMDS(command *AuthenticatedCLICommand) func(cmd
 
 		setContextErr := r.setAuthenticatedWithMDSContext(command)
 		if setContextErr != nil {
-			if _, ok := setContextErr.(*errors.NotLoggedInError); ok { //nolint:gosimple // false positive
+			if _, ok := setContextErr.(*errors.NotLoggedInError); ok {
 				var netrcMachineName string
 				if ctx := command.Config.Context(); ctx != nil {
 					netrcMachineName = ctx.GetNetrcMachineName()

--- a/internal/pkg/cmd/prerunner_test.go
+++ b/internal/pkg/cmd/prerunner_test.go
@@ -122,7 +122,7 @@ func getPreRunBase() *pcmd.PreRun {
 	}
 }
 
-func TestPreRun_Anonymous_SetLoggingLevel(t *testing.T) {
+func TestPreRun_Anonymous_SetLoggingLevel(t *testing.T) { //nolint:paralleltest
 	featureflags.Init(nil, true, false)
 
 	tests := map[string]log.Level{
@@ -149,6 +149,8 @@ func TestPreRun_Anonymous_SetLoggingLevel(t *testing.T) {
 }
 
 func TestPreRun_HasAPIKey_SetupLoggingAndCheckForUpdates(t *testing.T) {
+	t.Parallel()
+
 	calledAnonymous := false
 
 	r := getPreRunBase()
@@ -177,6 +179,8 @@ func TestPreRun_HasAPIKey_SetupLoggingAndCheckForUpdates(t *testing.T) {
 }
 
 func TestPreRun_TokenExpires(t *testing.T) {
+	t.Parallel()
+
 	cfg := v1.AuthenticatedCloudConfigMock()
 	cfg.Context().State.AuthToken = expiredAuthTokenForDevCloud
 
@@ -198,6 +202,8 @@ func TestPreRun_TokenExpires(t *testing.T) {
 }
 
 func Test_UpdateToken(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name      string
 		isCloud   bool
@@ -241,7 +247,10 @@ func Test_UpdateToken(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			var cfg *v1.Config
 			if tt.isCloud {
 				cfg = v1.AuthenticatedCloudConfigMock()
@@ -293,6 +302,8 @@ func Test_UpdateToken(t *testing.T) {
 }
 
 func TestPrerun_AutoLogin(t *testing.T) {
+	t.Parallel()
+
 	type credentialsFuncReturnValues struct {
 		creds *pauth.Credentials
 		err   error
@@ -407,7 +418,10 @@ func TestPrerun_AutoLogin(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			var cfg *v1.Config
 			if tt.isCloud {
 				cfg = v1.AuthenticatedCloudConfigMock()
@@ -538,6 +552,8 @@ func TestPrerun_AutoLogin(t *testing.T) {
 }
 
 func TestPrerun_ReLoginToLastOrgUsed(t *testing.T) {
+	t.Parallel()
+
 	ccloudCreds := &pauth.Credentials{
 		Username: "username",
 		Password: "password",
@@ -611,6 +627,8 @@ func TestPrerun_ReLoginToLastOrgUsed(t *testing.T) {
 }
 
 func TestPrerun_AutoLoginNotTriggeredIfLoggedIn(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name    string
 		isCloud bool
@@ -624,7 +642,10 @@ func TestPrerun_AutoLoginNotTriggeredIfLoggedIn(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			var cfg *v1.Config
 			if tt.isCloud {
 				cfg = v1.AuthenticatedCloudConfigMock()
@@ -682,6 +703,8 @@ func TestPrerun_AutoLoginNotTriggeredIfLoggedIn(t *testing.T) {
 }
 
 func TestPreRun_HasAPIKeyCommand(t *testing.T) {
+	t.Parallel()
+
 	userNameConfigLoggedIn := v1.AuthenticatedCloudConfigMock()
 	userNameConfigLoggedIn.Context().State.AuthToken = validAuthToken
 
@@ -750,7 +773,10 @@ func TestPreRun_HasAPIKeyCommand(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			r := getPreRunBase()
 			r.Config = tt.config
 
@@ -779,6 +805,8 @@ func TestPreRun_HasAPIKeyCommand(t *testing.T) {
 }
 
 func TestInitializeOnPremKafkaRest(t *testing.T) {
+	t.Parallel()
+
 	cfg := v1.AuthenticatedOnPremConfigMock()
 	cfg.Context().State.AuthToken = validAuthToken
 	r := getPreRunBase()
@@ -787,21 +815,23 @@ func TestInitializeOnPremKafkaRest(t *testing.T) {
 	cobraCmd.Flags().CountP("verbose", "v", "Increase verbosity")
 	cobraCmd.Flags().Bool("unsafe-trace", false, "")
 	c := pcmd.NewAuthenticatedCLICommand(cobraCmd, r)
-	t.Run("InitializeOnPremKafkaRest_ValidMdsToken", func(t *testing.T) {
-		err := r.InitializeOnPremKafkaRest(c)(c.Command, []string{})
-		require.NoError(t, err)
-		kafkaREST, err := c.GetKafkaREST()
-		require.NoError(t, err)
-		auth, ok := kafkaREST.Context.Value(krsdk.ContextAccessToken).(string)
-		require.True(t, ok)
-		require.Equal(t, validAuthToken, auth)
-	})
+
+	err := r.InitializeOnPremKafkaRest(c)(c.Command, []string{})
+	require.NoError(t, err)
+	kafkaREST, err := c.GetKafkaREST()
+	require.NoError(t, err)
+	auth, ok := kafkaREST.Context.Value(krsdk.ContextAccessToken).(string)
+	require.True(t, ok)
+	require.Equal(t, validAuthToken, auth)
+
 	r.Config.Context().State.AuthToken = ""
 	buf := new(bytes.Buffer)
 	c.SetOut(buf)
 }
 
 func TestConvertToMetricsBaseURL(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name        string
 		inputUrl    string
@@ -839,7 +869,10 @@ func TestConvertToMetricsBaseURL(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			got := pcmd.ConvertToMetricsBaseURL(tt.inputUrl)
 			if got != tt.expectedUrl {
 				t.Errorf("got = %v, want %v", got, tt.expectedUrl)

--- a/internal/pkg/cmd/run_requirements_test.go
+++ b/internal/pkg/cmd/run_requirements_test.go
@@ -78,6 +78,8 @@ var (
 )
 
 func TestErrIfMissingRunRequirement_NoError(t *testing.T) {
+	t.Parallel()
+
 	for _, test := range []struct {
 		req string
 		cfg *v1.Config
@@ -100,6 +102,8 @@ func TestErrIfMissingRunRequirement_NoError(t *testing.T) {
 }
 
 func TestErrIfMissingRunRequirement_Error(t *testing.T) {
+	t.Parallel()
+
 	for _, test := range []struct {
 		req string
 		cfg *v1.Config
@@ -126,11 +130,15 @@ func TestErrIfMissingRunRequirement_Error(t *testing.T) {
 }
 
 func TestErrIfMissingRunRequirement_Root(t *testing.T) {
+	t.Parallel()
+
 	err := ErrIfMissingRunRequirement(&cobra.Command{}, nil)
 	require.NoError(t, err)
 }
 
 func TestErrIfMissingRunRequirement_Subcommand(t *testing.T) {
+	t.Parallel()
+
 	a := &cobra.Command{Annotations: map[string]string{RunRequirement: RequireCloudLogin}}
 	b := &cobra.Command{}
 	a.AddCommand(b)

--- a/internal/pkg/config/v1/config_test.go
+++ b/internal/pkg/config/v1/config_test.go
@@ -271,7 +271,7 @@ func SetupTestInputs(isCloud bool) *TestInputs {
 	return testInputs
 }
 
-func TestConfig_Load(t *testing.T) {
+func TestConfig_Load(t *testing.T) { //nolint:paralleltest,tparallel
 	testConfigsOnPrem := SetupTestInputs(false)
 	testConfigsCloud := SetupTestInputs(true)
 	tests := []struct {
@@ -319,7 +319,10 @@ func TestConfig_Load(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			cfg := New()
 			cfg.Filename = tt.file
 			for _, context := range tt.want.Contexts {
@@ -341,7 +344,7 @@ func TestConfig_Load(t *testing.T) {
 	}
 }
 
-func TestConfig_Save(t *testing.T) {
+func TestConfig_Save(t *testing.T) { //nolint:paralleltest
 	testConfigsOnPrem := SetupTestInputs(false)
 	testConfigsCloud := SetupTestInputs(true)
 	tests := []struct {
@@ -393,7 +396,7 @@ func TestConfig_Save(t *testing.T) {
 			kafkaOverwrite: "lkc-clusterFlag",
 		},
 	}
-	for _, tt := range tests {
+	for _, tt := range tests { //nolint:paralleltest
 		t.Run(tt.name, func(t *testing.T) {
 			configFile, _ := os.CreateTemp("", "TestConfig_Save.json")
 			tt.config.Filename = configFile.Name()
@@ -434,6 +437,8 @@ func TestConfig_Save(t *testing.T) {
 }
 
 func TestConfig_SaveWithAccountOverwrite(t *testing.T) {
+	t.Parallel()
+
 	testConfigsCloud := SetupTestInputs(true)
 	tests := []struct {
 		name             string
@@ -450,7 +455,10 @@ func TestConfig_SaveWithAccountOverwrite(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			configFile, _ := os.CreateTemp("", "TestConfig_Save.json")
 			tt.config.Filename = configFile.Name()
 			tt.config.SavedCredentials = map[string]*LoginCredential{
@@ -497,6 +505,8 @@ func replacePlaceholdersInWant(t *testing.T, got []byte, want []byte) string {
 }
 
 func TestConfig_OverwrittenKafka(t *testing.T) {
+	t.Parallel()
+
 	testConfigsCloud := SetupTestInputs(true)
 
 	tests := []struct {
@@ -545,6 +555,8 @@ func TestConfig_OverwrittenKafka(t *testing.T) {
 }
 
 func TestConfig_OverwrittenContext(t *testing.T) {
+	t.Parallel()
+
 	testConfigsCloud := SetupTestInputs(true)
 
 	tests := []struct {
@@ -584,6 +596,8 @@ func TestConfig_OverwrittenContext(t *testing.T) {
 }
 
 func TestConfig_OverwrittenAccount(t *testing.T) {
+	t.Parallel()
+
 	testConfigsCloud := SetupTestInputs(true)
 
 	tests := []struct {
@@ -631,6 +645,8 @@ func TestConfig_OverwrittenAccount(t *testing.T) {
 }
 
 func TestConfig_getFilename(t *testing.T) {
+	t.Parallel()
+
 	home, err := os.UserHomeDir()
 	require.NoError(t, err)
 	path := filepath.Join(home, ".confluent", "config.json")
@@ -638,6 +654,8 @@ func TestConfig_getFilename(t *testing.T) {
 }
 
 func TestConfig_AddContext(t *testing.T) {
+	t.Parallel()
+
 	filename := "/tmp/TestConfig_AddContext.json"
 	conf := AuthenticatedOnPremConfigMock()
 	conf.Filename = filename
@@ -694,7 +712,10 @@ func TestConfig_AddContext(t *testing.T) {
 		failAddingExistingContextTest,
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			err := tt.config.AddContext(tt.contextName, tt.platformName, tt.credentialName, tt.kafkaClusters, tt.kafka,
 				tt.schemaRegistryClusters, tt.state, MockOrgResourceId)
 			if (err != nil) != tt.wantErr {
@@ -712,6 +733,8 @@ func TestConfig_AddContext(t *testing.T) {
 }
 
 func TestConfig_CreateContext(t *testing.T) {
+	t.Parallel()
+
 	cfg := &Config{
 		BaseConfig:    &config.BaseConfig{Ver: config.Version{Version: version.Must(version.NewVersion("1.0.0"))}},
 		ContextStates: make(map[string]*ContextState),
@@ -731,6 +754,8 @@ func TestConfig_CreateContext(t *testing.T) {
 }
 
 func TestConfig_UseContext(t *testing.T) {
+	t.Parallel()
+
 	cfg := AuthenticatedCloudConfigMock()
 	contextName := cfg.Context().Name
 	cfg.CurrentContext = ""
@@ -764,7 +789,10 @@ func TestConfig_UseContext(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			cfg := tt.fields.Config
 			if err := cfg.UseContext(tt.args.name); (err != nil) != tt.wantErr {
 				t.Errorf("UseContext() error = %v, wantErr %v", err, tt.wantErr)
@@ -777,6 +805,8 @@ func TestConfig_UseContext(t *testing.T) {
 }
 
 func TestConfig_FindContext(t *testing.T) {
+	t.Parallel()
+
 	type fields struct {
 		Contexts map[string]*Context
 	}
@@ -790,21 +820,25 @@ func TestConfig_FindContext(t *testing.T) {
 		want    *Context
 		wantErr bool
 	}{
-		{name: "success finding existing context",
+		{
+			name:    "success finding existing context",
 			fields:  fields{Contexts: map[string]*Context{"test-context": {Name: "test-context"}}},
 			args:    args{name: "test-context"},
 			want:    &Context{Name: "test-context"},
 			wantErr: false,
 		},
-		{name: "error finding nonexistent context",
+		{
+			name:    "error finding nonexistent context",
 			fields:  fields{Contexts: map[string]*Context{}},
 			args:    args{name: "test-context"},
-			want:    nil,
 			wantErr: true,
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			cfg := &Config{Contexts: tt.fields.Contexts}
 			got, err := cfg.FindContext(tt.args.name)
 			if (err != nil) != tt.wantErr {
@@ -819,6 +853,8 @@ func TestConfig_FindContext(t *testing.T) {
 }
 
 func TestConfig_Context(t *testing.T) {
+	t.Parallel()
+
 	type fields struct {
 		Contexts       map[string]*Context
 		CurrentContext string
@@ -831,25 +867,22 @@ func TestConfig_Context(t *testing.T) {
 		{
 			name: "succeed getting current context",
 			fields: fields{
-				Contexts: map[string]*Context{"test-context": {
-					Name: "test-context",
-				}},
+				Contexts:       map[string]*Context{"test-context": {Name: "test-context"}},
 				CurrentContext: "test-context",
 			},
-			want: &Context{
-				Name: "test-context",
-			},
+			want: &Context{Name: "test-context"},
 		},
 		{
-			name: "error getting current context when not set",
-			fields: fields{
-				Contexts: map[string]*Context{},
-			},
-			want: nil,
+			name:   "error getting current context when not set",
+			fields: fields{Contexts: map[string]*Context{}},
+			want:   nil,
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			cfg := &Config{
 				Contexts:       tt.fields.Contexts,
 				CurrentContext: tt.fields.CurrentContext,
@@ -863,6 +896,8 @@ func TestConfig_Context(t *testing.T) {
 }
 
 func TestKafkaClusterContext_SetAndGetActiveKafkaCluster_Env(t *testing.T) {
+	t.Parallel()
+
 	testInputs := SetupTestInputs(true)
 	ctx := testInputs.statefulConfig.Context()
 	// temp file so json files in test_json do not get overwritten
@@ -919,6 +954,8 @@ func TestKafkaClusterContext_SetAndGetActiveKafkaCluster_Env(t *testing.T) {
 }
 
 func TestKafkaClusterContext_SetAndGetActiveKafkaCluster_NonEnv(t *testing.T) {
+	t.Parallel()
+
 	testInputs := SetupTestInputs(false)
 	ctx := testInputs.statefulConfig.Context()
 	// temp file so json files in test_json do not get overwritten
@@ -957,6 +994,8 @@ func TestKafkaClusterContext_SetAndGetActiveKafkaCluster_NonEnv(t *testing.T) {
 }
 
 func TestKafkaClusterContext_AddAndGetKafkaClusterConfig(t *testing.T) {
+	t.Parallel()
+
 	clusterID := "lkc-abcdefg"
 
 	kcc := &KafkaClusterConfig{
@@ -980,6 +1019,8 @@ func TestKafkaClusterContext_AddAndGetKafkaClusterConfig(t *testing.T) {
 }
 
 func TestKafkaClusterContext_DeleteAPIKey(t *testing.T) {
+	t.Parallel()
+
 	clusterID := "lkc-abcdefg"
 	apiKey := "akey"
 	kcc := &KafkaClusterConfig{
@@ -1011,6 +1052,8 @@ func TestKafkaClusterContext_DeleteAPIKey(t *testing.T) {
 }
 
 func TestKafkaClusterContext_RemoveKafkaCluster(t *testing.T) {
+	t.Parallel()
+
 	clusterID := "lkc-abcdefg"
 	apiKey := "akey"
 	kcc := &KafkaClusterConfig{
@@ -1040,6 +1083,8 @@ func TestKafkaClusterContext_RemoveKafkaCluster(t *testing.T) {
 }
 
 func TestConfig_IsCloud_True(t *testing.T) {
+	t.Parallel()
+
 	for _, platform := range cloudPlatforms {
 		// test case: org not suspended
 		cfg := &Config{
@@ -1054,6 +1099,8 @@ func TestConfig_IsCloud_True(t *testing.T) {
 }
 
 func TestConfig_IsCloud_False(t *testing.T) {
+	t.Parallel()
+
 	// test case: platform name not cloud
 	configs := []*Config{
 		nil,
@@ -1091,6 +1138,8 @@ func TestConfig_IsCloud_False(t *testing.T) {
 }
 
 func TestConfig_IsCloudLoginAllowFreeTrialEnded_True(t *testing.T) {
+	t.Parallel()
+
 	for _, platform := range cloudPlatforms {
 		// test case: org not suspended
 		cfg := &Config{
@@ -1117,6 +1166,8 @@ func TestConfig_IsCloudLoginAllowFreeTrialEnded_True(t *testing.T) {
 }
 
 func TestConfig_IsCloudLoginAllowFreeTrialEnded_False(t *testing.T) {
+	t.Parallel()
+
 	// test case: platform name not cloud
 	configs := []*Config{
 		nil,
@@ -1146,6 +1197,8 @@ func TestConfig_IsCloudLoginAllowFreeTrialEnded_False(t *testing.T) {
 }
 
 func TestConfig_IsOnPrem_True(t *testing.T) {
+	t.Parallel()
+
 	cfg := &Config{
 		Contexts:       map[string]*Context{"context": {PlatformName: "https://example.com"}},
 		CurrentContext: "context",
@@ -1154,6 +1207,8 @@ func TestConfig_IsOnPrem_True(t *testing.T) {
 }
 
 func TestConfig_IsOnPrem_False(t *testing.T) {
+	t.Parallel()
+
 	configs := []*Config{
 		nil,
 		{

--- a/internal/pkg/docs/doc_page_test.go
+++ b/internal/pkg/docs/doc_page_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestPrintDocPage(t *testing.T) {
+	t.Parallel()
+
 	root1 := &cobra.Command{
 		Use:   "a",
 		Short: "Short description.",
@@ -136,11 +138,15 @@ func TestPrintDocPage(t *testing.T) {
 }
 
 func TestPrintWarnings_NoWarnings(t *testing.T) {
+	t.Parallel()
+
 	cmd := &cobra.Command{}
 	require.Empty(t, printWarnings(cmd, 0))
 }
 
 func TestPrintWarnings_ConfluentLocal(t *testing.T) {
+	t.Parallel()
+
 	confluent := &cobra.Command{Use: "confluent"}
 	local := &cobra.Command{Use: "local"}
 	confluent.AddCommand(local)
@@ -156,6 +162,8 @@ func TestPrintWarnings_ConfluentLocal(t *testing.T) {
 }
 
 func TestPrintSphinxBlock_NoArgs(t *testing.T) {
+	t.Parallel()
+
 	expected := []string{
 		".. key:: val",
 		"",
@@ -165,6 +173,8 @@ func TestPrintSphinxBlock_NoArgs(t *testing.T) {
 }
 
 func TestPrintSphinxBlock_Args(t *testing.T) {
+	t.Parallel()
+
 	args := map[string]string{
 		"key-a": "val-a",
 		"key-b": "val-b",
@@ -181,6 +191,8 @@ func TestPrintSphinxBlock_Args(t *testing.T) {
 }
 
 func TestPrintUsageAndDescription(t *testing.T) {
+	t.Parallel()
+
 	cmd := &cobra.Command{
 		Use:  "command",
 		Long: "Description of `command`.",
@@ -201,11 +213,15 @@ func TestPrintUsageAndDescription(t *testing.T) {
 }
 
 func TestPrintNotes_NoNotes(t *testing.T) {
+	t.Parallel()
+
 	cmd := &cobra.Command{}
 	require.Empty(t, printNotes(cmd, 0))
 }
 
 func TestPrintNotes_ConfluentLocal(t *testing.T) {
+	t.Parallel()
+
 	confluent := &cobra.Command{Use: "confluent"}
 	local := &cobra.Command{Use: "local"}
 	confluent.AddCommand(local)
@@ -219,6 +235,8 @@ func TestPrintNotes_ConfluentLocal(t *testing.T) {
 }
 
 func TestPrintNotes_ConfluentIAMRoleBindingCreate(t *testing.T) {
+	t.Parallel()
+
 	confluent := &cobra.Command{Use: "confluent"}
 	iam := &cobra.Command{Use: "iam"}
 	rbac := &cobra.Command{Use: "rbac"}
@@ -239,6 +257,8 @@ func TestPrintNotes_ConfluentIAMRoleBindingCreate(t *testing.T) {
 }
 
 func TestPrintNotes_ConfluentSecret(t *testing.T) {
+	t.Parallel()
+
 	confluent := &cobra.Command{Use: "confluent"}
 	secret := &cobra.Command{Use: "secret"}
 	confluent.AddCommand(secret)
@@ -252,6 +272,8 @@ func TestPrintNotes_ConfluentSecret(t *testing.T) {
 }
 
 func TestPrintFlags(t *testing.T) {
+	t.Parallel()
+
 	cmd := &cobra.Command{}
 	cmd.Flags().String("flag", "", "Flag description.")
 
@@ -267,6 +289,8 @@ func TestPrintFlags(t *testing.T) {
 }
 
 func TestPrintFlags_RequiredFlag(t *testing.T) {
+	t.Parallel()
+
 	cmd := &cobra.Command{}
 	cmd.Flags().String("flag", "", "Flag description.")
 	require.NoError(t, cmd.MarkFlagRequired("flag"))
@@ -283,6 +307,8 @@ func TestPrintFlags_RequiredFlag(t *testing.T) {
 }
 
 func TestPrintGlobalFlags(t *testing.T) {
+	t.Parallel()
+
 	a := &cobra.Command{}
 	a.PersistentFlags().String("global-flag", "", "Global flag description.")
 	b := &cobra.Command{}
@@ -301,12 +327,16 @@ func TestPrintGlobalFlags(t *testing.T) {
 }
 
 func TestPrintFlagSet_NoFlags(t *testing.T) {
+	t.Parallel()
+
 	section, ok := printFlagSet(new(pflag.FlagSet))
 	require.False(t, ok)
 	require.Equal(t, []string{"No flags.", ""}, section)
 }
 
 func TestPrintFlagSet(t *testing.T) {
+	t.Parallel()
+
 	flags := new(pflag.FlagSet)
 	flags.String("flag", "", "Flag description.")
 
@@ -322,6 +352,8 @@ func TestPrintFlagSet(t *testing.T) {
 }
 
 func TestPrintExamplesSection_NoExamples(t *testing.T) {
+	t.Parallel()
+
 	cmd := &cobra.Command{}
 
 	rows, ok := printExamples(cmd)
@@ -330,6 +362,8 @@ func TestPrintExamplesSection_NoExamples(t *testing.T) {
 }
 
 func TestPrintExamplesSection_TextOnly(t *testing.T) {
+	t.Parallel()
+
 	cmd := &cobra.Command{
 		Example: examples.BuildExampleString(
 			examples.Example{Text: "Text-only example."},
@@ -347,6 +381,8 @@ func TestPrintExamplesSection_TextOnly(t *testing.T) {
 }
 
 func TestPrintExamplesSection_CodeOnly(t *testing.T) {
+	t.Parallel()
+
 	cmd := &cobra.Command{
 		Example: examples.BuildExampleString(
 			examples.Example{Code: "command subcommand"},
@@ -366,6 +402,8 @@ func TestPrintExamplesSection_CodeOnly(t *testing.T) {
 }
 
 func TestPrintExamplesSection_DoubleCodeBlock(t *testing.T) {
+	t.Parallel()
+
 	cmd := &cobra.Command{
 		Example: examples.BuildExampleString(
 			examples.Example{Code: "command subcommand"},
@@ -387,6 +425,8 @@ func TestPrintExamplesSection_DoubleCodeBlock(t *testing.T) {
 }
 
 func TestPrintExamplesSection_FullExample(t *testing.T) {
+	t.Parallel()
+
 	cmd := &cobra.Command{
 		Example: examples.BuildExampleString(
 			examples.Example{
@@ -411,6 +451,8 @@ func TestPrintExamplesSection_FullExample(t *testing.T) {
 }
 
 func TestPrintExamplesSection_TwoExamples(t *testing.T) {
+	t.Parallel()
+
 	cmd := &cobra.Command{
 		Example: examples.BuildExampleString(
 			examples.Example{
@@ -445,6 +487,8 @@ func TestPrintExamplesSection_TwoExamples(t *testing.T) {
 }
 
 func TestPrintSeeAlso(t *testing.T) {
+	t.Parallel()
+
 	a := &cobra.Command{Use: "a", Short: "Description of A."}
 	b := &cobra.Command{Use: "b"}
 

--- a/internal/pkg/docs/index_page_test.go
+++ b/internal/pkg/docs/index_page_test.go
@@ -10,6 +10,8 @@ import (
 var doNothingFunc = func(_ *cobra.Command, _ []string) {}
 
 func TestPrintIndexPage(t *testing.T) {
+	t.Parallel()
+
 	cmd := &cobra.Command{Use: "command"}
 
 	a1 := &cobra.Command{Use: "a", Short: "Description 1.", Aliases: []string{"alias"}}
@@ -88,6 +90,8 @@ func TestPrintIndexPage(t *testing.T) {
 }
 
 func TestPrintRootIndexPage(t *testing.T) {
+	t.Parallel()
+
 	cmd := &cobra.Command{Use: "command"}
 
 	a1 := &cobra.Command{Use: "a"}
@@ -131,6 +135,8 @@ func TestPrintRootIndexPage(t *testing.T) {
 }
 
 func TestFlatten(t *testing.T) {
+	t.Parallel()
+
 	arrs := [][]string{
 		{"a", "b"},
 		{"c", "d"},
@@ -140,6 +146,8 @@ func TestFlatten(t *testing.T) {
 }
 
 func TestPrintComments(t *testing.T) {
+	t.Parallel()
+
 	expected := []string{
 		"..",
 		"   WARNING: This documentation is auto-generated from the confluentinc/cli repository and should not be manually edited.",
@@ -150,6 +158,8 @@ func TestPrintComments(t *testing.T) {
 }
 
 func TestPrintHeader(t *testing.T) {
+	t.Parallel()
+
 	cmd := &cobra.Command{Use: "command"}
 
 	expected := []string{
@@ -161,6 +171,8 @@ func TestPrintHeader(t *testing.T) {
 }
 
 func TestPrintTitle_Root(t *testing.T) {
+	t.Parallel()
+
 	cmd := &cobra.Command{Use: "command"}
 
 	expected := []string{
@@ -173,6 +185,8 @@ func TestPrintTitle_Root(t *testing.T) {
 }
 
 func TestPrintTitle_NonRoot(t *testing.T) {
+	t.Parallel()
+
 	a := &cobra.Command{Use: "a"}
 	b := &cobra.Command{Use: "b"}
 
@@ -188,6 +202,8 @@ func TestPrintTitle_NonRoot(t *testing.T) {
 }
 
 func TestPrintInlineScript(t *testing.T) {
+	t.Parallel()
+
 	expected := []string{
 		".. raw:: html",
 		"",
@@ -201,6 +217,8 @@ func TestPrintInlineScript(t *testing.T) {
 }
 
 func TestPrintTableOfContents(t *testing.T) {
+	t.Parallel()
+
 	a1 := &cobra.Command{Use: "a"}
 	a2 := &cobra.Command{Use: "a"}
 
@@ -230,6 +248,8 @@ func TestPrintTableOfContents(t *testing.T) {
 }
 
 func TestPrintLink(t *testing.T) {
+	t.Parallel()
+
 	a := &cobra.Command{Use: "a"}
 	b := &cobra.Command{Use: "b"}
 
@@ -240,11 +260,15 @@ func TestPrintLink(t *testing.T) {
 }
 
 func TestPrintAliases_Empty(t *testing.T) {
+	t.Parallel()
+
 	cmd := new(cobra.Command)
 	require.Empty(t, printAliases(cmd))
 }
 
 func TestPrintAliases(t *testing.T) {
+	t.Parallel()
+
 	cmd := &cobra.Command{
 		Use:     "long-command",
 		Aliases: []string{"lc"},
@@ -261,6 +285,8 @@ func TestPrintAliases(t *testing.T) {
 }
 
 func TestPrintDescription_Root(t *testing.T) {
+	t.Parallel()
+
 	cmd := &cobra.Command{Use: "command"}
 
 	expected := []string{
@@ -274,6 +300,8 @@ func TestPrintDescription_Root(t *testing.T) {
 }
 
 func TestPrintDescription(t *testing.T) {
+	t.Parallel()
+
 	a := &cobra.Command{Use: "a"}
 	b := &cobra.Command{Use: "b", Short: "Description."}
 
@@ -290,11 +318,15 @@ func TestPrintDescription(t *testing.T) {
 }
 
 func TestPrintLongestDescription_Short(t *testing.T) {
+	t.Parallel()
+
 	cmd := &cobra.Command{Short: "Description."}
 	require.Equal(t, "Description.", printLongestDescription(cmd))
 }
 
 func TestPrintLongestDescription_Long(t *testing.T) {
+	t.Parallel()
+
 	cmd := &cobra.Command{
 		Short: "Description.",
 		Long:  "Long description.",
@@ -303,14 +335,20 @@ func TestPrintLongestDescription_Long(t *testing.T) {
 }
 
 func TestFormatReST_CodeSnippet(t *testing.T) {
+	t.Parallel()
+
 	require.Equal(t, "Description of ``command``.", formatReST("Description of `command`."))
 }
 
 func TestFormatReST_Target(t *testing.T) {
+	t.Parallel()
+
 	require.Equal(t, `"target\_" "target\_"`, formatReST(`"target_" "target_"`))
 }
 
 func TestPrintSubcommands(t *testing.T) {
+	t.Parallel()
+
 	a := &cobra.Command{Use: "a"}
 	b := &cobra.Command{
 		Use:   "b",
@@ -335,21 +373,29 @@ func TestPrintSubcommands(t *testing.T) {
 }
 
 func TestPrintSphinxRef(t *testing.T) {
+	t.Parallel()
+
 	cmd := &cobra.Command{Use: "command"}
 	require.Equal(t, ":ref:`command-ref`", printSphinxRef(cmd))
 }
 
 func TestPrintRef_Root(t *testing.T) {
+	t.Parallel()
+
 	cmd := &cobra.Command{Use: "command"}
 	require.Equal(t, "command-ref", printRef(cmd, false))
 }
 
 func TestPrintRef_Overview(t *testing.T) {
+	t.Parallel()
+
 	cmd := &cobra.Command{Use: "command"}
 	require.Equal(t, "command-ref-index", printRef(cmd, true))
 }
 
 func TestPrintRef(t *testing.T) {
+	t.Parallel()
+
 	a := &cobra.Command{Use: "a"}
 	b := &cobra.Command{Use: "b"}
 
@@ -359,6 +405,8 @@ func TestPrintRef(t *testing.T) {
 }
 
 func TestDedent(t *testing.T) {
+	t.Parallel()
+
 	arr := []string{
 		" a ",
 		" b ",

--- a/internal/pkg/docs/tab_test.go
+++ b/internal/pkg/docs/tab_test.go
@@ -8,6 +8,8 @@ import (
 )
 
 func TestPrintTabbedSection_Hidden(t *testing.T) {
+	t.Parallel()
+
 	printSection := func(*cobra.Command) ([]string, bool) { return []string{}, false }
 	tabs := make([]Tab, 1)
 
@@ -16,6 +18,8 @@ func TestPrintTabbedSection_Hidden(t *testing.T) {
 }
 
 func TestPrintTabbedSection_Unified(t *testing.T) {
+	t.Parallel()
+
 	printSection := func(*cobra.Command) ([]string, bool) { return []string{"Content"}, true }
 	tabs := make([]Tab, 2)
 
@@ -30,6 +34,8 @@ func TestPrintTabbedSection_Unified(t *testing.T) {
 }
 
 func TestPrintTabbedSection_Tabbed(t *testing.T) {
+	t.Parallel()
+
 	printSection := func(cmd *cobra.Command) ([]string, bool) { return []string{cmd.Short, ""}, true }
 	tabs := []Tab{
 		{
@@ -62,6 +68,8 @@ func TestPrintTabbedSection_Tabbed(t *testing.T) {
 }
 
 func TestPrintSection(t *testing.T) {
+	t.Parallel()
+
 	expected := []string{
 		"Title",
 		"~~~~~",
@@ -74,21 +82,31 @@ func TestPrintSection(t *testing.T) {
 }
 
 func TestAreEqual_DifferentLen(t *testing.T) {
+	t.Parallel()
+
 	require.False(t, areEqual([]string{}, []string{""}))
 }
 
 func TestAreEqual_DifferentElements(t *testing.T) {
+	t.Parallel()
+
 	require.False(t, areEqual([]string{"a"}, []string{"b"}))
 }
 
 func TestAreEqual_True(t *testing.T) {
+	t.Parallel()
+
 	require.True(t, areEqual([]string{"a"}, []string{"a"}))
 }
 
 func TestIndent(t *testing.T) {
+	t.Parallel()
+
 	require.Equal(t, []string{" a", " b"}, indent(" ", []string{"a", "b"}))
 }
 
 func TestIndent_WithNewlines(t *testing.T) {
+	t.Parallel()
+
 	require.Equal(t, []string{" a", " b", " c"}, indent(" ", []string{"a", "b\nc"}))
 }

--- a/internal/pkg/dynamic-config/dynamic_config_test.go
+++ b/internal/pkg/dynamic-config/dynamic_config_test.go
@@ -13,14 +13,14 @@ import (
 )
 
 func TestDynamicConfig_ParseFlagsIntoConfig(t *testing.T) {
+	t.Parallel()
+
 	config := v1.AuthenticatedCloudConfigMock()
 	dynamicConfigBase := New(config, pmock.NewClientMock(), pmock.NewV2ClientMock())
 
 	config = v1.AuthenticatedCloudConfigMock()
 	dynamicConfigFlag := New(config, pmock.NewClientMock(), pmock.NewV2ClientMock())
-	dynamicConfigFlag.Contexts["test-context"] = &v1.Context{
-		Name: "test-context",
-	}
+	dynamicConfigFlag.Contexts["test-context"] = &v1.Context{Name: "test-context"}
 	tests := []struct {
 		name           string
 		context        string
@@ -45,9 +45,7 @@ func TestDynamicConfig_ParseFlagsIntoConfig(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		cmd := &cobra.Command{
-			Run: func(cmd *cobra.Command, args []string) {},
-		}
+		cmd := &cobra.Command{Run: func(cmd *cobra.Command, args []string) {}}
 		cmd.Flags().String("context", "", "Context name.")
 		err := cmd.ParseFlags([]string{"--context", tt.context})
 		require.NoError(t, err)

--- a/internal/pkg/dynamic-config/dynamic_context_test.go
+++ b/internal/pkg/dynamic-config/dynamic_context_test.go
@@ -31,6 +31,8 @@ var (
 )
 
 func TestFindKafkaCluster_Unexpired(t *testing.T) {
+	t.Parallel()
+
 	update := time.Now()
 
 	d := &DynamicContext{
@@ -49,6 +51,8 @@ func TestFindKafkaCluster_Unexpired(t *testing.T) {
 }
 
 func TestFindKafkaCluster_Expired(t *testing.T) {
+	t.Parallel()
+
 	update := time.Now().Add(-7 * 24 * time.Hour)
 
 	d := &DynamicContext{
@@ -97,6 +101,8 @@ func stringPtr(s string) *string {
 }
 
 func TestDynamicContext_ParseFlagsIntoContext(t *testing.T) {
+	t.Parallel()
+
 	client := buildCcloudMockClient()
 	tests := []struct {
 		name           string

--- a/internal/pkg/errors/catcher_test.go
+++ b/internal/pkg/errors/catcher_test.go
@@ -22,6 +22,8 @@ type test struct {
 }
 
 func TestCatchClustersExceedError(t *testing.T) {
+	t.Parallel()
+
 	tt := test{
 		name:     "cluster exceed",
 		err:      New(paymentRequiredErrorMsg),
@@ -39,6 +41,8 @@ func TestCatchClustersExceedError(t *testing.T) {
 }
 
 func TestCatchServiceAccountExceedError(t *testing.T) {
+	t.Parallel()
+
 	tt := test{
 		name:     "service accounts exceed",
 		err:      New(paymentRequiredErrorMsg),

--- a/internal/pkg/errors/handle_test.go
+++ b/internal/pkg/errors/handle_test.go
@@ -17,6 +17,8 @@ Suggestions:
 )
 
 func TestHandleError(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name    string
 		err     error
@@ -52,7 +54,10 @@ func TestHandleError(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			var err error
 			if err = HandleCommon(tt.err); (err != nil) != tt.wantErr {
 				t.Errorf("HandleCommon()\nerror: %v\nwantErr: %v", err, tt.wantErr)
@@ -65,6 +70,8 @@ func TestHandleError(t *testing.T) {
 }
 
 func TestDisplaySuggestionsMessage(t *testing.T) {
+	t.Parallel()
+
 	suggestion := "This is a suggestion"
 	err := NewErrorWithSuggestions("im an error hi", suggestion)
 	require.Equal(t, fmt.Sprintf(wantSuggestionsMsgFormat, suggestion), DisplaySuggestionsMessage(err))

--- a/internal/pkg/featureflags/announcements_and_deprecation_test.go
+++ b/internal/pkg/featureflags/announcements_and_deprecation_test.go
@@ -8,10 +8,14 @@ import (
 )
 
 func TestGetAnnouncementsOrDeprecation_BadFormat(t *testing.T) {
+	t.Parallel()
+
 	require.Empty(t, GetAnnouncementsOrDeprecation(""))
 }
 
 func TestGetAnnouncementsOrDeprecation(t *testing.T) {
+	t.Parallel()
+
 	resp := []any{
 		map[string]any{
 			"pattern": "command",
@@ -56,6 +60,8 @@ func TestGetAnnouncementsOrDeprecation(t *testing.T) {
 }
 
 func TestDeprecateCommandTree(t *testing.T) {
+	t.Parallel()
+
 	cmds := dummyCmds()
 	DeprecateCommandTree(cmds[0])
 	for _, cmd := range cmds {
@@ -65,6 +71,8 @@ func TestDeprecateCommandTree(t *testing.T) {
 }
 
 func TestDeprecateFlags(t *testing.T) {
+	t.Parallel()
+
 	cmds := dummyCmds()
 	DeprecateFlags(cmds[0], []string{"flag1", "f"})
 	for _, cmd := range cmds {

--- a/internal/pkg/featureflags/feature_flags_test.go
+++ b/internal/pkg/featureflags/feature_flags_test.go
@@ -108,5 +108,6 @@ func (suite *LaunchDarklyTestSuite) TestContextToLDUser() {
 }
 
 func TestLaunchDarklySuite(t *testing.T) {
+	t.Parallel()
 	suite.Run(t, new(LaunchDarklyTestSuite))
 }

--- a/internal/pkg/form/field_test.go
+++ b/internal/pkg/form/field_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestRead(t *testing.T) {
+	t.Parallel()
+
 	var field Field
 
 	prompt := &mock.Prompt{
@@ -22,6 +24,8 @@ func TestRead(t *testing.T) {
 }
 
 func TestRead_Password(t *testing.T) {
+	t.Parallel()
+
 	field := Field{IsHidden: true}
 
 	prompt := &mock.Prompt{
@@ -35,6 +39,8 @@ func TestRead_Password(t *testing.T) {
 }
 
 func TestValidate_YesOrNo(t *testing.T) {
+	t.Parallel()
+
 	field := Field{IsYesOrNo: true}
 
 	for _, val := range []string{"y", "yes"} {
@@ -54,6 +60,8 @@ func TestValidate_YesOrNo(t *testing.T) {
 }
 
 func TestValidate_DefaultVal(t *testing.T) {
+	t.Parallel()
+
 	field := Field{DefaultValue: "default"}
 
 	res, err := field.validate("")
@@ -62,6 +70,8 @@ func TestValidate_DefaultVal(t *testing.T) {
 }
 
 func TestValidate(t *testing.T) {
+	t.Parallel()
+
 	var field Field
 
 	res, err := field.validate("res")
@@ -70,12 +80,16 @@ func TestValidate(t *testing.T) {
 }
 
 func TestValidate_RegexFail(t *testing.T) {
+	t.Parallel()
+
 	field := Field{Regex: `(?:[a-z0-9!#$%&'*+\/=?^_\x60{|}~-]+(?:\.[a-z0-9!#$%&'*+\/=?^_\x60{|}~-]+)*|"(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21\x23-\x5b\x5d-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])*")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\[(?:(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9]))\.){3}(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9])|[a-z0-9-]*[a-z0-9]:(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21-\x5a\x53-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])+)\])`}
 	_, err := field.validate("milestodzo.com")
 	require.Error(t, err)
 }
 
 func TestValidate_RegexSuccess(t *testing.T) {
+	t.Parallel()
+
 	field := Field{Regex: `(?:[a-z0-9!#$%&'*+\/=?^_\x60{|}~-]+(?:\.[a-z0-9!#$%&'*+\/=?^_\x60{|}~-]+)*|"(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21\x23-\x5b\x5d-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])*")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\[(?:(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9]))\.){3}(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9])|[a-z0-9-]*[a-z0-9]:(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21-\x5a\x53-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])+)\])`}
 	res, err := field.validate("mtodzo@confluent.io")
 	require.Equal(t, "mtodzo@confluent.io", res)
@@ -83,16 +97,22 @@ func TestValidate_RegexSuccess(t *testing.T) {
 }
 
 func TestString(t *testing.T) {
+	t.Parallel()
+
 	field := Field{Prompt: "Username"}
 	require.Equal(t, "Username: ", field.String())
 }
 
 func TestString_YesOrNo(t *testing.T) {
+	t.Parallel()
+
 	field := Field{Prompt: "Ok?", IsYesOrNo: true}
 	require.Equal(t, "Ok? (y/n): ", field.String())
 }
 
 func TestString_DefaultValue(t *testing.T) {
+	t.Parallel()
+
 	field := Field{Prompt: "Username", DefaultValue: "user"}
 	require.Equal(t, "Username: (user) ", field.String())
 }

--- a/internal/pkg/form/form_test.go
+++ b/internal/pkg/form/form_test.go
@@ -10,6 +10,8 @@ import (
 )
 
 func TestPrompt(t *testing.T) {
+	t.Parallel()
+
 	f := New(
 		Field{ID: "username", Prompt: "Username"},
 		Field{ID: "password", Prompt: "Password", IsHidden: true},

--- a/internal/pkg/kafkarest/kafkarest_test.go
+++ b/internal/pkg/kafkarest/kafkarest_test.go
@@ -13,6 +13,8 @@ import (
 )
 
 func TestNewError(t *testing.T) {
+	t.Parallel()
+
 	req := require.New(t)
 	url := "http://my-url"
 	neturlMsg := "net-error"

--- a/internal/pkg/linter/rules_test.go
+++ b/internal/pkg/linter/rules_test.go
@@ -24,6 +24,8 @@ func fails(fieldValue string, properNouns []string, t *testing.T) {
 }
 
 func TestRequireNotTitleCase(t *testing.T) {
+	t.Parallel()
+
 	passes("This is fine.", []string{}, t)
 	fails("This Isn't fine.", []string{}, t)
 	passes("This is fine Kafka.", []string{"Kafka"}, t)
@@ -34,9 +36,13 @@ func TestRequireNotTitleCase(t *testing.T) {
 }
 
 func TestFlagKebabCase(t *testing.T) {
+	t.Parallel()
+
 	rule := RequireFlagKebabCase
 
 	t.Run("invalid flag name", func(t *testing.T) {
+		t.Parallel()
+
 		cmd := &cobra.Command{Run: func(cmd *cobra.Command, args []string) {}}
 		cmd.Flags().String("caCertPath", "", "not a valid kebab-case name")
 		err := cmd.Execute()
@@ -46,6 +52,8 @@ func TestFlagKebabCase(t *testing.T) {
 	})
 
 	t.Run("valid flag name", func(t *testing.T) {
+		t.Parallel()
+
 		cmd := &cobra.Command{Run: func(cmd *cobra.Command, args []string) {}}
 		cmd.Flags().String("ca-cert-path", "", "tis a valid kebab-case name")
 		err := cmd.Execute()
@@ -56,6 +64,8 @@ func TestFlagKebabCase(t *testing.T) {
 }
 
 func TestFlagUsageRealWords(t *testing.T) {
+	t.Parallel()
+
 	req := require.New(t)
 	rule := RequireFlagUsageRealWords
 
@@ -74,6 +84,8 @@ snake
 	SetVocab(gs)
 
 	t.Run("gibberish", func(t *testing.T) {
+		t.Parallel()
+
 		cmd := &cobra.Command{Run: func(cmd *cobra.Command, args []string) {}}
 		cmd.Flags().String("elvish", "", "Mae govannen.")
 		err := cmd.Execute()
@@ -83,6 +95,8 @@ snake
 	})
 
 	t.Run("sophisticated prose", func(t *testing.T) {
+		t.Parallel()
+
 		cmd := &cobra.Command{Run: func(cmd *cobra.Command, args []string) {}}
 		cmd.Flags().String("sonnet", "", "Fillet of a fenny snake.")
 		err := cmd.Execute()

--- a/internal/pkg/local/confluent_current_test.go
+++ b/internal/pkg/local/confluent_current_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestGetSavedCurrentDir(t *testing.T) {
+	t.Parallel()
+
 	req := require.New(t)
 
 	cc := NewConfluentCurrentManager()
@@ -22,6 +24,8 @@ func TestGetSavedCurrentDir(t *testing.T) {
 }
 
 func TestCreateAndTrackCurrentDir(t *testing.T) {
+	t.Parallel()
+
 	req := require.New(t)
 
 	dir, err := createTestDir()
@@ -44,6 +48,8 @@ func TestCreateAndTrackCurrentDir(t *testing.T) {
 }
 
 func TestGetCurrentDirFromTrackingFile(t *testing.T) {
+	t.Parallel()
+
 	req := require.New(t)
 
 	dir, err := createTestDir()
@@ -62,6 +68,8 @@ func TestGetCurrentDirFromTrackingFile(t *testing.T) {
 }
 
 func TestGetServiceDir(t *testing.T) {
+	t.Parallel()
+
 	req := require.New(t)
 
 	dir, err := createTestDir()
@@ -77,6 +85,8 @@ func TestGetServiceDir(t *testing.T) {
 }
 
 func TestGetDataDir(t *testing.T) {
+	t.Parallel()
+
 	req := require.New(t)
 
 	dir, err := createTestDir()
@@ -95,6 +105,8 @@ func TestGetDataDir(t *testing.T) {
 }
 
 func TestGetDataDirKSQL(t *testing.T) {
+	t.Parallel()
+
 	req := require.New(t)
 
 	dir, err := createTestDir()
@@ -114,6 +126,8 @@ func TestGetDataDirKSQL(t *testing.T) {
 }
 
 func TestGetSavedPidFile(t *testing.T) {
+	t.Parallel()
+
 	req := require.New(t)
 
 	cc := NewConfluentCurrentManager()
@@ -125,6 +139,8 @@ func TestGetSavedPidFile(t *testing.T) {
 }
 
 func TestSetAndGetPid(t *testing.T) {
+	t.Parallel()
+
 	req := require.New(t)
 
 	dir, err := createTestDir()
@@ -141,6 +157,8 @@ func TestSetAndGetPid(t *testing.T) {
 }
 
 func TestGetDefaultRootDir(t *testing.T) {
+	t.Parallel()
+
 	req := require.New(t)
 
 	cc := NewConfluentCurrentManager()
@@ -148,6 +166,8 @@ func TestGetDefaultRootDir(t *testing.T) {
 }
 
 func TestRootDirFromEnv(t *testing.T) {
+	t.Parallel()
+
 	req := require.New(t)
 
 	cc := NewConfluentCurrentManager()
@@ -158,6 +178,8 @@ func TestRootDirFromEnv(t *testing.T) {
 }
 
 func TestGetSavedTrackingFile(t *testing.T) {
+	t.Parallel()
+
 	req := require.New(t)
 
 	cc := NewConfluentCurrentManager()
@@ -166,6 +188,8 @@ func TestGetSavedTrackingFile(t *testing.T) {
 }
 
 func TestGetTrackingFile(t *testing.T) {
+	t.Parallel()
+
 	req := require.New(t)
 
 	cc := NewConfluentCurrentManager()
@@ -177,6 +201,8 @@ func TestGetTrackingFile(t *testing.T) {
 }
 
 func TestGetServiceFile(t *testing.T) {
+	t.Parallel()
+
 	req := require.New(t)
 
 	dir, err := createTestDir()
@@ -192,6 +218,8 @@ func TestGetServiceFile(t *testing.T) {
 }
 
 func TestGetRandomChildDir(t *testing.T) {
+	t.Parallel()
+
 	req := require.New(t)
 
 	parentDir, err := createTestDir()

--- a/internal/pkg/local/confluent_home_test.go
+++ b/internal/pkg/local/confluent_home_test.go
@@ -25,8 +25,7 @@ type ConfluentHomeTestSuite struct {
 	ch *ConfluentHomeManager
 }
 
-func TestConfluentHomeTestSuite(t *testing.T) {
-	t.Parallel()
+func TestConfluentHomeTestSuite(t *testing.T) { //nolint:paralleltest
 	suite.Run(t, new(ConfluentHomeTestSuite))
 }
 

--- a/internal/pkg/local/confluent_home_test.go
+++ b/internal/pkg/local/confluent_home_test.go
@@ -26,6 +26,7 @@ type ConfluentHomeTestSuite struct {
 }
 
 func TestConfluentHomeTestSuite(t *testing.T) {
+	t.Parallel()
 	suite.Run(t, new(ConfluentHomeTestSuite))
 }
 

--- a/internal/pkg/local/utils_test.go
+++ b/internal/pkg/local/utils_test.go
@@ -8,6 +8,8 @@ import (
 )
 
 func TestBuildTabbedList(t *testing.T) {
+	t.Parallel()
+
 	req := require.New(t)
 
 	arr := []string{"a", "b"}
@@ -16,6 +18,8 @@ func TestBuildTabbedList(t *testing.T) {
 }
 
 func TestExtractConfig(t *testing.T) {
+	t.Parallel()
+
 	req := require.New(t)
 
 	in := []byte("key1=val1\nkey2=val2\n#commented=val\n")
@@ -29,6 +33,8 @@ func TestExtractConfig(t *testing.T) {
 }
 
 func TestCollectFlags(t *testing.T) {
+	t.Parallel()
+
 	req := require.New(t)
 
 	flags := pflag.NewFlagSet("", pflag.ExitOnError)

--- a/internal/pkg/log/logger_test.go
+++ b/internal/pkg/log/logger_test.go
@@ -8,6 +8,8 @@ import (
 )
 
 func TestLogger_Flush(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name     string
 		level    Level
@@ -25,7 +27,10 @@ func TestLogger_Flush(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			buf := new(bytes.Buffer)
 			l := New(tt.level, buf)
 			l.Debug("hi there")

--- a/internal/pkg/netrc/netrc_handler_test.go
+++ b/internal/pkg/netrc/netrc_handler_test.go
@@ -51,6 +51,8 @@ var (
 )
 
 func TestGetMatchingNetrcMachineNameWithContextName(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name    string
 		want    *Machine
@@ -105,7 +107,10 @@ func TestGetMatchingNetrcMachineNameWithContextName(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			netrcHandler := NewNetrcHandler(tt.file)
 			var machine *Machine
 			var err error
@@ -137,6 +142,8 @@ func isIdenticalMachine(expect, actual *Machine) bool {
 }
 
 func TestGetMatchingNetrcMachineNameFromURL(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name    string
 		want    *Machine
@@ -189,7 +196,10 @@ func TestGetMatchingNetrcMachineNameFromURL(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			netrcHandler := NewNetrcHandler(tt.file)
 			var machine *Machine
 			var err error
@@ -215,6 +225,8 @@ func TestGetMatchingNetrcMachineNameFromURL(t *testing.T) {
 }
 
 func TestGetMachineNameRegex(t *testing.T) {
+	t.Parallel()
+
 	url := "https://confluent.cloud"
 	ccloudCtxName := "login-csreesangkom@confleunt.io-https://confluent.cloud"
 	confluentCtxName := "login-csreesangkom@confluent.io-http://localhost:8090"
@@ -309,7 +321,10 @@ func TestGetMachineNameRegex(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			regex := getMachineNameRegex(tt.params)
 			for _, machineName := range tt.matchNames {
 				if !regex.Match([]byte(machineName)) {

--- a/internal/pkg/netrc/utils_test.go
+++ b/internal/pkg/netrc/utils_test.go
@@ -8,6 +8,8 @@ import (
 )
 
 func TestParseNetrcMachineName(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name        string
 		machineName string
@@ -45,7 +47,10 @@ func TestParseNetrcMachineName(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			got, err := ParseNetrcMachineName(tt.machineName)
 			require.NoError(t, err)
 			compareMachineContextInfo(t, tt.want, got)

--- a/internal/pkg/output/table_test.go
+++ b/internal/pkg/output/table_test.go
@@ -19,6 +19,8 @@ type out struct {
 }
 
 func TestTable(t *testing.T) {
+	t.Parallel()
+
 	tests := map[string][]string{
 		Human.String(): {
 			"+-------------+-----------------+",
@@ -66,6 +68,8 @@ func TestTable(t *testing.T) {
 }
 
 func TestTable_NoAutoWrap(t *testing.T) {
+	t.Parallel()
+
 	tests := map[string][]string{
 		Human.String(): {
 			"+-------------+------------+",
@@ -129,6 +133,8 @@ func TestTable_NoAutoWrap(t *testing.T) {
 }
 
 func TestTable_Filter(t *testing.T) {
+	t.Parallel()
+
 	tests := map[string][]string{
 		Human.String(): {
 			"+-------------+-----------------+",
@@ -170,6 +176,8 @@ func TestTable_Filter(t *testing.T) {
 }
 
 func TestTable_Omitempty(t *testing.T) {
+	t.Parallel()
+
 	tests := map[string][]string{
 		Human.String(): {
 			"+---------+------------+",
@@ -213,6 +221,8 @@ func TestTable_Omitempty(t *testing.T) {
 }
 
 func TestTable_Map(t *testing.T) {
+	t.Parallel()
+
 	tests := map[string][]string{
 		Human.String(): {
 			"+---+-------+",
@@ -246,6 +256,8 @@ func TestTable_Map(t *testing.T) {
 }
 
 func TestTable_EmptyMap(t *testing.T) {
+	t.Parallel()
+
 	tests := map[string][]string{
 		Human.String(): {
 			"None found.",
@@ -275,6 +287,8 @@ func TestTable_EmptyMap(t *testing.T) {
 }
 
 func TestList(t *testing.T) {
+	t.Parallel()
+
 	tests := map[string][]string{
 		Human.String(): {
 			"  Current | ID |    Name    | Description  ",
@@ -332,6 +346,8 @@ func TestList(t *testing.T) {
 }
 
 func TestList_Empty(t *testing.T) {
+	t.Parallel()
+
 	tests := map[string][]string{
 		Human.String(): {
 			"None found.",

--- a/internal/pkg/plugin/plugin_test.go
+++ b/internal/pkg/plugin/plugin_test.go
@@ -17,11 +17,15 @@ import (
 )
 
 func TestIsExec_Dir(t *testing.T) {
+	t.Parallel()
+
 	f := &mock.FileInfo{ModeVal: fs.ModeDir}
 	require.False(t, isExecutable(f))
 }
 
 func TestIsExec_Executable(t *testing.T) {
+	t.Parallel()
+
 	if runtime.GOOS == "windows" {
 		assert.False(t, isExecutable(&mock.FileInfo{NameVal: "hello.nonexe"}))
 		assert.True(t, isExecutable(&mock.FileInfo{NameVal: "hello.exe"}))
@@ -38,6 +42,8 @@ type pluginWalkInfo struct {
 }
 
 func TestPluginFromEntry(t *testing.T) {
+	t.Parallel()
+
 	if runtime.GOOS == "windows" {
 		tests := []pluginWalkInfo{
 			{"confluent-plugin1.exe", fs.ModePerm, "confluent-plugin1"},
@@ -73,6 +79,8 @@ func TestPluginFromEntry(t *testing.T) {
 }
 
 func TestSearchPath(t *testing.T) {
+	t.Parallel()
+
 	root, err := os.MkdirTemp(os.TempDir(), "plugin_test")
 	require.NoError(t, err)
 	defer func() {

--- a/internal/pkg/properties/properties_test.go
+++ b/internal/pkg/properties/properties_test.go
@@ -7,76 +7,104 @@ import (
 )
 
 func TestParseLines_Empty(t *testing.T) {
+	t.Parallel()
+
 	lines := parseLines("")
 	require.Empty(t, lines)
 }
 
 func TestParseLines_Comment(t *testing.T) {
+	t.Parallel()
+
 	lines := parseLines("#key=val")
 	require.Empty(t, lines)
 }
 
 func TestParseLines_Basic(t *testing.T) {
+	t.Parallel()
+
 	lines := parseLines("key=val")
 	require.Equal(t, []string{"key=val"}, lines)
 }
 
 func TestParseLines_TrimSpace(t *testing.T) {
+	t.Parallel()
+
 	lines := parseLines("  key=val  ")
 	require.Equal(t, []string{"key=val"}, lines)
 }
 
 func TestParseLines_MultilineProperties(t *testing.T) {
+	t.Parallel()
+
 	lines := parseLines("key=line1\\\nline2")
 	require.Equal(t, []string{"key=line1line2"}, lines)
 }
 
 func TestParseLines_MultipleLines(t *testing.T) {
+	t.Parallel()
+
 	lines := parseLines("key1=val1\nkey2=val2")
 	require.Equal(t, []string{"key1=val1", "key2=val2"}, lines)
 }
 
 func TestToMap_Basic(t *testing.T) {
+	t.Parallel()
+
 	m, err := toMap([]string{"key=val"})
 	require.NoError(t, err)
 	require.Equal(t, map[string]string{"key": "val"}, m)
 }
 
 func TestToMap_Override(t *testing.T) {
+	t.Parallel()
+
 	m, err := toMap([]string{"key=val1", "key=val2"})
 	require.NoError(t, err)
 	require.Equal(t, map[string]string{"key": "val2"}, m)
 }
 
 func TestToMap_Error(t *testing.T) {
+	t.Parallel()
+
 	_, err := toMap([]string{"string without equal sign"})
 	require.Error(t, err)
 }
 
 func TestConfigFlagToMap_Basic(t *testing.T) {
+	t.Parallel()
+
 	m, err := ConfigFlagToMap([]string{"key=val"})
 	require.NoError(t, err)
 	require.Equal(t, map[string]string{"key": "val"}, m)
 }
 
 func TestConfigFlagToMap_Override(t *testing.T) {
+	t.Parallel()
+
 	m, err := ConfigFlagToMap([]string{"key=val1", "key=val2"})
 	require.NoError(t, err)
 	require.Equal(t, map[string]string{"key": "val2"}, m)
 }
 
 func TestConfigFlagToMap_Error(t *testing.T) {
+	t.Parallel()
+
 	_, err := ConfigFlagToMap([]string{"string without equal sign"})
 	require.Error(t, err)
 }
 
 func TestConfigFlagToMap_ValueWithComma(t *testing.T) {
+	t.Parallel()
+
 	m, err := ConfigFlagToMap([]string{"key=val1", "val2"})
 	require.NoError(t, err)
 	require.Equal(t, map[string]string{"key": "val1,val2"}, m)
 }
 
 func TestConfigFlagToMap_ValueWithEquals(t *testing.T) {
+	t.Parallel()
+
 	m, err := ConfigFlagToMap([]string{"key=val1=val2"})
 	require.NoError(t, err)
 	require.Equal(t, map[string]string{"key": "val1=val2"}, m)

--- a/internal/pkg/releasenotes/docs_update_handler_test.go
+++ b/internal/pkg/releasenotes/docs_update_handler_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestDocsUpdateHandler(t *testing.T) {
+	t.Parallel()
+
 	newReleaseNotes := `|confluent-cli| v1.2.0 Release Notes
 ====================================
 
@@ -36,7 +38,10 @@ Bug Fixes
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			docsUpdateHandler := NewDocsUpdateHandler(docsPageHeader, tt.docsFile)
 			docs, err := docsUpdateHandler.getUpdatedDocsPage(newReleaseNotes)
 			require.NoError(t, err)

--- a/internal/pkg/releasenotes/release_notes_builder_test.go
+++ b/internal/pkg/releasenotes/release_notes_builder_test.go
@@ -19,6 +19,7 @@ type ReleaseNotesBuilderTestSuite struct {
 }
 
 func TestReleaseNotesBuilderTestSuite(t *testing.T) {
+	t.Parallel()
 	suite.Run(t, new(ReleaseNotesBuilderTestSuite))
 }
 

--- a/internal/pkg/releasenotes/release_notes_test.go
+++ b/internal/pkg/releasenotes/release_notes_test.go
@@ -10,6 +10,8 @@ import (
 )
 
 func TestNew(t *testing.T) {
+	t.Parallel()
+
 	r := New()
 	require.Empty(t, r.major)
 	require.Empty(t, r.minor)
@@ -17,6 +19,8 @@ func TestNew(t *testing.T) {
 }
 
 func TestNewFromBody(t *testing.T) {
+	t.Parallel()
+
 	r := NewFromBody(strings.Join([]string{
 		"Release Notes             ",
 		"-------------             ",
@@ -46,6 +50,8 @@ func TestNewFromBody(t *testing.T) {
 }
 
 func TestMerge(t *testing.T) {
+	t.Parallel()
+
 	a := &ReleaseNotes{
 		major: []string{"A"},
 		minor: []string{"A"},
@@ -65,6 +71,8 @@ func TestMerge(t *testing.T) {
 }
 
 func TestGetBump_Major(t *testing.T) {
+	t.Parallel()
+
 	r := &ReleaseNotes{
 		major: []string{""},
 		minor: []string{""},
@@ -76,6 +84,8 @@ func TestGetBump_Major(t *testing.T) {
 }
 
 func TestGetBump_Minor(t *testing.T) {
+	t.Parallel()
+
 	r := &ReleaseNotes{
 		major: []string{},
 		minor: []string{""},
@@ -87,6 +97,8 @@ func TestGetBump_Minor(t *testing.T) {
 }
 
 func TestGetBump_Patch(t *testing.T) {
+	t.Parallel()
+
 	r := &ReleaseNotes{
 		major: []string{},
 		minor: []string{},
@@ -98,6 +110,8 @@ func TestGetBump_Patch(t *testing.T) {
 }
 
 func TestGetBump_ErrorNoUpdates(t *testing.T) {
+	t.Parallel()
+
 	r := &ReleaseNotes{
 		major: []string{},
 		minor: []string{},
@@ -108,6 +122,8 @@ func TestGetBump_ErrorNoUpdates(t *testing.T) {
 }
 
 func TestBumpVersion(t *testing.T) {
+	t.Parallel()
+
 	v := version.Must(version.NewSemver("1.1.1"))
 	assert.Equal(t, "2.0.0", bumpVersion(v, "major"))
 	assert.Equal(t, "1.2.0", bumpVersion(v, "minor"))

--- a/internal/pkg/secret/jaas_parser_test.go
+++ b/internal/pkg/secret/jaas_parser_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestJAASParser_String(t *testing.T) {
+	t.Parallel()
+
 	type args struct {
 		key             string
 		contents        string
@@ -79,7 +81,10 @@ listener.name.sasl_ssl.scram-sha-256.sasl.jaas.config/com.sun.security.auth.modu
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			req := require.New(t)
 			parser := NewJAASParser()
 			props, err := parser.ParseJAASConfigurationEntry(tt.args.contents, tt.args.key)
@@ -96,6 +101,8 @@ listener.name.sasl_ssl.scram-sha-256.sasl.jaas.config/com.sun.security.auth.modu
 }
 
 func TestJAASParser_StringUpdate(t *testing.T) {
+	t.Parallel()
+
 	type args struct {
 		key             string
 		contents        string
@@ -133,7 +140,10 @@ listener.name.sasl_ssl.scram-sha-256.sasl.jaas.config/com.sun.security.auth.modu
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			req := require.New(t)
 			parser := NewJAASParser()
 			_, err := parser.ParseJAASConfigurationEntry(tt.args.originalContent, tt.args.key)

--- a/internal/pkg/secret/password_protection_test.go
+++ b/internal/pkg/secret/password_protection_test.go
@@ -1023,7 +1023,10 @@ func TestPasswordProtectionSuite_RemoveConfigFileSecrets(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			req := require.New(t)
 
 			plugin, err := setUpDir(tt.args.masterKeyPassphrase, tt.args.secureDir, tt.args.configFilePath, tt.args.localSecureConfigPath, tt.args.contents)
@@ -1047,6 +1050,8 @@ func TestPasswordProtectionSuite_RemoveConfigFileSecrets(t *testing.T) {
 }
 
 func TestPasswordProtectionSuite_RotateDataKey(t *testing.T) {
+	t.Parallel()
+
 	type args struct {
 		contents               string
 		masterKeyPassphrase    string
@@ -1149,7 +1154,10 @@ func TestPasswordProtectionSuite_RotateDataKey(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			req := require.New(t)
 
 			plugin, err := setUpDir(tt.args.masterKeyPassphrase, tt.args.secureDir, tt.args.configFilePath, tt.args.localSecureConfigPath, tt.args.contents)

--- a/internal/pkg/secret/password_protection_test.go
+++ b/internal/pkg/secret/password_protection_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestPasswordProtectionSuite_CreateMasterKey(t *testing.T) {
+func TestPasswordProtectionSuite_CreateMasterKey(t *testing.T) { //nolint:paralleltest
 	type args struct {
 		masterKeyPassphrase   string
 		localSecureConfigPath string
@@ -92,7 +92,7 @@ func TestPasswordProtectionSuite_CreateMasterKey(t *testing.T) {
 			wantErrMsg: errors.EmptyPassphraseErrorMsg,
 		},
 	}
-	for _, tt := range tests {
+	for _, tt := range tests { //nolint:paralleltest
 		t.Run(tt.name, func(t *testing.T) {
 			req := require.New(t)
 
@@ -118,7 +118,7 @@ func TestPasswordProtectionSuite_CreateMasterKey(t *testing.T) {
 	}
 }
 
-func TestPasswordProtectionSuite_EncryptConfigFileSecrets(t *testing.T) {
+func TestPasswordProtectionSuite_EncryptConfigFileSecrets(t *testing.T) { //nolint:paralleltest
 	type args struct {
 		contents               string
 		masterKeyPassphrase    string
@@ -371,7 +371,7 @@ config.providers.securepass.class = io.confluent.kafka.security.config.provider.
 			wantErrMsg: errors.InvalidJSONFileFormatErrorMsg,
 		},
 	}
-	for _, tt := range tests {
+	for _, tt := range tests { //nolint:paralleltest
 		t.Run(tt.name, func(t *testing.T) {
 			req := require.New(t)
 
@@ -413,7 +413,7 @@ config.providers.securepass.class = io.confluent.kafka.security.config.provider.
 	}
 }
 
-func TestPasswordProtectionSuite_DecryptConfigFileSecrets(t *testing.T) {
+func TestPasswordProtectionSuite_DecryptConfigFileSecrets(t *testing.T) { //nolint:paralleltest
 	type args struct {
 		configFileContent      string
 		secretFileContent      string
@@ -629,7 +629,7 @@ config.properties/testPassword = ENC[AES/GCM/NoPadding,data:VXowRlNy9wP3Weq03Yry
 			wantOutputFile: "testPassword = password\n",
 		},
 	}
-	for _, tt := range tests {
+	for _, tt := range tests { //nolint:paralleltest
 		t.Run(tt.name, func(t *testing.T) {
 			req := require.New(t)
 
@@ -659,7 +659,7 @@ config.properties/testPassword = ENC[AES/GCM/NoPadding,data:VXowRlNy9wP3Weq03Yry
 	}
 }
 
-func TestPasswordProtectionSuite_AddConfigFileSecrets(t *testing.T) {
+func TestPasswordProtectionSuite_AddConfigFileSecrets(t *testing.T) { //nolint:paralleltest
 	type args struct {
 		contents               string
 		masterKeyPassphrase    string
@@ -757,7 +757,7 @@ func TestPasswordProtectionSuite_AddConfigFileSecrets(t *testing.T) {
 			wantSecretsFile: `config.json/credentials.password = ENC[AES/GCM/NoPadding,data:`,
 		},
 	}
-	for _, tt := range tests {
+	for _, tt := range tests { //nolint:paralleltest
 		t.Run(tt.name, func(t *testing.T) {
 			req := require.New(t)
 
@@ -782,7 +782,7 @@ func TestPasswordProtectionSuite_AddConfigFileSecrets(t *testing.T) {
 	}
 }
 
-func TestPasswordProtectionSuite_UpdateConfigFileSecrets(t *testing.T) {
+func TestPasswordProtectionSuite_UpdateConfigFileSecrets(t *testing.T) { //nolint:paralleltest
 	type args struct {
 		contents               string
 		masterKeyPassphrase    string
@@ -853,7 +853,7 @@ func TestPasswordProtectionSuite_UpdateConfigFileSecrets(t *testing.T) {
 			wantErr: false,
 		},
 	}
-	for _, tt := range tests {
+	for _, tt := range tests { //nolint:paralleltest
 		t.Run(tt.name, func(t *testing.T) {
 			req := require.New(t)
 
@@ -878,7 +878,7 @@ func TestPasswordProtectionSuite_UpdateConfigFileSecrets(t *testing.T) {
 	}
 }
 
-func TestPasswordProtectionSuite_RemoveConfigFileSecrets(t *testing.T) {
+func TestPasswordProtectionSuite_RemoveConfigFileSecrets(t *testing.T) { //nolint:paralleltest
 	type args struct {
 		contents               string
 		masterKeyPassphrase    string
@@ -1022,11 +1022,8 @@ func TestPasswordProtectionSuite_RemoveConfigFileSecrets(t *testing.T) {
 			wantErrMsg: fmt.Sprintf(errors.ConfigKeyNotEncryptedErrorMsg, "credentials/location"),
 		},
 	}
-	for _, tt := range tests {
-		tt := tt
+	for _, tt := range tests { //nolint:paralleltest
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
 			req := require.New(t)
 
 			plugin, err := setUpDir(tt.args.masterKeyPassphrase, tt.args.secureDir, tt.args.configFilePath, tt.args.localSecureConfigPath, tt.args.contents)
@@ -1049,9 +1046,7 @@ func TestPasswordProtectionSuite_RemoveConfigFileSecrets(t *testing.T) {
 	}
 }
 
-func TestPasswordProtectionSuite_RotateDataKey(t *testing.T) {
-	t.Parallel()
-
+func TestPasswordProtectionSuite_RotateDataKey(t *testing.T) { //nolint:paralleltest
 	type args struct {
 		contents               string
 		masterKeyPassphrase    string
@@ -1153,11 +1148,8 @@ func TestPasswordProtectionSuite_RotateDataKey(t *testing.T) {
 			wantErrMsg: errors.IncorrectPassphraseErrorMsg,
 		},
 	}
-	for _, tt := range tests {
-		tt := tt
+	for _, tt := range tests { //nolint:paralleltest
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
 			req := require.New(t)
 
 			plugin, err := setUpDir(tt.args.masterKeyPassphrase, tt.args.secureDir, tt.args.configFilePath, tt.args.localSecureConfigPath, tt.args.contents)
@@ -1199,7 +1191,7 @@ func TestPasswordProtectionSuite_RotateDataKey(t *testing.T) {
 	}
 }
 
-func TestPasswordProtectionSuite_RotateMasterKey(t *testing.T) {
+func TestPasswordProtectionSuite_RotateMasterKey(t *testing.T) { //nolint:paralleltest
 	type args struct {
 		contents               string
 		masterKeyPassphrase    string
@@ -1315,7 +1307,7 @@ func TestPasswordProtectionSuite_RotateMasterKey(t *testing.T) {
 			wantErrMsg: errors.SamePassphraseErrorMsg,
 		},
 	}
-	for _, tt := range tests {
+	for _, tt := range tests { //nolint:paralleltest
 		t.Run(tt.name, func(t *testing.T) {
 			req := require.New(t)
 

--- a/internal/pkg/serdes/serdes_test.go
+++ b/internal/pkg/serdes/serdes_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestSerializationProvider(t *testing.T) {
+	t.Parallel()
+
 	req := require.New(t)
 	valueFormats := []string{AVROSCHEMANAME, PROTOBUFSCHEMANAME, JSONSCHEMANAME, RAWSCHEMANAME}
 	schemaNames := []string{AVROSCHEMABACKEND, PROTOBUFSCHEMABACKEND, JSONSCHEMABACKEND, RAWSCHEMANAME}
@@ -28,6 +30,8 @@ func TestSerializationProvider(t *testing.T) {
 }
 
 func TestDeserializationProvider(t *testing.T) {
+	t.Parallel()
+
 	req := require.New(t)
 	valueFormats := []string{AVROSCHEMANAME, PROTOBUFSCHEMANAME, JSONSCHEMANAME, RAWSCHEMANAME}
 	schemaNames := []string{AVROSCHEMABACKEND, PROTOBUFSCHEMABACKEND, JSONSCHEMABACKEND, RAWSCHEMANAME}
@@ -44,6 +48,8 @@ func TestDeserializationProvider(t *testing.T) {
 }
 
 func TestStringSerdes(t *testing.T) {
+	t.Parallel()
+
 	req := require.New(t)
 
 	serializationProvider, _ := GetSerializationProvider(RAWSCHEMANAME)
@@ -60,7 +66,7 @@ func TestStringSerdes(t *testing.T) {
 	req.Equal(str, "somestring")
 }
 
-func TestAvroSerdesValid(t *testing.T) {
+func TestAvroSerdesValid(t *testing.T) { //nolint:paralleltest
 	req := require.New(t)
 
 	dir, err := sr.CreateTempDir()
@@ -94,7 +100,7 @@ func TestAvroSerdesValid(t *testing.T) {
 	req.NoError(os.RemoveAll(dir))
 }
 
-func TestAvroSerdesInvalid(t *testing.T) {
+func TestAvroSerdesInvalid(t *testing.T) { //nolint:paralleltest
 	req := require.New(t)
 
 	dir, err := sr.CreateTempDir()
@@ -129,6 +135,8 @@ func TestAvroSerdesInvalid(t *testing.T) {
 }
 
 func TestJsonSerdesValid(t *testing.T) {
+	t.Parallel()
+
 	req := require.New(t)
 
 	dir, err := sr.CreateTempDir()
@@ -161,7 +169,7 @@ func TestJsonSerdesValid(t *testing.T) {
 	req.NoError(os.RemoveAll(dir))
 }
 
-func TestJsonSerdesReference(t *testing.T) {
+func TestJsonSerdesReference(t *testing.T) { //nolint:paralleltest
 	req := require.New(t)
 
 	dir, err := sr.CreateTempDir()
@@ -198,7 +206,7 @@ func TestJsonSerdesReference(t *testing.T) {
 	req.NoError(os.RemoveAll(dir))
 }
 
-func TestJsonSerdesInvalid(t *testing.T) {
+func TestJsonSerdesInvalid(t *testing.T) { //nolint:paralleltest
 	req := require.New(t)
 
 	dir, err := sr.CreateTempDir()
@@ -238,7 +246,7 @@ func TestJsonSerdesInvalid(t *testing.T) {
 	req.NoError(os.RemoveAll(dir))
 }
 
-func TestProtobufSerdesValid(t *testing.T) {
+func TestProtobufSerdesValid(t *testing.T) { //nolint:paralleltest
 	req := require.New(t)
 
 	dir, err := sr.CreateTempDir()
@@ -277,7 +285,7 @@ func TestProtobufSerdesValid(t *testing.T) {
 	req.NoError(os.RemoveAll(dir))
 }
 
-func TestProtobufSerdesReference(t *testing.T) {
+func TestProtobufSerdesReference(t *testing.T) { //nolint:paralleltest
 	req := require.New(t)
 
 	dir, err := sr.CreateTempDir()
@@ -329,7 +337,7 @@ func TestProtobufSerdesReference(t *testing.T) {
 	req.NoError(os.RemoveAll(dir))
 }
 
-func TestProtobufSerdesInvalid(t *testing.T) {
+func TestProtobufSerdesInvalid(t *testing.T) { //nolint:paralleltest
 	req := require.New(t)
 
 	dir, err := sr.CreateTempDir()
@@ -375,7 +383,7 @@ func TestProtobufSerdesInvalid(t *testing.T) {
 	req.NoError(os.RemoveAll(dir))
 }
 
-func TestProtobufSerdesNestedValid(t *testing.T) {
+func TestProtobufSerdesNestedValid(t *testing.T) { //nolint:paralleltest
 	req := require.New(t)
 
 	dir, err := sr.CreateTempDir()

--- a/internal/pkg/update/client_test.go
+++ b/internal/pkg/update/client_test.go
@@ -24,6 +24,8 @@ import (
 )
 
 func TestNewClient(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name   string
 		params *ClientParams
@@ -57,7 +59,10 @@ func TestNewClient(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			if got := NewClient(tt.params); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("NewClient() = %#v, want %#v", got, tt.want)
 			}
@@ -65,7 +70,7 @@ func TestNewClient(t *testing.T) {
 	}
 }
 
-func TestCheckForUpdates(t *testing.T) {
+func TestCheckForUpdates(t *testing.T) { //nolint:paralleltest
 	tmpCheckFile1, err := os.CreateTemp("", "cli-test1-")
 	require.NoError(t, err)
 	defer os.Remove(tmpCheckFile1.Name())
@@ -351,10 +356,8 @@ func TestCheckForUpdates(t *testing.T) {
 			wantMinor: "",
 		},
 	}
-	for _, tt := range tests {
-		tt := tt
+	for _, tt := range tests { //nolint:paralleltest
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
 			major, minor, err := tt.client.CheckForUpdates(tt.args.name, tt.args.currentVersion, tt.args.forceCheck)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("client.CheckForUpdates() error = %v, wantErr %v", err, tt.wantErr)
@@ -371,6 +374,8 @@ func TestCheckForUpdates(t *testing.T) {
 }
 
 func TestCheckForUpdates_BehaviorOverTime(t *testing.T) {
+	t.Parallel()
+
 	req := require.New(t)
 
 	tmpDir, err := os.MkdirTemp("", "cli-test3-")
@@ -434,6 +439,8 @@ func TestCheckForUpdates_BehaviorOverTime(t *testing.T) {
 }
 
 func TestCheckForUpdates_NoCheckFileGiven(t *testing.T) {
+	t.Parallel()
+
 	req := require.New(t)
 
 	repo := &updateMock.Repository{
@@ -459,6 +466,8 @@ func TestCheckForUpdates_NoCheckFileGiven(t *testing.T) {
 }
 
 func TestVerifyChecksum(t *testing.T) {
+	t.Parallel()
+
 	checksums := test.LoadFixture(t, "update/checksums.golden")
 
 	mockRepository := &updateMock.Repository{
@@ -510,7 +519,10 @@ func TestVerifyChecksum(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			_, err := mockRepository.DownloadChecksums("confluent", tt.version)
 			if tt.wantDownloadErr {
 				require.Error(t, err)
@@ -529,6 +541,8 @@ func TestVerifyChecksum(t *testing.T) {
 }
 
 func TestGetLatestReleaseNotes(t *testing.T) {
+	t.Parallel()
+
 	currentVersion := "0.1.0"
 	releaseNotesVersion := "1.0.0"
 	releaseNotes := "nice release notes"
@@ -588,7 +602,10 @@ func TestGetLatestReleaseNotes(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			gotReleaseNotesVersion, gotReleaseNotes, err := tt.client.GetLatestReleaseNotes("confluent", currentVersion)
 			if tt.wantErr {
 				require.Error(t, err)
@@ -602,20 +619,24 @@ func TestGetLatestReleaseNotes(t *testing.T) {
 	}
 }
 
-func TestUpdateBinary(t *testing.T) {
+func TestUpdateBinary(t *testing.T) { //nolint:paralleltest
 	req := require.New(t)
 
 	binName := "fake_cli"
 
 	installDir, err := os.MkdirTemp("", "cli-test4-")
 	require.NoError(t, err)
-	defer os.Remove(installDir)
+	t.Cleanup(func() {
+		os.Remove(installDir)
+	})
 	installedBin := filepath.FromSlash(fmt.Sprintf("%s/%s", installDir, binName))
 	_ = os.WriteFile(installedBin, []byte("old version"), os.ModePerm)
 
 	downloadDir, err := os.MkdirTemp("", "cli-test5-")
 	require.NoError(t, err)
-	defer os.Remove(downloadDir)
+	t.Cleanup(func() {
+		os.Remove(downloadDir)
+	})
 	downloadedBin := filepath.FromSlash(fmt.Sprintf("%s/%s", downloadDir, binName))
 	_ = os.WriteFile(downloadedBin, []byte("new version"), os.ModePerm)
 
@@ -839,7 +860,7 @@ func TestUpdateBinary(t *testing.T) {
 			wantErr: true,
 		},
 	}
-	for _, tt := range tests {
+	for _, tt := range tests { //nolint:paralleltest
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.client.Out == nil {
 				tt.client.Out = os.Stdout
@@ -851,7 +872,7 @@ func TestUpdateBinary(t *testing.T) {
 	}
 }
 
-func TestPromptToDownload(t *testing.T) {
+func TestPromptToDownload(t *testing.T) { //nolint:paralleltest
 	req := require.New(t)
 
 	clock := clockwork.NewFakeClockAt(time.Now())
@@ -1022,7 +1043,7 @@ func TestPromptToDownload(t *testing.T) {
 			want: true,
 		},
 	}
-	for _, tt := range tests {
+	for _, tt := range tests { //nolint:paralleltest
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.client.Out == nil {
 				tt.client.Out = os.Stdout

--- a/internal/pkg/update/client_test.go
+++ b/internal/pkg/update/client_test.go
@@ -352,7 +352,9 @@ func TestCheckForUpdates(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			major, minor, err := tt.client.CheckForUpdates(tt.args.name, tt.args.currentVersion, tt.args.forceCheck)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("client.CheckForUpdates() error = %v, wantErr %v", err, tt.wantErr)

--- a/internal/pkg/update/s3/object_key_test.go
+++ b/internal/pkg/update/s3/object_key_test.go
@@ -75,6 +75,8 @@ func TestNewPrefixedKey(t *testing.T) {
 }
 
 func TestPrefixedKey_ParseVersion(t *testing.T) {
+	t.Parallel()
+
 	req := require.New(t)
 
 	makeVersion := func(v string) *version.Version {
@@ -194,11 +196,9 @@ func TestPrefixedKey_ParseVersion(t *testing.T) {
 			wantVer:   makeVersion("0.23.0"),
 		},
 		{
-			name:   "should support empty prefix",
-			fields: fields{},
-			args: args{
-				key: "fancy_0.23.0_darwin_amd64",
-			},
+			name:      "should support empty prefix",
+			fields:    fields{},
+			args:      args{key: "fancy_0.23.0_darwin_amd64"},
 			wantMatch: true,
 			wantVer:   makeVersion("0.23.0"),
 		},
@@ -210,15 +210,16 @@ func TestPrefixedKey_ParseVersion(t *testing.T) {
 				goos:      "windows",
 				goarch:    "386",
 			},
-			args: args{
-				key: "pre/0.23.0/fancy_0.23.0_windows_386.exe",
-			},
+			args:      args{key: "pre/0.23.0/fancy_0.23.0_windows_386.exe"},
 			wantMatch: true,
 			wantVer:   makeVersion("0.23.0"),
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			if tt.fields.Separator == "" {
 				tt.fields.Separator = "_"
 			}
@@ -249,6 +250,8 @@ func TestPrefixedKey_ParseVersion(t *testing.T) {
 }
 
 func TestPrefixedKey_URLFor(t *testing.T) {
+	t.Parallel()
+
 	req := require.New(t)
 	type fields struct {
 		Prefix          string
@@ -338,7 +341,10 @@ func TestPrefixedKey_URLFor(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			if tt.fields.OS == "" {
 				tt.fields.OS = "darwin"
 				tt.fields.Arch = "amd64"

--- a/internal/pkg/update/s3/object_key_test.go
+++ b/internal/pkg/update/s3/object_key_test.go
@@ -10,6 +10,8 @@ import (
 )
 
 func TestNewPrefixedKey(t *testing.T) {
+	t.Parallel()
+
 	type args struct {
 		prefix        string
 		sep           string
@@ -56,7 +58,10 @@ func TestNewPrefixedKey(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			got, err := NewPrefixedKey(tt.args.prefix, tt.args.sep, tt.args.prefixVersion)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("NewPrefixedKey() error = %v, wantErr %v", err, tt.wantErr)

--- a/internal/pkg/update/s3/public_test.go
+++ b/internal/pkg/update/s3/public_test.go
@@ -37,6 +37,8 @@ func NewMockPublicS3Error() *httptest.Server {
 }
 
 func TestPublicRepo_GetAvailableBinaryVersions(t *testing.T) {
+	t.Parallel()
+
 	req := require.New(t)
 
 	makeVersions := func(versions ...string) version.Collection {
@@ -106,13 +108,14 @@ func TestPublicRepo_GetAvailableBinaryVersions(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			// Need to inject these so tests pass in different environments (e.g., CI)
 			goos := "darwin"
 			goarch := "amd64"
-			r := NewPublicRepo(&PublicRepoParams{
-				S3BinPrefixFmt: "%s-cli",
-			})
+			r := NewPublicRepo(&PublicRepoParams{S3BinPrefixFmt: "%s-cli"})
 			r.endpoint = tt.fields.Endpoint
 			r.goos = goos
 			r.goarch = goarch
@@ -130,6 +133,8 @@ func TestPublicRepo_GetAvailableBinaryVersions(t *testing.T) {
 }
 
 func TestPublicRepo_GetLatestMajorAndMinorVersion(t *testing.T) {
+	t.Parallel()
+
 	req := require.New(t)
 
 	makeVersion := func(v string) *version.Version {
@@ -179,7 +184,10 @@ func TestPublicRepo_GetLatestMajorAndMinorVersion(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			// Need to inject these so tests pass in different environments (e.g., CI)
 			goos := "darwin"
 			goarch := "amd64"
@@ -207,6 +215,8 @@ func TestPublicRepo_GetLatestMajorAndMinorVersion(t *testing.T) {
 }
 
 func TestPublicRepo_GetAvailableReleaseNotesVersions(t *testing.T) {
+	t.Parallel()
+
 	req := require.New(t)
 
 	makeVersions := func(versions ...string) version.Collection {
@@ -274,7 +284,10 @@ func TestPublicRepo_GetAvailableReleaseNotesVersions(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			r := NewPublicRepo(&PublicRepoParams{
 				S3BinBucket:             tt.fields.S3BinBucket,
 				S3BinRegion:             tt.fields.S3BinRegion,
@@ -295,6 +308,8 @@ func TestPublicRepo_GetAvailableReleaseNotesVersions(t *testing.T) {
 }
 
 func TestPublicRepo_GetLatestReleaseNotesVersion(t *testing.T) {
+	t.Parallel()
+
 	req := require.New(t)
 
 	currentVersion := "v0.0.0"
@@ -362,10 +377,11 @@ func TestPublicRepo_GetLatestReleaseNotesVersion(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			r := NewPublicRepo(&PublicRepoParams{
-				S3ReleaseNotesPrefixFmt: "%s-cli/release-notes",
-			})
+			t.Parallel()
+
+			r := NewPublicRepo(&PublicRepoParams{S3ReleaseNotesPrefixFmt: "%s-cli/release-notes"})
 			r.endpoint = tt.fields.Endpoint
 
 			got, err := r.GetLatestReleaseNotesVersions(pversion.CLIName, currentVersion)
@@ -381,11 +397,15 @@ func TestPublicRepo_GetLatestReleaseNotesVersion(t *testing.T) {
 }
 
 func TestPublicRepo_DownloadVersion(t *testing.T) {
+	t.Parallel()
+
 	req := require.New(t)
 
 	downloadDir, err := os.MkdirTemp("", "cli-test5-")
 	require.NoError(t, err)
-	defer os.Remove(downloadDir)
+	t.Cleanup(func() {
+		os.Remove(downloadDir)
+	})
 
 	type fields struct {
 		Endpoint   string
@@ -467,7 +487,10 @@ func TestPublicRepo_DownloadVersion(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			// Need to inject these so tests pass in different environments (e.g., CI)
 			goos := "darwin"
 			goarch := "amd64"
@@ -497,11 +520,15 @@ func TestPublicRepo_DownloadVersion(t *testing.T) {
 }
 
 func TestPublicRepo_DownloadReleaseNotes(t *testing.T) {
+	t.Parallel()
+
 	req := require.New(t)
 
 	downloadDir, err := os.MkdirTemp("", "cli-test5-")
 	require.NoError(t, err)
-	defer os.Remove(downloadDir)
+	t.Cleanup(func() {
+		os.Remove(downloadDir)
+	})
 
 	type fields struct {
 		S3BinBucket string
@@ -539,7 +566,10 @@ func TestPublicRepo_DownloadReleaseNotes(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			r := NewPublicRepo(&PublicRepoParams{
 				S3BinBucket:             tt.fields.S3BinBucket,
 				S3BinRegion:             tt.fields.S3BinRegion,

--- a/internal/pkg/utils/utils_test.go
+++ b/internal/pkg/utils/utils_test.go
@@ -17,32 +17,38 @@ const (
 )
 
 func TestContains(t *testing.T) {
+	t.Parallel()
+
 	req := require.New(t)
 	req.True(types.Contains([]string{"a"}, "a"))
 }
 
 func TestDoesNotContain(t *testing.T) {
+	t.Parallel()
+
 	req := require.New(t)
 	req.False(types.Contains([]string{}, "a"))
 }
 
 func TestDoesPathExist(t *testing.T) {
-	t.Run("DoesPathExist: empty path returns false", func(t *testing.T) {
-		req := require.New(t)
-		valid := DoesPathExist("")
-		req.False(valid)
-	})
+	t.Parallel()
+
+	req := require.New(t)
+	valid := DoesPathExist("")
+	req.False(valid)
 }
 
 func TestLoadPropertiesFile(t *testing.T) {
-	t.Run("LoadPropertiesFile: empty path yields error", func(t *testing.T) {
-		req := require.New(t)
-		_, err := LoadPropertiesFile("")
-		req.Error(err)
-	})
+	t.Parallel()
+
+	req := require.New(t)
+	_, err := LoadPropertiesFile("")
+	req.Error(err)
 }
 
 func TestUserInviteEmailRegex(t *testing.T) {
+	t.Parallel()
+
 	type RegexTest struct {
 		email   string
 		matched bool
@@ -83,6 +89,8 @@ func TestUserInviteEmailRegex(t *testing.T) {
 }
 
 func TestIsFlagArg(t *testing.T) {
+	t.Parallel()
+
 	type testCase struct {
 		arg    string
 		isFlag bool
@@ -116,6 +124,8 @@ func TestIsFlagArg(t *testing.T) {
 }
 
 func TestIsFlagWithArg(t *testing.T) {
+	t.Parallel()
+
 	flagMap := getFlagMap()
 	type testCase struct {
 		flag     *pflag.Flag
@@ -151,6 +161,8 @@ func TestIsFlagWithArg(t *testing.T) {
 }
 
 func TestIsShorthandCountFlag(t *testing.T) {
+	t.Parallel()
+
 	flagMap := getFlagMap()
 	type testCase struct {
 		arg      string
@@ -220,6 +232,8 @@ func TestIsShorthandCountFlag(t *testing.T) {
 }
 
 func TestAbbreviate(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		input    string
 		maxLen   int
@@ -265,6 +279,8 @@ func getFlagMap() map[string]*pflag.Flag {
 }
 
 func TestCropString(t *testing.T) {
+	t.Parallel()
+
 	for _, tt := range []struct {
 		s       string
 		n       int
@@ -279,6 +295,8 @@ func TestCropString(t *testing.T) {
 }
 
 func TestArrayToCommaDelimitedString(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		input    []string
 		expected string

--- a/internal/pkg/version/version_test.go
+++ b/internal/pkg/version/version_test.go
@@ -7,6 +7,8 @@ import (
 )
 
 func TestVersion(t *testing.T) {
+	t.Parallel()
+
 	req := require.New(t)
 
 	v := NewVersion("1.2.3", "abc1234", "Fri Feb 22 20:55:53 UTC 2019")
@@ -18,6 +20,8 @@ func TestVersion(t *testing.T) {
 }
 
 func TestNewVersion_v0(t *testing.T) {
+	t.Parallel()
+
 	req := require.New(t)
 
 	v := NewVersion("0.0.0", "abc1234", "01/23/45")
@@ -28,6 +32,8 @@ func TestNewVersion_v0(t *testing.T) {
 }
 
 func TestNewVersion_Dirty(t *testing.T) {
+	t.Parallel()
+
 	req := require.New(t)
 
 	v := NewVersion("1.2.3-dirty-timmy", "abc1234", "01/23/45")
@@ -38,6 +44,8 @@ func TestNewVersion_Dirty(t *testing.T) {
 }
 
 func TestNewVersion_Unmerged(t *testing.T) {
+	t.Parallel()
+
 	req := require.New(t)
 
 	v := NewVersion("1.2.3-g16dd476", "abc1234", "01/23/45")

--- a/test/cli_test.go
+++ b/test/cli_test.go
@@ -74,6 +74,7 @@ type CLITestSuite struct {
 
 // TestCLI runs the CLI integration test suite.
 func TestCLI(t *testing.T) {
+	t.Parallel()
 	suite.Run(t, new(CLITestSuite))
 }
 

--- a/test/fixtures/output/plugin/cli-commands.golden
+++ b/test/fixtures/output/plugin/cli-commands.golden
@@ -1,7 +1,7 @@
 confluent - Confluent CLI
 
 Version:     v.*
-Git Ref:     [0-9a-f]{7,8}
+Git Ref:     [0-9a-f]{7,}
 Build Date:  20[0-9]{2}-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])T([0-1][0-9]|2[0-4]):[0-5][0-9]:[0-5][0-9]Z
 Go Version:  go.*
 Development: .*

--- a/test/fixtures/output/plugin/exact-name-overlap.golden
+++ b/test/fixtures/output/plugin/exact-name-overlap.golden
@@ -1,7 +1,7 @@
 confluent - Confluent CLI
 
 Version:     v.*
-Git Ref:     [0-9a-f]{7,8}
+Git Ref:     [0-9a-f]{7,}
 Build Date:  20[0-9]{2}-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])T([0-1][0-9]|2[0-4]):[0-5][0-9]:[0-5][0-9]Z
 Go Version:  go.*
 Development: .*

--- a/test/fixtures/output/version/version.golden
+++ b/test/fixtures/output/version/version.golden
@@ -1,7 +1,7 @@
 confluent - Confluent CLI
 
 Version:     v.*
-Git Ref:     [0-9a-f]{7,8}
+Git Ref:     [0-9a-f]{7,}
 Build Date:  20[0-9]{2}-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])T([0-1][0-9]|2[0-4]):[0-5][0-9]:[0-5][0-9]Z
 Go Version:  go.*
 Development: .*


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
Introduce two more linters, `tparallel` and `paralleltests`, which identify parallelizable tests and accept all suggestions. If CI isn't any faster, I'll close this PR since it adds complexity.

Local: 54s --> 53s
CI: 33s --> ?

Test & Review
-------------
Tests still pass, failing tests are marked as non-parallel with `//nolint`