### PR TITLE
Use common page token function in our mds pkg

### DIFF
--- a/internal/pkg/ccloudv2/mds.go
+++ b/internal/pkg/ccloudv2/mds.go
@@ -47,7 +47,7 @@ func (c *Client) ListIamRoleBindings(crnPattern, principal, roleName string) ([]
 		}
 		list = append(list, page.GetData()...)
 
-		pageToken, done, err = extractMdsNextPageToken(page.GetMetadata().Next)
+		pageToken, done, err = extractNextPageToken(page.GetMetadata().Next)
 		if err != nil {
 			return nil, err
 		}
@@ -68,13 +68,4 @@ func (c *Client) executeListIamV2RoleBindings(crnPattern, principal, roleName, p
 		req = req.PageToken(pageToken)
 	}
 	return c.MdsClient.RoleBindingsIamV2Api.ListIamV2RoleBindingsExecute(req)
-}
-
-func extractMdsNextPageToken(nextPageUrlStringNullable mdsv2.NullableString) (string, bool, error) {
-	if !nextPageUrlStringNullable.IsSet() || nextPageUrlStringNullable.Get() == nil {
-		return "", true, nil
-	}
-	nextPageUrlString := *nextPageUrlStringNullable.Get()
-	pageToken, err := extractPageToken(nextPageUrlString)
-	return pageToken, false, err
 }


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- PLACEHOLDER

New Features
- PLACEHOLDER

Bug Fixes
- PLACEHOLDER

Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
Switched to using the common `extractNextPageToken` function instead of the mds specific one since the backend now returns `"metadata":{}` on the last page, in line with other v2 paginated endpoints.

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
Ran all tests
Manual testing: Listed 10 role-bindings with page size 100 (our default) and 2.

Open Questions / Follow-ups
---------------------------
<!--
Optional: Anything open to discussion for the reviewer, out of scope of this PR, or follow-ups.
-->
