### PR TITLE
Fix `make publish-release-notes-to-s3` target [skip secret scan]

### DIFF
--- a/mk-files/release-notes.mk
+++ b/mk-files/release-notes.mk
@@ -33,7 +33,7 @@ publish-release-notes-to-docs-repo:
 .PHONY: publish-release-notes-to-s3
 publish-release-notes-to-s3:
 	$(aws-authenticate); \
-    aws s3 cp release-notes/latest-release.rst $(S3_BUCKET_PATH)/confluent-cli/release-notes/$(cat release-notes/version.txt)/release-notes.rst --acl public-read
+    aws s3 cp release-notes/latest-release.rst $(S3_BUCKET_PATH)/confluent-cli/release-notes/$$(cat release-notes/version.txt)/release-notes.rst --acl public-read
 
 .PHONY: clean-release-notes
 clean-release-notes:


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
Last release, the version got set to `""` and the release notes were placed in the `//` directory. Now they should be correctly placed in the `/v3.5.0/` directory, for example.