### PR TITLE
Don't check Salt on Windows

### DIFF
--- a/internal/pkg/config/v1/context_state.go
+++ b/internal/pkg/config/v1/context_state.go
@@ -2,6 +2,7 @@ package v1
 
 import (
 	"regexp"
+	"runtime"
 
 	"github.com/confluentinc/cli/internal/pkg/secret"
 )
@@ -21,7 +22,7 @@ type ContextState struct {
 
 func (c *ContextState) DecryptContextStateAuthToken(ctxName string) error {
 	reg := regexp.MustCompile(authTokenRegex)
-	if !reg.MatchString(c.AuthToken) && c.AuthToken != "" && c.Salt != nil {
+	if !reg.MatchString(c.AuthToken) && c.AuthToken != "" && (c.Salt != nil || runtime.GOOS == "windows") {
 		decryptedAuthToken, err := secret.Decrypt(ctxName, c.AuthToken, c.Salt, c.Nonce)
 		if err != nil {
 			return err
@@ -34,7 +35,7 @@ func (c *ContextState) DecryptContextStateAuthToken(ctxName string) error {
 
 func (c *ContextState) DecryptContextStateAuthRefreshToken(ctxName string) error {
 	reg := regexp.MustCompile(authRefreshTokenRegex)
-	if !reg.MatchString(c.AuthRefreshToken) && c.AuthRefreshToken != "" && c.Salt != nil {
+	if !reg.MatchString(c.AuthRefreshToken) && c.AuthRefreshToken != "" && (c.Salt != nil || runtime.GOOS == "windows") {
 		decryptedAuthRefreshToken, err := secret.Decrypt(ctxName, c.AuthRefreshToken, c.Salt, c.Nonce)
 		if err != nil {
 			return err


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- PLACEHOLDER

New Features
- PLACEHOLDER

Bug Fixes
- Fix a bug on Windows preventing decryption of authentication tokens

Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok
   * no: DO NOT MERGE until the required features are live in prod  

What
----
Before decrypting the auth token and auth refresh token, the CLI checked for a non-nil `Salt`. Salt is not used on Windows and is always nil, resulting in the cli not decrypting the tokens.

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
Manually tested on Windows (and Mac, to make sure this PR didn't introduce new bugs!) with the following steps:
`confluent login`
`confluent environment list`

Ran unit tests

Open Questions / Follow-ups
---------------------------
<!--
Optional: Anything open to discussion for the reviewer, out of scope of this PR, or follow-ups.
-->
