### PR TITLE
Stop refreshing tokens in the anonymous prerunner

### DIFF
--- a/internal/pkg/cmd/prerunner.go
+++ b/internal/pkg/cmd/prerunner.go
@@ -172,18 +172,6 @@ func (r *PreRun) Anonymous(command *CLICommand, willAuthenticate bool) func(*cob
 		r.notifyIfUpdateAvailable(cmd, command.Version.Version)
 		r.warnIfConfluentLocal(cmd)
 
-		if r.Config != nil {
-			ctx := command.Config.Context()
-			err := r.ValidateToken(command.Config, unsafeTrace)
-			switch err.(type) {
-			case *ccloudv1.ExpiredTokenError:
-				if err := ctx.DeleteUserAuth(); err != nil {
-					return err
-				}
-				output.ErrPrintln(errors.TokenExpiredMsg)
-			}
-		}
-
 		LabelRequiredFlags(cmd)
 
 		return nil
@@ -281,8 +269,10 @@ func (r *PreRun) Authenticated(command *AuthenticatedCLICommand) func(*cobra.Com
 			return err
 		}
 
-		if err := r.ValidateToken(command.Config, unsafeTrace); err != nil {
-			return err
+		if err := r.ValidateToken(command.Config); err != nil {
+			if err := r.updateToken(err, command.Config.Context(), unsafeTrace); err != nil {
+				return err
+			}
 		}
 
 		if err := r.setV2Clients(command); err != nil {
@@ -559,7 +549,13 @@ func (r *PreRun) AuthenticatedWithMDS(command *AuthenticatedCLICommand) func(*co
 			return err
 		}
 
-		return r.ValidateToken(command.Config, unsafeTrace)
+		if err := r.ValidateToken(command.Config); err != nil {
+			if err := r.updateToken(err, command.Config.Context(), unsafeTrace); err != nil {
+				return err
+			}
+		}
+
+		return nil
 	}
 }
 
@@ -808,8 +804,10 @@ func (r *PreRun) HasAPIKey(command *HasAPIKeyCLICommand) func(*cobra.Command, []
 				return err
 			}
 
-			if err := r.ValidateToken(command.Config, unsafeTrace); err != nil {
-				return err
+			if err := r.ValidateToken(command.Config); err != nil {
+				if err := r.updateToken(err, command.Config.Context(), unsafeTrace); err != nil {
+					return err
+				}
 			}
 
 			client, err := r.createCCloudClient(ctx, command.Version)
@@ -863,7 +861,7 @@ func (r *PreRun) HasAPIKey(command *HasAPIKeyCLICommand) func(*cobra.Command, []
 	}
 }
 
-func (r *PreRun) ValidateToken(config *dynamicconfig.DynamicConfig, unsafeTrace bool) error {
+func (r *PreRun) ValidateToken(config *dynamicconfig.DynamicConfig) error {
 	if config == nil {
 		return new(errors.NotLoggedInError)
 	}
@@ -871,39 +869,25 @@ func (r *PreRun) ValidateToken(config *dynamicconfig.DynamicConfig, unsafeTrace 
 	if ctx == nil {
 		return new(errors.NotLoggedInError)
 	}
-	err := r.JWTValidator.Validate(ctx.Context)
-	if err == nil {
-		return nil
-	}
-	switch err.(type) {
-	case *ccloudv1.InvalidTokenError:
-		return r.updateToken(new(ccloudv1.InvalidTokenError), ctx, unsafeTrace)
-	case *ccloudv1.ExpiredTokenError:
-		return r.updateToken(new(ccloudv1.ExpiredTokenError), ctx, unsafeTrace)
-	}
-	if err.Error() == errors.MalformedJWTNoExprErrorMsg {
-		return r.updateToken(errors.New(errors.MalformedJWTNoExprErrorMsg), ctx, unsafeTrace)
-	} else {
-		return r.updateToken(err, ctx, unsafeTrace)
-	}
+	return r.JWTValidator.Validate(ctx.Context)
 }
 
 func (r *PreRun) updateToken(tokenError error, ctx *dynamicconfig.DynamicContext, unsafeTrace bool) error {
-	if ctx == nil {
-		log.CliLogger.Debug("Dynamic context is nil. Cannot attempt to update auth token.")
-		return tokenError
-	}
 	log.CliLogger.Debug("Updating auth tokens")
 	token, refreshToken, err := r.getUpdatedAuthToken(ctx, unsafeTrace)
 	if err != nil || token == "" {
 		log.CliLogger.Debug("Failed to update auth tokens")
+		_ = ctx.DeleteUserAuth()
+
+		if _, ok := tokenError.(*ccloudv1.InvalidTokenError); ok {
+			tokenError = new(ccloudv1.InvalidTokenError)
+		}
+
 		return tokenError
 	}
+
 	log.CliLogger.Debug("Successfully updated auth tokens")
-	if err := ctx.UpdateAuthTokens(token, refreshToken); err != nil {
-		return tokenError
-	}
-	return nil
+	return ctx.UpdateAuthTokens(token, refreshToken)
 }
 
 func (r *PreRun) getUpdatedAuthToken(ctx *dynamicconfig.DynamicContext, unsafeTrace bool) (string, string, error) {

--- a/internal/pkg/errors/strings.go
+++ b/internal/pkg/errors/strings.go
@@ -87,7 +87,6 @@ const (
 	NoMajorVersionUpdateMsg = "No major version updates are available.\n"
 
 	// cmd package
-	TokenExpiredMsg      = "Your token has expired. You are now logged out."
 	NotifyMajorUpdateMsg = "A major version update is available for %s from (current: %s, latest: %s).\nTo view release notes and install the update, please run `%s update --major`.\n\n"
 	NotifyMinorUpdateMsg = "A minor version update is available for %s from (current: %s, latest: %s).\nTo view release notes and install the update, please run `%s update`.\n\n"
 	AutoLoginMsg         = "Successful auto log in with non-interactive credentials.\n"

--- a/test/login_test.go
+++ b/test/login_test.go
@@ -87,8 +87,8 @@ func (s *CLITestSuite) TestCcloudErrors() {
 		require.Contains(t, output, fmt.Sprintf(errors.LoggedInAsMsgWithOrg, "expired@user.com", "abc-123", "Confluent"))
 		require.Contains(t, output, fmt.Sprintf(errors.LoggedInUsingEnvMsg, "a-595"))
 		output = runCommand(t, testBin, []string{}, "kafka cluster list", 1, "")
-		require.Contains(t, output, errors.TokenExpiredMsg)
-		require.Contains(t, output, errors.NotLoggedInErrorMsg)
+		require.Contains(t, output, errors.ExpiredTokenErrorMsg)
+		require.Contains(t, output, errors.ComposeSuggestionsMessage(errors.ExpiredTokenSuggestions))
 	})
 
 	s.T().Run("malformed token", func(t *testing.T) {


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
It's a bit disorienting to run an unauthenticated command such as `confluent version` and see a message such as "token expired"... ideally these functions should not perform any authentication-related logic.

Refactored the `ValidateToken()` and `updateToken()` so they do what their names suggest, and prevent tokens from being updated/deleted by the Anonymous prerunner.

While testing #1871, I would occasionally see two calls to `/api/sessions` if the token was expired and the user ran `confluent login`, which inspired this PR.

Test & Review
-------------
Manual testing, patched unit/integration tests

Open Questions / Follow-ups
---------------------------
There is still an issue with logging in to SSO accounts in different environments (i.e. prod and then fedramp) which will also need to be fixed.