### PR TITLE
Add custom release notes to GitHub release

### DIFF
--- a/mk-files/release.mk
+++ b/mk-files/release.mk
@@ -76,7 +76,7 @@ gorelease:
 	$(aws-authenticate) && \
 	echo "BUILDING FOR DARWIN, WINDOWS, AND ALPINE LINUX" && \
 	go install github.com/goreleaser/goreleaser@$(GORELEASER_VERSION) && \
-	VERSION=$(VERSION) GITHUB_TOKEN=$(token) S3FOLDER=$(S3_STAG_FOLDER_NAME)/confluent-cli GOEXPERIMENT=boringcrypto goreleaser release --clean --timeout 60m -f .goreleaser.yml; \
+	VERSION=$(VERSION) GITHUB_TOKEN=$(token) S3FOLDER=$(S3_STAG_FOLDER_NAME)/confluent-cli GOEXPERIMENT=boringcrypto goreleaser release --clean -f .goreleaser.yml --release-notes release-notes/latest-release.rst --timeout 60m; \
 	rm -f CLIEVCodeSigningCertificate2.pfx && \
 	echo "BUILDING FOR GLIBC LINUX" && \
 	scripts/build_linux_glibc.sh && \


### PR DESCRIPTION
What
----
Instead of the default commit history changelog, upload the release notes (which were previously only uploaded to S3) to GitHub.
https://goreleaser.com/customization/release/#custom-release-notes

Test & Review
-------------
Will test in this week's release.