### PR TITLE
On `confluent update`, no longer remove CLI if path is different

### DIFF
--- a/internal/pkg/update/client.go
+++ b/internal/pkg/update/client.go
@@ -269,6 +269,8 @@ func (c *client) UpdateBinary(cliName, version, path string, noVerify bool) erro
 	newPath := filepath.Join(filepath.Dir(path), cliName)
 
 	if c.OS == "windows" {
+		newPath += ".exe"
+
 		// The old version will get deleted automatically eventually as we put it in the system's or user's temp dir
 		previousVersionBinary := filepath.Join(downloadDir, cliName+".old")
 		err = c.fs.Move(path, previousVersionBinary)

--- a/internal/pkg/update/client.go
+++ b/internal/pkg/update/client.go
@@ -299,13 +299,6 @@ func (c *client) UpdateBinary(cliName, version, path string, noVerify bool) erro
 		return errors.Wrapf(err, errors.ChmodErrorMsg, newPath)
 	}
 
-	// After updating `ccloud` to `confluent`, remove `ccloud`.
-	if newPath != path {
-		if err := c.fs.Remove(path); err != nil {
-			return errors.Wrapf(err, "unable to remove %s", path)
-		}
-	}
-
 	return nil
 }
 


### PR DESCRIPTION
Release Notes
-------------
Bug Fixes
- Fix `confluent update` for Windows

Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
When updating from `ccloud` to `confluent`, the path was different, and we deleted `ccloud`. On Windows, the path can be different due to the difference between `confluent` and `confluent.exe`. This PR deletes that check since it's no longer relevant.

Test & Review
-------------
Waiting for validation from @sgagniere that this fixes the issue on Windows.