### PR TITLE
Update autocompletion for `api-key describe` and `connect cluster pause/resume`

### DIFF
--- a/internal/cmd/api-key/command_describe.go
+++ b/internal/cmd/api-key/command_describe.go
@@ -27,10 +27,11 @@ type out struct {
 
 func (c *command) newDescribeCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "describe <id>",
-		Short: "Describe an API key.",
-		Args:  cobra.ExactArgs(1),
-		RunE:  c.describe,
+		Use:               "describe <id>",
+		Short:             "Describe an API key.",
+		Args:              cobra.ExactArgs(1),
+		ValidArgsFunction: pcmd.NewValidArgsFunction(c.validArgs),
+		RunE:              c.describe,
 	}
 
 	pcmd.AddOutputFlag(cmd)

--- a/internal/cmd/connect/command_cluster.go
+++ b/internal/cmd/connect/command_cluster.go
@@ -48,6 +48,10 @@ func (c *clusterCommand) validArgs(cmd *cobra.Command, args []string) []string {
 		return nil
 	}
 
+	return c.validArgsMultiple(cmd, args)
+}
+
+func (c *clusterCommand) validArgsMultiple(cmd *cobra.Command, args []string) []string {
 	if err := c.PersistentPreRunE(cmd, args); err != nil {
 		return nil
 	}

--- a/internal/cmd/connect/command_cluster_pause.go
+++ b/internal/cmd/connect/command_cluster_pause.go
@@ -16,7 +16,7 @@ func (c *clusterCommand) newPauseCommand() *cobra.Command {
 		Use:               "pause <id-1> [id-2] ... [id-N]",
 		Short:             "Pause connectors.",
 		Args:              cobra.MinimumNArgs(1),
-		ValidArgsFunction: pcmd.NewValidArgsFunction(c.validArgs),
+		ValidArgsFunction: pcmd.NewValidArgsFunction(c.validArgsMultiple),
 		RunE:              c.pause,
 		Annotations:       map[string]string{pcmd.RunRequirement: pcmd.RequireNonAPIKeyCloudLogin},
 		Example: examples.BuildExampleString(

--- a/internal/cmd/connect/command_cluster_resume.go
+++ b/internal/cmd/connect/command_cluster_resume.go
@@ -16,7 +16,7 @@ func (c *clusterCommand) newResumeCommand() *cobra.Command {
 		Use:               "resume <id-1> [id-2] ... [id-N]",
 		Short:             "Resume connectors.",
 		Args:              cobra.MinimumNArgs(1),
-		ValidArgsFunction: pcmd.NewValidArgsFunction(c.validArgs),
+		ValidArgsFunction: pcmd.NewValidArgsFunction(c.validArgsMultiple),
 		RunE:              c.resume,
 		Annotations:       map[string]string{pcmd.RunRequirement: pcmd.RequireNonAPIKeyCloudLogin},
 		Example: examples.BuildExampleString(


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- PLACEHOLDER

New Features
- Add argument autocompletion for `confluent api-key describe`
- Add support for autocompleting multiple arguments for `confluent connect cluster pause` and `confluent connect cluster resume`

Bug Fixes
- PLACEHOLDER

Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
The `api-key describe` change is self explanatory.

For `pause` and `resume`, I split the old `validArgs` function into two functions `validArgs` and `validArgsMultiple`, where only `validArgs` checks the length of args.

References
----------
n/a

Test & Review
-------------
Manual testing. For connect, I checked that I can autocomplete multiple arguments for `pause` and `resume` but not for `describe`, which only accepts 1 argument.

Open Questions / Follow-ups
---------------------------
I'm going to make these changes in the CLI-2065 PR to support multiple argument autocompletion for delete commands.
