### PR TITLE
[CLI-2137] remove prefix check for `anonymous-id`

### DIFF
--- a/internal/pkg/cmd/prerunner.go
+++ b/internal/pkg/cmd/prerunner.go
@@ -834,6 +834,12 @@ func (r *PreRun) HasAPIKey(command *HasAPIKeyCLICommand) func(*cobra.Command, []
 		var clusterId string
 		switch ctx.Credential.CredentialType {
 		case v1.APIKey:
+			if cmd.Flags().Changed("cluster") {
+				output.ErrPrintln("WARNING: The `--cluster` flag is not parsed when using API key credentials.")
+			}
+			if cmd.Flags().Changed("environment") {
+				output.ErrPrintln("WARNING: The `--environment` flag is not parsed when using API key credentials.")
+			}
 			clusterId = r.getClusterIdForAPIKeyCredential(ctx)
 		case v1.Username:
 			unsafeTrace, err := cmd.Flags().GetBool("unsafe-trace")

--- a/internal/pkg/cmd/prerunner.go
+++ b/internal/pkg/cmd/prerunner.go
@@ -838,7 +838,7 @@ func (r *PreRun) HasAPIKey(command *HasAPIKeyCLICommand) func(*cobra.Command, []
 				output.ErrPrintln("WARNING: The `--cluster` flag is ignored when using API key credentials.")
 			}
 			if cmd.Flags().Changed("environment") {
-				output.ErrPrintln("WARNING: The `--environment` flag is not parsed when using API key credentials.")
+				output.ErrPrintln("WARNING: The `--environment` flag is ignored when using API key credentials.")
 			}
 			clusterId = r.getClusterIdForAPIKeyCredential(ctx)
 		case v1.Username:

--- a/internal/pkg/cmd/prerunner.go
+++ b/internal/pkg/cmd/prerunner.go
@@ -835,7 +835,7 @@ func (r *PreRun) HasAPIKey(command *HasAPIKeyCLICommand) func(*cobra.Command, []
 		switch ctx.Credential.CredentialType {
 		case v1.APIKey:
 			if cmd.Flags().Changed("cluster") {
-				output.ErrPrintln("WARNING: The `--cluster` flag is not parsed when using API key credentials.")
+				output.ErrPrintln("WARNING: The `--cluster` flag is ignored when using API key credentials.")
 			}
 			if cmd.Flags().Changed("environment") {
 				output.ErrPrintln("WARNING: The `--environment` flag is not parsed when using API key credentials.")

--- a/internal/pkg/dynamic-config/dynamic_context.go
+++ b/internal/pkg/dynamic-config/dynamic_context.go
@@ -108,7 +108,7 @@ func (d *DynamicContext) GetKafkaClusterForCommand() (*v1.KafkaClusterConfig, er
 	}
 
 	cluster, err := d.FindKafkaCluster(clusterId)
-	if presource.LookupType(clusterId) != presource.KafkaCluster {
+	if presource.LookupType(clusterId) != presource.KafkaCluster && clusterId != "anonymous-id" {
 		return nil, errors.Errorf(errors.KafkaClusterMissingPrefixErrorMsg, clusterId)
 	}
 	return cluster, errors.CatchKafkaNotFoundError(err, clusterId, nil)


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- PLACEHOLDER

New Features
- PLACEHOLDER

Bug Fixes
- Allow ``confluent kafka topic produce`` to run when using a context created with ``confluent context create``

Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
The `anonymous-id` Kafka cluster id should not be checked for the `lkc-` prefix.

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
Manual testing using the steps outlined in the ticket.

Open Questions / Follow-ups
---------------------------
<!--
Optional: Anything open to discussion for the reviewer, out of scope of this PR, or follow-ups.
-->
