### PR TITLE
[CLI-2383] Add pagination to `ksql cluster list`

### DIFF
--- a/internal/cmd/ksql/command.go
+++ b/internal/cmd/ksql/command.go
@@ -132,8 +132,8 @@ func autocompleteClusters(environment string, client *ccloudv2.Client) []string 
 		return nil
 	}
 
-	suggestions := make([]string, len(clusters.Data))
-	for i, cluster := range clusters.Data {
+	suggestions := make([]string, len(clusters))
+	for i, cluster := range clusters {
 		suggestions[i] = fmt.Sprintf("%s\t%s", cluster.GetId(), cluster.Spec.GetDisplayName())
 	}
 	return suggestions

--- a/internal/cmd/ksql/command_cluster_list.go
+++ b/internal/cmd/ksql/command_cluster_list.go
@@ -34,7 +34,7 @@ func (c *ksqlCommand) list(cmd *cobra.Command, _ []string) error {
 	}
 
 	list := output.NewList(cmd)
-	for _, cluster := range clusters.Data {
+	for _, cluster := range clusters {
 		list.Add(c.formatClusterForDisplayAndList(&cluster))
 	}
 	return list.Print()

--- a/internal/pkg/cmd/flags.go
+++ b/internal/pkg/cmd/flags.go
@@ -214,8 +214,8 @@ func autocompleteKSQLClusters(environmentId string, client *ccloudv2.Client) []s
 		return nil
 	}
 
-	suggestions := make([]string, len(clusters.Data))
-	for i, cluster := range clusters.Data {
+	suggestions := make([]string, len(clusters))
+	for i, cluster := range clusters {
 		suggestions[i] = fmt.Sprintf("%s\t%s", cluster.GetId(), cluster.Spec.GetDisplayName())
 	}
 	return suggestions


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- PLACEHOLDER

New Features
- PLACEHOLDER

Bug Fixes
- Fix a bug which could prevent some KSQL clusters from being listed in `confluent ksql cluster list`

Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
`ListKsqlClusters` in `pkg/ccloudv2/ksql.go` was missing pagination support.

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
Ran all tests
Manual testing:
- created 3 ksql clusters
- checked that list shows all 3
- tested page token handling by manually setting the page size from 100 to 2 and checking that it still showed all 3
- did the same as above with a page size of 1

Open Questions / Follow-ups
---------------------------
<!--
Optional: Anything open to discussion for the reviewer, out of scope of this PR, or follow-ups.
-->
