### PR TITLE
[CIAM-2686] Add identity namespace behind an LD flag

### DIFF
--- a/internal/cmd/api-key/command_describe.go
+++ b/internal/cmd/api-key/command_describe.go
@@ -1,7 +1,6 @@
 package apikey
 
 import (
-	"github.com/confluentinc/cli/internal/pkg/featureflags"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -11,6 +10,7 @@ import (
 	pcmd "github.com/confluentinc/cli/internal/pkg/cmd"
 	v1 "github.com/confluentinc/cli/internal/pkg/config/v1"
 	"github.com/confluentinc/cli/internal/pkg/errors"
+	"github.com/confluentinc/cli/internal/pkg/featureflags"
 	"github.com/confluentinc/cli/internal/pkg/output"
 )
 

--- a/internal/cmd/api-key/command_describe.go
+++ b/internal/cmd/api-key/command_describe.go
@@ -1,6 +1,7 @@
 package apikey
 
 import (
+	"github.com/confluentinc/cli/internal/pkg/featureflags"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -10,7 +11,6 @@ import (
 	pcmd "github.com/confluentinc/cli/internal/pkg/cmd"
 	v1 "github.com/confluentinc/cli/internal/pkg/config/v1"
 	"github.com/confluentinc/cli/internal/pkg/errors"
-	"github.com/confluentinc/cli/internal/pkg/featureflags"
 	"github.com/confluentinc/cli/internal/pkg/output"
 )
 

--- a/internal/cmd/iam/command_rbac.go
+++ b/internal/cmd/iam/command_rbac.go
@@ -16,6 +16,7 @@ var (
 	dataplaneNamespace      = optional.NewString("dataplane")
 	ksqlNamespace           = optional.NewString("ksql")
 	streamCatalogNamespace  = optional.NewString("streamcatalog")
+	identityNamespace       = optional.NewString("identity")
 )
 
 func newRBACCommand(cfg *v1.Config, prerunner pcmd.PreRunner) *cobra.Command {

--- a/internal/cmd/iam/command_rbac_role_describe.go
+++ b/internal/cmd/iam/command_rbac_role_describe.go
@@ -11,7 +11,9 @@ import (
 	"github.com/confluentinc/mds-sdk-go-public/mdsv2alpha1"
 
 	pcmd "github.com/confluentinc/cli/internal/pkg/cmd"
+	v1 "github.com/confluentinc/cli/internal/pkg/config/v1"
 	"github.com/confluentinc/cli/internal/pkg/errors"
+	"github.com/confluentinc/cli/internal/pkg/featureflags"
 	"github.com/confluentinc/cli/internal/pkg/output"
 )
 
@@ -49,6 +51,12 @@ func (c *roleCommand) ccloudDescribe(cmd *cobra.Command, role string) error {
 		ksqlNamespace.Value(),
 		publicNamespace.Value(),
 		streamCatalogNamespace.Value(),
+	}
+
+	// check if IdentityAdmin is enabled
+	ldClient := v1.GetCcloudLaunchDarklyClient(c.Context.PlatformName)
+	if featureflags.Manager.BoolVariation("auth.rbac.identity_admin.enable", c.Context, ldClient, true, false) {
+		namespacesList = append(namespacesList, identityNamespace.Value())
 	}
 
 	namespaces := optional.NewString(strings.Join(namespacesList, ","))

--- a/internal/cmd/iam/command_rbac_role_list.go
+++ b/internal/cmd/iam/command_rbac_role_list.go
@@ -7,6 +7,8 @@ import (
 	"github.com/spf13/cobra"
 
 	pcmd "github.com/confluentinc/cli/internal/pkg/cmd"
+	v1 "github.com/confluentinc/cli/internal/pkg/config/v1"
+	"github.com/confluentinc/cli/internal/pkg/featureflags"
 	"github.com/confluentinc/cli/internal/pkg/output"
 )
 
@@ -48,6 +50,16 @@ func (c *roleCommand) ccloudList(cmd *cobra.Command) error {
 	roles, err := c.namespaceRoles(opt)
 	if err != nil {
 		return err
+	}
+
+	// check if IdentityAdmin is enabled
+	ldClient := v1.GetCcloudLaunchDarklyClient(c.Context.PlatformName)
+	if featureflags.Manager.BoolVariation("auth.rbac.identity_admin.enable", c.Context, ldClient, true, false) {
+		identityRoles, err := c.namespaceRoles(identityNamespace)
+		if err != nil {
+			return err
+		}
+		roles = append(roles, identityRoles...)
 	}
 
 	if output.GetFormat(cmd).IsSerialized() {


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- N/A

New Features
- N/A (adds a new namespace but is hidden behind LD flag so not user-facing)

Bug Fixes
- N/A

Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
We are adding a new namespace `identity` behind an LD flag so that during EA we can introduce customers to the new role, `IdentityAdmin`,  in this namespace.

This PR adds the `identity` namespace to the `role describe` and `role list`.

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
Tested manually in stag.
```
confluent iam rbac role describe IdentityAdmin               
+---------------+-----------------------------------------------------------------+
| Name          | IdentityAdmin                                                   |
| Access Policy | [                                                               |
|               |   {                                                             |
|               |     "bindingScope": "organization",                             |
|               |     "bindWithResource": false,                                  |
|               |     "allowedOperations": [                                      |
|               |       {                                                         |
|               |         "resourceType": "CloudApiKey",                          |
|               |         "operations": ["Describe", "Alter", "Delete", "Create"] |
|               |       },                                                        |
|               |       {                                                         |
|               |         "resourceType": "User",                                 |
|               |         "operations": ["Describe", "Create", "Invite"]          |
|               |       },                                                        |
|               |       {                                                         |
|               |         "resourceType": "Organization",                         |
|               |         "operations": ["Describe"]                              |
|               |       },                                                        |
|               |       {                                                         |
|               |         "resourceType": "ServiceAccount",                       |
|               |         "operations": ["Describe", "Alter", "Create"]           |
|               |       }                                                         |
|               |     ]                                                           |
|               |   }                                                             |
|               | ]                                                               |
|               |                                                                 |
+---------------+-----------------------------------------------------------------+

```

Open Questions / Follow-ups
---------------------------
<!--
Optional: Anything open to discussion for the reviewer, out of scope of this PR, or follow-ups.
-->
