### PR TITLE
Prevent `""` environment from being stored in configuration file

### DIFF
--- a/internal/pkg/config/v1/context.go
+++ b/internal/pkg/config/v1/context.go
@@ -40,7 +40,7 @@ func newContext(name string, platform *Platform, credential *Credential, kafkaCl
 		Credential:             credential,
 		CredentialName:         credential.Name,
 		CurrentEnvironment:     envId,
-		Environments:           map[string]*EnvironmentContext{envId: {}},
+		Environments:           map[string]*EnvironmentContext{},
 		SchemaRegistryClusters: schemaRegistryClusters,
 		State:                  state,
 		Config:                 config,


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
A small papercut: After #1840, a environment named `""` was being created in the `environments` field of the configuration file. This has no impact, but we should still clean it up. The root cause is the `envId` field that gets passed into the following function is always `""`, except during tests (unit tests that should actually be integration tests) where it is not empty, but also has no impact and can be deleted. Will clean the relevant tests in the future.

Test & Review
-------------
All tests still pass.