### PR TITLE
Improve README installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ When opening a PR, please make sure to follow our [contribution guide](CONTRIBUT
 
 The Confluent CLI is available to install for macOS, Linux, and Windows.
 
+#### Scripted installation
+
+Install the latest version of `confluent` to `/usr/local/bin`:
+
+    curl -sL https://raw.githubusercontent.com/confluentinc/cli/main/install.sh | sh -s -- -b /usr/local/bin
+
 #### macOS
 
 1. Download the latest macOS tar.gz file for your architecture type from https://github.com/confluentinc/cli/releases/latest
@@ -41,7 +47,13 @@ The Confluent CLI is available to install for macOS, Linux, and Windows.
 
 #### Install a Specific Version
 
-See the [releases page](https://github.com/confluentinc/cli/releases) for a complete list of versions available for download.
+Print a complete list of versions available for download:
+
+    curl -sL https://raw.githubusercontent.com/confluentinc/cli/main/install.sh | sh -s -- -l
+
+Install `confluent` v3.6.0 to `/usr/local/bin`:
+
+    curl -sL https://raw.githubusercontent.com/confluentinc/cli/main/install.sh | sh -s -- -b /usr/local/bin v3.6.0
 
 ### Building from Source
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,16 @@ Install the latest version of `confluent` to `/usr/local/bin`:
 2. Unzip `confluent_X.X.X_windows_amd64.zip`
 3. Run `confluent.exe`
 
+#### Docker
+
+Pull the latest version:
+
+    docker pull confluentinc/confluent-cli:latest
+
+Pull `confluent` v3.6.0:
+
+    docker pull confluentinc/confluent-cli:3.6.0
+
 #### Install a Specific Version
 
 Print a complete list of versions available for download:
@@ -53,7 +63,7 @@ Print a complete list of versions available for download:
 
 Install `confluent` v3.6.0 to `/usr/local/bin`:
 
-    curl -sL https://raw.githubusercontent.com/confluentinc/cli/main/install.sh | sh -s -- -b /usr/local/bin v3.6.0
+    curl -sL https://raw.githubusercontent.com/confluentinc/cli/main/install.sh | sh -s -- -b /usr/local/bin 3.6.0
 
 ### Building from Source
 


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
From the discussion in https://github.com/confluentinc/cli/pull/1818 there's some room for improvement in our installation instructions.
* We should recommend installing to `/usr/local/bin`
* We can directly reference the install script now that the repository is source-available
* We should include installation instructions for Docker