### PR TITLE
Avoid confusion with `kafka acl` commands in `iam acl` command documentation

### DIFF
--- a/internal/cmd/iam/command_acl.go
+++ b/internal/cmd/iam/command_acl.go
@@ -32,7 +32,7 @@ type aclCommand struct {
 func newACLCommand(prerunner pcmd.PreRunner) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:         "acl",
-		Short:       "Manage Kafka ACLs (5.4+ only).",
+		Short:       "Manage centralized ACLs.",
 		Annotations: map[string]string{pcmd.RunRequirement: pcmd.RequireOnPremLogin},
 	}
 

--- a/internal/cmd/iam/command_acl_create.go
+++ b/internal/cmd/iam/command_acl_create.go
@@ -14,8 +14,7 @@ import (
 func (c *aclCommand) newCreateCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create",
-		Short: "Create a Kafka ACL.",
-		Long:  "Create a Kafka ACL. This command only works with centralized ACLs.",
+		Short: "Create a centralized ACL.",
 		Args:  cobra.NoArgs,
 		RunE:  c.create,
 		Example: examples.BuildExampleString(
@@ -25,7 +24,7 @@ func (c *aclCommand) newCreateCommand() *cobra.Command {
 			},
 			examples.Example{
 				Text: `Create an ACL that grants the specified user "write" permission on all topics in the specified Kafka cluster:`,
-				Code: "confluent iam acl create --allow --principal User:User1 --operation write --topic '*' --kafka-cluster <kafka-cluster-id>",
+				Code: `confluent iam acl create --allow --principal User:User1 --operation write --topic "*" --kafka-cluster <kafka-cluster-id>`,
 			},
 			examples.Example{
 				Text: `Create an ACL that assigns a group "read" access to all topics that use the specified prefix in the specified Kafka cluster:`,

--- a/internal/cmd/iam/command_acl_delete.go
+++ b/internal/cmd/iam/command_acl_delete.go
@@ -12,14 +12,13 @@ import (
 func (c *aclCommand) newDeleteCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "delete",
-		Short: "Delete a Kafka ACL.",
-		Long:  "Delete a Kafka ACL. This command only works with centralized ACLs.",
+		Short: "Delete a centralized ACL.",
 		Args:  cobra.NoArgs,
 		RunE:  c.delete,
 		Example: examples.BuildExampleString(
 			examples.Example{
 				Text: `Delete an ACL that granted the specified user access to the "test" topic in the specified cluster.`,
-				Code: "confluent iam acl delete --kafka-cluster <kafka-cluster-id> --allow --principal User:Jane --topic test --operation write --host *",
+				Code: `confluent iam acl delete --kafka-cluster <kafka-cluster-id> --allow --principal User:Jane --topic test --operation write --host "*"`,
 			},
 		),
 	}

--- a/internal/cmd/iam/command_acl_list.go
+++ b/internal/cmd/iam/command_acl_list.go
@@ -10,8 +10,7 @@ import (
 func (c *aclCommand) newListCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
-		Short: "List Kafka ACLs for a resource.",
-		Long:  "List Kafka ACLs for a resource. This command only works with centralized ACLs.",
+		Short: "List centralized ACLs for a resource.",
 		Args:  cobra.NoArgs,
 		RunE:  c.list,
 		Example: examples.BuildExampleString(
@@ -20,7 +19,7 @@ func (c *aclCommand) newListCommand() *cobra.Command {
 				Code: "confluent iam acl list --kafka-cluster <kafka-cluster-id>",
 			},
 			examples.Example{
-				Text: `List all the ACLs for the specified cluster that include "allow" permissions for the user Jane:`,
+				Text: `List all the ACLs for the specified cluster that include "allow" permissions for user "Jane":`,
 				Code: "confluent iam acl list --kafka-cluster <kafka-cluster-id> --allow --principal User:Jane",
 			},
 		),


### PR DESCRIPTION
Release Notes
-------------
New Features
- Improve documentation for `confluent iam acl` commands

Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
The `confluent kafka acl` commands are subtly different from the `confluent iam acl` commands, so they should be disambiguated.