### PR TITLE
Store current environment at top level of context

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -93,7 +93,6 @@ require (
 	github.com/confluentinc/proto-go-setter v0.3.0 // indirect
 	github.com/envoyproxy/protoc-gen-validate v0.9.1 // indirect
 	github.com/go-logr/logr v1.2.3 // indirect
-	github.com/go-test/deep v1.1.0 // indirect
 	github.com/gobwas/httphead v0.1.0 // indirect
 	github.com/gobwas/pool v0.2.1 // indirect
 	github.com/gobwas/ws v1.1.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -93,6 +93,7 @@ require (
 	github.com/confluentinc/proto-go-setter v0.3.0 // indirect
 	github.com/envoyproxy/protoc-gen-validate v0.9.1 // indirect
 	github.com/go-logr/logr v1.2.3 // indirect
+	github.com/go-test/deep v1.1.0 // indirect
 	github.com/gobwas/httphead v0.1.0 // indirect
 	github.com/gobwas/pool v0.2.1 // indirect
 	github.com/gobwas/ws v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -185,6 +185,8 @@ github.com/go-openapi/jsonpointer v0.0.0-20160704185906-46af16f9f7b1/go.mod h1:+
 github.com/go-openapi/jsonreference v0.0.0-20160704190145-13c6e3589ad9/go.mod h1:W3Z9FmVs9qj+KR4zFKmDPGiLdk1D9Rlm7cyMvf57TTg=
 github.com/go-openapi/spec v0.0.0-20160808142527-6aced65f8501/go.mod h1:J8+jY1nAiCcj+friV/PDoE1/3eeccG9LYBs0tYvLOWc=
 github.com/go-openapi/swag v0.0.0-20160704191624-1d0bd113de87/go.mod h1:DXUve3Dpr1UfpPtxFw+EFuQ41HhCWZfha5jSVRG7C7I=
+github.com/go-test/deep v1.1.0 h1:WOcxcdHcvdgThNXjw0t76K42FXTU7HpNQWHpA2HHNlg=
+github.com/go-test/deep v1.1.0/go.mod h1:5C2ZWiW0ErCdrYzpqxLbTX7MG14M9iiw8DgHncVwcsE=
 github.com/go-yaml/yaml v2.1.0+incompatible h1:RYi2hDdss1u4YE7GwixGzWwVo47T8UQwnTLB6vQiq+o=
 github.com/go-yaml/yaml v2.1.0+incompatible/go.mod h1:w2MrLa16VYP0jy6N7M5kHaCkaLENm+P+Tv+MfurjSw0=
 github.com/gobuffalo/flect v1.0.2 h1:eqjPGSo2WmjgY2XlpGwo2NXgL3RucAKo4k4qQMNA5sA=

--- a/go.sum
+++ b/go.sum
@@ -185,8 +185,6 @@ github.com/go-openapi/jsonpointer v0.0.0-20160704185906-46af16f9f7b1/go.mod h1:+
 github.com/go-openapi/jsonreference v0.0.0-20160704190145-13c6e3589ad9/go.mod h1:W3Z9FmVs9qj+KR4zFKmDPGiLdk1D9Rlm7cyMvf57TTg=
 github.com/go-openapi/spec v0.0.0-20160808142527-6aced65f8501/go.mod h1:J8+jY1nAiCcj+friV/PDoE1/3eeccG9LYBs0tYvLOWc=
 github.com/go-openapi/swag v0.0.0-20160704191624-1d0bd113de87/go.mod h1:DXUve3Dpr1UfpPtxFw+EFuQ41HhCWZfha5jSVRG7C7I=
-github.com/go-test/deep v1.1.0 h1:WOcxcdHcvdgThNXjw0t76K42FXTU7HpNQWHpA2HHNlg=
-github.com/go-test/deep v1.1.0/go.mod h1:5C2ZWiW0ErCdrYzpqxLbTX7MG14M9iiw8DgHncVwcsE=
 github.com/go-yaml/yaml v2.1.0+incompatible h1:RYi2hDdss1u4YE7GwixGzWwVo47T8UQwnTLB6vQiq+o=
 github.com/go-yaml/yaml v2.1.0+incompatible/go.mod h1:w2MrLa16VYP0jy6N7M5kHaCkaLENm+P+Tv+MfurjSw0=
 github.com/gobuffalo/flect v1.0.2 h1:eqjPGSo2WmjgY2XlpGwo2NXgL3RucAKo4k4qQMNA5sA=

--- a/internal/cmd/api-key/command_test.go
+++ b/internal/cmd/api-key/command_test.go
@@ -132,7 +132,7 @@ func (suite *APITestSuite) SetupTest() {
 	suite.conf = v1.AuthenticatedCloudConfigMock()
 	ctx := suite.conf.Context()
 
-	srCluster := ctx.SchemaRegistryClusters[ctx.GetEnvironment().GetId()]
+	srCluster := ctx.SchemaRegistryClusters[ctx.GetCurrentEnvironment()]
 	srCluster.SrCredentials = &v1.APIKeyPair{Key: apiKeyVal, Secret: apiSecretVal}
 	cluster := ctx.KafkaClusterContext.GetActiveKafkaClusterConfig()
 	// Set up audit logs

--- a/internal/cmd/environment/command.go
+++ b/internal/cmd/environment/command.go
@@ -7,7 +7,7 @@ import (
 )
 
 type command struct {
-	*pcmd.AuthenticatedStateFlagCommand
+	*pcmd.AuthenticatedCLICommand
 }
 
 func New(prerunner pcmd.PreRunner) *cobra.Command {
@@ -18,7 +18,7 @@ func New(prerunner pcmd.PreRunner) *cobra.Command {
 		Annotations: map[string]string{pcmd.RunRequirement: pcmd.RequireNonAPIKeyCloudLogin},
 	}
 
-	c := &command{pcmd.NewAuthenticatedStateFlagCommand(cmd, prerunner)}
+	c := &command{pcmd.NewAuthenticatedCLICommand(cmd, prerunner)}
 
 	cmd.AddCommand(c.newCreateCommand())
 	cmd.AddCommand(c.newDeleteCommand())

--- a/internal/cmd/environment/command_create.go
+++ b/internal/cmd/environment/command_create.go
@@ -47,7 +47,7 @@ func (c *command) create(cmd *cobra.Command, args []string) error {
 	}
 
 	c.Context.AddEnvironment(environment.GetId())
-	c.Config.Save()
+	_ = c.Config.Save()
 
 	return nil
 }

--- a/internal/cmd/environment/command_create.go
+++ b/internal/cmd/environment/command_create.go
@@ -19,6 +19,7 @@ func (c *command) newCreateCommand() *cobra.Command {
 		RunE:  c.create,
 	}
 
+	pcmd.AddContextFlag(cmd, c.CLICommand)
 	pcmd.AddOutputFlag(cmd)
 
 	return cmd
@@ -35,12 +36,18 @@ func (c *command) create(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	environmentId, _ := c.EnvironmentId()
 	table := output.NewTable(cmd)
 	table.Add(&out{
-		IsCurrent: environment.Id == environmentId,
-		Id:        environment.Id,
-		Name:      environment.Name,
+		IsCurrent: environment.GetId() == c.Context.GetCurrentEnvironment(),
+		Id:        environment.GetId(),
+		Name:      environment.GetName(),
 	})
-	return table.Print()
+	if err := table.Print(); err != nil {
+		return err
+	}
+
+	c.Context.AddEnvironment(environment.GetId())
+	c.Config.Save()
+
+	return nil
 }

--- a/internal/cmd/environment/command_create.go
+++ b/internal/cmd/environment/command_create.go
@@ -1,11 +1,9 @@
 package environment
 
 import (
-	"context"
-
 	"github.com/spf13/cobra"
 
-	ccloudv1 "github.com/confluentinc/ccloud-sdk-go-v1-public"
+	orgv2 "github.com/confluentinc/ccloud-sdk-go-v2/org/v2"
 
 	pcmd "github.com/confluentinc/cli/internal/pkg/cmd"
 	"github.com/confluentinc/cli/internal/pkg/output"
@@ -26,12 +24,8 @@ func (c *command) newCreateCommand() *cobra.Command {
 }
 
 func (c *command) create(cmd *cobra.Command, args []string) error {
-	account := &ccloudv1.Account{
-		Name:           args[0],
-		OrganizationId: c.Context.GetOrganization().GetId(),
-	}
-
-	environment, err := c.Client.Account.Create(context.Background(), account)
+	environment := orgv2.OrgV2Environment{DisplayName: orgv2.PtrString(args[0])}
+	environment, err := c.V2Client.CreateOrgEnvironment(environment)
 	if err != nil {
 		return err
 	}
@@ -40,7 +34,7 @@ func (c *command) create(cmd *cobra.Command, args []string) error {
 	table.Add(&out{
 		IsCurrent: environment.GetId() == c.Context.GetCurrentEnvironment(),
 		Id:        environment.GetId(),
-		Name:      environment.GetName(),
+		Name:      environment.GetDisplayName(),
 	})
 	if err := table.Print(); err != nil {
 		return err

--- a/internal/cmd/environment/command_delete.go
+++ b/internal/cmd/environment/command_delete.go
@@ -55,7 +55,7 @@ func (c *command) delete(cmd *cobra.Command, args []string) error {
 	}
 
 	c.Context.DeleteEnvironment(id)
-	c.Config.Save()
+	_ = c.Config.Save()
 
 	return nil
 }

--- a/internal/cmd/environment/command_delete.go
+++ b/internal/cmd/environment/command_delete.go
@@ -21,6 +21,7 @@ func (c *command) newDeleteCommand() *cobra.Command {
 		RunE:              c.delete,
 	}
 
+	pcmd.AddContextFlag(cmd, c.CLICommand)
 	pcmd.AddForceFlag(cmd)
 
 	return cmd
@@ -45,13 +46,16 @@ func (c *command) delete(cmd *cobra.Command, args []string) error {
 	}
 
 	output.ErrPrintf(errors.DeletedResourceMsg, resource.Environment, id)
-	environmentId, _ := c.EnvironmentId()
-	if id == environmentId {
-		c.Context.SetCurrentEnvironment("")
 
+	if id == c.Context.GetCurrentEnvironment() {
+		c.Context.SetCurrentEnvironment("")
 		if err := c.Config.Save(); err != nil {
-			return errors.Wrap(err, errors.EnvSwitchErrorMsg)
+			return err
 		}
 	}
+
+	c.Context.DeleteEnvironment(id)
+	c.Config.Save()
+
 	return nil
 }

--- a/internal/cmd/environment/command_delete.go
+++ b/internal/cmd/environment/command_delete.go
@@ -30,19 +30,18 @@ func (c *command) newDeleteCommand() *cobra.Command {
 func (c *command) delete(cmd *cobra.Command, args []string) error {
 	id := args[0]
 
-	environment, httpResp, err := c.V2Client.GetOrgEnvironment(id)
+	environment, err := c.V2Client.GetOrgEnvironment(id)
 	if err != nil {
-		return errors.CatchOrgV2ResourceNotFoundError(err, resource.Environment, httpResp)
+		return errors.NewErrorWithSuggestions(err.Error(), "List available environments with `confluent environment list`.")
 	}
 
-	promptMsg := fmt.Sprintf(errors.DeleteResourceConfirmMsg, resource.Environment, id, *environment.DisplayName)
-	if _, err := form.ConfirmDeletion(cmd, promptMsg, *environment.DisplayName); err != nil {
+	promptMsg := fmt.Sprintf(errors.DeleteResourceConfirmMsg, resource.Environment, id, environment.GetDisplayName())
+	if _, err := form.ConfirmDeletion(cmd, promptMsg, environment.GetDisplayName()); err != nil {
 		return err
 	}
 
-	httpResp, err = c.V2Client.DeleteOrgEnvironment(id)
-	if err != nil {
-		return errors.CatchOrgV2ResourceNotFoundError(err, resource.Environment, httpResp)
+	if err := c.V2Client.DeleteOrgEnvironment(id); err != nil {
+		return err
 	}
 
 	output.ErrPrintf(errors.DeletedResourceMsg, resource.Environment, id)

--- a/internal/cmd/environment/command_delete.go
+++ b/internal/cmd/environment/command_delete.go
@@ -47,7 +47,7 @@ func (c *command) delete(cmd *cobra.Command, args []string) error {
 	output.ErrPrintf(errors.DeletedResourceMsg, resource.Environment, id)
 	environmentId, _ := c.EnvironmentId()
 	if id == environmentId {
-		c.Context.SetEnvironment(nil)
+		c.Context.SetCurrentEnvironment("")
 
 		if err := c.Config.Save(); err != nil {
 			return errors.Wrap(err, errors.EnvSwitchErrorMsg)

--- a/internal/cmd/environment/command_describe.go
+++ b/internal/cmd/environment/command_describe.go
@@ -6,7 +6,6 @@ import (
 	pcmd "github.com/confluentinc/cli/internal/pkg/cmd"
 	"github.com/confluentinc/cli/internal/pkg/errors"
 	"github.com/confluentinc/cli/internal/pkg/output"
-	"github.com/confluentinc/cli/internal/pkg/resource"
 )
 
 type out struct {
@@ -31,9 +30,9 @@ func (c *command) newDescribeCommand() *cobra.Command {
 }
 
 func (c *command) describe(cmd *cobra.Command, args []string) error {
-	environment, httpResp, err := c.V2Client.GetOrgEnvironment(args[0])
+	environment, err := c.V2Client.GetOrgEnvironment(args[0])
 	if err != nil {
-		return errors.CatchOrgV2ResourceNotFoundError(err, resource.Environment, httpResp)
+		return errors.NewErrorWithSuggestions(err.Error(), "List available environments with `confluent environment list`.")
 	}
 
 	table := output.NewTable(cmd)

--- a/internal/cmd/environment/command_describe.go
+++ b/internal/cmd/environment/command_describe.go
@@ -24,6 +24,7 @@ func (c *command) newDescribeCommand() *cobra.Command {
 		RunE:              c.describe,
 	}
 
+	pcmd.AddContextFlag(cmd, c.CLICommand)
 	pcmd.AddOutputFlag(cmd)
 
 	return cmd
@@ -35,12 +36,11 @@ func (c *command) describe(cmd *cobra.Command, args []string) error {
 		return errors.CatchOrgV2ResourceNotFoundError(err, resource.Environment, httpResp)
 	}
 
-	environmentId, _ := c.EnvironmentId()
 	table := output.NewTable(cmd)
 	table.Add(&out{
-		IsCurrent: *environment.Id == environmentId,
-		Id:        *environment.Id,
-		Name:      *environment.DisplayName,
+		IsCurrent: environment.GetId() == c.Context.GetCurrentEnvironment(),
+		Id:        environment.GetId(),
+		Name:      environment.GetDisplayName(),
 	})
 	return table.Print()
 }

--- a/internal/cmd/environment/command_list.go
+++ b/internal/cmd/environment/command_list.go
@@ -27,11 +27,10 @@ func (c *command) list(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	environmentId, _ := c.EnvironmentId()
 	list := output.NewList(cmd)
 	for _, environment := range environments {
 		list.Add(&out{
-			IsCurrent: environment.GetId() == environmentId,
+			IsCurrent: environment.GetId() == c.Context.GetCurrentEnvironment(),
 			Id:        environment.GetId(),
 			Name:      environment.GetDisplayName(),
 		})

--- a/internal/cmd/environment/command_update.go
+++ b/internal/cmd/environment/command_update.go
@@ -6,9 +6,7 @@ import (
 	orgv2 "github.com/confluentinc/ccloud-sdk-go-v2/org/v2"
 
 	pcmd "github.com/confluentinc/cli/internal/pkg/cmd"
-	"github.com/confluentinc/cli/internal/pkg/errors"
 	"github.com/confluentinc/cli/internal/pkg/output"
-	"github.com/confluentinc/cli/internal/pkg/resource"
 )
 
 func (c *command) newUpdateCommand() *cobra.Command {
@@ -30,17 +28,15 @@ func (c *command) newUpdateCommand() *cobra.Command {
 }
 
 func (c *command) update(cmd *cobra.Command, args []string) error {
-	id := args[0]
-
 	name, err := cmd.Flags().GetString("name")
 	if err != nil {
 		return err
 	}
 
-	updateEnvironment := orgv2.OrgV2Environment{DisplayName: orgv2.PtrString(name)}
-	environment, httpResp, err := c.V2Client.UpdateOrgEnvironment(id, updateEnvironment)
+	environment := orgv2.OrgV2Environment{DisplayName: orgv2.PtrString(name)}
+	environment, err = c.V2Client.UpdateOrgEnvironment(args[0], environment)
 	if err != nil {
-		return errors.CatchOrgV2ResourceNotFoundError(err, resource.Environment, httpResp)
+		return err
 	}
 
 	table := output.NewTable(cmd)

--- a/internal/cmd/environment/command_use.go
+++ b/internal/cmd/environment/command_use.go
@@ -1,17 +1,11 @@
 package environment
 
 import (
-	"context"
-	"fmt"
-
 	"github.com/spf13/cobra"
-
-	ccloudv1 "github.com/confluentinc/ccloud-sdk-go-v1-public"
 
 	pcmd "github.com/confluentinc/cli/internal/pkg/cmd"
 	"github.com/confluentinc/cli/internal/pkg/errors"
 	"github.com/confluentinc/cli/internal/pkg/output"
-	"github.com/confluentinc/cli/internal/pkg/resource"
 )
 
 func (c *command) newUseCommand() *cobra.Command {
@@ -31,8 +25,8 @@ func (c *command) newUseCommand() *cobra.Command {
 func (c *command) use(cmd *cobra.Command, args []string) error {
 	id := args[0]
 
-	if _, err := c.Client.Account.Get(context.Background(), &ccloudv1.Account{Id: id}); err != nil {
-		return errors.NewErrorWithSuggestions(fmt.Sprintf(errors.EnvNotFoundErrorMsg, id), fmt.Sprintf(errors.OrgResourceNotFoundSuggestions, resource.Environment))
+	if _, err := c.V2Client.GetOrgEnvironment(id); err != nil {
+		return errors.NewErrorWithSuggestions(err.Error(), "List available environments with `confluent environment list`.")
 	}
 
 	c.Context.SetCurrentEnvironment(id)

--- a/internal/cmd/environment/command_use.go
+++ b/internal/cmd/environment/command_use.go
@@ -31,12 +31,11 @@ func (c *command) newUseCommand() *cobra.Command {
 func (c *command) use(cmd *cobra.Command, args []string) error {
 	id := args[0]
 
-	environment, err := c.Client.Account.Get(context.Background(), &ccloudv1.Account{Id: id})
-	if err != nil {
+	if _, err := c.Client.Account.Get(context.Background(), &ccloudv1.Account{Id: id}); err != nil {
 		return errors.NewErrorWithSuggestions(fmt.Sprintf(errors.EnvNotFoundErrorMsg, id), fmt.Sprintf(errors.OrgResourceNotFoundSuggestions, resource.Environment))
 	}
-	c.Context.SetEnvironment(environment)
 
+	c.Context.SetCurrentEnvironment(id)
 	if err := c.Config.Save(); err != nil {
 		return errors.Wrap(err, errors.EnvSwitchErrorMsg)
 	}

--- a/internal/cmd/environment/command_use.go
+++ b/internal/cmd/environment/command_use.go
@@ -37,9 +37,9 @@ func (c *command) use(cmd *cobra.Command, args []string) error {
 
 	c.Context.SetCurrentEnvironment(id)
 	if err := c.Config.Save(); err != nil {
-		return errors.Wrap(err, errors.EnvSwitchErrorMsg)
+		return err
 	}
 
-	output.Printf(errors.UsingEnvMsg, id)
+	output.Printf("Now using \"%s\" as the default (active) environment.\n", id)
 	return nil
 }

--- a/internal/cmd/iam/command_rbac_role_binding.go
+++ b/internal/cmd/iam/command_rbac_role_binding.go
@@ -517,7 +517,7 @@ func (c *roleBindingCommand) parseV2RoleBinding(cmd *cobra.Command) (*mdsv2.IamV
 }
 
 func (c *roleBindingCommand) parseV2BaseCrnPattern(cmd *cobra.Command) (string, error) {
-	orgResourceId := c.State.Auth.Account.GetOrgResourceId()
+	orgResourceId := c.Context.GetOrganization().GetResourceId()
 	crnPattern := "crn://confluent.cloud/organization=" + orgResourceId
 
 	if cmd.Flags().Changed("current-environment") {

--- a/internal/cmd/iam/command_rbac_role_binding_test.go
+++ b/internal/cmd/iam/command_rbac_role_binding_test.go
@@ -20,7 +20,7 @@ type RoleBindingTestSuite struct {
 
 func (suite *RoleBindingTestSuite) SetupSuite() {
 	suite.conf = v1.AuthenticatedCloudConfigMock()
-	v1.AddEnvironmentToConfigMock(suite.conf, env123, env123)
+	v1.AddEnvironmentToConfigMock(suite.conf, env123)
 }
 
 func TestParseAndValidateResourcePattern_Prefixed(t *testing.T) {

--- a/internal/cmd/kafka/command_cluster_describe.go
+++ b/internal/cmd/kafka/command_cluster_describe.go
@@ -64,7 +64,7 @@ func (c *clusterCommand) describe(cmd *cobra.Command, args []string) error {
 	}
 
 	ctx := c.Context.Config.Context()
-	c.Context.Config.SetOverwrittenActiveKafka(ctx.KafkaClusterContext.GetActiveKafkaClusterId())
+	c.Context.Config.SetOverwrittenCurrentKafkaCluster(ctx.KafkaClusterContext.GetActiveKafkaClusterId())
 	ctx.KafkaClusterContext.SetActiveKafkaCluster(lkc)
 
 	environmentId, err := c.EnvironmentId()

--- a/internal/cmd/kafka/command_cluster_update.go
+++ b/internal/cmd/kafka/command_cluster_update.go
@@ -95,7 +95,7 @@ func (c *clusterCommand) update(cmd *cobra.Command, args []string, prompt form.P
 	}
 
 	ctx := c.Context.Config.Context()
-	c.Context.Config.SetOverwrittenActiveKafka(ctx.KafkaClusterContext.GetActiveKafkaClusterId())
+	c.Context.Config.SetOverwrittenCurrentKafkaCluster(ctx.KafkaClusterContext.GetActiveKafkaClusterId())
 	ctx.KafkaClusterContext.SetActiveKafkaCluster(clusterID)
 
 	return c.outputKafkaClusterDescription(cmd, &updatedCluster, true)

--- a/internal/cmd/kafka/command_cluster_use.go
+++ b/internal/cmd/kafka/command_cluster_use.go
@@ -40,6 +40,6 @@ func (c *clusterCommand) use(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	output.ErrPrintf(errors.UseKafkaClusterMsg, clusterID, c.Context.GetEnvironment().GetId())
+	output.ErrPrintf(errors.UseKafkaClusterMsg, clusterID, c.Context.GetCurrentEnvironment())
 	return nil
 }

--- a/internal/cmd/login/command.go
+++ b/internal/cmd/login/command.go
@@ -146,14 +146,14 @@ func (c *command) loginCCloud(cmd *cobra.Command, url string) error {
 		return err
 	}
 
-	currentEnv, currentOrg, err := pauth.PersistCCloudCredentialsToConfig(c.Config.Config, client, url, credentials, save)
+	currentEnvironment, currentOrg, err := pauth.PersistCCloudCredentialsToConfig(c.Config.Config, client, url, credentials, save)
 	if err != nil {
 		return err
 	}
 
 	output.Printf(errors.LoggedInAsMsgWithOrg, credentials.Username, currentOrg.GetResourceId(), currentOrg.GetName())
-	if currentEnv != nil {
-		log.CliLogger.Debugf(errors.LoggedInUsingEnvMsg, currentEnv.GetId(), currentEnv.GetName())
+	if currentEnvironment != "" {
+		log.CliLogger.Debugf(errors.LoggedInUsingEnvMsg, currentEnvironment)
 	}
 
 	// if org is at the end of free trial, print instruction about how to add payment method to unsuspend the org.

--- a/internal/cmd/prompt/command.go
+++ b/internal/cmd/prompt/command.go
@@ -49,22 +49,8 @@ func New(cfg *v1.Config) *cobra.Command {
 				if ctx == nil {
 					return none
 				}
-				if id := ctx.GetEnvironment().GetId(); id != "" {
+				if id := ctx.GetCurrentEnvironment(); id != "" {
 					return id
-				}
-				return none
-			},
-		},
-		{
-			Name: 'E',
-			Desc: `The name of the current environment in use. E.g., "default", "prod-team1"`,
-			Func: func() string {
-				ctx := cfg.Context()
-				if ctx == nil {
-					return none
-				}
-				if name := ctx.GetEnvironment().GetName(); name != "" {
-					return name
 				}
 				return none
 			},

--- a/internal/cmd/schema-registry/command_schema_test.go
+++ b/internal/cmd/schema-registry/command_schema_test.go
@@ -51,7 +51,7 @@ func (suite *SchemaTestSuite) SetupSuite() {
 		},
 	}
 	ctx := suite.conf.Context()
-	srCluster := ctx.SchemaRegistryClusters[ctx.GetEnvironment().GetId()]
+	srCluster := ctx.SchemaRegistryClusters[ctx.GetCurrentEnvironment()]
 	srCluster.SrCredentials = &v1.APIKeyPair{Key: "key", Secret: "secret"}
 	cluster := ctx.KafkaClusterContext.GetActiveKafkaClusterConfig()
 	suite.kafkaCluster = &ccstructs.KafkaCluster{

--- a/internal/cmd/schema-registry/command_subject_test.go
+++ b/internal/cmd/schema-registry/command_subject_test.go
@@ -35,7 +35,7 @@ type SubjectTestSuite struct {
 func (suite *SubjectTestSuite) SetupSuite() {
 	suite.conf = v1.AuthenticatedCloudConfigMock()
 	ctx := suite.conf.Context()
-	srCluster := ctx.SchemaRegistryClusters[ctx.GetEnvironment().GetId()]
+	srCluster := ctx.SchemaRegistryClusters[ctx.GetCurrentEnvironment()]
 	srCluster.SrCredentials = &v1.APIKeyPair{Key: "key", Secret: "secret"}
 	cluster := ctx.KafkaClusterContext.GetActiveKafkaClusterConfig()
 	suite.kafkaCluster = &ccstructs.KafkaCluster{

--- a/internal/pkg/auth/auth.go
+++ b/internal/pkg/auth/auth.go
@@ -100,7 +100,7 @@ func PersistCCloudCredentialsToConfig(config *v1.Config, client *ccloudv1.Client
 
 	ctx := config.Context()
 	if ctx.CurrentEnvironment == "" && len(user.GetAccounts()) > 0 {
-		ctx.CurrentEnvironment = user.GetAccounts()[0].GetId()
+		ctx.SetCurrentEnvironment(user.GetAccounts()[0].GetId())
 		if err := config.Save(); err != nil {
 			return "", nil, err
 		}

--- a/internal/pkg/auth/auth.go
+++ b/internal/pkg/auth/auth.go
@@ -92,7 +92,7 @@ func PersistCCloudCredentialsToConfig(config *v1.Config, client *ccloudv1.Client
 		return "", nil, err
 	}
 
-	state := getCCloudContextState(config, ctxName, credentials.AuthToken, credentials.AuthRefreshToken, user)
+	state := getCCloudContextState(credentials.AuthToken, credentials.AuthRefreshToken, user)
 
 	if err := addOrUpdateContext(config, true, credentials, ctxName, url, state, "", user.GetOrganization().GetResourceId(), save); err != nil {
 		return "", nil, err
@@ -187,7 +187,7 @@ func addOrUpdateContext(config *v1.Config, isCloud bool, credentials *Credential
 	return config.UseContext(ctxName)
 }
 
-func getCCloudContextState(config *v1.Config, ctxName, token, refreshToken string, user *ccloudv1.GetMeReply) *v1.ContextState {
+func getCCloudContextState(token, refreshToken string, user *ccloudv1.GetMeReply) *v1.ContextState {
 	return &v1.ContextState{
 		Auth: &v1.AuthConfig{
 			User:         user.GetUser(),

--- a/internal/pkg/ccloudv2/org.go
+++ b/internal/pkg/ccloudv2/org.go
@@ -23,24 +23,28 @@ func (c *Client) orgApiContext() context.Context {
 	return context.WithValue(context.Background(), orgv2.ContextAccessToken, c.AuthToken)
 }
 
-func (c *Client) CreateOrgEnvironment(environment orgv2.OrgV2Environment) (orgv2.OrgV2Environment, *http.Response, error) {
+func (c *Client) CreateOrgEnvironment(environment orgv2.OrgV2Environment) (orgv2.OrgV2Environment, error) {
 	req := c.OrgClient.EnvironmentsOrgV2Api.CreateOrgV2Environment(c.orgApiContext()).OrgV2Environment(environment)
-	return c.OrgClient.EnvironmentsOrgV2Api.CreateOrgV2EnvironmentExecute(req)
+	res, r, err := c.OrgClient.EnvironmentsOrgV2Api.CreateOrgV2EnvironmentExecute(req)
+	return res, errors.CatchCCloudV2Error(err, r)
 }
 
-func (c *Client) GetOrgEnvironment(envId string) (orgv2.OrgV2Environment, *http.Response, error) {
+func (c *Client) GetOrgEnvironment(envId string) (orgv2.OrgV2Environment, error) {
 	req := c.OrgClient.EnvironmentsOrgV2Api.GetOrgV2Environment(c.orgApiContext(), envId)
-	return c.OrgClient.EnvironmentsOrgV2Api.GetOrgV2EnvironmentExecute(req)
+	res, r, err := c.OrgClient.EnvironmentsOrgV2Api.GetOrgV2EnvironmentExecute(req)
+	return res, errors.CatchCCloudV2Error(err, r)
 }
 
-func (c *Client) UpdateOrgEnvironment(envId string, updateEnvironment orgv2.OrgV2Environment) (orgv2.OrgV2Environment, *http.Response, error) {
+func (c *Client) UpdateOrgEnvironment(envId string, updateEnvironment orgv2.OrgV2Environment) (orgv2.OrgV2Environment, error) {
 	req := c.OrgClient.EnvironmentsOrgV2Api.UpdateOrgV2Environment(c.orgApiContext(), envId).OrgV2Environment(updateEnvironment)
-	return c.OrgClient.EnvironmentsOrgV2Api.UpdateOrgV2EnvironmentExecute(req)
+	res, r, err := c.OrgClient.EnvironmentsOrgV2Api.UpdateOrgV2EnvironmentExecute(req)
+	return res, errors.CatchCCloudV2Error(err, r)
 }
 
-func (c *Client) DeleteOrgEnvironment(envId string) (*http.Response, error) {
+func (c *Client) DeleteOrgEnvironment(envId string) error {
 	req := c.OrgClient.EnvironmentsOrgV2Api.DeleteOrgV2Environment(c.orgApiContext(), envId)
-	return c.OrgClient.EnvironmentsOrgV2Api.DeleteOrgV2EnvironmentExecute(req)
+	r, err := c.OrgClient.EnvironmentsOrgV2Api.DeleteOrgV2EnvironmentExecute(req)
+	return errors.CatchCCloudV2Error(err, r)
 }
 
 func (c *Client) ListOrgEnvironments() ([]orgv2.OrgV2Environment, error) {

--- a/internal/pkg/cmd/flags.go
+++ b/internal/pkg/cmd/flags.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/spf13/cobra"
@@ -180,11 +179,11 @@ func AutocompleteEnvironments(v1Client *ccloudv1.Client, v2Client *ccloudv2.Clie
 	}
 
 	if auditLog := v1.GetAuditLog(ctx.Context); auditLog != nil {
-		auditLogAccount, err := v1Client.Account.Get(context.Background(), &ccloudv1.Account{Id: auditLog.GetAccountId()})
+		environment, err := v2Client.GetOrgEnvironment(auditLog.GetAccountId())
 		if err != nil {
 			return nil
 		}
-		suggestions = append(suggestions, fmt.Sprintf("%s\t%s", auditLog.GetAccountId(), auditLogAccount.GetName()))
+		suggestions = append(suggestions, fmt.Sprintf("%s\t%s", auditLog.GetAccountId(), environment.GetDisplayName()))
 	}
 
 	return suggestions

--- a/internal/pkg/cmd/prerunner.go
+++ b/internal/pkg/cmd/prerunner.go
@@ -167,10 +167,10 @@ func (c *AuthenticatedCLICommand) AuthToken() string {
 }
 
 func (c *AuthenticatedCLICommand) EnvironmentId() (string, error) {
-	if c.Context.GetEnvironment() == nil {
-		return "", errors.NewErrorWithSuggestions(errors.NoEnvironmentFoundErrorMsg, errors.NoEnvironmentFoundSuggestions)
+	if id := c.Context.GetCurrentEnvironment(); id != "" {
+		return id, nil
 	}
-	return c.Context.GetEnvironment().GetId(), nil
+	return "", errors.NewErrorWithSuggestions(errors.NoEnvironmentFoundErrorMsg, errors.NoEnvironmentFoundSuggestions)
 }
 
 func (h *HasAPIKeyCLICommand) AddCommand(cmd *cobra.Command) {
@@ -398,7 +398,7 @@ func (r *PreRun) ccloudAutoLogin(netrcMachineName string) error {
 
 	log.CliLogger.Debug(errors.AutoLoginMsg)
 	log.CliLogger.Debugf(errors.LoggedInAsMsgWithOrg, credentials.Username, currentOrg.ResourceId, currentOrg.Name)
-	log.CliLogger.Debugf(errors.LoggedInUsingEnvMsg, currentEnv.GetId(), currentEnv.GetName())
+	log.CliLogger.Debugf(errors.LoggedInUsingEnvMsg, currentEnv)
 
 	return nil
 }

--- a/internal/pkg/config/v1/auth_config.go
+++ b/internal/pkg/config/v1/auth_config.go
@@ -5,7 +5,10 @@ import ccloudv1 "github.com/confluentinc/ccloud-sdk-go-v1-public"
 // AuthConfig represents an authenticated user.
 type AuthConfig struct {
 	User         *ccloudv1.User         `json:"user"`
-	Account      *ccloudv1.Account      `json:"account"`
-	Accounts     []*ccloudv1.Account    `json:"accounts"`
 	Organization *ccloudv1.Organization `json:"organization"`
+
+	// Deprecated
+	Account *ccloudv1.Account `json:"account,omitempty"`
+	// Deprecated
+	Accounts []*ccloudv1.Account `json:"accounts,omitempty"`
 }

--- a/internal/pkg/config/v1/config.go
+++ b/internal/pkg/config/v1/config.go
@@ -11,8 +11,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/go-version"
 
-	ccloudv1 "github.com/confluentinc/ccloud-sdk-go-v1-public"
-
 	"github.com/confluentinc/cli/internal/pkg/ccloudv2"
 	"github.com/confluentinc/cli/internal/pkg/config"
 	"github.com/confluentinc/cli/internal/pkg/errors"
@@ -93,32 +91,32 @@ type Config struct {
 	IsTest  bool              `json:"-"`
 	Version *pversion.Version `json:"-"`
 
-	overwrittenAccount     *ccloudv1.Account
-	overwrittenCurrContext string
-	overwrittenActiveKafka string
+	overwrittenCurrentContext      string
+	overwrittenCurrentEnvironment  string
+	overwrittenCurrentKafkaCluster string
 }
 
-func (c *Config) SetOverwrittenAccount(acct *ccloudv1.Account) {
-	if c.overwrittenAccount == nil {
-		c.overwrittenAccount = acct
+func (c *Config) SetOverwrittenCurrentContext(context string) {
+	if context == "" {
+		context = emptyFieldIndicator
+	}
+	if c.overwrittenCurrentContext == "" {
+		c.overwrittenCurrentContext = context
 	}
 }
 
-func (c *Config) SetOverwrittenCurrContext(contextName string) {
-	if contextName == "" {
-		contextName = emptyFieldIndicator
-	}
-	if c.overwrittenCurrContext == "" {
-		c.overwrittenCurrContext = contextName
+func (c *Config) SetOverwrittenCurrentEnvironment(environmentId string) {
+	if c.overwrittenCurrentEnvironment == "" {
+		c.overwrittenCurrentEnvironment = environmentId
 	}
 }
 
-func (c *Config) SetOverwrittenActiveKafka(clusterId string) {
+func (c *Config) SetOverwrittenCurrentKafkaCluster(clusterId string) {
 	if clusterId == "" {
 		clusterId = emptyFieldIndicator
 	}
-	if c.overwrittenActiveKafka == "" {
-		c.overwrittenActiveKafka = clusterId
+	if c.overwrittenCurrentKafkaCluster == "" {
+		c.overwrittenCurrentKafkaCluster = clusterId
 	}
 }
 
@@ -206,7 +204,7 @@ func (c *Config) Load() error {
 // Save writes the CLI config to disk.
 func (c *Config) Save() error {
 	tempKafka := c.resolveOverwrittenKafka()
-	tempAccount := c.resolveOverwrittenAccount()
+	tempEnvironment := c.resolveOverwrittenCurrentEnvironment()
 	tempContext := c.resolveOverwrittenContext()
 	var tempAuthToken string
 	var tempAuthRefreshToken string
@@ -240,7 +238,7 @@ func (c *Config) Save() error {
 	}
 
 	c.restoreOverwrittenContext(tempContext)
-	c.restoreOverwrittenAccount(tempAccount)
+	c.restoreOverwrittenEnvironment(tempEnvironment)
 	c.restoreOverwrittenKafka(tempKafka)
 	c.restoreOverwrittenAuthToken(tempAuthToken)
 	c.restoreOverwrittenAuthRefreshToken(tempAuthRefreshToken)
@@ -284,35 +282,32 @@ func (c *Config) encryptContextStateTokens(tempAuthToken, tempAuthRefreshToken s
 func (c *Config) resolveOverwrittenKafka() string {
 	ctx := c.Context()
 	var tempKafka string
-	if c.overwrittenActiveKafka != "" && ctx != nil && ctx.KafkaClusterContext != nil {
-		if c.overwrittenActiveKafka == emptyFieldIndicator {
-			c.overwrittenActiveKafka = ""
+	if c.overwrittenCurrentKafkaCluster != "" && ctx != nil && ctx.KafkaClusterContext != nil {
+		if c.overwrittenCurrentKafkaCluster == emptyFieldIndicator {
+			c.overwrittenCurrentKafkaCluster = ""
 		}
 		tempKafka = ctx.KafkaClusterContext.GetActiveKafkaClusterId()
-		ctx.KafkaClusterContext.SetActiveKafkaCluster(c.overwrittenActiveKafka)
+		ctx.KafkaClusterContext.SetActiveKafkaCluster(c.overwrittenCurrentKafkaCluster)
 	}
 	return tempKafka
 }
 
 // Restore the flag cluster back into the struct so that it is used for any execution after Save()
 func (c *Config) restoreOverwrittenKafka(tempKafka string) {
-	ctx := c.Context()
 	if tempKafka != "" {
-		ctx.KafkaClusterContext.SetActiveKafkaCluster(tempKafka)
+		c.Context().KafkaClusterContext.SetActiveKafkaCluster(tempKafka)
 	}
 }
 
 func (c *Config) restoreOverwrittenAuthToken(tempAuthToken string) {
-	ctx := c.Context()
 	if tempAuthToken != "" {
-		ctx.GetState().AuthToken = tempAuthToken
+		c.Context().GetState().AuthToken = tempAuthToken
 	}
 }
 
 func (c *Config) restoreOverwrittenAuthRefreshToken(tempAuthRefreshToken string) {
-	ctx := c.Context()
 	if tempAuthRefreshToken != "" {
-		ctx.GetState().AuthRefreshToken = tempAuthRefreshToken
+		c.Context().GetState().AuthRefreshToken = tempAuthRefreshToken
 	}
 }
 
@@ -320,12 +315,12 @@ func (c *Config) restoreOverwrittenAuthRefreshToken(tempAuthRefreshToken string)
 // Return the overwriting flag context value so that it can be restored after writing the file
 func (c *Config) resolveOverwrittenContext() string {
 	var tempContext string
-	if c.overwrittenCurrContext != "" && c != nil {
-		if c.overwrittenCurrContext == emptyFieldIndicator {
-			c.overwrittenCurrContext = ""
+	if c.overwrittenCurrentContext != "" && c != nil {
+		if c.overwrittenCurrentContext == emptyFieldIndicator {
+			c.overwrittenCurrentContext = ""
 		}
 		tempContext = c.CurrentContext
-		c.CurrentContext = c.overwrittenCurrContext
+		c.CurrentContext = c.overwrittenCurrentContext
 	}
 	return tempContext
 }
@@ -339,21 +334,19 @@ func (c *Config) restoreOverwrittenContext(tempContext string) {
 
 // Switch the initial config account back into the struct so that it is saved and not the flag value
 // Return the overwriting flag account value so that it can be restored after writing the file
-func (c *Config) resolveOverwrittenAccount() *ccloudv1.Account {
-	ctx := c.Context()
-	var tempAccount *ccloudv1.Account
-	if c.overwrittenAccount != nil && ctx != nil && ctx.State != nil && ctx.State.Auth != nil {
-		tempAccount = ctx.GetEnvironment()
-		ctx.State.Auth.Account = c.overwrittenAccount
+func (c *Config) resolveOverwrittenCurrentEnvironment() string {
+	var tempEnvironment string
+	if c.overwrittenCurrentEnvironment != "" {
+		tempEnvironment = c.Context().GetCurrentEnvironment()
+		c.Context().CurrentEnvironment = c.overwrittenCurrentEnvironment
 	}
-	return tempAccount
+	return tempEnvironment
 }
 
 // Restore the flag account back into the struct so that it is used for any execution after Save()
-func (c *Config) restoreOverwrittenAccount(tempAccount *ccloudv1.Account) {
-	ctx := c.Context()
-	if tempAccount != nil {
-		ctx.State.Auth.Account = tempAccount
+func (c *Config) restoreOverwrittenEnvironment(id string) {
+	if id != "" {
+		c.Context().CurrentEnvironment = id
 	}
 }
 
@@ -425,7 +418,7 @@ func (c *Config) FindContext(name string) (*Context, error) {
 	return context, nil
 }
 
-func (c *Config) AddContext(name, platformName, credentialName string, kafkaClusters map[string]*KafkaClusterConfig, kafka string, schemaRegistryClusters map[string]*SchemaRegistryCluster, state *ContextState, orgResourceId string) error {
+func (c *Config) AddContext(name, platformName, credentialName string, kafkaClusters map[string]*KafkaClusterConfig, kafka string, schemaRegistryClusters map[string]*SchemaRegistryCluster, state *ContextState, orgResourceId, envId string) error {
 	if _, ok := c.Contexts[name]; ok {
 		return fmt.Errorf(errors.ContextAlreadyExistsErrorMsg, name)
 	}
@@ -440,7 +433,7 @@ func (c *Config) AddContext(name, platformName, credentialName string, kafkaClus
 		return fmt.Errorf(errors.PlatformNotFoundErrorMsg, platformName)
 	}
 
-	ctx, err := newContext(name, platform, credential, kafkaClusters, kafka, schemaRegistryClusters, state, c, orgResourceId)
+	ctx, err := newContext(name, platform, credential, kafkaClusters, kafka, schemaRegistryClusters, state, c, orgResourceId, envId)
 	if err != nil {
 		return err
 	}
@@ -461,28 +454,9 @@ func (c *Config) CreateContext(name, bootstrapURL, apiKey, apiSecret string) err
 		Key:    apiKey,
 		Secret: apiSecret,
 	}
-	apiKeys := map[string]*APIKeyPair{
-		apiKey: apiKeyPair,
-	}
-	kafkaClusterCfg := &KafkaClusterConfig{
-		ID:        "anonymous-id",
-		Name:      "anonymous-cluster",
-		Bootstrap: bootstrapURL,
-		APIKeys:   apiKeys,
-		APIKey:    apiKey,
-	}
-	kafkaClusters := map[string]*KafkaClusterConfig{
-		kafkaClusterCfg.ID: kafkaClusterCfg,
-	}
-	platform := &Platform{Server: bootstrapURL}
-
-	// Inject credential and platforms name for now, until users can provide custom names.
-	platform.Name = strings.TrimPrefix(platform.Server, "https://")
 
 	// Hardcoded for now, since username/password isn't implemented yet.
 	credential := &Credential{
-		Username:       "",
-		Password:       "",
 		APIKeyPair:     apiKeyPair,
 		CredentialType: APIKey,
 	}
@@ -500,11 +474,26 @@ func (c *Config) CreateContext(name, bootstrapURL, apiKey, apiSecret string) err
 		return err
 	}
 
+	// Inject credential and platforms name for now, until users can provide custom names.
+	platform := &Platform{
+		Server: bootstrapURL,
+		Name:   strings.TrimPrefix(bootstrapURL, "https://"),
+	}
+
 	if err := c.SavePlatform(platform); err != nil {
 		return err
 	}
 
-	return c.AddContext(name, platform.Name, credential.Name, kafkaClusters, kafkaClusterCfg.ID, nil, nil, "")
+	kafkaClusterCfg := &KafkaClusterConfig{
+		ID:        "anonymous-id",
+		Name:      "anonymous-cluster",
+		Bootstrap: bootstrapURL,
+		APIKeys:   map[string]*APIKeyPair{apiKey: apiKeyPair},
+		APIKey:    apiKey,
+	}
+	kafkaClusters := map[string]*KafkaClusterConfig{kafkaClusterCfg.ID: kafkaClusterCfg}
+
+	return c.AddContext(name, platform.Name, credential.Name, kafkaClusters, kafkaClusterCfg.ID, nil, nil, "", "")
 }
 
 // UseContext sets the current context, if it exists.

--- a/internal/pkg/config/v1/config.go
+++ b/internal/pkg/config/v1/config.go
@@ -338,7 +338,7 @@ func (c *Config) resolveOverwrittenCurrentEnvironment() string {
 	var tempEnvironment string
 	if c.overwrittenCurrentEnvironment != "" {
 		tempEnvironment = c.Context().GetCurrentEnvironment()
-		c.Context().CurrentEnvironment = c.overwrittenCurrentEnvironment
+		c.Context().SetCurrentEnvironment(c.overwrittenCurrentEnvironment)
 	}
 	return tempEnvironment
 }
@@ -346,7 +346,7 @@ func (c *Config) resolveOverwrittenCurrentEnvironment() string {
 // Restore the flag account back into the struct so that it is used for any execution after Save()
 func (c *Config) restoreOverwrittenEnvironment(id string) {
 	if id != "" {
-		c.Context().CurrentEnvironment = id
+		c.Context().SetCurrentEnvironment(id)
 	}
 }
 

--- a/internal/pkg/config/v1/config_test.go
+++ b/internal/pkg/config/v1/config_test.go
@@ -397,7 +397,7 @@ func TestConfig_SaveWithEnvironmentOverwrite(t *testing.T) {
 		EncryptedPassword: "encrypted-password",
 	}}
 	config.SetOverwrittenCurrentEnvironment(config.Context().GetCurrentEnvironment())
-	config.Context().CurrentEnvironment = "env-flag"
+	config.Context().SetCurrentEnvironment("env-flag")
 	err = config.Save()
 	require.NoError(t, err)
 
@@ -809,7 +809,7 @@ func TestKafkaClusterContext_SetAndGetActiveKafkaCluster_Env(t *testing.T) {
 	require.Equal(t, ctx.KafkaClusterContext.GetActiveKafkaClusterConfig().ID, activeKafka)
 
 	// switch environment add the kafka cluster, and set it as active cluster
-	ctx.CurrentEnvironment = otherEnvironmentId
+	ctx.SetCurrentEnvironment(otherEnvironmentId)
 	ctx.KafkaClusterContext.AddKafkaClusterConfig(otherKafkaCluster)
 	ctx.KafkaClusterContext.SetActiveKafkaCluster(otherKafkaCluster.ID)
 	activeKafka = ctx.KafkaClusterContext.GetActiveKafkaClusterId()
@@ -817,7 +817,7 @@ func TestKafkaClusterContext_SetAndGetActiveKafkaCluster_Env(t *testing.T) {
 	require.Equal(t, ctx.KafkaClusterContext.GetActiveKafkaClusterConfig().ID, activeKafka)
 
 	// switch environment back
-	ctx.CurrentEnvironment = testInputs.environment
+	ctx.SetCurrentEnvironment(testInputs.environment)
 	activeKafka = ctx.KafkaClusterContext.GetActiveKafkaClusterId()
 	require.Equal(t, testInputs.activeKafka, activeKafka)
 	require.Equal(t, ctx.KafkaClusterContext.GetActiveKafkaClusterConfig().ID, activeKafka)

--- a/internal/pkg/config/v1/config_test.go
+++ b/internal/pkg/config/v1/config_test.go
@@ -35,16 +35,12 @@ var (
 	apiSecretString = "def-secret-456"
 	kafkaClusterID  = "anonymous-id"
 	contextName     = "my-context"
-	accountID       = "acc-123"
+	environmentId   = "acc-123"
 	cloudPlatforms  = []string{
 		"devel.cpdev.cloud",
 		"stag.cpdev.cloud",
 		"confluent.cloud",
 		"premium-oryx.gcp.priv.cpdev.cloud",
-	}
-	account = &ccloudv1.Account{
-		Id:   accountID,
-		Name: "test-env",
 	}
 	regularOrgContextState = &ContextState{
 		Auth: &AuthConfig{
@@ -52,21 +48,13 @@ var (
 				Id:    123,
 				Email: "test-user@email",
 			},
-			Account: account,
-			Accounts: []*ccloudv1.Account{
-				account,
-			},
 			Organization: testserver.RegularOrg,
 		},
 		AuthToken:        "eyJ.eyJ.abc",
 		AuthRefreshToken: "v1.abc",
 	}
 	suspendedOrgContextState = func(eventType ccloudv1.SuspensionEventType) *ContextState {
-		return &ContextState{
-			Auth: &AuthConfig{
-				Organization: testserver.SuspendedOrg(eventType),
-			},
-		}
+		return &ContextState{Auth: &AuthConfig{Organization: testserver.SuspendedOrg(eventType)}}
 	}
 )
 
@@ -76,7 +64,7 @@ type TestInputs struct {
 	statefulConfig       *Config
 	statelessConfig      *Config
 	twoEnvStatefulConfig *Config
-	account              *ccloudv1.Account
+	environment          string
 }
 
 func SetupTestInputs(isCloud bool) *TestInputs {
@@ -89,9 +77,7 @@ func SetupTestInputs(isCloud bool) *TestInputs {
 		platform.Name = testserver.TestCloudUrl.String()
 	}
 	apiCredential := &Credential{
-		Name:     "api-key-abc-key-123",
-		Username: "",
-		Password: "",
+		Name: "api-key-abc-key-123",
 		APIKeyPair: &APIKeyPair{
 			Key:    apiKeyString,
 			Secret: apiSecretString,
@@ -101,40 +87,14 @@ func SetupTestInputs(isCloud bool) *TestInputs {
 	loginCredential := &Credential{
 		Name:           "username-test-user",
 		Username:       "test-user",
-		Password:       "",
-		APIKeyPair:     nil,
 		CredentialType: 0,
 	}
-	savedCredentials := map[string]*LoginCredential{
-		contextName: {
-			IsCloud:           isCloud,
-			Username:          "test-user",
-			EncryptedPassword: "encrypted-password",
-		},
-	}
-	account2 := &ccloudv1.Account{
-		Id:   "env-flag",
-		Name: "test-env2",
-	}
-	testInputs.account = account
-	twoEnvState := &ContextState{
-		Auth: &AuthConfig{
-			User: &ccloudv1.User{
-				Id:    123,
-				Email: "test-user@email",
-			},
-			Account: account,
-			Accounts: []*ccloudv1.Account{
-				account,
-				account2,
-			},
-			Organization: &ccloudv1.Organization{
-				Id:   321,
-				Name: "test-org",
-			},
-		},
-		AuthToken: "abc123",
-	}
+	savedCredentials := map[string]*LoginCredential{contextName: {
+		IsCloud:           isCloud,
+		Username:          "test-user",
+		EncryptedPassword: "encrypted-password",
+	}}
+	testInputs.environment = environmentId
 	testInputs.kafkaClusters = map[string]*KafkaClusterConfig{
 		kafkaClusterID: {
 			ID:        kafkaClusterID,
@@ -151,13 +111,15 @@ func SetupTestInputs(isCloud bool) *TestInputs {
 	}
 	testInputs.activeKafka = kafkaClusterID
 	statefulContext := &Context{
-		Name:           contextName,
-		Platform:       platform,
-		PlatformName:   platform.Name,
-		Credential:     loginCredential,
-		CredentialName: loginCredential.Name,
+		Name:               contextName,
+		Platform:           platform,
+		PlatformName:       platform.Name,
+		Credential:         loginCredential,
+		CredentialName:     loginCredential.Name,
+		CurrentEnvironment: environmentId,
+		Environments:       map[string]*EnvironmentContext{environmentId: {}},
 		SchemaRegistryClusters: map[string]*SchemaRegistryCluster{
-			accountID: {
+			environmentId: {
 				Id:                     "lsrc-123",
 				SchemaRegistryEndpoint: "http://some-lsrc-endpoint",
 				SrCredentials:          nil,
@@ -171,24 +133,29 @@ func SetupTestInputs(isCloud bool) *TestInputs {
 		PlatformName:           platform.Name,
 		Credential:             apiCredential,
 		CredentialName:         apiCredential.Name,
+		Environments:           map[string]*EnvironmentContext{},
 		SchemaRegistryClusters: map[string]*SchemaRegistryCluster{},
 		State:                  &ContextState{},
 		Config:                 &Config{SavedCredentials: savedCredentials},
 	}
 	twoEnvStatefulContext := &Context{
-		Name:           contextName,
-		Platform:       platform,
-		PlatformName:   platform.Name,
-		Credential:     loginCredential,
-		CredentialName: loginCredential.Name,
+		Name:               contextName,
+		Platform:           platform,
+		PlatformName:       platform.Name,
+		Credential:         loginCredential,
+		CredentialName:     loginCredential.Name,
+		CurrentEnvironment: "acc-123",
+		Environments: map[string]*EnvironmentContext{
+			"acc-123":  {},
+			"env-flag": {},
+		},
 		SchemaRegistryClusters: map[string]*SchemaRegistryCluster{
-			accountID: {
+			environmentId: {
 				Id:                     "lsrc-123",
 				SchemaRegistryEndpoint: "http://some-lsrc-endpoint",
-				SrCredentials:          nil,
 			},
 		},
-		State: twoEnvState,
+		State: regularOrgContextState,
 	}
 	context := "onprem"
 	if isCloud {
@@ -199,20 +166,14 @@ func SetupTestInputs(isCloud bool) *TestInputs {
 			Filename: fmt.Sprintf("test_json/stateful_%s.json", context),
 			Ver:      config.Version{Version: ver},
 		},
-		Platforms: map[string]*Platform{
-			platform.Name: platform,
-		},
+		Platforms: map[string]*Platform{platform.Name: platform},
 		Credentials: map[string]*Credential{
 			apiCredential.Name:   apiCredential,
 			loginCredential.Name: loginCredential,
 		},
-		Contexts: map[string]*Context{
-			contextName: statefulContext,
-		},
-		ContextStates: map[string]*ContextState{
-			contextName: regularOrgContextState,
-		},
 		CurrentContext:   contextName,
+		Contexts:         map[string]*Context{contextName: statefulContext},
+		ContextStates:    map[string]*ContextState{contextName: regularOrgContextState},
 		IsTest:           true,
 		SavedCredentials: savedCredentials,
 	}
@@ -221,19 +182,13 @@ func SetupTestInputs(isCloud bool) *TestInputs {
 			Filename: fmt.Sprintf("test_json/stateless_%s.json", context),
 			Ver:      config.Version{Version: ver},
 		},
-		Platforms: map[string]*Platform{
-			platform.Name: platform,
-		},
+		Platforms: map[string]*Platform{platform.Name: platform},
 		Credentials: map[string]*Credential{
 			apiCredential.Name:   apiCredential,
 			loginCredential.Name: loginCredential,
 		},
-		Contexts: map[string]*Context{
-			contextName: statelessContext,
-		},
-		ContextStates: map[string]*ContextState{
-			contextName: {},
-		},
+		Contexts:         map[string]*Context{contextName: statelessContext},
+		ContextStates:    map[string]*ContextState{contextName: {}},
 		CurrentContext:   contextName,
 		IsTest:           true,
 		SavedCredentials: savedCredentials,
@@ -243,20 +198,14 @@ func SetupTestInputs(isCloud bool) *TestInputs {
 			Filename: fmt.Sprintf("test_json/stateful_%s.json", context),
 			Ver:      config.Version{Version: ver},
 		},
-		Platforms: map[string]*Platform{
-			platform.Name: platform,
-		},
+		Platforms: map[string]*Platform{platform.Name: platform},
 		Credentials: map[string]*Credential{
 			apiCredential.Name:   apiCredential,
 			loginCredential.Name: loginCredential,
 		},
-		Contexts: map[string]*Context{
-			contextName: twoEnvStatefulContext,
-		},
-		ContextStates: map[string]*ContextState{
-			contextName: twoEnvState,
-		},
 		CurrentContext: contextName,
+		Contexts:       map[string]*Context{contextName: twoEnvStatefulContext},
+		ContextStates:  map[string]*ContextState{contextName: regularOrgContextState},
 		IsTest:         true,
 	}
 
@@ -301,23 +250,23 @@ func TestConfig_Load(t *testing.T) {
 			want: testConfigsCloud.statefulConfig,
 			file: "test_json/stateful_cloud.json",
 		},
-		{
-			name: "should load disable update checks and disable updates",
-			want: &Config{
-				BaseConfig: &config.BaseConfig{
-					Filename: "test_json/load_disable_update.json",
-					Ver:      config.Version{Version: ver},
-				},
-				DisableUpdates:     true,
-				DisableUpdateCheck: true,
-				Platforms:          map[string]*Platform{},
-				Credentials:        map[string]*Credential{},
-				Contexts:           map[string]*Context{},
-				ContextStates:      map[string]*ContextState{},
-				SavedCredentials:   map[string]*LoginCredential{},
-			},
-			file: "test_json/load_disable_update.json",
-		},
+		// {
+		// 	name: "should load disable update checks and disable updates",
+		// 	want: &Config{
+		// 		BaseConfig: &config.BaseConfig{
+		// 			Filename: "test_json/load_disable_update.json",
+		// 			Ver:      config.Version{Version: ver},
+		// 		},
+		// 		DisableUpdates:     true,
+		// 		DisableUpdateCheck: true,
+		// 		Platforms:          map[string]*Platform{},
+		// 		Credentials:        map[string]*Credential{},
+		// 		Contexts:           map[string]*Context{},
+		// 		ContextStates:      map[string]*ContextState{},
+		// 		SavedCredentials:   map[string]*LoginCredential{},
+		// 	},
+		// 	file: "test_json/load_disable_update.json",
+		// },
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -336,7 +285,7 @@ func TestConfig_Load(t *testing.T) {
 			tt.want.Version = cfg.Version
 
 			if !t.Failed() && !reflect.DeepEqual(cfg, tt.want) {
-				t.Errorf("Config.Load() =\n %+v, want \n%+v", cfg, tt.want)
+				t.Errorf("Config.Load() =\n%+v, want \n%+v", cfg, tt.want)
 			}
 		})
 	}
@@ -407,11 +356,11 @@ func TestConfig_Save(t *testing.T) {
 				},
 			}
 			if tt.kafkaOverwrite != "" {
-				tt.config.SetOverwrittenActiveKafka(ctx.KafkaClusterContext.GetActiveKafkaClusterId())
+				tt.config.SetOverwrittenCurrentKafkaCluster(ctx.KafkaClusterContext.GetActiveKafkaClusterId())
 				ctx.KafkaClusterContext.SetActiveKafkaCluster(tt.kafkaOverwrite)
 			}
 			if tt.contextOverwrite != "" {
-				tt.config.SetOverwrittenCurrContext(tt.config.CurrentContext)
+				tt.config.SetOverwrittenCurrentContext(tt.config.CurrentContext)
 				tt.config.CurrentContext = tt.contextOverwrite
 			}
 			if err := tt.config.Save(); (err != nil) != tt.wantErr {
@@ -434,60 +383,39 @@ func TestConfig_Save(t *testing.T) {
 	}
 }
 
-func TestConfig_SaveWithAccountOverwrite(t *testing.T) {
+func TestConfig_SaveWithEnvironmentOverwrite(t *testing.T) {
+	configFile, err := os.CreateTemp("", "TestConfig_Save.json")
+	require.NoError(t, err)
+	defer os.Remove(configFile.Name())
+
 	testConfigsCloud := SetupTestInputs(true)
-	tests := []struct {
-		name             string
-		config           *Config
-		wantFile         string
-		wantErr          bool
-		accountOverwrite *ccloudv1.Account
-	}{
-		{
-			name:             "save cloud config with state and account overwrite to file",
-			config:           testConfigsCloud.twoEnvStatefulConfig,
-			wantFile:         "test_json/account_overwrite.json",
-			accountOverwrite: &ccloudv1.Account{Id: "env-flag"},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			configFile, _ := os.CreateTemp("", "TestConfig_Save.json")
-			tt.config.Filename = configFile.Name()
-			tt.config.SavedCredentials = map[string]*LoginCredential{
-				contextName: {
-					IsCloud:           true,
-					Username:          "test-user",
-					EncryptedPassword: "encrypted-password",
-				},
-			}
-			if tt.accountOverwrite != nil {
-				tt.config.SetOverwrittenAccount(tt.config.Context().GetEnvironment())
-				tt.config.Context().State.Auth.Account = tt.accountOverwrite
-			}
-			if err := tt.config.Save(); (err != nil) != tt.wantErr {
-				t.Errorf("Config.Save() error = %v, wantErr %v", err, tt.wantErr)
-			}
-			got, _ := os.ReadFile(configFile.Name())
-			got = append(got, '\n') // account for extra newline at the end of the json file
-			want, _ := os.ReadFile(tt.wantFile)
-			wantString := replacePlaceholdersInWant(t, got, want)
-			if utils.NormalizeNewLines(string(got)) != utils.NormalizeNewLines(wantString) {
-				t.Errorf("Config.Save() = %v\n want = %v", utils.NormalizeNewLines(string(got)), utils.NormalizeNewLines(wantString))
-			}
-			fd, err := os.Stat(configFile.Name())
-			require.NoError(t, err)
-			if runtime.GOOS != "windows" && fd.Mode() != 0600 {
-				t.Errorf("Config.Save() file should only be readable by user")
-			}
-			os.Remove(configFile.Name())
-		})
+	config := testConfigsCloud.twoEnvStatefulConfig
+	config.Filename = configFile.Name()
+	config.SavedCredentials = map[string]*LoginCredential{contextName: {
+		IsCloud:           true,
+		Username:          "test-user",
+		EncryptedPassword: "encrypted-password",
+	}}
+	config.SetOverwrittenCurrentEnvironment(config.Context().GetCurrentEnvironment())
+	config.Context().CurrentEnvironment = "env-flag"
+	err = config.Save()
+	require.NoError(t, err)
+
+	got, _ := os.ReadFile(configFile.Name())
+	want, _ := os.ReadFile("test_json/account_overwrite.json")
+	wantString := replacePlaceholdersInWant(t, got, want)
+	require.Equal(t, utils.NormalizeNewLines(wantString), utils.NormalizeNewLines(string(got)))
+
+	fd, err := os.Stat(configFile.Name())
+	require.NoError(t, err)
+	if runtime.GOOS != "windows" && fd.Mode() != 0600 {
+		t.Errorf("Config.Save() file should only be readable by user")
 	}
 }
 
 func replacePlaceholdersInWant(t *testing.T, got []byte, want []byte) string {
-	data := Config{}
-	err := json.Unmarshal(got, &data)
+	data := &Config{}
+	err := json.Unmarshal(got, data)
 	require.NoError(t, err)
 	wantString := strings.ReplaceAll(string(want), authTokenPlaceholder, data.ContextStates[contextName].AuthToken)
 	wantString = strings.ReplaceAll(wantString, authRefreshTokenPlaceholder, data.ContextStates[contextName].AuthRefreshToken)
@@ -525,7 +453,7 @@ func TestConfig_OverwrittenKafka(t *testing.T) {
 	}
 	for _, tt := range tests {
 		ctx := tt.config.Context()
-		tt.config.SetOverwrittenActiveKafka(tt.overwrittenVal)
+		tt.config.SetOverwrittenCurrentKafkaCluster(tt.overwrittenVal)
 		// resolve should reset the active kafka to be the overwritten value and return the flag value to be used in restore
 		tempKafka := tt.config.resolveOverwrittenKafka()
 		require.Equal(t, tt.activeKafka, tempKafka)
@@ -541,7 +469,7 @@ func TestConfig_OverwrittenKafka(t *testing.T) {
 		} else {
 			require.Equal(t, tempKafka, ctx.KafkaClusterContext.ActiveKafkaCluster)
 		}
-		tt.config.overwrittenActiveKafka = ""
+		tt.config.overwrittenCurrentKafkaCluster = ""
 	}
 }
 
@@ -572,7 +500,7 @@ func TestConfig_OverwrittenContext(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt.config.SetOverwrittenCurrContext(tt.overwrittenVal)
+		tt.config.SetOverwrittenCurrentContext(tt.overwrittenVal)
 		// resolve should reset the current context to be the overwritten value and return the flag value to be used in restore
 		tempContext := tt.config.resolveOverwrittenContext()
 		require.Equal(t, tt.overwrittenVal, tt.config.CurrentContext)
@@ -580,29 +508,29 @@ func TestConfig_OverwrittenContext(t *testing.T) {
 		// restore should reset the current context to be the flag value
 		tt.config.restoreOverwrittenContext(tempContext)
 		require.Equal(t, tt.currContext, tt.config.CurrentContext)
-		tt.config.overwrittenCurrContext = ""
+		tt.config.overwrittenCurrentContext = ""
 	}
 }
 
-func TestConfig_OverwrittenAccount(t *testing.T) {
+func TestConfig_OverwrittenEnvironment(t *testing.T) {
 	testConfigsCloud := SetupTestInputs(true)
 
 	tests := []struct {
-		name           string
-		config         *Config
-		overwrittenVal *ccloudv1.Account // simulates initial environment (account) value overwritten by a environment flag
-		activeAccount  string            // simulates the environment (account) flag value
+		name                          string
+		config                        *Config
+		currentEnvironment            string // simulates the environment flag value
+		overwrittenCurrentEnvironment string // simulates initial environment value overwritten by a environment flag
 	}{
 		{
-			name:          "test no overwrite value",
-			config:        testConfigsCloud.statefulConfig,
-			activeAccount: testConfigsCloud.statefulConfig.Context().GetEnvironment().GetId(),
+			name:               "test no overwrite value",
+			config:             testConfigsCloud.statefulConfig,
+			currentEnvironment: testConfigsCloud.statefulConfig.Context().GetCurrentEnvironment(),
 		},
 		{
-			name:           "test with overwrite value",
-			config:         testConfigsCloud.statefulConfig,
-			overwrittenVal: &ccloudv1.Account{Id: "env-test"},
-			activeAccount:  testConfigsCloud.statefulConfig.Context().GetEnvironment().GetId(),
+			name:                          "test with overwrite value",
+			config:                        testConfigsCloud.statefulConfig,
+			currentEnvironment:            testConfigsCloud.statefulConfig.Context().GetCurrentEnvironment(),
+			overwrittenCurrentEnvironment: "env-test",
 		},
 		{
 			name:   "test no overwrite value",
@@ -610,24 +538,24 @@ func TestConfig_OverwrittenAccount(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt.config.SetOverwrittenAccount(tt.overwrittenVal)
-		if tt.config.Context().State.Auth == nil {
-			tempAccount := tt.config.resolveOverwrittenAccount()
-			require.Nil(t, tempAccount)
-			tt.config.restoreOverwrittenAccount(tempAccount)
-			require.Nil(t, tt.config.Context().State.Auth)
+		tt.config.SetOverwrittenCurrentEnvironment(tt.overwrittenCurrentEnvironment)
+		if tt.config.Context().CurrentEnvironment == "" {
+			tempAccount := tt.config.resolveOverwrittenCurrentEnvironment()
+			require.Empty(t, tempAccount)
+			tt.config.restoreOverwrittenEnvironment(tempAccount)
+			require.Empty(t, tt.config.Context().CurrentEnvironment)
 		} else {
 			// resolve should reset the current context to be the overwritten value and return the flag value to be used in restore
-			tempAccount := tt.config.resolveOverwrittenAccount()
-			if tt.overwrittenVal != nil {
-				require.Equal(t, tt.overwrittenVal, tt.config.Context().GetEnvironment())
-				require.Equal(t, tt.activeAccount, tempAccount.Id)
+			tempAccount := tt.config.resolveOverwrittenCurrentEnvironment()
+			if tt.overwrittenCurrentEnvironment != "" {
+				require.Equal(t, tt.overwrittenCurrentEnvironment, tt.config.Context().GetCurrentEnvironment())
+				require.Equal(t, tt.currentEnvironment, tempAccount)
 			}
 			// restore should reset the current context to be the flag value
-			tt.config.restoreOverwrittenAccount(tempAccount)
-			require.Equal(t, tt.activeAccount, tt.config.Context().GetEnvironment().GetId())
+			tt.config.restoreOverwrittenEnvironment(tempAccount)
+			require.Equal(t, tt.currentEnvironment, tt.config.Context().GetCurrentEnvironment())
 		}
-		tt.config.overwrittenAccount = nil
+		tt.config.overwrittenCurrentEnvironment = ""
 	}
 }
 
@@ -655,6 +583,7 @@ func TestConfig_AddContext(t *testing.T) {
 		contextName            string
 		platformName           string
 		credentialName         string
+		currentEnvironment     string
 		kafkaClusters          map[string]*KafkaClusterConfig
 		kafka                  string
 		schemaRegistryClusters map[string]*SchemaRegistryCluster
@@ -671,6 +600,7 @@ func TestConfig_AddContext(t *testing.T) {
 		contextName:            context.Name,
 		platformName:           context.PlatformName,
 		credentialName:         context.CredentialName,
+		currentEnvironment:     context.CurrentEnvironment,
 		kafkaClusters:          context.KafkaClusterContext.KafkaClusterConfigs,
 		kafka:                  context.KafkaClusterContext.ActiveKafkaCluster,
 		schemaRegistryClusters: context.SchemaRegistryClusters,
@@ -696,8 +626,7 @@ func TestConfig_AddContext(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := tt.config.AddContext(tt.contextName, tt.platformName, tt.credentialName, tt.kafkaClusters, tt.kafka,
-				tt.schemaRegistryClusters, tt.state, MockOrgResourceId)
+			err := tt.config.AddContext(tt.contextName, tt.platformName, tt.credentialName, tt.kafkaClusters, tt.kafka, tt.schemaRegistryClusters, tt.state, MockOrgResourceId, tt.currentEnvironment)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("AddContext() error = %v, wantErr %v", err, tt.wantErr)
 			}
@@ -748,18 +677,13 @@ func TestConfig_UseContext(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name: "succeed setting valid context",
-			fields: fields{
-				Config: cfg,
-			},
-			args:    args{name: contextName},
-			wantErr: false,
+			name:   "succeed setting valid context",
+			fields: fields{Config: cfg},
+			args:   args{name: contextName},
 		},
 		{
-			name: "fail setting nonexistent context",
-			fields: fields{
-				Config: cfg,
-			},
+			name:    "fail setting nonexistent context",
+			fields:  fields{Config: cfg},
 			args:    args{name: "some-context"},
 			wantErr: true,
 		},
@@ -792,11 +716,10 @@ func TestConfig_FindContext(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name:    "success finding existing context",
-			fields:  fields{Contexts: map[string]*Context{"test-context": {Name: "test-context"}}},
-			args:    args{name: "test-context"},
-			want:    &Context{Name: "test-context"},
-			wantErr: false,
+			name:   "success finding existing context",
+			fields: fields{Contexts: map[string]*Context{"test-context": {Name: "test-context"}}},
+			args:   args{name: "test-context"},
+			want:   &Context{Name: "test-context"},
 		},
 		{
 			name:    "error finding nonexistent context",
@@ -834,21 +757,15 @@ func TestConfig_Context(t *testing.T) {
 		{
 			name: "succeed getting current context",
 			fields: fields{
-				Contexts: map[string]*Context{"test-context": {
-					Name: "test-context",
-				}},
+				Contexts:       map[string]*Context{"test-context": {Name: "test-context"}},
 				CurrentContext: "test-context",
 			},
-			want: &Context{
-				Name: "test-context",
-			},
+			want: &Context{Name: "test-context"},
 		},
 		{
-			name: "error getting current context when not set",
-			fields: fields{
-				Contexts: map[string]*Context{},
-			},
-			want: nil,
+			name:   "error getting current context when not set",
+			fields: fields{Contexts: map[string]*Context{}},
+			want:   nil,
 		},
 	}
 	for _, tt := range tests {
@@ -873,50 +790,36 @@ func TestKafkaClusterContext_SetAndGetActiveKafkaCluster_Env(t *testing.T) {
 	ctx.Config.Filename = configFile.Name()
 
 	// Creating another environment with another kafka cluster
-	otherAccountId := "other-abc"
-	otherAccount := &ccloudv1.Account{
-		Id:   otherAccountId,
-		Name: "other-account",
-	}
-	otherKafkaClusterId := "other-kafka"
+	otherEnvironmentId := "other-abc"
+	ctx.Environments[otherEnvironmentId] = &EnvironmentContext{}
+
 	otherKafkaCluster := &KafkaClusterConfig{
-		ID:        otherKafkaClusterId,
+		ID:        "other-kafka",
 		Name:      "lit",
 		Bootstrap: "http://test",
-		APIKeys: map[string]*APIKeyPair{
-			"akey": {
-				Key:    "akey",
-				Secret: "asecret",
-			},
-		},
+		APIKeys: map[string]*APIKeyPair{"akey": {
+			Key:    "akey",
+			Secret: "asecret",
+		}},
 		APIKey: "akey",
 	}
 
-	ctx.State.Auth.Accounts = append(ctx.State.Auth.Accounts, otherAccount)
-	var activeKafka string
-
-	activeKafka = ctx.KafkaClusterContext.GetActiveKafkaClusterId()
-	if activeKafka != testInputs.activeKafka {
-		t.Errorf("GetActiveKafkaClusterId() got %s, want %s.", activeKafka, testInputs.activeKafka)
-	}
+	activeKafka := ctx.KafkaClusterContext.GetActiveKafkaClusterId()
+	require.Equal(t, testInputs.activeKafka, activeKafka)
 	require.Equal(t, ctx.KafkaClusterContext.GetActiveKafkaClusterConfig().ID, activeKafka)
 
 	// switch environment add the kafka cluster, and set it as active cluster
-	ctx.State.Auth.Account = otherAccount
+	ctx.CurrentEnvironment = otherEnvironmentId
 	ctx.KafkaClusterContext.AddKafkaClusterConfig(otherKafkaCluster)
-	ctx.KafkaClusterContext.SetActiveKafkaCluster(otherKafkaClusterId)
+	ctx.KafkaClusterContext.SetActiveKafkaCluster(otherKafkaCluster.ID)
 	activeKafka = ctx.KafkaClusterContext.GetActiveKafkaClusterId()
-	if activeKafka != otherKafkaClusterId {
-		t.Errorf("After setting active kafka in new environment, GetActiveKafkaClusterId() got %s, want %s.", activeKafka, testInputs.activeKafka)
-	}
+	require.Equal(t, otherKafkaCluster.ID, activeKafka)
 	require.Equal(t, ctx.KafkaClusterContext.GetActiveKafkaClusterConfig().ID, activeKafka)
 
 	// switch environment back
-	ctx.State.Auth.Account = testInputs.account
+	ctx.CurrentEnvironment = testInputs.environment
 	activeKafka = ctx.KafkaClusterContext.GetActiveKafkaClusterId()
-	if activeKafka != testInputs.activeKafka {
-		t.Errorf("After switching to back to first environment, GetActiveKafkaClusterId() got %s, want %s.", activeKafka, testInputs.activeKafka)
-	}
+	require.Equal(t, testInputs.activeKafka, activeKafka)
 	require.Equal(t, ctx.KafkaClusterContext.GetActiveKafkaClusterConfig().ID, activeKafka)
 	_ = os.Remove(configFile.Name())
 }

--- a/internal/pkg/config/v1/config_test.go
+++ b/internal/pkg/config/v1/config_test.go
@@ -250,23 +250,23 @@ func TestConfig_Load(t *testing.T) {
 			want: testConfigsCloud.statefulConfig,
 			file: "test_json/stateful_cloud.json",
 		},
-		// {
-		// 	name: "should load disable update checks and disable updates",
-		// 	want: &Config{
-		// 		BaseConfig: &config.BaseConfig{
-		// 			Filename: "test_json/load_disable_update.json",
-		// 			Ver:      config.Version{Version: ver},
-		// 		},
-		// 		DisableUpdates:     true,
-		// 		DisableUpdateCheck: true,
-		// 		Platforms:          map[string]*Platform{},
-		// 		Credentials:        map[string]*Credential{},
-		// 		Contexts:           map[string]*Context{},
-		// 		ContextStates:      map[string]*ContextState{},
-		// 		SavedCredentials:   map[string]*LoginCredential{},
-		// 	},
-		// 	file: "test_json/load_disable_update.json",
-		// },
+		{
+			name: "should load disable update checks and disable updates",
+			want: &Config{
+				BaseConfig: &config.BaseConfig{
+					Filename: "test_json/load_disable_update.json",
+					Ver:      config.Version{Version: ver},
+				},
+				DisableUpdates:     true,
+				DisableUpdateCheck: true,
+				Platforms:          map[string]*Platform{},
+				Credentials:        map[string]*Credential{},
+				Contexts:           map[string]*Context{},
+				ContextStates:      map[string]*ContextState{},
+				SavedCredentials:   map[string]*LoginCredential{},
+			},
+			file: "test_json/load_disable_update.json",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/pkg/config/v1/config_test.go
+++ b/internal/pkg/config/v1/config_test.go
@@ -302,7 +302,6 @@ func TestConfig_Save(t *testing.T) {
 		wantErr          bool
 		kafkaOverwrite   string
 		contextOverwrite string
-		accountOverwrite *ccloudv1.Account
 	}{
 		{
 			name:     "save on-prem config with state to file",

--- a/internal/pkg/config/v1/context.go
+++ b/internal/pkg/config/v1/context.go
@@ -212,6 +212,7 @@ func (c *Context) GetCurrentEnvironment() string {
 
 func (c *Context) SetCurrentEnvironment(id string) {
 	c.CurrentEnvironment = id
+
 	if auth := c.GetAuth(); auth != nil {
 		auth.Account = nil
 		auth.Accounts = nil

--- a/internal/pkg/config/v1/context.go
+++ b/internal/pkg/config/v1/context.go
@@ -18,6 +18,8 @@ type Context struct {
 	NetrcMachineName       string                            `json:"netrc_machine_name"`
 	PlatformName           string                            `json:"platform"`
 	CredentialName         string                            `json:"credential"`
+	CurrentEnvironment     string                            `json:"current_environment,omitempty"`
+	Environments           map[string]*EnvironmentContext    `json:"environments,omitempty"`
 	KafkaClusterContext    *KafkaClusterContext              `json:"kafka_cluster_context"`
 	SchemaRegistryClusters map[string]*SchemaRegistryCluster `json:"schema_registry_clusters"`
 	LastOrgId              string                            `json:"last_org_id"`
@@ -29,7 +31,7 @@ type Context struct {
 	Config     *Config       `json:"-"`
 }
 
-func newContext(name string, platform *Platform, credential *Credential, kafkaClusters map[string]*KafkaClusterConfig, kafka string, schemaRegistryClusters map[string]*SchemaRegistryCluster, state *ContextState, config *Config, orgResourceId string) (*Context, error) {
+func newContext(name string, platform *Platform, credential *Credential, kafkaClusters map[string]*KafkaClusterConfig, kafka string, schemaRegistryClusters map[string]*SchemaRegistryCluster, state *ContextState, config *Config, orgResourceId, envId string) (*Context, error) {
 	ctx := &Context{
 		Name:                   name,
 		NetrcMachineName:       name,
@@ -37,6 +39,8 @@ func newContext(name string, platform *Platform, credential *Credential, kafkaCl
 		PlatformName:           platform.Name,
 		Credential:             credential,
 		CredentialName:         credential.Name,
+		CurrentEnvironment:     envId,
+		Environments:           map[string]*EnvironmentContext{envId: {}},
 		SchemaRegistryClusters: schemaRegistryClusters,
 		State:                  state,
 		Config:                 config,
@@ -59,6 +63,9 @@ func (c *Context) validate() error {
 	}
 	if c.PlatformName == "" || c.Platform == nil {
 		return errors.NewCorruptedConfigError(errors.UnspecifiedPlatformErrorMsg, c.Name, c.Config.Filename)
+	}
+	if c.Environments == nil {
+		c.Environments = map[string]*EnvironmentContext{}
 	}
 	if c.SchemaRegistryClusters == nil {
 		c.SchemaRegistryClusters = map[string]*SchemaRegistryCluster{}
@@ -98,7 +105,7 @@ func (c *Context) hasBasicCloudLogin() bool {
 	credType := c.Credential.CredentialType
 	switch credType {
 	case Username:
-		return c.GetAuthToken() != "" && c.GetEnvironment().GetId() != ""
+		return c.GetAuthToken() != "" && c.GetCurrentEnvironment() != ""
 	case APIKey:
 		return false
 	default:
@@ -191,32 +198,32 @@ func (c *Context) GetSuspensionStatus() *ccloudv1.SuspensionStatus {
 	return c.GetOrganization().GetSuspensionStatus()
 }
 
-func (c *Context) GetEnvironment() *ccloudv1.Account {
+func (c *Context) GetCurrentEnvironment() string {
+	if c.CurrentEnvironment != "" {
+		return c.CurrentEnvironment
+	}
+
 	if auth := c.GetAuth(); auth != nil {
-		return auth.Account
+		return auth.Account.GetId()
 	}
-	return nil
+
+	return ""
 }
 
-func (c *Context) SetEnvironment(environment *ccloudv1.Account) {
-	if c.GetAuth() == nil {
-		c.SetAuth(new(AuthConfig))
-	}
-	c.GetAuth().Account = environment
-}
-
-func (c *Context) GetEnvironments() []*ccloudv1.Account {
+func (c *Context) SetCurrentEnvironment(id string) {
+	c.CurrentEnvironment = id
 	if auth := c.GetAuth(); auth != nil {
-		return auth.Accounts
+		auth.Account = nil
+		auth.Accounts = nil
 	}
-	return nil
-}
 
-func (c *Context) SetEnvironments(environments []*ccloudv1.Account) {
-	if c.GetAuth() == nil {
-		c.SetAuth(new(AuthConfig))
+	if id != "" {
+		if _, ok := c.Environments[id]; !ok {
+			c.Environments[id] = &EnvironmentContext{}
+		}
+	} else {
+		delete(c.Environments, id)
 	}
-	c.GetAuth().Accounts = environments
 }
 
 func (c *Context) GetAuthToken() string {
@@ -227,8 +234,8 @@ func (c *Context) GetAuthToken() string {
 }
 
 func (c *Context) GetAuthRefreshToken() string {
-	if c.State != nil {
-		return c.State.AuthRefreshToken
+	if state := c.GetState(); state != nil {
+		return state.AuthRefreshToken
 	}
 	return ""
 }

--- a/internal/pkg/config/v1/context.go
+++ b/internal/pkg/config/v1/context.go
@@ -199,7 +199,7 @@ func (c *Context) GetSuspensionStatus() *ccloudv1.SuspensionStatus {
 }
 
 func (c *Context) GetCurrentEnvironment() string {
-	if c.CurrentEnvironment != "" {
+	if c != nil && c.CurrentEnvironment != "" {
 		return c.CurrentEnvironment
 	}
 
@@ -213,18 +213,24 @@ func (c *Context) GetCurrentEnvironment() string {
 func (c *Context) SetCurrentEnvironment(id string) {
 	c.CurrentEnvironment = id
 
+	if id != "" {
+		c.AddEnvironment(id)
+	}
+
 	if auth := c.GetAuth(); auth != nil {
 		auth.Account = nil
 		auth.Accounts = nil
 	}
+}
 
-	if id != "" {
-		if _, ok := c.Environments[id]; !ok {
-			c.Environments[id] = &EnvironmentContext{}
-		}
-	} else {
-		delete(c.Environments, id)
+func (c *Context) AddEnvironment(id string) {
+	if _, ok := c.Environments[id]; !ok {
+		c.Environments[id] = &EnvironmentContext{}
 	}
+}
+
+func (c *Context) DeleteEnvironment(id string) {
+	delete(c.Environments, id)
 }
 
 func (c *Context) GetAuthToken() string {

--- a/internal/pkg/config/v1/environment_context.go
+++ b/internal/pkg/config/v1/environment_context.go
@@ -1,0 +1,3 @@
+package v1
+
+type EnvironmentContext struct{}

--- a/internal/pkg/config/v1/kafka_cluster_context.go
+++ b/internal/pkg/config/v1/kafka_cluster_context.go
@@ -33,26 +33,23 @@ func NewKafkaClusterContext(ctx *Context, activeKafka string, kafkaClusters map[
 }
 
 func newKafkaClusterEnvironmentContext(activeKafka string, kafkaClusters map[string]*KafkaClusterConfig, ctx *Context) *KafkaClusterContext {
-	kafkaEnvContext := &KafkaEnvContext{
-		ActiveKafkaCluster:  activeKafka,
-		KafkaClusterConfigs: kafkaClusters,
+	return &KafkaClusterContext{
+		EnvContext: true,
+		KafkaEnvContexts: map[string]*KafkaEnvContext{ctx.GetCurrentEnvironment(): {
+			ActiveKafkaCluster:  activeKafka,
+			KafkaClusterConfigs: kafkaClusters,
+		}},
+		Context: ctx,
 	}
-	kafkaClusterContext := &KafkaClusterContext{
-		EnvContext:       true,
-		KafkaEnvContexts: map[string]*KafkaEnvContext{ctx.GetEnvironment().GetId(): kafkaEnvContext},
-		Context:          ctx,
-	}
-	return kafkaClusterContext
 }
 
 func newKafkaClusterNonEnvironmentContext(activeKafka string, kafkaClusters map[string]*KafkaClusterConfig, ctx *Context) *KafkaClusterContext {
-	kafkaClusterContext := &KafkaClusterContext{
+	return &KafkaClusterContext{
 		EnvContext:          false,
 		ActiveKafkaCluster:  activeKafka,
 		KafkaClusterConfigs: kafkaClusters,
 		Context:             ctx,
 	}
-	return kafkaClusterContext
 }
 
 func (k *KafkaClusterContext) GetActiveKafkaClusterId() string {
@@ -129,7 +126,7 @@ func (k *KafkaClusterContext) DeleteAPIKey(apiKey string) {
 }
 
 func (k *KafkaClusterContext) GetCurrentKafkaEnvContext() *KafkaEnvContext {
-	curEnv := k.Context.GetEnvironment().GetId()
+	curEnv := k.Context.GetCurrentEnvironment()
 	if k.KafkaEnvContexts[curEnv] == nil {
 		k.KafkaEnvContexts[curEnv] = &KafkaEnvContext{
 			ActiveKafkaCluster:  "",

--- a/internal/pkg/config/v1/mock.go
+++ b/internal/pkg/config/v1/mock.go
@@ -100,13 +100,11 @@ func APICredentialConfigMock() *Config {
 	platform := createPlatform(bootstrapServer, bootstrapServer)
 
 	kafkaCluster := createKafkaCluster(anonymousKafkaId, anonymousKafkaName, kafkaAPIKeyPair)
-	kafkaClusters := map[string]*KafkaClusterConfig{
-		kafkaCluster.ID: kafkaCluster,
-	}
+	kafkaClusters := map[string]*KafkaClusterConfig{kafkaCluster.ID: kafkaCluster}
 
 	cfg := New()
 
-	ctx, err := newContext(mockContextName, platform, credential, kafkaClusters, kafkaCluster.ID, nil, contextState, cfg, "")
+	ctx, err := newContext(mockContextName, platform, credential, kafkaClusters, kafkaCluster.ID, nil, contextState, cfg, "", "")
 	if err != nil {
 		panic(err)
 	}
@@ -133,7 +131,7 @@ type mockConfigParams struct {
 }
 
 func AuthenticatedConfigMock(params mockConfigParams) *Config {
-	authConfig := createAuthConfig(params.userId, params.username, params.userResourceId, params.envId, params.orgId, params.orgResourceId)
+	authConfig := createAuthConfig(params.userId, params.username, params.userResourceId, params.orgId, params.orgResourceId)
 	credential := createUsernameCredential(params.credentialName, authConfig)
 	contextState := createContextState(authConfig, mockAuthToken)
 
@@ -141,20 +139,16 @@ func AuthenticatedConfigMock(params mockConfigParams) *Config {
 
 	kafkaAPIKeyPair := createAPIKeyPair(kafkaAPIKey, kafkaAPISecret)
 	kafkaCluster := createKafkaCluster(kafkaClusterId, kafkaClusterName, kafkaAPIKeyPair)
-	kafkaClusters := map[string]*KafkaClusterConfig{
-		kafkaCluster.ID: kafkaCluster,
-	}
+	kafkaClusters := map[string]*KafkaClusterConfig{kafkaCluster.ID: kafkaCluster}
 
 	srAPIKeyPair := createAPIKeyPair(srAPIKey, srAPISecret)
 	srCluster := createSRCluster(srAPIKeyPair)
-	srClusters := map[string]*SchemaRegistryCluster{
-		MockEnvironmentId: srCluster,
-	}
+	srClusters := map[string]*SchemaRegistryCluster{MockEnvironmentId: srCluster}
 
 	cfg := New()
 	cfg.IsTest = true
 
-	ctx, err := newContext(params.contextName, platform, credential, kafkaClusters, kafkaCluster.ID, srClusters, contextState, cfg, params.orgResourceId)
+	ctx, err := newContext(params.contextName, platform, credential, kafkaClusters, kafkaCluster.ID, srClusters, contextState, cfg, params.orgResourceId, params.envId)
 	if err != nil {
 		panic(err)
 	}
@@ -185,19 +179,17 @@ func createPlatform(name, server string) *Platform {
 	}
 }
 
-func createAuthConfig(userId int32, email, userResourceId, envId string, organizationId int32, orgResourceId string) *AuthConfig {
+func createAuthConfig(userId int32, email, userResourceId string, organizationId int32, orgResourceId string) *AuthConfig {
 	return &AuthConfig{
 		User: &ccloudv1.User{
 			Id:         userId,
 			Email:      email,
 			ResourceId: userResourceId,
 		},
-		Account: &ccloudv1.Account{Id: envId},
 		Organization: &ccloudv1.Organization{
 			Id:         organizationId,
 			ResourceId: orgResourceId,
 		},
-		Accounts: []*ccloudv1.Account{{Id: envId}},
 	}
 }
 
@@ -247,10 +239,7 @@ func setUpConfig(conf *Config, ctx *Context, platform *Platform, credential *Cre
 	}
 }
 
-func AddEnvironmentToConfigMock(cfg *Config, id, name string) {
+func AddEnvironmentToConfigMock(cfg *Config, id string) {
 	ctx := cfg.Context()
-	ctx.State.Auth.Accounts = append(ctx.GetEnvironments(), &ccloudv1.Account{
-		Id:   id,
-		Name: name,
-	})
+	ctx.Environments[id] = &EnvironmentContext{}
 }

--- a/internal/pkg/config/v1/test_json/account_overwrite.json
+++ b/internal/pkg/config/v1/test_json/account_overwrite.json
@@ -36,6 +36,11 @@
       "netrc_machine_name": "",
       "platform": "http://127.0.0.1:1024",
       "credential": "username-test-user",
+      "current_environment": "acc-123",
+      "environments": {
+        "acc-123": {},
+        "env-flag": {}
+      },
       "kafka_cluster_context": {
         "environment_context": true,
         "kafka_environment_contexts": {
@@ -76,20 +81,6 @@
           "id": 123,
           "email": "test-user@email"
         },
-        "account": {
-          "id": "acc-123",
-          "name": "test-env"
-        },
-        "accounts": [
-          {
-            "id": "acc-123",
-            "name": "test-env"
-          },
-          {
-            "id": "env-flag",
-            "name": "test-env2"
-          }
-        ],
         "organization": {
           "id": 321,
           "name": "test-org"

--- a/internal/pkg/config/v1/test_json/stateful_cloud.json
+++ b/internal/pkg/config/v1/test_json/stateful_cloud.json
@@ -36,6 +36,10 @@
       "netrc_machine_name": "",
       "platform": "http://127.0.0.1:1024",
       "credential": "username-test-user",
+      "current_environment": "acc-123",
+      "environments": {
+        "acc-123": {}
+      },
       "kafka_cluster_context": {
         "environment_context": true,
         "kafka_environment_contexts": {
@@ -76,16 +80,6 @@
           "id": 123,
           "email": "test-user@email"
         },
-        "account": {
-          "id": "acc-123",
-          "name": "test-env"
-        },
-        "accounts": [
-          {
-            "id": "acc-123",
-            "name": "test-env"
-          }
-        ],
         "organization": {
           "id": 321,
           "name": "test-org"

--- a/internal/pkg/config/v1/test_json/stateful_cloud_save.json
+++ b/internal/pkg/config/v1/test_json/stateful_cloud_save.json
@@ -36,6 +36,10 @@
       "netrc_machine_name": "",
       "platform": "http://127.0.0.1:1024",
       "credential": "username-test-user",
+      "current_environment": "acc-123",
+      "environments": {
+        "acc-123": {}
+      },
       "kafka_cluster_context": {
         "environment_context": true,
         "kafka_environment_contexts": {
@@ -76,16 +80,6 @@
           "id": 123,
           "email": "test-user@email"
         },
-        "account": {
-          "id": "acc-123",
-          "name": "test-env"
-        },
-        "accounts": [
-          {
-            "id": "acc-123",
-            "name": "test-env"
-          }
-        ],
         "organization": {
           "id": 321,
           "name": "test-org"

--- a/internal/pkg/config/v1/test_json/stateful_onprem.json
+++ b/internal/pkg/config/v1/test_json/stateful_onprem.json
@@ -36,6 +36,10 @@
       "netrc_machine_name": "",
       "platform": "http://test",
       "credential": "username-test-user",
+      "current_environment": "acc-123",
+      "environments": {
+        "acc-123": {}
+      },
       "kafka_cluster_context": {
         "environment_context": false,
         "active_kafka": "anonymous-id",
@@ -72,16 +76,6 @@
           "id": 123,
           "email": "test-user@email"
         },
-        "account": {
-          "id": "acc-123",
-          "name": "test-env"
-        },
-        "accounts": [
-          {
-            "id": "acc-123",
-            "name": "test-env"
-          }
-        ],
         "organization": {
           "id": 321,
           "name": "test-org"

--- a/internal/pkg/config/v1/test_json/stateful_onprem_save.json
+++ b/internal/pkg/config/v1/test_json/stateful_onprem_save.json
@@ -36,6 +36,10 @@
       "netrc_machine_name": "",
       "platform": "http://test",
       "credential": "username-test-user",
+      "current_environment": "acc-123",
+      "environments": {
+        "acc-123": {}
+      },
       "kafka_cluster_context": {
         "environment_context": false,
         "active_kafka": "anonymous-id",
@@ -72,16 +76,6 @@
           "id": 123,
           "email": "test-user@email"
         },
-        "account": {
-          "id": "acc-123",
-          "name": "test-env"
-        },
-        "accounts": [
-          {
-            "id": "acc-123",
-            "name": "test-env"
-          }
-        ],
         "organization": {
           "id": 321,
           "name": "test-org"

--- a/internal/pkg/dynamic-config/dynamic_config.go
+++ b/internal/pkg/dynamic-config/dynamic_config.go
@@ -37,7 +37,7 @@ func (d *DynamicConfig) ParseFlagsIntoConfig(cmd *cobra.Command) error {
 		if _, err := d.FindContext(context); err != nil {
 			return err
 		}
-		d.Config.SetOverwrittenCurrContext(d.Config.CurrentContext)
+		d.Config.SetOverwrittenCurrentContext(d.Config.CurrentContext)
 		d.Config.CurrentContext = context
 	}
 

--- a/internal/pkg/dynamic-config/dynamic_context.go
+++ b/internal/pkg/dynamic-config/dynamic_context.go
@@ -38,25 +38,9 @@ func (d *DynamicContext) ParseFlagsIntoContext(cmd *cobra.Command, client *cclou
 		if d.Credential.CredentialType == v1.APIKey {
 			return errors.New(errors.EnvironmentFlagWithApiLoginErrorMsg)
 		}
-
-		// If environment ID is not found in config, make api call and check against those accounts
-		if !d.verifyEnvironmentId(environment, d.GetEnvironments()) {
-			if client == nil {
-				return fmt.Errorf(errors.EnvironmentNotFoundErrorMsg, environment, d.Name)
-			}
-
-			accounts, err := d.getAllEnvironments(client)
-			if err != nil {
-				return err
-			}
-
-			if d.verifyEnvironmentId(environment, accounts) {
-				d.SetEnvironments(accounts)
-				_ = d.Save()
-			} else {
-				return fmt.Errorf(errors.EnvironmentNotFoundErrorMsg, environment, d.Name)
-			}
-		}
+		ctx := d.Config.Context()
+		d.Config.SetOverwrittenCurrentEnvironment(ctx.CurrentEnvironment)
+		ctx.SetCurrentEnvironment(environment)
 	}
 
 	if cluster, _ := cmd.Flags().GetString("cluster"); cluster != "" {
@@ -64,38 +48,11 @@ func (d *DynamicContext) ParseFlagsIntoContext(cmd *cobra.Command, client *cclou
 			return errors.New(errors.ClusterFlagWithApiLoginErrorMsg)
 		}
 		ctx := d.Config.Context()
-		d.Config.SetOverwrittenActiveKafka(ctx.KafkaClusterContext.GetActiveKafkaClusterId())
+		d.Config.SetOverwrittenCurrentKafkaCluster(ctx.KafkaClusterContext.GetActiveKafkaClusterId())
 		ctx.KafkaClusterContext.SetActiveKafkaCluster(cluster)
 	}
 
 	return nil
-}
-
-// getAllEnvironments retrives all environments listed by ccloud v1 client.
-// It also includes the audit-log environment when that's enabled
-func (d *DynamicContext) getAllEnvironments(client *ccloudv1.Client) ([]*ccloudv1.Account, error) {
-	environments, err := client.Account.List(context.Background(), &ccloudv1.Account{})
-	if err != nil {
-		return environments, err
-	}
-
-	if d.State.Auth == nil || d.State.Auth.Organization == nil || d.State.Auth.Organization.GetAuditLog() == nil || d.State.Auth.Organization.AuditLog.ServiceAccountId == 0 {
-		return environments, nil
-	}
-	auditLogAccountId := d.State.Auth.Organization.GetAuditLog().GetAccountId()
-	auditLogEnvironment, err := client.Account.Get(context.Background(), &ccloudv1.Account{Id: auditLogAccountId})
-	return append(environments, auditLogEnvironment), err
-}
-
-func (d *DynamicContext) verifyEnvironmentId(envId string, environments []*ccloudv1.Account) bool {
-	for _, env := range environments {
-		if env.Id == envId {
-			d.Config.SetOverwrittenAccount(d.GetEnvironment())
-			d.State.Auth.Account = env
-			return true
-		}
-	}
-	return false
 }
 
 func (d *DynamicContext) GetKafkaClusterForCommand() (*v1.KafkaClusterConfig, error) {
@@ -229,15 +186,11 @@ func (d *DynamicContext) HasLogin() bool {
 }
 
 func (d *DynamicContext) AuthenticatedEnvId() (string, error) {
-	if _, err := d.AuthenticatedState(); err != nil {
-		return "", err
+	if id := d.GetCurrentEnvironment(); id != "" {
+		return id, nil
 	}
 
-	if env := d.GetEnvironment(); env != nil {
-		return env.Id, nil
-	} else {
-		return "", errors.NewErrorWithSuggestions(errors.NoEnvironmentFoundErrorMsg, errors.NoEnvironmentFoundSuggestions)
-	}
+	return "", errors.NewErrorWithSuggestions(errors.NoEnvironmentFoundErrorMsg, errors.NoEnvironmentFoundSuggestions)
 }
 
 // AuthenticatedState returns the context's state if authenticated, and an error otherwise.

--- a/internal/pkg/dynamic-config/dynamic_context_test.go
+++ b/internal/pkg/dynamic-config/dynamic_context_test.go
@@ -51,17 +51,11 @@ func TestFindKafkaCluster_Expired(t *testing.T) {
 
 	d := &DynamicContext{
 		Context: &v1.Context{
-			KafkaClusterContext: &v1.KafkaClusterContext{
-				KafkaClusterConfigs: map[string]*v1.KafkaClusterConfig{
-					"lkc-123456": {LastUpdate: update},
-				},
-			},
-			Credential: &v1.Credential{CredentialType: v1.Username},
-			State: &v1.ContextState{
-				Auth:      &v1.AuthConfig{Account: &ccloudv1.Account{Id: "env-123456"}},
-				AuthToken: "token",
-			},
-			Config: &v1.Config{BaseConfig: &config.BaseConfig{Ver: config.Version{Version: &version.Version{}}}},
+			CurrentEnvironment:  "env-123456",
+			KafkaClusterContext: &v1.KafkaClusterContext{KafkaClusterConfigs: map[string]*v1.KafkaClusterConfig{"lkc-123456": {LastUpdate: update}}},
+			Credential:          &v1.Credential{CredentialType: v1.Username},
+			State:               &v1.ContextState{AuthToken: "token"},
+			Config:              &v1.Config{BaseConfig: &config.BaseConfig{Ver: config.Version{Version: &version.Version{}}}},
 		},
 		V2Client: &ccloudv2.Client{
 			CmkClient: &cmkv2.APIClient{
@@ -135,9 +129,7 @@ func TestDynamicContext_ParseFlagsIntoContext(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		cmd := &cobra.Command{
-			Run: func(cmd *cobra.Command, args []string) {},
-		}
+		cmd := &cobra.Command{Run: func(cmd *cobra.Command, args []string) {}}
 		cmd.Flags().String("environment", "", "Environment ID.")
 		cmd.Flags().String("cluster", "", "Kafka cluster ID.")
 		err := cmd.ParseFlags([]string{"--cluster", tt.cluster, "--environment", tt.environment})
@@ -163,7 +155,7 @@ func TestDynamicContext_ParseFlagsIntoContext(t *testing.T) {
 
 func buildCcloudMockClient() *ccloudv1.Client {
 	client := pmock.NewClientMock()
-	client.Account = &ccloudv1mock.AccountInterface{ListFunc: func(ctx context.Context, account *ccloudv1.Account) ([]*ccloudv1.Account, error) {
+	client.Account = &ccloudv1mock.AccountInterface{ListFunc: func(_ context.Context, _ *ccloudv1.Account) ([]*ccloudv1.Account, error) {
 		return []*ccloudv1.Account{{Id: apiEnvironment}}, nil
 	}}
 	return client

--- a/internal/pkg/dynamic-config/dynamic_context_test.go
+++ b/internal/pkg/dynamic-config/dynamic_context_test.go
@@ -25,7 +25,6 @@ var (
 	flagEnvironment  = "env-test"
 	flagCluster      = "lkc-0001"
 	flagClusterInEnv = "lkc-0002"
-	badFlagEnv       = "bad-env"
 	apiEnvironment   = "env-from-api-call"
 )
 

--- a/internal/pkg/dynamic-config/dynamic_context_test.go
+++ b/internal/pkg/dynamic-config/dynamic_context_test.go
@@ -185,20 +185,16 @@ func getClusterFlagContext() *DynamicContext {
 	return clusterFlagContext
 }
 
-// TODO
 func getEnvFlagContext() *DynamicContext {
 	config := v1.AuthenticatedCloudConfigMock()
 	envFlagContext := NewDynamicContext(config.Context(), pmock.NewClientMock(), pmock.NewV2ClientMock())
-	envFlagContext.State.Auth.Accounts = append(envFlagContext.State.Auth.Accounts, &ccloudv1.Account{Name: flagEnvironment, Id: flagEnvironment})
+	envFlagContext.Environments[flagEnvironment] = &v1.EnvironmentContext{}
 	return envFlagContext
 }
 
-// TODO
 func getEnvAndClusterFlagContext() *DynamicContext {
-	config := v1.AuthenticatedCloudConfigMock()
-	envAndClusterFlagContext := NewDynamicContext(config.Context(), pmock.NewClientMock(), pmock.NewV2ClientMock())
+	envAndClusterFlagContext := getEnvFlagContext()
 
-	envAndClusterFlagContext.State.Auth.Accounts = append(envAndClusterFlagContext.State.Auth.Accounts, &ccloudv1.Account{Name: flagEnvironment, Id: flagEnvironment})
 	envAndClusterFlagContext.KafkaClusterContext.KafkaEnvContexts[flagEnvironment] = &v1.KafkaEnvContext{
 		ActiveKafkaCluster:  "",
 		KafkaClusterConfigs: map[string]*v1.KafkaClusterConfig{},

--- a/internal/pkg/errors/error_message.go
+++ b/internal/pkg/errors/error_message.go
@@ -473,8 +473,8 @@ const (
 	FailedToReadInputErrorMsg = "failed to read input"
 
 	// Flag parsing errors
-	EnvironmentFlagWithApiLoginErrorMsg = `"environment" flag should not be passed for API key context`
-	ClusterFlagWithApiLoginErrorMsg     = `"cluster" flag should not be passed for API key context, cluster is inferred`
+	EnvironmentFlagWithApiLoginErrorMsg = "`--environment` flag should not be passed for API key context"
+	ClusterFlagWithApiLoginErrorMsg     = "`--cluster` flag should not be passed for API key context, cluster is inferred"
 
 	// Partition command errors
 	SpecifyPartitionIdWithTopicErrorMsg = "must specify topic along with partition ID"

--- a/internal/pkg/errors/strings.go
+++ b/internal/pkg/errors/strings.go
@@ -8,7 +8,7 @@ const (
 	// auth commands
 	LoggedInAsMsg                 = "Logged in as \"%s\".\n"
 	LoggedInAsMsgWithOrg          = "Logged in as \"%s\" for organization \"%s\" (\"%s\").\n"
-	LoggedInUsingEnvMsg           = "Using environment \"%s\" (\"%s\").\n"
+	LoggedInUsingEnvMsg           = "Using environment \"%s\".\n"
 	LoggedOutMsg                  = "You are now logged out."
 	WroteCredentialsToKeychainMsg = "Wrote login credentials to keychain\n"
 	RemoveNetrcCredentialsMsg     = "Removed credentials for user \"%s\" from netrc file \"%s\"\n"

--- a/internal/pkg/errors/strings.go
+++ b/internal/pkg/errors/strings.go
@@ -31,9 +31,6 @@ const (
 	PausedConnectorMsg  = "Paused connector \"%s\".\n"
 	ResumedConnectorMsg = "Resumed connector \"%s\".\n"
 
-	// environment commands
-	UsingEnvMsg = "Now using \"%s\" as the default (active) environment.\n"
-
 	// kafka cluster commands
 	UseKafkaClusterMsg               = "Set Kafka cluster \"%s\" as the active cluster for environment \"%s\".\n"
 	CopyByokAwsPermissionsHeaderMsg  = `Copy and append these permissions into the key policy "Statements" field of the ARN in your AWS key management system to authorize access for your Confluent Cloud cluster.`

--- a/internal/pkg/featureflags/feature_flags.go
+++ b/internal/pkg/featureflags/feature_flags.go
@@ -257,7 +257,7 @@ func (ld *launchDarklyManager) contextToLDUser(ctx *dynamicconfig.DynamicContext
 		setCustomAttribute(custom, "org.resource_id", ldvalue.String(id))
 	}
 	// environment (account) info
-	if id := ctx.GetEnvironment().GetId(); id != "" {
+	if id := ctx.GetCurrentEnvironment(); id != "" {
 		setCustomAttribute(custom, "environment.id", ldvalue.String(id))
 	}
 	customValueMap := custom.Build()

--- a/test/cli_test.go
+++ b/test/cli_test.go
@@ -112,7 +112,6 @@ func (s *CLITestSuite) runIntegrationTest(tt CLITest) {
 		isAuditLogDisabled := os.Getenv("DISABLE_AUDIT_LOG") == "true"
 		if isAuditLogDisabled != tt.disableAuditLog {
 			s.TestBackend.Close()
-			s.TestBackend = nil
 			os.Setenv("DISABLE_AUDIT_LOG", strconv.FormatBool(tt.disableAuditLog))
 			s.TestBackend = testserver.StartTestBackend(t, tt.disableAuditLog)
 		}
@@ -226,7 +225,7 @@ func runCommand(t *testing.T, binaryName string, env []string, argString string,
 
 	out, err := cmd.CombinedOutput()
 	if exitCode == 0 {
-		require.NoError(t, err)
+		require.NoError(t, err, string(out))
 	}
 	require.Equal(t, exitCode, cmd.ProcessState.ExitCode())
 

--- a/test/environment_test.go
+++ b/test/environment_test.go
@@ -2,15 +2,13 @@ package test
 
 func (s *CLITestSuite) TestEnvironment() {
 	tests := []CLITest{
-		// Only log in at the beginning so active env is not reset
-		// tt.workflow=true so login is not reset
 		{args: "environment list", fixture: "environment/1.golden", login: "cloud"},
 		{args: "environment use not-595", fixture: "environment/2.golden"},
 		{args: "environment update not-595 --name new-other-name", fixture: "environment/3.golden"},
 		{args: "environment list", fixture: "environment/4.golden"},
 		{args: "environment list -o json", fixture: "environment/5.golden"},
 		{args: "environment list -o yaml", fixture: "environment/6.golden"},
-		{args: "environment use non-existent-id", fixture: "environment/7.golden", exitCode: 1},
+		{args: "environment use env-dne", fixture: "environment/7.golden", exitCode: 1},
 		{args: "environment create saucayyy", fixture: "environment/8.golden"},
 		{args: "environment create saucayyy -o json", fixture: "environment/9.golden"},
 		{args: "environment create saucayyy -o yaml", fixture: "environment/10.golden"},

--- a/test/fixtures/output/environment/12.golden
+++ b/test/fixtures/output/environment/12.golden
@@ -1,4 +1,4 @@
-Error: environment not found or access forbidden: 403 Forbidden
+Error: 404 Not Found
 
 Suggestions:
     List available environments with `confluent environment list`.

--- a/test/fixtures/output/environment/3.golden
+++ b/test/fixtures/output/environment/3.golden
@@ -1,1 +1,5 @@
-Updated the name of environment "not-595" to "new-other-name".
++---------+----------------+
+| Current | true           |
+| ID      | not-595        |
+| Name    | new-other-name |
++---------+----------------+

--- a/test/fixtures/output/environment/4.golden
+++ b/test/fixtures/output/environment/4.golden
@@ -1,6 +1,6 @@
-  Current |      ID      |      Name       
-----------+--------------+-----------------
-          | a-595        | default         
-          | env-123      | env123          
-          | env-srUpdate | srUpdate        
-  *       | not-595      | new-other-name  
+  Current |      ID      |   Name    
+----------+--------------+-----------
+          | a-595        | default   
+          | env-123      | env123    
+          | env-srUpdate | srUpdate  
+  *       | not-595      | other     

--- a/test/fixtures/output/environment/5.golden
+++ b/test/fixtures/output/environment/5.golden
@@ -17,6 +17,6 @@
   {
     "is_current": true,
     "id": "not-595",
-    "name": "new-other-name"
+    "name": "other"
   }
 ]

--- a/test/fixtures/output/environment/6.golden
+++ b/test/fixtures/output/environment/6.golden
@@ -9,4 +9,4 @@
   name: srUpdate
 - is_current: true
   id: not-595
-  name: new-other-name
+  name: other

--- a/test/fixtures/output/environment/7.golden
+++ b/test/fixtures/output/environment/7.golden
@@ -1,4 +1,4 @@
-Error: environment "non-existent-id" not found
+Error: 404 Not Found
 
 Suggestions:
     List available environments with `confluent environment list`.

--- a/test/login_test.go
+++ b/test/login_test.go
@@ -26,7 +26,7 @@ var (
 	passwordPlaceholder     = "<PASSWORD_PLACEHOLDER>"
 	loggedInAsOutput        = fmt.Sprintf(errors.LoggedInAsMsg, "good@user.com")
 	loggedInAsWithOrgOutput = fmt.Sprintf(errors.LoggedInAsMsgWithOrg, "good@user.com", "abc-123", "Confluent")
-	loggedInEnvOutput       = fmt.Sprintf(errors.LoggedInUsingEnvMsg, "a-595", "default")
+	loggedInEnvOutput       = fmt.Sprintf(errors.LoggedInUsingEnvMsg, "a-595")
 )
 
 func (s *CLITestSuite) TestLogin_Help() {
@@ -66,7 +66,7 @@ func (s *CLITestSuite) TestLogin_VariousOrgSuspensionStatus() {
 		env := []string{fmt.Sprintf("%s=end-of-free-trial-suspended@user.com", pauth.ConfluentCloudEmail), fmt.Sprintf("%s=pass1", pauth.ConfluentCloudPassword)}
 		output := runCommand(t, testBin, env, args, 0, "")
 		require.Contains(t, output, fmt.Sprintf(errors.LoggedInAsMsgWithOrg, "end-of-free-trial-suspended@user.com", "abc-123", "Confluent"))
-		require.Contains(t, output, fmt.Sprintf(errors.LoggedInUsingEnvMsg, "a-595", "default"))
+		require.Contains(t, output, fmt.Sprintf(errors.LoggedInUsingEnvMsg, "a-595"))
 		require.Contains(t, output, fmt.Sprintf(errors.EndOfFreeTrialErrorMsg, "test-org"))
 	})
 }
@@ -85,7 +85,7 @@ func (s *CLITestSuite) TestCcloudErrors() {
 		env := []string{fmt.Sprintf("%s=expired@user.com", pauth.ConfluentCloudEmail), fmt.Sprintf("%s=pass1", pauth.ConfluentCloudPassword)}
 		output := runCommand(t, testBin, env, args, 0, "")
 		require.Contains(t, output, fmt.Sprintf(errors.LoggedInAsMsgWithOrg, "expired@user.com", "abc-123", "Confluent"))
-		require.Contains(t, output, fmt.Sprintf(errors.LoggedInUsingEnvMsg, "a-595", "default"))
+		require.Contains(t, output, fmt.Sprintf(errors.LoggedInUsingEnvMsg, "a-595"))
 		output = runCommand(t, testBin, []string{}, "kafka cluster list", 1, "")
 		require.Contains(t, output, errors.TokenExpiredMsg)
 		require.Contains(t, output, errors.NotLoggedInErrorMsg)
@@ -95,7 +95,7 @@ func (s *CLITestSuite) TestCcloudErrors() {
 		env := []string{fmt.Sprintf("%s=malformed@user.com", pauth.ConfluentCloudEmail), fmt.Sprintf("%s=pass1", pauth.ConfluentCloudPassword)}
 		output := runCommand(t, testBin, env, args, 0, "")
 		require.Contains(t, output, fmt.Sprintf(errors.LoggedInAsMsgWithOrg, "malformed@user.com", "abc-123", "Confluent"))
-		require.Contains(t, output, fmt.Sprintf(errors.LoggedInUsingEnvMsg, "a-595", "default"))
+		require.Contains(t, output, fmt.Sprintf(errors.LoggedInUsingEnvMsg, "a-595"))
 
 		output = runCommand(t, testBin, []string{}, "kafka cluster list", 1, "")
 		require.Contains(t, output, errors.CorruptedTokenErrorMsg)
@@ -108,7 +108,7 @@ func (s *CLITestSuite) TestCcloudErrors() {
 		require.Contains(t, output, errors.LoggedOutMsg)
 		output = runCommand(t, testBin, env, args, 0, "")
 		require.Contains(t, output, fmt.Sprintf(errors.LoggedInAsMsgWithOrg, "invalid@user.com", "abc-123", "Confluent"))
-		require.Contains(t, output, fmt.Sprintf(errors.LoggedInUsingEnvMsg, "a-595", "default"))
+		require.Contains(t, output, fmt.Sprintf(errors.LoggedInUsingEnvMsg, "a-595"))
 
 		output = runCommand(t, testBin, []string{}, "kafka cluster list", 1, "")
 		require.Contains(t, output, errors.CorruptedTokenErrorMsg)

--- a/test/test-server/ccloud_handlers.go
+++ b/test/test-server/ccloud_handlers.go
@@ -83,7 +83,11 @@ func handleMe(t *testing.T, isAuditLogEnabled bool) http.HandlerFunc {
 			orgResourceId = "abc-123"
 		}
 
-		org := &ccloudv1.Organization{Id: 42, ResourceId: orgResourceId, Name: "Confluent"}
+		org := &ccloudv1.Organization{
+			Id:         42,
+			ResourceId: orgResourceId,
+			Name:       "Confluent",
+		}
 		if !isAuditLogEnabled {
 			org.AuditLog = &ccloudv1.AuditLog{
 				ClusterId:        "lkc-ab123",
@@ -93,8 +97,7 @@ func handleMe(t *testing.T, isAuditLogEnabled bool) http.HandlerFunc {
 			}
 		}
 
-		isOrgOnMarketplace := os.Getenv("IS_ORG_ON_MARKETPLACE") == "true"
-		if isOrgOnMarketplace {
+		if os.Getenv("IS_ORG_ON_MARKETPLACE") == "true" {
 			org.Marketplace = &ccloudv1.Marketplace{Partner: ccloudv1.MarketplacePartner_AWS}
 		}
 

--- a/test/test-server/ccloud_handlers.go
+++ b/test/test-server/ccloud_handlers.go
@@ -169,57 +169,6 @@ func handleLoginRealm(t *testing.T) http.HandlerFunc {
 	}
 }
 
-// Handler for: "/api/accounts/{id}"
-func handleEnvironment(t *testing.T) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		vars := mux.Vars(r)
-		envId := vars["id"]
-		if env := isValidEnvironmentId(environments, envId); env != nil {
-			switch r.Method {
-			case http.MethodGet: // called by `environment use`
-				b, err := ccstructs.MarshalJSONToBytes(&ccloudv1.GetAccountReply{Account: env})
-				require.NoError(t, err)
-				_, err = io.WriteString(w, string(b))
-				require.NoError(t, err)
-			case http.MethodPut: // called by `environment create`
-				req := &ccloudv1.CreateAccountRequest{}
-				err := ccstructs.UnmarshalJSON(r.Body, req)
-				require.NoError(t, err)
-				env.Name = req.Account.Name
-				b, err := ccstructs.MarshalJSONToBytes(&ccloudv1.CreateAccountReply{Account: env})
-				require.NoError(t, err)
-				_, err = io.WriteString(w, string(b))
-				require.NoError(t, err)
-			}
-		} else {
-			// env not found
-			w.WriteHeader(http.StatusNotFound)
-		}
-	}
-}
-
-// Handler for: "/api/accounts" Post
-func handleEnvironments(t *testing.T) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		if r.Method == http.MethodPost {
-			req := &ccloudv1.CreateAccountRequest{}
-			err := ccstructs.UnmarshalJSON(r.Body, req)
-			require.NoError(t, err)
-
-			createAccountReply := &ccloudv1.CreateAccountReply{
-				Account: &ccloudv1.Account{
-					Id:   "a-5555",
-					Name: req.Account.Name,
-				},
-			}
-			b, err := ccstructs.MarshalJSONToBytes(createAccountReply)
-			require.NoError(t, err)
-			_, err = io.WriteString(w, string(b))
-			require.NoError(t, err)
-		}
-	}
-}
-
 // Handler for: "/api/organizations/{id}/payment_info"
 func handlePaymentInfo(t *testing.T) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {

--- a/test/test-server/ccloud_router.go
+++ b/test/test-server/ccloud_router.go
@@ -10,8 +10,6 @@ import (
 )
 
 var ccloudHandlers = []route{
-	{"/api/accounts", handleEnvironments},
-	{"/api/accounts/{id}", handleEnvironment},
 	{"/api/env_metadata", handleEnvMetadata},
 	{"/api/external_identities", handleExternalIdentities},
 	{"/api/growth/v1/free-trial-info", handleFreeTrialInfo},

--- a/test/test-server/org_handlers.go
+++ b/test/test-server/org_handlers.go
@@ -41,10 +41,15 @@ func handleOrgEnvironment(t *testing.T) http.HandlerFunc {
 				_, err := io.WriteString(w, "")
 				require.NoError(t, err)
 			case http.MethodPatch: // `environment update {id} --name`
-				req := orgv2.OrgV2Environment{}
-				err := json.NewDecoder(r.Body).Decode(&req)
+				req := &orgv2.OrgV2Environment{}
+				err := json.NewDecoder(r.Body).Decode(req)
 				require.NoError(t, err)
+
 				env.DisplayName = req.DisplayName
+
+				req.Id = orgv2.PtrString(envId)
+				err = json.NewEncoder(w).Encode(req)
+				require.NoError(t, err)
 			}
 		} else {
 			// env not found

--- a/test/test-server/utils.go
+++ b/test/test-server/utils.go
@@ -15,7 +15,6 @@ import (
 	cmkv2 "github.com/confluentinc/ccloud-sdk-go-v2/cmk/v2"
 	iamv2 "github.com/confluentinc/ccloud-sdk-go-v2/iam/v2"
 	mdsv2 "github.com/confluentinc/ccloud-sdk-go-v2/mds/v2"
-	orgv2 "github.com/confluentinc/ccloud-sdk-go-v2/org/v2"
 )
 
 var (
@@ -353,22 +352,4 @@ func isRoleBindingMatch(rolebinding mdsv2.IamV2RoleBinding, principal, roleName,
 		return false
 	}
 	return true
-}
-
-func isValidEnvironmentId(environments []*ccloudv1.Account, reqEnvId string) *ccloudv1.Account {
-	for _, env := range environments {
-		if reqEnvId == env.Id {
-			return env
-		}
-	}
-	return nil
-}
-
-func isValidOrgEnvironmentId(environments []*orgv2.OrgV2Environment, reqEnvId string) *orgv2.OrgV2Environment {
-	for _, env := range environments {
-		if reqEnvId == *env.Id {
-			return env
-		}
-	}
-	return nil
 }


### PR DESCRIPTION
Release Notes
-------------
New Features
- Add `--context` flag to all `environment` subcommands

Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
This is a pre-step for `use` commands that we plan to add in the future. This fixes a few problems:
* Storing the entire environment struct stores unnecessary info and bloats the configuration file
* Storing the entire environment struct can result in data getting out-of-sync with the backend if a user interacts with the UI
* Storing at the top level will allow us to store a hierarchy of the "current" resources that have been marked with the relevant `use` commands

Test & Review
-------------
Updated all relevant unit and integration tests, additional manual testing