### PR TITLE
Consolidate command types

### DIFF
--- a/internal/cmd/api-key/command.go
+++ b/internal/cmd/api-key/command.go
@@ -18,7 +18,7 @@ import (
 )
 
 type command struct {
-	*pcmd.AuthenticatedStateFlagCommand
+	*pcmd.AuthenticatedCLICommand
 	keystore     keystore.KeyStore
 	flagResolver pcmd.FlagResolver
 }
@@ -39,9 +39,9 @@ func New(prerunner pcmd.PreRunner, keystore keystore.KeyStore, resolver pcmd.Fla
 	}
 
 	c := &command{
-		AuthenticatedStateFlagCommand: pcmd.NewAuthenticatedStateFlagCommand(cmd, prerunner),
-		keystore:                      keystore,
-		flagResolver:                  resolver,
+		AuthenticatedCLICommand: pcmd.NewAuthenticatedCLICommand(cmd, prerunner),
+		keystore:                keystore,
+		flagResolver:            resolver,
 	}
 
 	cmd.AddCommand(c.newCreateCommand())

--- a/internal/cmd/asyncapi/command_export.go
+++ b/internal/cmd/asyncapi/command_export.go
@@ -27,7 +27,7 @@ import (
 )
 
 type command struct {
-	*pcmd.AuthenticatedStateFlagCommand
+	*pcmd.AuthenticatedCLICommand
 }
 
 type confluentBinding struct {
@@ -64,7 +64,7 @@ func newExportCommand(prerunner pcmd.PreRunner) *cobra.Command {
 		Args:  cobra.NoArgs,
 	}
 
-	c := &command{pcmd.NewAuthenticatedStateFlagCommand(cmd, prerunner)}
+	c := &command{pcmd.NewAuthenticatedCLICommand(cmd, prerunner)}
 	cmd.RunE = c.export
 
 	cmd.Flags().String("file", "asyncapi-spec.yaml", "Output file name.")

--- a/internal/cmd/asyncapi/command_import.go
+++ b/internal/cmd/asyncapi/command_import.go
@@ -107,7 +107,7 @@ func newImportCommand(prerunner pcmd.PreRunner) *cobra.Command {
 		),
 	}
 
-	c := &command{pcmd.NewAuthenticatedStateFlagCommand(cmd, prerunner)}
+	c := &command{pcmd.NewAuthenticatedCLICommand(cmd, prerunner)}
 	cmd.RunE = c.asyncapiImport
 	cmd.Flags().String("file", "", "Input file name.")
 	cmd.Flags().Bool("overwrite", false, "Overwrite existing topics with the same name.")

--- a/internal/cmd/audit-log/command_config.go
+++ b/internal/cmd/audit-log/command_config.go
@@ -11,7 +11,7 @@ import (
 )
 
 type configCommand struct {
-	*pcmd.AuthenticatedStateFlagCommand
+	*pcmd.AuthenticatedCLICommand
 }
 
 func newConfigCommand(prerunner pcmd.PreRunner) *cobra.Command {
@@ -22,7 +22,7 @@ func newConfigCommand(prerunner pcmd.PreRunner) *cobra.Command {
 		Annotations: map[string]string{pcmd.RunRequirement: pcmd.RequireOnPremLogin},
 	}
 
-	c := &configCommand{pcmd.NewAuthenticatedWithMDSStateFlagCommand(cmd, prerunner)}
+	c := &configCommand{pcmd.NewAuthenticatedWithMDSCLICommand(cmd, prerunner)}
 
 	cmd.AddCommand(c.newDescribeCommand())
 	cmd.AddCommand(c.newEditCommand())

--- a/internal/cmd/audit-log/command_route.go
+++ b/internal/cmd/audit-log/command_route.go
@@ -11,7 +11,7 @@ import (
 )
 
 type routeCommand struct {
-	*pcmd.AuthenticatedStateFlagCommand
+	*pcmd.AuthenticatedCLICommand
 }
 
 func newRouteCommand(prerunner pcmd.PreRunner) *cobra.Command {
@@ -22,7 +22,7 @@ func newRouteCommand(prerunner pcmd.PreRunner) *cobra.Command {
 		Annotations: map[string]string{pcmd.RunRequirement: pcmd.RequireOnPremLogin},
 	}
 
-	c := &routeCommand{pcmd.NewAuthenticatedWithMDSStateFlagCommand(cmd, prerunner)}
+	c := &routeCommand{pcmd.NewAuthenticatedWithMDSCLICommand(cmd, prerunner)}
 
 	cmd.AddCommand(c.newListCommand())
 	cmd.AddCommand(c.newLookupCommand())

--- a/internal/cmd/byok/command.go
+++ b/internal/cmd/byok/command.go
@@ -7,7 +7,7 @@ import (
 )
 
 type command struct {
-	*pcmd.AuthenticatedStateFlagCommand
+	*pcmd.AuthenticatedCLICommand
 }
 
 func New(prerunner pcmd.PreRunner) *cobra.Command {
@@ -17,7 +17,7 @@ func New(prerunner pcmd.PreRunner) *cobra.Command {
 		Annotations: map[string]string{pcmd.RunRequirement: pcmd.RequireNonAPIKeyCloudLogin},
 	}
 
-	c := &command{pcmd.NewAuthenticatedStateFlagCommand(cmd, prerunner)}
+	c := &command{pcmd.NewAuthenticatedCLICommand(cmd, prerunner)}
 
 	cmd.AddCommand(c.newCreateCommand())
 	cmd.AddCommand(c.newDeleteCommand())

--- a/internal/cmd/connect/command_cluster.go
+++ b/internal/cmd/connect/command_cluster.go
@@ -14,7 +14,7 @@ import (
 const clusterType = "connect-cluster"
 
 type clusterCommand struct {
-	*pcmd.AuthenticatedStateFlagCommand
+	*pcmd.AuthenticatedCLICommand
 }
 
 func newClusterCommand(cfg *v1.Config, prerunner pcmd.PreRunner) *cobra.Command {
@@ -27,7 +27,7 @@ func newClusterCommand(cfg *v1.Config, prerunner pcmd.PreRunner) *cobra.Command 
 	c := new(clusterCommand)
 
 	if cfg.IsCloudLogin() {
-		c.AuthenticatedStateFlagCommand = pcmd.NewAuthenticatedStateFlagCommand(cmd, prerunner)
+		c.AuthenticatedCLICommand = pcmd.NewAuthenticatedCLICommand(cmd, prerunner)
 		cmd.AddCommand(c.newCreateCommand())
 		cmd.AddCommand(c.newDeleteCommand())
 		cmd.AddCommand(c.newDescribeCommand())
@@ -36,7 +36,7 @@ func newClusterCommand(cfg *v1.Config, prerunner pcmd.PreRunner) *cobra.Command 
 		cmd.AddCommand(c.newResumeCommand())
 		cmd.AddCommand(c.newUpdateCommand())
 	} else {
-		c.AuthenticatedStateFlagCommand = pcmd.NewAuthenticatedWithMDSStateFlagCommand(cmd, prerunner)
+		c.AuthenticatedCLICommand = pcmd.NewAuthenticatedWithMDSCLICommand(cmd, prerunner)
 		cmd.AddCommand(c.newListCommandOnPrem())
 	}
 

--- a/internal/cmd/connect/command_plugin.go
+++ b/internal/cmd/connect/command_plugin.go
@@ -9,7 +9,7 @@ import (
 )
 
 type pluginCommand struct {
-	*pcmd.AuthenticatedStateFlagCommand
+	*pcmd.AuthenticatedCLICommand
 }
 
 func newPluginCommand(prerunner pcmd.PreRunner) *cobra.Command {
@@ -19,7 +19,7 @@ func newPluginCommand(prerunner pcmd.PreRunner) *cobra.Command {
 		Annotations: map[string]string{pcmd.RunRequirement: pcmd.RequireNonAPIKeyCloudLogin},
 	}
 
-	c := &pluginCommand{pcmd.NewAuthenticatedStateFlagCommand(cmd, prerunner)}
+	c := &pluginCommand{pcmd.NewAuthenticatedCLICommand(cmd, prerunner)}
 
 	cmd.AddCommand(c.newDescribeCommand())
 	cmd.AddCommand(c.newListCommand())

--- a/internal/cmd/iam/command_acl.go
+++ b/internal/cmd/iam/command_acl.go
@@ -26,7 +26,7 @@ type out struct {
 }
 
 type aclCommand struct {
-	*pcmd.AuthenticatedStateFlagCommand
+	*pcmd.AuthenticatedCLICommand
 }
 
 func newACLCommand(prerunner pcmd.PreRunner) *cobra.Command {
@@ -36,7 +36,7 @@ func newACLCommand(prerunner pcmd.PreRunner) *cobra.Command {
 		Annotations: map[string]string{pcmd.RunRequirement: pcmd.RequireOnPremLogin},
 	}
 
-	c := &aclCommand{pcmd.NewAuthenticatedWithMDSStateFlagCommand(cmd, prerunner)}
+	c := &aclCommand{pcmd.NewAuthenticatedWithMDSCLICommand(cmd, prerunner)}
 
 	cmd.AddCommand(c.newCreateCommand())
 	cmd.AddCommand(c.newDeleteCommand())

--- a/internal/cmd/iam/command_rbac_role.go
+++ b/internal/cmd/iam/command_rbac_role.go
@@ -15,7 +15,7 @@ import (
 )
 
 type roleCommand struct {
-	*pcmd.AuthenticatedStateFlagCommand
+	*pcmd.AuthenticatedCLICommand
 	cfg *v1.Config
 }
 
@@ -34,9 +34,9 @@ func newRoleCommand(cfg *v1.Config, prerunner pcmd.PreRunner) *cobra.Command {
 	c := &roleCommand{cfg: cfg}
 
 	if cfg.IsOnPremLogin() {
-		c.AuthenticatedStateFlagCommand = pcmd.NewAuthenticatedWithMDSStateFlagCommand(cmd, prerunner)
+		c.AuthenticatedCLICommand = pcmd.NewAuthenticatedWithMDSCLICommand(cmd, prerunner)
 	} else {
-		c.AuthenticatedStateFlagCommand = pcmd.NewAuthenticatedStateFlagCommand(cmd, prerunner)
+		c.AuthenticatedCLICommand = pcmd.NewAuthenticatedCLICommand(cmd, prerunner)
 	}
 
 	cmd.AddCommand(c.newDescribeCommand())

--- a/internal/cmd/iam/command_rbac_role_binding.go
+++ b/internal/cmd/iam/command_rbac_role_binding.go
@@ -55,7 +55,7 @@ type roleBindingOptions struct {
 }
 
 type roleBindingCommand struct {
-	*pcmd.AuthenticatedStateFlagCommand
+	*pcmd.AuthenticatedCLICommand
 	cfg *v1.Config
 }
 
@@ -83,9 +83,9 @@ func newRoleBindingCommand(cfg *v1.Config, prerunner pcmd.PreRunner) *cobra.Comm
 	c := &roleBindingCommand{cfg: cfg}
 
 	if cfg.IsOnPremLogin() {
-		c.AuthenticatedStateFlagCommand = pcmd.NewAuthenticatedWithMDSStateFlagCommand(cmd, prerunner)
+		c.AuthenticatedCLICommand = pcmd.NewAuthenticatedWithMDSCLICommand(cmd, prerunner)
 	} else {
-		c.AuthenticatedStateFlagCommand = pcmd.NewAuthenticatedStateFlagCommand(cmd, prerunner)
+		c.AuthenticatedCLICommand = pcmd.NewAuthenticatedCLICommand(cmd, prerunner)
 	}
 
 	cmd.AddCommand(c.newCreateCommand())

--- a/internal/cmd/kafka/command_acl.go
+++ b/internal/cmd/kafka/command_acl.go
@@ -20,7 +20,7 @@ import (
 )
 
 type aclCommand struct {
-	*pcmd.AuthenticatedStateFlagCommand
+	*pcmd.AuthenticatedCLICommand
 }
 
 func newAclCommand(cfg *v1.Config, prerunner pcmd.PreRunner) *cobra.Command {
@@ -29,7 +29,7 @@ func newAclCommand(cfg *v1.Config, prerunner pcmd.PreRunner) *cobra.Command {
 		Short: "Manage Kafka ACLs.",
 	}
 
-	c := &aclCommand{pcmd.NewAuthenticatedStateFlagCommand(cmd, prerunner)}
+	c := &aclCommand{pcmd.NewAuthenticatedCLICommand(cmd, prerunner)}
 
 	if cfg.IsCloudLogin() {
 		cmd.AddCommand(c.newCreateCommand())

--- a/internal/cmd/kafka/command_broker.go
+++ b/internal/cmd/kafka/command_broker.go
@@ -20,7 +20,7 @@ func newBrokerCommand(prerunner pcmd.PreRunner) *cobra.Command {
 		Annotations: map[string]string{pcmd.RunRequirement: pcmd.RequireOnPremLogin},
 	}
 
-	c := &brokerCommand{pcmd.NewAuthenticatedCLICommand(cmd, prerunner)}
+	c := &brokerCommand{pcmd.NewAuthenticatedWithMDSCLICommand(cmd, prerunner)}
 	cmd.PersistentPreRunE = prerunner.InitializeOnPremKafkaRest(c.AuthenticatedCLICommand)
 
 	cmd.AddCommand(c.newDeleteCommand())

--- a/internal/cmd/kafka/command_broker.go
+++ b/internal/cmd/kafka/command_broker.go
@@ -10,7 +10,7 @@ import (
 )
 
 type brokerCommand struct {
-	*pcmd.AuthenticatedStateFlagCommand
+	*pcmd.AuthenticatedCLICommand
 }
 
 func newBrokerCommand(prerunner pcmd.PreRunner) *cobra.Command {
@@ -20,7 +20,7 @@ func newBrokerCommand(prerunner pcmd.PreRunner) *cobra.Command {
 		Annotations: map[string]string{pcmd.RunRequirement: pcmd.RequireOnPremLogin},
 	}
 
-	c := &brokerCommand{pcmd.NewAuthenticatedStateFlagCommand(cmd, prerunner)}
+	c := &brokerCommand{pcmd.NewAuthenticatedCLICommand(cmd, prerunner)}
 	cmd.PersistentPreRunE = prerunner.InitializeOnPremKafkaRest(c.AuthenticatedCLICommand)
 
 	cmd.AddCommand(c.newDeleteCommand())

--- a/internal/cmd/kafka/command_cluster.go
+++ b/internal/cmd/kafka/command_cluster.go
@@ -25,7 +25,7 @@ var availabilitiesToModel = map[string]string{
 }
 
 type clusterCommand struct {
-	*pcmd.AuthenticatedStateFlagCommand
+	*pcmd.AuthenticatedCLICommand
 }
 
 func newClusterCommand(cfg *v1.Config, prerunner pcmd.PreRunner) *cobra.Command {
@@ -38,9 +38,9 @@ func newClusterCommand(cfg *v1.Config, prerunner pcmd.PreRunner) *cobra.Command 
 	c := &clusterCommand{}
 
 	if cfg.IsCloudLogin() {
-		c.AuthenticatedStateFlagCommand = pcmd.NewAuthenticatedStateFlagCommand(cmd, prerunner)
+		c.AuthenticatedCLICommand = pcmd.NewAuthenticatedCLICommand(cmd, prerunner)
 	} else {
-		c.AuthenticatedStateFlagCommand = pcmd.NewAuthenticatedWithMDSStateFlagCommand(cmd, prerunner)
+		c.AuthenticatedCLICommand = pcmd.NewAuthenticatedWithMDSCLICommand(cmd, prerunner)
 	}
 
 	cmd.AddCommand(c.newCreateCommand(cfg))

--- a/internal/cmd/kafka/command_cluster_test.go
+++ b/internal/cmd/kafka/command_cluster_test.go
@@ -200,7 +200,7 @@ func (suite *KafkaClusterTestSuite) TestGetLkcForDescribe() {
 	cmd := new(cobra.Command)
 	cfg := v1.AuthenticatedCloudConfigMock()
 	prerunner := &pcmd.PreRun{Config: cfg}
-	c := &clusterCommand{pcmd.NewAuthenticatedStateFlagCommand(cmd, prerunner)}
+	c := &clusterCommand{pcmd.NewAuthenticatedCLICommand(cmd, prerunner)}
 	c.Config = dynamicconfig.New(cfg, nil, nil)
 	lkc, err := c.getLkcForDescribe([]string{"lkc-123"})
 	req.Equal("lkc-123", lkc)

--- a/internal/cmd/kafka/command_consumergroup.go
+++ b/internal/cmd/kafka/command_consumergroup.go
@@ -10,7 +10,7 @@ import (
 )
 
 type consumerGroupCommand struct {
-	*pcmd.AuthenticatedStateFlagCommand
+	*pcmd.AuthenticatedCLICommand
 }
 
 type consumerData struct {
@@ -48,7 +48,7 @@ func newConsumerGroupCommand(prerunner pcmd.PreRunner) *cobra.Command {
 		Hidden:      true,
 	}
 
-	c := &consumerGroupCommand{pcmd.NewAuthenticatedStateFlagCommand(cmd, prerunner)}
+	c := &consumerGroupCommand{pcmd.NewAuthenticatedCLICommand(cmd, prerunner)}
 
 	cmd.AddCommand(c.newDescribeCommand())
 	cmd.AddCommand(newLagCommand(prerunner))
@@ -70,7 +70,7 @@ func (c *consumerGroupCommand) validArgs(cmd *cobra.Command, args []string) []st
 }
 
 func (c *consumerGroupCommand) autocompleteConsumerGroups() []string {
-	consumerGroupDataList, err := listConsumerGroups(c.AuthenticatedStateFlagCommand)
+	consumerGroupDataList, err := listConsumerGroups(c.AuthenticatedCLICommand)
 	if err != nil {
 		return nil
 	}
@@ -82,7 +82,7 @@ func (c *consumerGroupCommand) autocompleteConsumerGroups() []string {
 	return suggestions
 }
 
-func listConsumerGroups(flagCmd *pcmd.AuthenticatedStateFlagCommand) (*kafkarestv3.ConsumerGroupDataList, error) {
+func listConsumerGroups(flagCmd *pcmd.AuthenticatedCLICommand) (*kafkarestv3.ConsumerGroupDataList, error) {
 	kafkaREST, lkc, err := getKafkaRestProxyAndLkcId(flagCmd)
 	if err != nil {
 		return nil, err

--- a/internal/cmd/kafka/command_consumergroup_describe.go
+++ b/internal/cmd/kafka/command_consumergroup_describe.go
@@ -40,7 +40,7 @@ func (c *consumerGroupCommand) newDescribeCommand() *cobra.Command {
 func (c *consumerGroupCommand) describe(cmd *cobra.Command, args []string) error {
 	consumerGroupId := args[0]
 
-	kafkaREST, lkc, err := getKafkaRestProxyAndLkcId(c.AuthenticatedStateFlagCommand)
+	kafkaREST, lkc, err := getKafkaRestProxyAndLkcId(c.AuthenticatedCLICommand)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/kafka/command_consumergroup_lag.go
+++ b/internal/cmd/kafka/command_consumergroup_lag.go
@@ -22,7 +22,7 @@ type lagDataStruct struct {
 }
 
 type lagCommand struct {
-	*pcmd.AuthenticatedStateFlagCommand
+	*pcmd.AuthenticatedCLICommand
 }
 
 func newLagCommand(prerunner pcmd.PreRunner) *cobra.Command {
@@ -32,7 +32,7 @@ func newLagCommand(prerunner pcmd.PreRunner) *cobra.Command {
 		Hidden: true,
 	}
 
-	c := &lagCommand{pcmd.NewAuthenticatedStateFlagCommand(cmd, prerunner)}
+	c := &lagCommand{pcmd.NewAuthenticatedCLICommand(cmd, prerunner)}
 
 	cmd.AddCommand(c.newGetCommand())
 	cmd.AddCommand(c.newListCommand())
@@ -69,7 +69,7 @@ func (c *lagCommand) validArgs(cmd *cobra.Command, args []string) []string {
 }
 
 func (c *lagCommand) autocompleteConsumerGroups() []string {
-	consumerGroupDataList, err := listConsumerGroups(c.AuthenticatedStateFlagCommand)
+	consumerGroupDataList, err := listConsumerGroups(c.AuthenticatedCLICommand)
 	if err != nil {
 		return nil
 	}

--- a/internal/cmd/kafka/command_consumergroup_lag_get.go
+++ b/internal/cmd/kafka/command_consumergroup_lag_get.go
@@ -52,7 +52,7 @@ func (c *lagCommand) getLag(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	kafkaREST, lkc, err := getKafkaRestProxyAndLkcId(c.AuthenticatedStateFlagCommand)
+	kafkaREST, lkc, err := getKafkaRestProxyAndLkcId(c.AuthenticatedCLICommand)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/kafka/command_consumergroup_lag_list.go
+++ b/internal/cmd/kafka/command_consumergroup_lag_list.go
@@ -34,7 +34,7 @@ func (c *lagCommand) newListCommand() *cobra.Command {
 }
 
 func (c *lagCommand) list(cmd *cobra.Command, args []string) error {
-	kafkaREST, lkc, err := getKafkaRestProxyAndLkcId(c.AuthenticatedStateFlagCommand)
+	kafkaREST, lkc, err := getKafkaRestProxyAndLkcId(c.AuthenticatedCLICommand)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/kafka/command_consumergroup_lag_summarize.go
+++ b/internal/cmd/kafka/command_consumergroup_lag_summarize.go
@@ -48,7 +48,7 @@ func (c *lagCommand) newSummarizeCommand() *cobra.Command {
 func (c *lagCommand) summarize(cmd *cobra.Command, args []string) error {
 	consumerGroupId := args[0]
 
-	kafkaREST, lkc, err := getKafkaRestProxyAndLkcId(c.AuthenticatedStateFlagCommand)
+	kafkaREST, lkc, err := getKafkaRestProxyAndLkcId(c.AuthenticatedCLICommand)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/kafka/command_consumergroup_list.go
+++ b/internal/cmd/kafka/command_consumergroup_list.go
@@ -33,7 +33,7 @@ func (c *consumerGroupCommand) newListCommand() *cobra.Command {
 }
 
 func (c *consumerGroupCommand) list(cmd *cobra.Command, _ []string) error {
-	kafkaREST, lkc, err := getKafkaRestProxyAndLkcId(c.AuthenticatedStateFlagCommand)
+	kafkaREST, lkc, err := getKafkaRestProxyAndLkcId(c.AuthenticatedCLICommand)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/kafka/command_link.go
+++ b/internal/cmd/kafka/command_link.go
@@ -13,7 +13,7 @@ const (
 )
 
 type linkCommand struct {
-	*pcmd.AuthenticatedStateFlagCommand
+	*pcmd.AuthenticatedCLICommand
 }
 
 func newLinkCommand(cfg *v1.Config, prerunner pcmd.PreRunner) *cobra.Command {
@@ -26,14 +26,14 @@ func newLinkCommand(cfg *v1.Config, prerunner pcmd.PreRunner) *cobra.Command {
 	c := &linkCommand{}
 
 	if cfg.IsCloudLogin() {
-		c.AuthenticatedStateFlagCommand = pcmd.NewAuthenticatedStateFlagCommand(cmd, prerunner)
+		c.AuthenticatedCLICommand = pcmd.NewAuthenticatedCLICommand(cmd, prerunner)
 
 		cmd.AddCommand(c.newConfigurationCommand(cfg))
 		cmd.AddCommand(c.newCreateCommand())
 		cmd.AddCommand(c.newDeleteCommand())
 		cmd.AddCommand(c.newListCommand())
 	} else {
-		c.AuthenticatedStateFlagCommand = pcmd.NewAuthenticatedWithMDSStateFlagCommand(cmd, prerunner)
+		c.AuthenticatedCLICommand = pcmd.NewAuthenticatedWithMDSCLICommand(cmd, prerunner)
 		c.PersistentPreRunE = prerunner.InitializeOnPremKafkaRest(c.AuthenticatedCLICommand)
 
 		cmd.AddCommand(c.newConfigurationCommand(cfg))

--- a/internal/cmd/kafka/command_link_configuration_list.go
+++ b/internal/cmd/kafka/command_link_configuration_list.go
@@ -45,7 +45,7 @@ func (c *linkCommand) configurationList(cmd *cobra.Command, args []string) error
 		return errors.New(errors.RestProxyNotAvailableMsg)
 	}
 
-	clusterId, err := getKafkaClusterLkcId(c.AuthenticatedStateFlagCommand)
+	clusterId, err := getKafkaClusterLkcId(c.AuthenticatedCLICommand)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/kafka/command_link_configuration_update.go
+++ b/internal/cmd/kafka/command_link_configuration_update.go
@@ -64,7 +64,7 @@ func (c *linkCommand) configurationUpdate(cmd *cobra.Command, args []string) err
 		return errors.New(errors.RestProxyNotAvailableMsg)
 	}
 
-	clusterId, err := getKafkaClusterLkcId(c.AuthenticatedStateFlagCommand)
+	clusterId, err := getKafkaClusterLkcId(c.AuthenticatedCLICommand)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/kafka/command_link_create.go
+++ b/internal/cmd/kafka/command_link_create.go
@@ -148,7 +148,7 @@ func (c *linkCommand) create(cmd *cobra.Command, args []string) error {
 		return errors.New(errors.RestProxyNotAvailableMsg)
 	}
 
-	clusterId, err := getKafkaClusterLkcId(c.AuthenticatedStateFlagCommand)
+	clusterId, err := getKafkaClusterLkcId(c.AuthenticatedCLICommand)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/kafka/command_link_delete.go
+++ b/internal/cmd/kafka/command_link_delete.go
@@ -40,7 +40,7 @@ func (c *linkCommand) delete(cmd *cobra.Command, args []string) error {
 		return errors.New(errors.RestProxyNotAvailableMsg)
 	}
 
-	clusterId, err := getKafkaClusterLkcId(c.AuthenticatedStateFlagCommand)
+	clusterId, err := getKafkaClusterLkcId(c.AuthenticatedCLICommand)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/kafka/command_link_list.go
+++ b/internal/cmd/kafka/command_link_list.go
@@ -71,7 +71,7 @@ func (c *linkCommand) list(cmd *cobra.Command, _ []string) error {
 		return errors.New(errors.RestProxyNotAvailableMsg)
 	}
 
-	clusterId, err := getKafkaClusterLkcId(c.AuthenticatedStateFlagCommand)
+	clusterId, err := getKafkaClusterLkcId(c.AuthenticatedCLICommand)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/kafka/command_mirror.go
+++ b/internal/cmd/kafka/command_mirror.go
@@ -29,7 +29,7 @@ type mirrorOut struct {
 }
 
 type mirrorCommand struct {
-	*pcmd.AuthenticatedStateFlagCommand
+	*pcmd.AuthenticatedCLICommand
 }
 
 func newMirrorCommand(prerunner pcmd.PreRunner) *cobra.Command {
@@ -39,7 +39,7 @@ func newMirrorCommand(prerunner pcmd.PreRunner) *cobra.Command {
 		Annotations: map[string]string{pcmd.RunRequirement: pcmd.RequireNonAPIKeyCloudLogin},
 	}
 
-	c := &mirrorCommand{pcmd.NewAuthenticatedStateFlagCommand(cmd, prerunner)}
+	c := &mirrorCommand{pcmd.NewAuthenticatedCLICommand(cmd, prerunner)}
 
 	cmd.AddCommand(c.newCreateCommand())
 	cmd.AddCommand(c.newDescribeCommand())

--- a/internal/cmd/kafka/command_mirror_create.go
+++ b/internal/cmd/kafka/command_mirror_create.go
@@ -92,7 +92,7 @@ func (c *mirrorCommand) create(cmd *cobra.Command, args []string) error {
 		return errors.New(errors.RestProxyNotAvailableMsg)
 	}
 
-	lkc, err := getKafkaClusterLkcId(c.AuthenticatedStateFlagCommand)
+	lkc, err := getKafkaClusterLkcId(c.AuthenticatedCLICommand)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/kafka/command_mirror_describe.go
+++ b/internal/cmd/kafka/command_mirror_describe.go
@@ -51,7 +51,7 @@ func (c *mirrorCommand) describe(cmd *cobra.Command, args []string) error {
 		return errors.New(errors.RestProxyNotAvailableMsg)
 	}
 
-	lkc, err := getKafkaClusterLkcId(c.AuthenticatedStateFlagCommand)
+	lkc, err := getKafkaClusterLkcId(c.AuthenticatedCLICommand)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/kafka/command_mirror_failover.go
+++ b/internal/cmd/kafka/command_mirror_failover.go
@@ -57,7 +57,7 @@ func (c *mirrorCommand) failover(cmd *cobra.Command, args []string) error {
 		return errors.New(errors.RestProxyNotAvailableMsg)
 	}
 
-	lkc, err := getKafkaClusterLkcId(c.AuthenticatedStateFlagCommand)
+	lkc, err := getKafkaClusterLkcId(c.AuthenticatedCLICommand)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/kafka/command_mirror_list.go
+++ b/internal/cmd/kafka/command_mirror_list.go
@@ -58,7 +58,7 @@ func (c *mirrorCommand) list(cmd *cobra.Command, _ []string) error {
 		return errors.New(errors.RestProxyNotAvailableMsg)
 	}
 
-	lkc, err := getKafkaClusterLkcId(c.AuthenticatedStateFlagCommand)
+	lkc, err := getKafkaClusterLkcId(c.AuthenticatedCLICommand)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/kafka/command_mirror_pause.go
+++ b/internal/cmd/kafka/command_mirror_pause.go
@@ -57,7 +57,7 @@ func (c *mirrorCommand) pause(cmd *cobra.Command, args []string) error {
 		return errors.New(errors.RestProxyNotAvailableMsg)
 	}
 
-	lkc, err := getKafkaClusterLkcId(c.AuthenticatedStateFlagCommand)
+	lkc, err := getKafkaClusterLkcId(c.AuthenticatedCLICommand)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/kafka/command_mirror_promote.go
+++ b/internal/cmd/kafka/command_mirror_promote.go
@@ -57,7 +57,7 @@ func (c *mirrorCommand) promote(cmd *cobra.Command, args []string) error {
 		return errors.New(errors.RestProxyNotAvailableMsg)
 	}
 
-	lkc, err := getKafkaClusterLkcId(c.AuthenticatedStateFlagCommand)
+	lkc, err := getKafkaClusterLkcId(c.AuthenticatedCLICommand)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/kafka/command_mirror_resume.go
+++ b/internal/cmd/kafka/command_mirror_resume.go
@@ -60,7 +60,7 @@ func (c *mirrorCommand) resume(cmd *cobra.Command, args []string) error {
 		return errors.New(errors.RestProxyNotAvailableMsg)
 	}
 
-	lkc, err := getKafkaClusterLkcId(c.AuthenticatedStateFlagCommand)
+	lkc, err := getKafkaClusterLkcId(c.AuthenticatedCLICommand)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/kafka/command_partition.go
+++ b/internal/cmd/kafka/command_partition.go
@@ -22,7 +22,7 @@ func newPartitionCommand(prerunner pcmd.PreRunner) *cobra.Command {
 		Annotations: map[string]string{pcmd.RunRequirement: pcmd.RequireOnPremLogin},
 	}
 
-	c := &partitionCommand{pcmd.NewAuthenticatedCLICommand(cmd, prerunner)}
+	c := &partitionCommand{pcmd.NewAuthenticatedWithMDSCLICommand(cmd, prerunner)}
 	c.PersistentPreRunE = prerunner.InitializeOnPremKafkaRest(c.AuthenticatedCLICommand)
 
 	cmd.AddCommand(c.newDescribeCommand())

--- a/internal/cmd/kafka/command_partition.go
+++ b/internal/cmd/kafka/command_partition.go
@@ -12,7 +12,7 @@ import (
 )
 
 type partitionCommand struct {
-	*pcmd.AuthenticatedStateFlagCommand
+	*pcmd.AuthenticatedCLICommand
 }
 
 func newPartitionCommand(prerunner pcmd.PreRunner) *cobra.Command {
@@ -22,7 +22,7 @@ func newPartitionCommand(prerunner pcmd.PreRunner) *cobra.Command {
 		Annotations: map[string]string{pcmd.RunRequirement: pcmd.RequireOnPremLogin},
 	}
 
-	c := &partitionCommand{pcmd.NewAuthenticatedStateFlagCommand(cmd, prerunner)}
+	c := &partitionCommand{pcmd.NewAuthenticatedCLICommand(cmd, prerunner)}
 	c.PersistentPreRunE = prerunner.InitializeOnPremKafkaRest(c.AuthenticatedCLICommand)
 
 	cmd.AddCommand(c.newDescribeCommand())

--- a/internal/cmd/kafka/command_quota.go
+++ b/internal/cmd/kafka/command_quota.go
@@ -10,7 +10,7 @@ import (
 )
 
 type quotaCommand struct {
-	*pcmd.AuthenticatedStateFlagCommand
+	*pcmd.AuthenticatedCLICommand
 }
 
 func newQuotaCommand(prerunner pcmd.PreRunner) *cobra.Command {
@@ -20,7 +20,7 @@ func newQuotaCommand(prerunner pcmd.PreRunner) *cobra.Command {
 		Annotations: map[string]string{pcmd.RunRequirement: pcmd.RequireNonAPIKeyCloudLogin},
 	}
 
-	c := &quotaCommand{pcmd.NewAuthenticatedStateFlagCommand(cmd, prerunner)}
+	c := &quotaCommand{pcmd.NewAuthenticatedCLICommand(cmd, prerunner)}
 
 	cmd.AddCommand(c.newCreateCommand())
 	cmd.AddCommand(c.newDeleteCommand())

--- a/internal/cmd/kafka/command_replica.go
+++ b/internal/cmd/kafka/command_replica.go
@@ -7,7 +7,7 @@ import (
 )
 
 type replicaCommand struct {
-	*pcmd.AuthenticatedStateFlagCommand
+	*pcmd.AuthenticatedCLICommand
 }
 
 func newReplicaCommand(prerunner pcmd.PreRunner) *cobra.Command {
@@ -17,7 +17,7 @@ func newReplicaCommand(prerunner pcmd.PreRunner) *cobra.Command {
 		Annotations: map[string]string{pcmd.RunRequirement: pcmd.RequireOnPremLogin},
 	}
 
-	c := &replicaCommand{pcmd.NewAuthenticatedStateFlagCommand(cmd, prerunner)}
+	c := &replicaCommand{pcmd.NewAuthenticatedCLICommand(cmd, prerunner)}
 	c.PersistentPreRunE = prerunner.InitializeOnPremKafkaRest(c.AuthenticatedCLICommand)
 
 	cmd.AddCommand(c.newListCommand())

--- a/internal/cmd/kafka/command_replica.go
+++ b/internal/cmd/kafka/command_replica.go
@@ -17,7 +17,7 @@ func newReplicaCommand(prerunner pcmd.PreRunner) *cobra.Command {
 		Annotations: map[string]string{pcmd.RunRequirement: pcmd.RequireOnPremLogin},
 	}
 
-	c := &replicaCommand{pcmd.NewAuthenticatedCLICommand(cmd, prerunner)}
+	c := &replicaCommand{pcmd.NewAuthenticatedWithMDSCLICommand(cmd, prerunner)}
 	c.PersistentPreRunE = prerunner.InitializeOnPremKafkaRest(c.AuthenticatedCLICommand)
 
 	cmd.AddCommand(c.newListCommand())

--- a/internal/cmd/kafka/command_topic.go
+++ b/internal/cmd/kafka/command_topic.go
@@ -25,7 +25,7 @@ type hasAPIKeyTopicCommand struct {
 }
 
 type authenticatedTopicCommand struct {
-	*pcmd.AuthenticatedStateFlagCommand
+	*pcmd.AuthenticatedCLICommand
 	prerunner pcmd.PreRunner
 	clientID  string
 }
@@ -42,7 +42,7 @@ func newTopicCommand(cfg *v1.Config, prerunner pcmd.PreRunner, clientID string) 
 	}
 
 	if cfg.IsCloudLogin() {
-		c.AuthenticatedStateFlagCommand = pcmd.NewAuthenticatedStateFlagCommand(cmd, prerunner)
+		c.AuthenticatedCLICommand = pcmd.NewAuthenticatedCLICommand(cmd, prerunner)
 
 		cmd.AddCommand(newConsumeCommand(prerunner, clientID))
 		cmd.AddCommand(c.newCreateCommand())
@@ -52,7 +52,7 @@ func newTopicCommand(cfg *v1.Config, prerunner pcmd.PreRunner, clientID string) 
 		cmd.AddCommand(newProduceCommand(prerunner, clientID))
 		cmd.AddCommand(c.newUpdateCommand())
 	} else {
-		c.AuthenticatedStateFlagCommand = pcmd.NewAuthenticatedWithMDSStateFlagCommand(cmd, prerunner)
+		c.AuthenticatedCLICommand = pcmd.NewAuthenticatedWithMDSCLICommand(cmd, prerunner)
 		c.PersistentPreRunE = prerunner.InitializeOnPremKafkaRest(c.AuthenticatedCLICommand)
 
 		cmd.AddCommand(c.newConsumeCommandOnPrem())

--- a/internal/cmd/kafka/utils.go
+++ b/internal/cmd/kafka/utils.go
@@ -70,7 +70,7 @@ func toAlterConfigBatchRequestDataOnPrem(configsMap map[string]string) cpkafkare
 	return cpkafkarestv3.AlterConfigBatchRequestData{Data: kafkaRestConfigs}
 }
 
-func getKafkaClusterLkcId(c *pcmd.AuthenticatedStateFlagCommand) (string, error) {
+func getKafkaClusterLkcId(c *pcmd.AuthenticatedCLICommand) (string, error) {
 	kafkaClusterConfig, err := c.Context.GetKafkaClusterForCommand()
 	if err != nil {
 		return "", err
@@ -90,7 +90,7 @@ func handleOpenApiError(httpResp *_nethttp.Response, err error, client *cpkafkar
 	return err
 }
 
-func getKafkaRestProxyAndLkcId(c *pcmd.AuthenticatedStateFlagCommand) (*pcmd.KafkaREST, string, error) {
+func getKafkaRestProxyAndLkcId(c *pcmd.AuthenticatedCLICommand) (*pcmd.KafkaREST, string, error) {
 	kafkaREST, err := c.GetKafkaREST()
 	if err != nil {
 		return nil, "", err

--- a/internal/cmd/ksql/command.go
+++ b/internal/cmd/ksql/command.go
@@ -18,7 +18,7 @@ import (
 )
 
 type ksqlCommand struct {
-	*pcmd.AuthenticatedStateFlagCommand
+	*pcmd.AuthenticatedCLICommand
 }
 
 type ksqlCluster struct {

--- a/internal/cmd/ksql/command_cluster.go
+++ b/internal/cmd/ksql/command_cluster.go
@@ -15,14 +15,14 @@ func newClusterCommand(cfg *v1.Config, prerunner pcmd.PreRunner) *cobra.Command 
 	}
 
 	if cfg.IsCloudLogin() {
-		c := &ksqlCommand{pcmd.NewAuthenticatedStateFlagCommand(cmd, prerunner)}
+		c := &ksqlCommand{pcmd.NewAuthenticatedCLICommand(cmd, prerunner)}
 		cmd.AddCommand(c.newConfigureAclsCommand())
 		cmd.AddCommand(c.newCreateCommand())
 		cmd.AddCommand(c.newDeleteCommand())
 		cmd.AddCommand(c.newDescribeCommand())
 		cmd.AddCommand(c.newListCommand())
 	} else {
-		c := &ksqlCommand{pcmd.NewAuthenticatedWithMDSStateFlagCommand(cmd, prerunner)}
+		c := &ksqlCommand{pcmd.NewAuthenticatedWithMDSCLICommand(cmd, prerunner)}
 		cmd.AddCommand(c.newListCommandOnPrem())
 	}
 

--- a/internal/cmd/pipeline/command.go
+++ b/internal/cmd/pipeline/command.go
@@ -45,7 +45,7 @@ var (
 )
 
 type command struct {
-	*pcmd.AuthenticatedStateFlagCommand
+	*pcmd.AuthenticatedCLICommand
 }
 
 func New(cfg *v1.Config, prerunner pcmd.PreRunner) *cobra.Command {
@@ -55,7 +55,7 @@ func New(cfg *v1.Config, prerunner pcmd.PreRunner) *cobra.Command {
 		Annotations: map[string]string{pcmd.RunRequirement: pcmd.RequireNonAPIKeyCloudLogin},
 	}
 
-	c := &command{pcmd.NewAuthenticatedStateFlagCommand(cmd, prerunner)}
+	c := &command{pcmd.NewAuthenticatedCLICommand(cmd, prerunner)}
 
 	dc := dynamicconfig.New(cfg, nil, nil)
 	_ = dc.ParseFlagsIntoConfig(cmd)

--- a/internal/cmd/schema-registry/command.go
+++ b/internal/cmd/schema-registry/command.go
@@ -13,7 +13,7 @@ import (
 )
 
 type command struct {
-	*pcmd.AuthenticatedStateFlagCommand
+	*pcmd.AuthenticatedCLICommand
 	srClient *srsdk.APIClient
 }
 
@@ -27,9 +27,9 @@ func New(cfg *v1.Config, prerunner pcmd.PreRunner, srClient *srsdk.APIClient) *c
 
 	c := &command{srClient: srClient}
 	if cfg.IsCloudLogin() {
-		c.AuthenticatedStateFlagCommand = pcmd.NewAuthenticatedStateFlagCommand(cmd, prerunner)
+		c.AuthenticatedCLICommand = pcmd.NewAuthenticatedCLICommand(cmd, prerunner)
 	} else {
-		c.AuthenticatedStateFlagCommand = pcmd.NewAuthenticatedWithMDSStateFlagCommand(cmd, prerunner)
+		c.AuthenticatedCLICommand = pcmd.NewAuthenticatedWithMDSCLICommand(cmd, prerunner)
 	}
 
 	cmd.AddCommand(c.newClusterCommand(cfg))

--- a/mock/commander.go
+++ b/mock/commander.go
@@ -60,7 +60,7 @@ func NewPreRunnerMdsV2Mock(v2Client *ccloudv2.Client, mdsClient *mdsv2alpha1.API
 	}
 }
 
-func (c *Commander) Anonymous(command *pcmd.CLICommand, _ bool) func(cmd *cobra.Command, args []string) error {
+func (c *Commander) Anonymous(command *pcmd.CLICommand, _ bool) func(*cobra.Command, []string) error {
 	return func(cmd *cobra.Command, args []string) error {
 		if command != nil {
 			command.Version = c.Version
@@ -70,7 +70,7 @@ func (c *Commander) Anonymous(command *pcmd.CLICommand, _ bool) func(cmd *cobra.
 	}
 }
 
-func (c *Commander) Authenticated(command *pcmd.AuthenticatedCLICommand) func(cmd *cobra.Command, args []string) error {
+func (c *Commander) Authenticated(command *pcmd.AuthenticatedCLICommand) func(*cobra.Command, []string) error {
 	return func(cmd *cobra.Command, args []string) error {
 		if err := c.Anonymous(command.CLICommand, true)(cmd, args); err != nil {
 			return err
@@ -91,7 +91,7 @@ func (c *Commander) Authenticated(command *pcmd.AuthenticatedCLICommand) func(cm
 	}
 }
 
-func (c *Commander) AuthenticatedWithMDS(command *pcmd.AuthenticatedCLICommand) func(cmd *cobra.Command, args []string) error {
+func (c *Commander) AuthenticatedWithMDS(command *pcmd.AuthenticatedCLICommand) func(*cobra.Command, []string) error {
 	return func(cmd *cobra.Command, args []string) error {
 		if err := c.Anonymous(command.CLICommand, true)(cmd, args); err != nil {
 			return err
@@ -110,7 +110,7 @@ func (c *Commander) AuthenticatedWithMDS(command *pcmd.AuthenticatedCLICommand) 
 	}
 }
 
-func (c *Commander) HasAPIKey(command *pcmd.HasAPIKeyCLICommand) func(cmd *cobra.Command, args []string) error {
+func (c *Commander) HasAPIKey(command *pcmd.HasAPIKeyCLICommand) func(*cobra.Command, []string) error {
 	return func(cmd *cobra.Command, args []string) error {
 		if err := c.Anonymous(command.CLICommand, true)(cmd, args); err != nil {
 			return err
@@ -123,7 +123,7 @@ func (c *Commander) HasAPIKey(command *pcmd.HasAPIKeyCLICommand) func(cmd *cobra
 }
 
 // UseKafkaRest - The PreRun function registered by the mock prerunner for UseKafkaRestCLICommand
-func (c *Commander) InitializeOnPremKafkaRest(command *pcmd.AuthenticatedCLICommand) func(cmd *cobra.Command, args []string) error {
+func (c *Commander) InitializeOnPremKafkaRest(command *pcmd.AuthenticatedCLICommand) func(*cobra.Command, []string) error {
 	return func(cmd *cobra.Command, args []string) error {
 		err := c.AuthenticatedWithMDS(command)(cmd, args)
 		if err != nil {
@@ -134,14 +134,14 @@ func (c *Commander) InitializeOnPremKafkaRest(command *pcmd.AuthenticatedCLIComm
 	}
 }
 
-func (c *Commander) ParseFlagsIntoContext(command *pcmd.AuthenticatedCLICommand) func(cmd *cobra.Command, args []string) error {
+func (c *Commander) ParseFlagsIntoContext(command *pcmd.AuthenticatedCLICommand) func(*cobra.Command, []string) error {
 	return func(cmd *cobra.Command, args []string) error {
 		ctx := command.Context
 		return ctx.ParseFlagsIntoContext(cmd, command.Client)
 	}
 }
 
-func (c *Commander) AnonymousParseFlagsIntoContext(command *pcmd.CLICommand) func(cmd *cobra.Command, args []string) error {
+func (c *Commander) AnonymousParseFlagsIntoContext(command *pcmd.CLICommand) func(*cobra.Command, []string) error {
 	return func(cmd *cobra.Command, args []string) error {
 		ctx := command.Config.Context()
 		return ctx.ParseFlagsIntoContext(cmd, nil)


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
While investigating a separate issue, I realized that most commands are "StateFlag" commands, and the few commands that aren't don't have the same flags, i.e. `--environment` or `--cluster` (and if they did, they should also "StateFlag" commands). This PR makes all authenticated commands "StateFlag" commands by default.

Test & Review
-------------
Verified tests still pass.