### PR TITLE
Remove calls for cluster info in feature flags

### DIFF
--- a/internal/pkg/featureflags/feature_flags.go
+++ b/internal/pkg/featureflags/feature_flags.go
@@ -275,11 +275,6 @@ func setCustomAttribute(custom ldvalue.ValueMapBuilder, key string, value ldvalu
 	custom.Set(key, value)
 }
 
-func parsePkcFromBootstrap(bootstrap string) string {
-	r := regexp.MustCompile("pkc-([a-z0-9]+)")
-	return r.FindString(bootstrap)
-}
-
 func writeFlagsToConfig(ctx *dynamicconfig.DynamicContext, key string, vals map[string]any, user lduser.User, client v1.LaunchDarklyClient) {
 	if ctx == nil {
 		return

--- a/internal/pkg/featureflags/feature_flags.go
+++ b/internal/pkg/featureflags/feature_flags.go
@@ -261,17 +261,6 @@ func (ld *launchDarklyManager) contextToLDUser(ctx *dynamicconfig.DynamicContext
 	if id := ctx.GetEnvironment().GetId(); id != "" {
 		setCustomAttribute(custom, "environment.id", ldvalue.String(id))
 	}
-	// cluster info
-	cluster, _ := ctx.GetKafkaClusterForCommand()
-	if cluster != nil {
-		if cluster.ID != "" {
-			setCustomAttribute(custom, "cluster.id", ldvalue.String(cluster.ID))
-		}
-		if cluster.Bootstrap != "" {
-			physicalClusterId := parsePkcFromBootstrap(cluster.Bootstrap)
-			setCustomAttribute(custom, "cluster.physicalClusterId", ldvalue.String(physicalClusterId))
-		}
-	}
 	customValueMap := custom.Build()
 	if customValueMap.Count() > 0 {
 		userBuilder.CustomAll(customValueMap)

--- a/internal/pkg/featureflags/feature_flags.go
+++ b/internal/pkg/featureflags/feature_flags.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"regexp"
 	"time"
 
 	"github.com/dghubble/sling"

--- a/internal/pkg/featureflags/feature_flags_test.go
+++ b/internal/pkg/featureflags/feature_flags_test.go
@@ -101,10 +101,6 @@ func (suite *LaunchDarklyTestSuite) TestContextToLDUser() {
 	req.Equal(v1.MockOrgResourceId, orgResourceId.StringValue())
 	environmentId, _ := user.GetCustom("environment.id")
 	req.Equal(v1.MockEnvironmentId, environmentId.StringValue())
-	clusterId, _ := user.GetCustom("cluster.id")
-	req.Equal(v1.MockKafkaClusterId(), clusterId.StringValue())
-	pkc, _ := user.GetCustom("cluster.physicalClusterId")
-	req.Equal("pkc-abc123", pkc.StringValue())
 }
 
 func TestLaunchDarklySuite(t *testing.T) {


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- PLACEHOLDER

New Features
- PLACEHOLDER

Bug Fixes
- PLACEHOLDER

Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
We don't appear to be using this for any flags, and it's responsible for multiple calls to `GetKafkaClusterForCommand()` at the start of almost every command.

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
ran (updated) tests

Open Questions / Follow-ups
---------------------------
<!--
Optional: Anything open to discussion for the reviewer, out of scope of this PR, or follow-ups.
-->
