### PR TITLE
Check salt length for old contexts as well to avoid incorrect salt length error in decryption

### DIFF
--- a/internal/pkg/config/v1/context_state.go
+++ b/internal/pkg/config/v1/context_state.go
@@ -21,7 +21,7 @@ type ContextState struct {
 
 func (c *ContextState) DecryptContextStateAuthToken(ctxName string) error {
 	reg := regexp.MustCompile(authTokenRegex)
-	if !reg.MatchString(c.AuthToken) && c.AuthToken != "" {
+	if !reg.MatchString(c.AuthToken) && c.AuthToken != "" && c.Salt != nil {
 		decryptedAuthToken, err := secret.Decrypt(ctxName, c.AuthToken, c.Salt, c.Nonce)
 		if err != nil {
 			return err
@@ -34,7 +34,7 @@ func (c *ContextState) DecryptContextStateAuthToken(ctxName string) error {
 
 func (c *ContextState) DecryptContextStateAuthRefreshToken(ctxName string) error {
 	reg := regexp.MustCompile(authRefreshTokenRegex)
-	if !reg.MatchString(c.AuthRefreshToken) && c.AuthRefreshToken != "" {
+	if !reg.MatchString(c.AuthRefreshToken) && c.AuthRefreshToken != "" && c.Salt != nil {
 		decryptedAuthRefreshToken, err := secret.Decrypt(ctxName, c.AuthRefreshToken, c.Salt, c.Nonce)
 		if err != nil {
 			return err


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- PLACEHOLDER

New Features
- PLACEHOLDER

Bug Fixes
- Fixed a decryption error when running ``confluent context list`` with old contexts from `~/.confluent/config.json`

Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->
when logged in with older than 3.2.0, then you run newer 3.2.0, new salt and nonce will only be generated for current context that you're logged into. When running `context list`, other old contexts are only being read and i.e. some random mock contexts with mock tokens (not jwt format) would be decrypted, while there's no salt or nonce used to generate them in the first place. Add a check when decrypting tokens, only decrypt when: it is a valid format token, it's not nil, and it already has salt/nonce that were used to generate the token.

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
<!--
Has it been tested? How?
Copy and paste any instructions or steps that can save the reviewer time.
-->

Open Questions / Follow-ups
---------------------------
<!--
Optional: Anything open to discussion for the reviewer, out of scope of this PR, or follow-ups.
-->
