### PR TITLE
AsyncAPI: Export number of partitions

### DIFF
--- a/internal/cmd/asyncapi/command_export.go
+++ b/internal/cmd/asyncapi/command_export.go
@@ -31,7 +31,8 @@ type command struct {
 }
 
 type confluentBinding struct {
-	Configs map[string]string `json:"x-configs"`
+	Partitions int32             `json:"x-partitions,omitempty"`
+	Configs    map[string]string `json:"x-configs"`
 }
 
 type bindings struct {
@@ -286,11 +287,19 @@ func (c *command) getBindings(clusterId, topicName string) (*bindings, error) {
 	if err != nil {
 		return nil, err
 	}
+	var numPartitions int32
+	partitionsResp, _, err := kafkaREST.CloudClient.ListKafkaPartitions(clusterId, topicName)
+	if err != nil {
+		log.CliLogger.Debugf("Unable to get topic partitions: %v", err)
+	}
+	if partitionsResp.Data != nil {
+		numPartitions = int32(len(partitionsResp.Data))
+	}
 	configsMap := make(map[string]string)
 	for _, config := range configs.Data {
 		configsMap[config.GetName()] = config.GetValue()
 	}
-	var channelBindings any = confluentBinding{configsMap}
+	var channelBindings any = confluentBinding{Partitions: numPartitions, Configs: configsMap}
 	messageBindings := spec.MessageBindingsObject{Kafka: &spec.KafkaMessage{Key: &spec.KafkaMessageKey{Schema: map[string]any{"type": "string"}}}}
 	operationBindings := spec.OperationBindingsObject{Kafka: &spec.KafkaOperation{
 		GroupID:  &spec.KafkaOperationGroupID{Schema: map[string]any{"type": "string"}},

--- a/internal/cmd/asyncapi/command_export.go
+++ b/internal/cmd/asyncapi/command_export.go
@@ -31,8 +31,8 @@ type command struct {
 }
 
 type confluentBinding struct {
-	XPartitions int32             `json:"x-partitions,omitempty"`
-	Configs     map[string]string `json:"x-configs"`
+	Partitions int32             `json:"x-partitions,omitempty"`
+	Configs    map[string]string `json:"x-configs"`
 }
 
 type bindings struct {
@@ -300,8 +300,8 @@ func (c *command) getBindings(clusterId, topicName string) (*bindings, error) {
 		configsMap[config.GetName()] = config.GetValue()
 	}
 	var channelBindings any = confluentBinding{
-		XPartitions: numPartitions,
-		Configs:     configsMap,
+		Partitions: numPartitions,
+		Configs:    configsMap,
 	}
 	messageBindings := spec.MessageBindingsObject{Kafka: &spec.KafkaMessage{Key: &spec.KafkaMessageKey{Schema: map[string]any{"type": "string"}}}}
 	operationBindings := spec.OperationBindingsObject{Kafka: &spec.KafkaOperation{

--- a/internal/cmd/asyncapi/command_export.go
+++ b/internal/cmd/asyncapi/command_export.go
@@ -31,8 +31,8 @@ type command struct {
 }
 
 type confluentBinding struct {
-	Partitions int32             `json:"x-partitions,omitempty"`
-	Configs    map[string]string `json:"x-configs"`
+	XPartitions int32             `json:"x-partitions,omitempty"`
+	XConfigs    map[string]string `json:"x-configs,omitempty"`
 }
 
 type bindings struct {
@@ -300,8 +300,8 @@ func (c *command) getBindings(clusterId, topicName string) (*bindings, error) {
 		configsMap[config.GetName()] = config.GetValue()
 	}
 	var channelBindings any = confluentBinding{
-		Partitions: numPartitions,
-		Configs:    configsMap,
+		XPartitions: numPartitions,
+		XConfigs:    configsMap,
 	}
 	messageBindings := spec.MessageBindingsObject{Kafka: &spec.KafkaMessage{Key: &spec.KafkaMessageKey{Schema: map[string]any{"type": "string"}}}}
 	operationBindings := spec.OperationBindingsObject{Kafka: &spec.KafkaOperation{

--- a/internal/cmd/asyncapi/command_export.go
+++ b/internal/cmd/asyncapi/command_export.go
@@ -290,7 +290,7 @@ func (c *command) getBindings(clusterId, topicName string) (*bindings, error) {
 	var numPartitions int32
 	partitionsResp, _, err := kafkaREST.CloudClient.ListKafkaPartitions(clusterId, topicName)
 	if err != nil {
-		log.CliLogger.Debugf("Unable to get topic partitions: %v", err)
+		return nil, fmt.Errorf("unable to get topic partitions: %v", err)
 	}
 	if partitionsResp.Data != nil {
 		numPartitions = int32(len(partitionsResp.Data))
@@ -299,7 +299,10 @@ func (c *command) getBindings(clusterId, topicName string) (*bindings, error) {
 	for _, config := range configs.Data {
 		configsMap[config.GetName()] = config.GetValue()
 	}
-	var channelBindings any = confluentBinding{Partitions: numPartitions, Configs: configsMap}
+	var channelBindings any = confluentBinding{
+		Partitions: numPartitions,
+		Configs:    configsMap,
+	}
 	messageBindings := spec.MessageBindingsObject{Kafka: &spec.KafkaMessage{Key: &spec.KafkaMessageKey{Schema: map[string]any{"type": "string"}}}}
 	operationBindings := spec.OperationBindingsObject{Kafka: &spec.KafkaOperation{
 		GroupID:  &spec.KafkaOperationGroupID{Schema: map[string]any{"type": "string"}},

--- a/internal/cmd/asyncapi/command_export.go
+++ b/internal/cmd/asyncapi/command_export.go
@@ -31,8 +31,8 @@ type command struct {
 }
 
 type confluentBinding struct {
-	Partitions int32             `json:"x-partitions,omitempty"`
-	Configs    map[string]string `json:"x-configs"`
+	XPartitions int32             `json:"x-partitions,omitempty"`
+	Configs     map[string]string `json:"x-configs"`
 }
 
 type bindings struct {
@@ -300,8 +300,8 @@ func (c *command) getBindings(clusterId, topicName string) (*bindings, error) {
 		configsMap[config.GetName()] = config.GetValue()
 	}
 	var channelBindings any = confluentBinding{
-		Partitions: numPartitions,
-		Configs:    configsMap,
+		XPartitions: numPartitions,
+		Configs:     configsMap,
 	}
 	messageBindings := spec.MessageBindingsObject{Kafka: &spec.KafkaMessage{Key: &spec.KafkaMessageKey{Schema: map[string]any{"type": "string"}}}}
 	operationBindings := spec.OperationBindingsObject{Kafka: &spec.KafkaOperation{

--- a/internal/cmd/asyncapi/command_import.go
+++ b/internal/cmd/asyncapi/command_import.go
@@ -41,7 +41,8 @@ type flagsImport struct {
 }
 
 type kafkaBinding struct {
-	XConfigs map[string]string `yaml:"x-configs"`
+	Partitions int32             `yaml:"x-partitions"`
+	XConfigs   map[string]string `yaml:"x-configs"`
 }
 
 type Message struct {
@@ -270,6 +271,9 @@ func (c *command) createTopic(details *accountDetails, topicName string, kafkaBi
 	createTopicRequestData := kafkarestv3.CreateTopicRequestData{
 		TopicName: topicName,
 		Configs:   &topicConfigs,
+	}
+	if kafkaBinding.Partitions != 0 {
+		createTopicRequestData.PartitionsCount = &kafkaBinding.Partitions
 	}
 	kafkaRest, err := c.GetKafkaREST()
 	if err != nil {

--- a/internal/cmd/asyncapi/command_import.go
+++ b/internal/cmd/asyncapi/command_import.go
@@ -41,8 +41,8 @@ type flagsImport struct {
 }
 
 type kafkaBinding struct {
-	Partitions int32             `yaml:"x-partitions"`
-	XConfigs   map[string]string `yaml:"x-configs"`
+	XPartitions int32             `yaml:"x-partitions"`
+	XConfigs    map[string]string `yaml:"x-configs"`
 }
 
 type Message struct {
@@ -272,8 +272,8 @@ func (c *command) createTopic(details *accountDetails, topicName string, kafkaBi
 		TopicName: topicName,
 		Configs:   &topicConfigs,
 	}
-	if kafkaBinding.Partitions != 0 {
-		createTopicRequestData.PartitionsCount = &kafkaBinding.Partitions
+	if kafkaBinding.XPartitions != 0 {
+		createTopicRequestData.PartitionsCount = &kafkaBinding.XPartitions
 	}
 	kafkaRest, err := c.GetKafkaREST()
 	if err != nil {

--- a/test/fixtures/output/asyncapi/asyncapi-spec.yaml
+++ b/test/fixtures/output/asyncapi/asyncapi-spec.yaml
@@ -19,6 +19,7 @@ channels:
         $ref: '#/components/messages/Topic1Message'
     bindings:
       kafka:
+        x-partitions: 3
         x-configs:
           cleanup.policy: delete
           delete.retention.ms: "86400000"


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->


New Features
- Support for number of topic partitions in `confluent asyncapi export` 


Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   Yes

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->
 - Add number of partitions in the AsyncAPI Specification file created using `confluent asyncapi export`. 
 - The command `confluent asyncapi import` will check `x-partitions` field in Kafka bindings for each channel while creating a new topic. 
References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
<!--
Has it been tested? How?
Copy and paste any instructions or steps that can save the reviewer time.
-->
Tested locally against devel account.

Open Questions / Follow-ups
---------------------------
<!--
Optional: Anything open to discussion for the reviewer, out of scope of this PR, or follow-ups.
-->
