### PR TITLE
Fix CCloud environment lookup for SSO login

### DIFF
--- a/internal/pkg/auth/sso/auth0_utils.go
+++ b/internal/pkg/auth/sso/auth0_utils.go
@@ -1,6 +1,7 @@
 package sso
 
 import (
+	"net/url"
 	"strings"
 
 	testserver "github.com/confluentinc/cli/test/test-server"
@@ -15,24 +16,28 @@ var auth0ClientIds = map[string]string{
 }
 
 func GetAuth0CCloudClientIdFromBaseUrl(baseUrl string) string {
-	if baseUrl == "" {
-		baseUrl = "https://confluent.cloud"
-	}
-
-	var env string
-	if baseUrl == "https://confluent.cloud" {
-		env = "prod"
-	} else if strings.HasSuffix(baseUrl, "priv.cpdev.cloud") {
-		env = "cpd"
-	} else if baseUrl == "https://devel.cpdev.cloud" {
-		env = "devel"
-	} else if baseUrl == "https://stag.cpdev.cloud" {
-		env = "stag"
-	} else if baseUrl == testserver.TestCloudUrl.String() {
-		env = "test"
-	} else {
-		return ""
-	}
-
+	env := getCCloudEnvFromBaseUrl(baseUrl)
 	return auth0ClientIds[env]
+}
+
+func getCCloudEnvFromBaseUrl(baseUrl string) string {
+	u, err := url.Parse(baseUrl)
+	if err != nil {
+		return "prod"
+	}
+
+	if strings.HasSuffix(u.Host, "priv.cpdev.cloud") {
+		return "cpd"
+	}
+
+	switch u.Host {
+	case "stag.cpdev.cloud":
+		return "stag"
+	case "devel.cpdev.cloud":
+		return "devel"
+	case testserver.TestCloudUrl.Host:
+		return "test"
+	default:
+		return "prod"
+	}
 }

--- a/internal/pkg/auth/sso/auth0_utils_test.go
+++ b/internal/pkg/auth/sso/auth0_utils_test.go
@@ -3,8 +3,9 @@ package sso
 import (
 	"testing"
 
-	testserver "github.com/confluentinc/cli/test/test-server"
 	"github.com/stretchr/testify/assert"
+
+	testserver "github.com/confluentinc/cli/test/test-server"
 )
 
 func TestGetCCloudEnvFromBaseUrl(t *testing.T) {

--- a/internal/pkg/auth/sso/auth0_utils_test.go
+++ b/internal/pkg/auth/sso/auth0_utils_test.go
@@ -1,0 +1,28 @@
+package sso
+
+import (
+	"testing"
+
+	testserver "github.com/confluentinc/cli/test/test-server"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetCCloudEnvFromBaseUrl(t *testing.T) {
+	for baseUrl, want := range map[string]string{
+		"":                                "prod",
+		":no-scheme-error.com":            "prod",
+		"confluent.cloud":                 "prod",
+		"default-to-prod.com":             "prod",
+		"https://confluent.cloud":         "prod",
+		"https://confluent.cloud/":        "prod",
+		"https://devel.cpdev.cloud":       "devel",
+		"https://devel.cpdev.cloud/":      "devel",
+		"https://prefix.priv.cpdev.cloud": "cpd",
+		"https://stag.cpdev.cloud":        "stag",
+		"https://stag.cpdev.cloud/":       "stag",
+		testserver.TestCloudUrl.String():  "test",
+	} {
+		env := getCCloudEnvFromBaseUrl(baseUrl)
+		assert.Equal(t, want, env)
+	}
+}


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
* `confluent login --url https://stag.cpdev.cloud/` was not working for SSO logins (note the trailing slash).
* Default to "prod" in case of an error

Test & Review
-------------
Unit tested changes.