### PR TITLE
Revert "Conditionally strip "v" from version in packaging"

### DIFF
--- a/debian/Makefile
+++ b/debian/Makefile
@@ -1,5 +1,4 @@
 SHELL=/bin/bash
-CLI_VERSION_NO_V=$(shell echo $(VERSION) | sed 's,^v,,' )
 
 ifndef VERSION
 	VERSION=$(CLI_VERSION)
@@ -61,8 +60,7 @@ install: apply-patches
 		mkdir -p $${dir} ; \
 		ext=""; if [[ $${dir} =~ windows_.+ ]]; then ext=".exe"; fi ; \
 		filepath=$${dir}/confluent$${ext} ; \
-		ver=$(CLI_VERSION_NO_V); if [[ $(CLI_VERSION) =~ v2\..+ ]]; then ver=$(CLI_VERSION); fi; \
-		curl -f -s https://s3-us-west-2.amazonaws.com/confluent.cloud/confluent-cli/binaries/$(CLI_VERSION)/confluent_$${ver}_$${dir}$${ext} -o $${filepath} ; \
+		curl -f -s https://s3-us-west-2.amazonaws.com/confluent.cloud/confluent-cli/binaries/$(CLI_VERSION)/confluent_$(CLI_VERSION)_$${dir}$${ext} -o $${filepath} ; \
 		chmod 755 $${filepath} ; \
 	done
 

--- a/debian/patches/standard_build_layout.patch
+++ b/debian/patches/standard_build_layout.patch
@@ -1,6 +1,6 @@
---- cli/Makefile	2023-03-13 11:12:50.000000000 -0700
-+++ debian/Makefile	2023-03-13 11:24:31.000000000 -0700
-@@ -1,128 +1,132 @@
+--- cli/Makefile	2023-03-08 16:17:59.000000000 -0800
++++ debian/Makefile	2022-12-12 17:29:13.000000000 -0800
+@@ -1,128 +1,130 @@
 -SHELL              := /bin/bash
 -ALL_SRC            := $(shell find . -name "*.go" | grep -v -e vendor)
 -GORELEASER_VERSION := v1.15.2
@@ -63,7 +63,6 @@
 -S3_STAG_FOLDER_NAME=cli-release-stag
 -S3_STAG_PATH=s3://confluent.cloud/$(S3_STAG_FOLDER_NAME)
 +SHELL=/bin/bash
-+CLI_VERSION_NO_V=$(shell echo $(VERSION) | sed 's,^v,,' )
  
 -.PHONY: clean
 -clean:
@@ -164,8 +163,7 @@
 +		mkdir -p $${dir} ; \
 +		ext=""; if [[ $${dir} =~ windows_.+ ]]; then ext=".exe"; fi ; \
 +		filepath=$${dir}/confluent$${ext} ; \
-+		ver=$(CLI_VERSION_NO_V); if [[ $(CLI_VERSION) =~ v2\..+ ]]; then ver=$(CLI_VERSION); fi; \
-+		curl -f -s https://s3-us-west-2.amazonaws.com/confluent.cloud/confluent-cli/binaries/$(CLI_VERSION)/confluent_$${ver}_$${dir}$${ext} -o $${filepath} ; \
++		curl -f -s https://s3-us-west-2.amazonaws.com/confluent.cloud/confluent-cli/binaries/$(CLI_VERSION)/confluent_$(CLI_VERSION)_$${dir}$${ext} -o $${filepath} ; \
 +		chmod 755 $${filepath} ; \
 +	done
 +


### PR DESCRIPTION
Reverts confluentinc/cli#1784

I misdiagnosed the error (RPM packaging downloads binaries, not archives), and this change made things worse.