### PR TITLE
Replace our pointer conversion functions with SDK equivalents

### DIFF
--- a/test/test-server/kafka_rest_router.go
+++ b/test/test-server/kafka_rest_router.go
@@ -250,16 +250,16 @@ func handleKafkaRPTopicConfigs(t *testing.T) http.HandlerFunc {
 					Data: []cpkafkarestv3.TopicConfigData{
 						{
 							Name:  "cleanup.policy",
-							Value: stringPtr("delete"),
+							Value: cpkafkarestv3.PtrString("delete"),
 						},
 						{
 							Name:       "compression.type",
-							Value:      stringPtr("producer"),
+							Value:      cpkafkarestv3.PtrString("producer"),
 							IsReadOnly: true,
 						},
 						{
 							Name:  "retention.ms",
-							Value: stringPtr("604800000"),
+							Value: cpkafkarestv3.PtrString("604800000"),
 						},
 					},
 				}
@@ -272,11 +272,11 @@ func handleKafkaRPTopicConfigs(t *testing.T) http.HandlerFunc {
 					Data: []cpkafkarestv3.TopicConfigData{
 						{
 							Name:  "compression.type",
-							Value: stringPtr("gzip"),
+							Value: cpkafkarestv3.PtrString("gzip"),
 						},
 						{
 							Name:  "retention.ms",
-							Value: stringPtr("1"),
+							Value: cpkafkarestv3.PtrString("1"),
 						},
 					},
 				}
@@ -633,7 +633,7 @@ func handleKafkaRPLink(t *testing.T) http.HandlerFunc {
 			err := json.NewEncoder(w).Encode(cpkafkarestv3.ListLinksResponseData{
 				Kind:            "",
 				Metadata:        cpkafkarestv3.ResourceMetadata{},
-				SourceClusterId: stringPtr("cluster-1"),
+				SourceClusterId: cpkafkarestv3.PtrString("cluster-1"),
 				LinkName:        "link-1",
 				LinkId:          "LINKID1",
 				TopicsNames:     []string{"link-1-topic-1", "link-1-topic-2"},
@@ -1618,8 +1618,4 @@ func writeErrorResponse(responseWriter http.ResponseWriter, statusCode int, erro
 	}`, errorCode, message)
 	_, err := io.WriteString(responseWriter, errorResponseBody)
 	return err
-}
-
-func stringPtr(s string) *string {
-	return &s
 }

--- a/test/test-server/quotas_handler.go
+++ b/test/test-server/quotas_handler.go
@@ -19,45 +19,45 @@ func handleAppliedQuotas(t *testing.T) http.HandlerFunc {
 		quotaCode := r.URL.Query().Get("id")
 
 		quota1 := servicequotav1.ServiceQuotaV1AppliedQuota{
-			Id:           stringToPtr("quota_a"),
-			Scope:        stringToPtr("kafka_cluster"),
-			DisplayName:  stringToPtr("Quota A"),
+			Id:           servicequotav1.PtrString("quota_a"),
+			Scope:        servicequotav1.PtrString("kafka_cluster"),
+			DisplayName:  servicequotav1.PtrString("Quota A"),
 			Organization: servicequotav1.NewObjectReference("org-123", "", ""),
 			KafkaCluster: servicequotav1.NewObjectReference("lkc-1", "", ""),
 			Environment:  servicequotav1.NewObjectReference("env-1", "", ""),
-			Usage:        int32ToPtr(10),
-			AppliedLimit: int32ToPtr(15),
+			Usage:        servicequotav1.PtrInt32(10),
+			AppliedLimit: servicequotav1.PtrInt32(15),
 		}
 
 		quota2 := servicequotav1.ServiceQuotaV1AppliedQuota{
-			Id:           stringToPtr("quota_a"),
-			Scope:        stringToPtr("kafka_cluster"),
-			DisplayName:  stringToPtr("Qutoa A"),
+			Id:           servicequotav1.PtrString("quota_a"),
+			Scope:        servicequotav1.PtrString("kafka_cluster"),
+			DisplayName:  servicequotav1.PtrString("Qutoa A"),
 			Organization: servicequotav1.NewObjectReference("org-123", "", ""),
 			KafkaCluster: servicequotav1.NewObjectReference("lkc-2", "", ""),
 			Environment:  servicequotav1.NewObjectReference("env-2", "", ""),
-			Usage:        int32ToPtr(11),
-			AppliedLimit: int32ToPtr(16),
+			Usage:        servicequotav1.PtrInt32(11),
+			AppliedLimit: servicequotav1.PtrInt32(16),
 		}
 
 		quota3 := servicequotav1.ServiceQuotaV1AppliedQuota{
-			Id:           stringToPtr("quota_b"),
-			Scope:        stringToPtr("kafka_cluster"),
-			DisplayName:  stringToPtr("Quota B"),
+			Id:           servicequotav1.PtrString("quota_b"),
+			Scope:        servicequotav1.PtrString("kafka_cluster"),
+			DisplayName:  servicequotav1.PtrString("Quota B"),
 			Organization: servicequotav1.NewObjectReference("org-123", "", ""),
 			KafkaCluster: servicequotav1.NewObjectReference("lkc-1", "", ""),
 			Environment:  servicequotav1.NewObjectReference("env-1", "", ""),
-			AppliedLimit: int32ToPtr(17),
+			AppliedLimit: servicequotav1.PtrInt32(17),
 		}
 
 		quota4 := servicequotav1.ServiceQuotaV1AppliedQuota{
-			Id:           stringToPtr("quota_b"),
-			Scope:        stringToPtr("kafka_cluster"),
-			DisplayName:  stringToPtr("Quota B"),
+			Id:           servicequotav1.PtrString("quota_b"),
+			Scope:        servicequotav1.PtrString("kafka_cluster"),
+			DisplayName:  servicequotav1.PtrString("Quota B"),
 			Organization: servicequotav1.NewObjectReference("org-123", "", ""),
 			KafkaCluster: servicequotav1.NewObjectReference("lkc-2", "", ""),
 			Environment:  servicequotav1.NewObjectReference("env-2", "", ""),
-			AppliedLimit: int32ToPtr(18),
+			AppliedLimit: servicequotav1.PtrInt32(18),
 		}
 
 		filteredData := filterQuotaResults([]servicequotav1.ServiceQuotaV1AppliedQuota{quota1, quota2, quota3, quota4}, environment, network, kafkaCluster, quotaCode)
@@ -72,14 +72,6 @@ func handleAppliedQuotas(t *testing.T) http.HandlerFunc {
 		_, err = io.WriteString(w, string(reply))
 		require.NoError(t, err)
 	}
-}
-
-func stringToPtr(s string) *string {
-	return &s
-}
-
-func int32ToPtr(i int32) *int32 {
-	return &i
 }
 
 func filterQuotaResults(quotaList []servicequotav1.ServiceQuotaV1AppliedQuota, environment string, network string, kafkaCluster string, quotaCode string) []servicequotav1.ServiceQuotaV1AppliedQuota {

--- a/test/test-server/streamsharing_handler.go
+++ b/test/test-server/streamsharing_handler.go
@@ -15,9 +15,9 @@ import (
 func getTestConsumerShare() cdxv1.CdxV1ConsumerShare {
 	expiresAt, _ := time.Parse(time.RFC3339, "2022-07-22T22:08:41+00:00")
 	return cdxv1.CdxV1ConsumerShare{
-		Id:                       stringToPtr("ss-12345"),
-		ProviderUserName:         stringToPtr("provider"),
-		ProviderOrganizationName: stringPtr("provider org"),
+		Id:                       cdxv1.PtrString("ss-12345"),
+		ProviderUserName:         cdxv1.PtrString("provider"),
+		ProviderOrganizationName: cdxv1.PtrString("provider org"),
 		Status:                   &cdxv1.CdxV1ConsumerShareStatus{Phase: "active"},
 		InviteExpiresAt:          &expiresAt,
 	}
@@ -25,14 +25,14 @@ func getTestConsumerShare() cdxv1.CdxV1ConsumerShare {
 
 func getTestConsumerSharedResource() cdxv1.CdxV1ConsumerSharedResource {
 	return cdxv1.CdxV1ConsumerSharedResource{
-		Id: stringToPtr("sr-12345"),
+		Id: cdxv1.PtrString("sr-12345"),
 	}
 }
 
 func getTestAWSNetwork() *cdxv1.CdxV1AwsNetwork {
 	return &cdxv1.CdxV1AwsNetwork{
 		Kind:                       "AwsNetwork",
-		PrivateLinkEndpointService: stringToPtr("com.amazonaws.vpce.us-west-2.vpce-svc-0000000000"),
+		PrivateLinkEndpointService: cdxv1.PtrString("com.amazonaws.vpce.us-west-2.vpce-svc-0000000000"),
 	}
 }
 
@@ -41,11 +41,11 @@ func getTestProviderShare() cdxv1.CdxV1ProviderShare {
 	redeemedAt, _ := time.Parse(time.RFC3339, "2022-07-21T22:08:41+00:00")
 	expiresAt, _ := time.Parse(time.RFC3339, "2022-07-22T22:08:41+00:00")
 	return cdxv1.CdxV1ProviderShare{
-		Id:                       stringToPtr("ss-12345"),
-		ConsumerUserName:         stringToPtr("consumer"),
-		ConsumerOrganizationName: stringToPtr("consumer org"),
+		Id:                       cdxv1.PtrString("ss-12345"),
+		ConsumerUserName:         cdxv1.PtrString("consumer"),
+		ConsumerOrganizationName: cdxv1.PtrString("consumer org"),
 		Status:                   &cdxv1.CdxV1ProviderShareStatus{Phase: "active"},
-		DeliveryMethod:           stringToPtr("email"),
+		DeliveryMethod:           cdxv1.PtrString("email"),
 		RedeemedAt:               &redeemedAt,
 		InvitedAt:                &invitedAt,
 		InviteExpiresAt:          &expiresAt,
@@ -127,13 +127,13 @@ func handleStreamSharingConsumerShare(t *testing.T) http.HandlerFunc {
 func handleStreamSharingRedeemToken(t *testing.T) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		response := cdxv1.CdxV1RedeemTokenResponse{
-			Id:                   stringPtr("ss-12345"),
-			ApiKey:               stringPtr("00000000000000000000"),
-			Secret:               stringPtr("00000000000000000000"),
-			KafkaBootstrapUrl:    stringPtr("pkc-00000.us-east1.gcp.confluent.cloud:9092"),
-			SchemaRegistryUrl:    stringToPtr("https://psrc-xyz123.us-west-2.aws.cpdev.cloud"),
-			SchemaRegistryApiKey: stringPtr("00000000000000000000"),
-			SchemaRegistrySecret: stringPtr("00000000000000000000"),
+			Id:                   cdxv1.PtrString("ss-12345"),
+			ApiKey:               cdxv1.PtrString("00000000000000000000"),
+			Secret:               cdxv1.PtrString("00000000000000000000"),
+			KafkaBootstrapUrl:    cdxv1.PtrString("pkc-00000.us-east1.gcp.confluent.cloud:9092"),
+			SchemaRegistryUrl:    cdxv1.PtrString("https://psrc-xyz123.us-west-2.aws.cpdev.cloud"),
+			SchemaRegistryApiKey: cdxv1.PtrString("00000000000000000000"),
+			SchemaRegistrySecret: cdxv1.PtrString("00000000000000000000"),
 			Resources: &[]cdxv1.CdxV1RedeemTokenResponseResourcesOneOf{
 				{
 					CdxV1SharedTopic: &cdxv1.CdxV1SharedTopic{
@@ -171,7 +171,7 @@ func handleConsumerSharedResources(t *testing.T) http.HandlerFunc {
 func handlePrivateLinkNetworkConfig(t *testing.T) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		network := cdxv1.CdxV1Network{
-			DnsDomain:       stringToPtr("abc123.us-west-2.aws.stag.cpdev.cloud"),
+			DnsDomain:       cdxv1.PtrString("abc123.us-west-2.aws.stag.cpdev.cloud"),
 			Zones:           &[]string{"usw2-az1", "usw2-az3", "usw2-az2"},
 			ZonalSubdomains: &map[string]string{"usw2-az2": "usw2-az2.abc123.us-west-2.aws.stag.cpdev.cloud"},
 			Cloud:           &cdxv1.CdxV1NetworkCloudOneOf{CdxV1AwsNetwork: getTestAWSNetwork()},


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- PLACEHOLDER

New Features
- PLACEHOLDER

Bug Fixes
- PLACEHOLDER

Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
I'm splitting off some of the tangential changes from the CLI-2065 into separate PRs since that one is getting large.

The SDKs we're using already come with functions to convert strings and int32s to pointers so there's no need to write our own functions to do it. We also had two identical versions of the string to pointer function, which are both removed here.

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
Tests still pass.

Open Questions / Follow-ups
---------------------------
<!--
Optional: Anything open to discussion for the reviewer, out of scope of this PR, or follow-ups.
-->
