### PR TITLE
Fix incompatible `--nodebuginfo` flag in debian packaging

### DIFF
--- a/debian/Makefile
+++ b/debian/Makefile
@@ -101,7 +101,7 @@ rpm: RPM_BUILDING/SOURCES/$(FULL_PACKAGE_TITLE)-$(RPM_VERSION).tar.gz
 	echo "Building the RPM"
 	NO_DEBUG_FLAG='--nodebuginfo'
 	if [[ "$(cat /etc/redhat-release | awk -v RS=[0-9]+ '{print RT+0;exit}')" =~ "7.*" ]]; then \
-		NO_DEBUG_FLAG='--define "debug_package %{nil}"'
+		NO_DEBUG_FLAG='--define "debug_package %{nil}"'; \
 	fi
 	rpmbuild --define="_topdir `pwd`/RPM_BUILDING" $(NO_DEBUG_FLAG) -tb $<
 	find RPM_BUILDING/{,S}RPMS/ -type f | xargs -n1 -iXXX mv XXX .

--- a/debian/Makefile
+++ b/debian/Makefile
@@ -99,7 +99,11 @@ endif
 
 rpm: RPM_BUILDING/SOURCES/$(FULL_PACKAGE_TITLE)-$(RPM_VERSION).tar.gz
 	echo "Building the RPM"
-	rpmbuild --define="_topdir `pwd`/RPM_BUILDING" --nodebuginfo -tb $<
+	NO_DEBUG_FLAG='--nodebuginfo'
+	if [[ "$(cat /etc/redhat-release | awk -v RS=[0-9]+ '{print RT+0;exit}')" =~ "7.*" ]]; then \
+		NO_DEBUG_FLAG='--define "debug_package %{nil}"'
+	fi
+	rpmbuild --define="_topdir `pwd`/RPM_BUILDING" $(NO_DEBUG_FLAG) -tb $<
 	find RPM_BUILDING/{,S}RPMS/ -type f | xargs -n1 -iXXX mv XXX .
 	echo
 	echo "================================================="

--- a/debian/Makefile
+++ b/debian/Makefile
@@ -99,11 +99,7 @@ endif
 
 rpm: RPM_BUILDING/SOURCES/$(FULL_PACKAGE_TITLE)-$(RPM_VERSION).tar.gz
 	echo "Building the RPM"
-	NO_DEBUG_FLAG='--nodebuginfo'
-	if [[ "$(cat /etc/redhat-release | awk -v RS=[0-9]+ '{print RT+0;exit}')" =~ "7.*" ]]; then \
-		NO_DEBUG_FLAG='--define "debug_package %{nil}"'; \
-	fi
-	rpmbuild --define="_topdir `pwd`/RPM_BUILDING" $(NO_DEBUG_FLAG) -tb $<
+	rpmbuild --define="_topdir `pwd`/RPM_BUILDING" --nodebuginfo -tb $< || rpmbuild --define="_topdir `pwd`/RPM_BUILDING" -tb $<
 	find RPM_BUILDING/{,S}RPMS/ -type f | xargs -n1 -iXXX mv XXX .
 	echo
 	echo "================================================="

--- a/debian/patches/standard_build_layout.patch
+++ b/debian/patches/standard_build_layout.patch
@@ -1,6 +1,6 @@
---- cli/Makefile	2023-03-15 15:40:55.000000000 -0700
-+++ debian/Makefile	2023-03-15 13:03:15.000000000 -0700
-@@ -1,128 +1,130 @@
+--- cli/Makefile	2023-03-16 12:39:29.000000000 -0700
++++ debian/Makefile	2023-03-16 13:01:06.000000000 -0700
+@@ -1,128 +1,134 @@
 -SHELL              := /bin/bash
 -ALL_SRC            := $(shell find . -name "*.go" | grep -v -e vendor)
 -GORELEASER_VERSION := v1.15.2
@@ -214,7 +214,11 @@
 -test: unit-test integration-test
 +rpm: RPM_BUILDING/SOURCES/$(FULL_PACKAGE_TITLE)-$(RPM_VERSION).tar.gz
 +	echo "Building the RPM"
-+	rpmbuild --define="_topdir `pwd`/RPM_BUILDING" --nodebuginfo -tb $<
++	NO_DEBUG_FLAG='--nodebuginfo'
++	if [[ "$(cat /etc/redhat-release | awk -v RS=[0-9]+ '{print RT+0;exit}')" =~ "7.*" ]]; then \
++		NO_DEBUG_FLAG='--define "debug_package %{nil}"'; \
++	fi
++	rpmbuild --define="_topdir `pwd`/RPM_BUILDING" $(NO_DEBUG_FLAG) -tb $<
 +	find RPM_BUILDING/{,S}RPMS/ -type f | xargs -n1 -iXXX mv XXX .
 +	echo
 +	echo "================================================="

--- a/debian/patches/standard_build_layout.patch
+++ b/debian/patches/standard_build_layout.patch
@@ -1,6 +1,6 @@
---- cli/Makefile	2023-03-16 12:39:29.000000000 -0700
-+++ debian/Makefile	2023-03-16 13:01:06.000000000 -0700
-@@ -1,128 +1,134 @@
+--- cli/Makefile	2023-03-16 13:51:16.000000000 -0700
++++ debian/Makefile	2023-03-16 13:57:10.000000000 -0700
+@@ -1,128 +1,130 @@
 -SHELL              := /bin/bash
 -ALL_SRC            := $(shell find . -name "*.go" | grep -v -e vendor)
 -GORELEASER_VERSION := v1.15.2
@@ -214,11 +214,7 @@
 -test: unit-test integration-test
 +rpm: RPM_BUILDING/SOURCES/$(FULL_PACKAGE_TITLE)-$(RPM_VERSION).tar.gz
 +	echo "Building the RPM"
-+	NO_DEBUG_FLAG='--nodebuginfo'
-+	if [[ "$(cat /etc/redhat-release | awk -v RS=[0-9]+ '{print RT+0;exit}')" =~ "7.*" ]]; then \
-+		NO_DEBUG_FLAG='--define "debug_package %{nil}"'; \
-+	fi
-+	rpmbuild --define="_topdir `pwd`/RPM_BUILDING" $(NO_DEBUG_FLAG) -tb $<
++	rpmbuild --define="_topdir `pwd`/RPM_BUILDING" --nodebuginfo -tb $< || rpmbuild --define="_topdir `pwd`/RPM_BUILDING" -tb $<
 +	find RPM_BUILDING/{,S}RPMS/ -type f | xargs -n1 -iXXX mv XXX .
 +	echo
 +	echo "================================================="


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
If EL7, use `--define "debug_package %{nil}"`, else (EL8) use `--nodebuginfo`.
https://stackoverflow.com/questions/36983051/rpmbuild-how-to-skip-generation-of-debuginfo-packages-without-change-spec-fi

Test & Review
-------------
Not sure how to test, need help from DevProd team.