### PR TITLE
Prevent panic in `api-key list` and `describe`

### DIFF
--- a/internal/cmd/api-key/command.go
+++ b/internal/cmd/api-key/command.go
@@ -105,8 +105,9 @@ func (c *command) getAllUsers() ([]*ccloudv1.User, error) {
 	}
 	users = append(users, adminUsers...)
 
-	currentUser := c.State.Auth.User
-	users = append(users, currentUser)
+	if currentUser := c.State.GetUser(); currentUser != nil {
+		users = append(users, currentUser)
+	}
 
 	return users, nil
 }

--- a/internal/cmd/api-key/command.go
+++ b/internal/cmd/api-key/command.go
@@ -105,7 +105,7 @@ func (c *command) getAllUsers() ([]*ccloudv1.User, error) {
 	}
 	users = append(users, adminUsers...)
 
-	if currentUser := c.State.GetUser(); currentUser != nil {
+	if currentUser := c.Context.GetUser(); currentUser != nil {
 		users = append(users, currentUser)
 	}
 

--- a/internal/cmd/api-key/command_list.go
+++ b/internal/cmd/api-key/command_list.go
@@ -153,10 +153,9 @@ func getServiceAccountsMap(serviceAccounts []iamv2.IamV2ServiceAccount) map[stri
 func getUsersMap(users []*ccloudv1.User) map[int32]*ccloudv1.User {
 	userMap := make(map[int32]*ccloudv1.User)
 	for _, user := range users {
-		if user == nil {
-			continue
+		if user != nil {
+			userMap[user.GetId()] = user
 		}
-		userMap[user.GetId()] = user
 	}
 	return userMap
 }

--- a/internal/cmd/api-key/command_list.go
+++ b/internal/cmd/api-key/command_list.go
@@ -153,7 +153,10 @@ func getServiceAccountsMap(serviceAccounts []iamv2.IamV2ServiceAccount) map[stri
 func getUsersMap(users []*ccloudv1.User) map[int32]*ccloudv1.User {
 	userMap := make(map[int32]*ccloudv1.User)
 	for _, user := range users {
-		userMap[user.Id] = user
+		if user == nil {
+			continue
+		}
+		userMap[user.GetId()] = user
 	}
 	return userMap
 }

--- a/internal/cmd/api-key/command_list.go
+++ b/internal/cmd/api-key/command_list.go
@@ -153,9 +153,7 @@ func getServiceAccountsMap(serviceAccounts []iamv2.IamV2ServiceAccount) map[stri
 func getUsersMap(users []*ccloudv1.User) map[int32]*ccloudv1.User {
 	userMap := make(map[int32]*ccloudv1.User)
 	for _, user := range users {
-		if user != nil {
-			userMap[user.GetId()] = user
-		}
+		userMap[user.GetId()] = user
 	}
 	return userMap
 }

--- a/internal/pkg/config/v1/context.go
+++ b/internal/pkg/config/v1/context.go
@@ -160,7 +160,7 @@ func (c *Context) GetState() *ContextState {
 }
 
 func (c *Context) GetAuth() *AuthConfig {
-	if c.State != nil {
+	if c.GetState() != nil {
 		return c.State.Auth
 	}
 	return nil

--- a/internal/pkg/config/v1/context_state.go
+++ b/internal/pkg/config/v1/context_state.go
@@ -3,6 +3,8 @@ package v1
 import (
 	"regexp"
 
+	ccloudv1 "github.com/confluentinc/ccloud-sdk-go-v1-public"
+
 	"github.com/confluentinc/cli/internal/pkg/secret"
 )
 
@@ -17,6 +19,20 @@ type ContextState struct {
 	AuthRefreshToken string      `json:"auth_refresh_token"`
 	Salt             []byte      `json:"salt,omitempty"`
 	Nonce            []byte      `json:"nonce,omitempty"`
+}
+
+func (c *ContextState) GetAuth() *AuthConfig {
+	if c != nil {
+		return c.Auth
+	}
+	return nil
+}
+
+func (c *ContextState) GetUser() *ccloudv1.User {
+	if auth := c.GetAuth(); auth != nil {
+		return auth.User
+	}
+	return nil
 }
 
 func (c *ContextState) DecryptContextStateAuthToken(ctxName string) error {

--- a/internal/pkg/config/v1/context_state.go
+++ b/internal/pkg/config/v1/context_state.go
@@ -3,8 +3,6 @@ package v1
 import (
 	"regexp"
 
-	ccloudv1 "github.com/confluentinc/ccloud-sdk-go-v1-public"
-
 	"github.com/confluentinc/cli/internal/pkg/secret"
 )
 
@@ -19,20 +17,6 @@ type ContextState struct {
 	AuthRefreshToken string      `json:"auth_refresh_token"`
 	Salt             []byte      `json:"salt,omitempty"`
 	Nonce            []byte      `json:"nonce,omitempty"`
-}
-
-func (c *ContextState) GetAuth() *AuthConfig {
-	if c != nil {
-		return c.Auth
-	}
-	return nil
-}
-
-func (c *ContextState) GetUser() *ccloudv1.User {
-	if auth := c.GetAuth(); auth != nil {
-		return auth.User
-	}
-	return nil
 }
 
 func (c *ContextState) DecryptContextStateAuthToken(ctxName string) error {


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- PLACEHOLDER

New Features
- PLACEHOLDER

Bug Fixes
- Prevent a panic which could occur in various ``confluent api-key`` commands

Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
If `State.Auth.User` is `nil` for whatever reason, a panic will result in `getAllUsers` when that function attempts to access the `User.Id` field.

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
<!--
Has it been tested? How?
Copy and paste any instructions or steps that can save the reviewer time.
-->

Open Questions / Follow-ups
---------------------------
Followup: investigate the cause of incorrectly populated contexts.
