### PR TITLE
Add suggestion to check access to /etc when cipher authentication fails

### DIFF
--- a/internal/pkg/secret/encryption_other.go
+++ b/internal/pkg/secret/encryption_other.go
@@ -92,7 +92,7 @@ func Decrypt(username, encrypted string, salt, nonce []byte) (string, error) {
 	}
 	decryptedPassword, err := aesgcm.Open(nil, nonce, cipherText, []byte(username))
 	if err != nil {
-		return "", errors.New(fmt.Sprintf("%s. %s", err.Error(), "Check cli read/write permission to /etc."))
+		return "", errors.New(fmt.Sprintf("%s. %s", err.Error(), "Check cli read/write permission to /etc/machine-id."))
 	}
 
 	return string(decryptedPassword), nil

--- a/internal/pkg/secret/encryption_other.go
+++ b/internal/pkg/secret/encryption_other.go
@@ -91,7 +91,7 @@ func Decrypt(username, encrypted string, salt, nonce []byte) (string, error) {
 	}
 	decryptedPassword, err := aesgcm.Open(nil, nonce, cipherText, []byte(username))
 	if err != nil {
-		return "", err
+		return "", errors.New(err.Error() + ". Check cli read/write permission to /etc.")
 	}
 
 	return string(decryptedPassword), nil

--- a/internal/pkg/secret/encryption_other.go
+++ b/internal/pkg/secret/encryption_other.go
@@ -8,6 +8,7 @@ import (
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/base64"
+	"fmt"
 	"os"
 	"strconv"
 
@@ -91,7 +92,7 @@ func Decrypt(username, encrypted string, salt, nonce []byte) (string, error) {
 	}
 	decryptedPassword, err := aesgcm.Open(nil, nonce, cipherText, []byte(username))
 	if err != nil {
-		return "", errors.New(err.Error() + ". Check cli read/write permission to /etc.")
+		return "", errors.New(fmt.Sprintf("%s. %s", err.Error(), "Check cli read/write permission to /etc."))
 	}
 
 	return string(decryptedPassword), nil

--- a/internal/pkg/secret/encryption_other.go
+++ b/internal/pkg/secret/encryption_other.go
@@ -92,7 +92,7 @@ func Decrypt(username, encrypted string, salt, nonce []byte) (string, error) {
 	}
 	decryptedPassword, err := aesgcm.Open(nil, nonce, cipherText, []byte(username))
 	if err != nil {
-		return "", fmt.Errorf("CLI does not have write permission for `/etc/machine-id`, or `~/.confluent/config.json` was corrupted: %w", err)
+		return "", fmt.Errorf("CLI does not have write permission for `/etc/machine-id`, or `~/.confluent/config.json` is corrupted: %w", err)
 	}
 
 	return string(decryptedPassword), nil

--- a/internal/pkg/secret/encryption_other.go
+++ b/internal/pkg/secret/encryption_other.go
@@ -92,7 +92,7 @@ func Decrypt(username, encrypted string, salt, nonce []byte) (string, error) {
 	}
 	decryptedPassword, err := aesgcm.Open(nil, nonce, cipherText, []byte(username))
 	if err != nil {
-		return "", errors.New(fmt.Sprintf("%s. %s", err.Error(), "Check cli read/write permission to /etc/machine-id."))
+		return "", fmt.Errorf("CLI does not have write permission for `/etc/machine-id`, or `~/.confluent/config.json` was corrupted: %w", err)
 	}
 
 	return string(decryptedPassword), nil


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- PLACEHOLDER

New Features
- Add suggestions to check CLI's access to ``/etc`` when encryption fails

Bug Fixes
- PLACEHOLDER

Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok  

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->
Add suggestion to check access to /etc when cipher authentication fails
```
mhe@C02DV0KVMD6T cli % confluent kafka topic list
Error: cipher: message authentication failed. Check cli read/write permission to /etc.
```

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
<!--
Has it been tested? How?
Copy and paste any instructions or steps that can save the reviewer time.
-->

Open Questions / Follow-ups
---------------------------
<!--
Optional: Anything open to discussion for the reviewer, out of scope of this PR, or follow-ups.
-->
