### PR TITLE
Resolve bug preventing permanent deletion of schemas

### DIFF
--- a/internal/cmd/schema-registry/command_schema_delete.go
+++ b/internal/cmd/schema-registry/command_schema_delete.go
@@ -78,11 +78,13 @@ func deleteSchema(cmd *cobra.Command, srClient *srsdk.APIClient, ctx context.Con
 		checkVersion = "latest"
 	}
 	if permanent {
-		opts := &srsdk.GetSchemaByVersionOpts{Deleted: optional.NewBool(true)}
-		if _, httpResp, err := srClient.DefaultApi.GetSchemaByVersion(ctx, subject, checkVersion, opts); err != nil {
-			return errors.CatchSchemaNotFoundError(err, httpResp)
-		} else if _, _, err := srClient.DefaultApi.GetSchemaByVersion(ctx, subject, checkVersion, nil); err == nil {
-			return errors.New("you must first soft delete a schema version before you can permanently delete it")
+		if checkVersion != "latest" {
+			opts := &srsdk.GetSchemaByVersionOpts{Deleted: optional.NewBool(true)}
+			if _, httpResp, err := srClient.DefaultApi.GetSchemaByVersion(ctx, subject, checkVersion, opts); err != nil {
+				return errors.CatchSchemaNotFoundError(err, httpResp)
+			} else if _, _, err := srClient.DefaultApi.GetSchemaByVersion(ctx, subject, checkVersion, nil); err == nil {
+				return errors.New("you must first soft delete a schema version before you can permanently delete it")
+			}
 		}
 	} else if _, httpResp, err := srClient.DefaultApi.GetSchemaByVersion(ctx, subject, checkVersion, nil); err != nil {
 		return errors.CatchSchemaNotFoundError(err, httpResp)

--- a/internal/cmd/schema-registry/command_schema_list.go
+++ b/internal/cmd/schema-registry/command_schema_list.go
@@ -43,6 +43,7 @@ func (c *command) newSchemaListCommand() *cobra.Command {
 	}
 
 	cmd.Flags().String("subject-prefix", "", "List schemas for subjects with a given prefix.")
+	cmd.Flags().Bool("deleted", false, "Include soft-deleted schemas.")
 	pcmd.AddApiKeyFlag(cmd, c.AuthenticatedCLICommand)
 	pcmd.AddApiSecretFlag(cmd)
 	pcmd.AddContextFlag(cmd, c.CLICommand)
@@ -67,7 +68,12 @@ func (c *command) listSchemas(cmd *cobra.Command, srClient *srsdk.APIClient, ctx
 		return err
 	}
 
-	opts := &srsdk.GetSchemasOpts{SubjectPrefix: optional.NewString(subjectPrefix)}
+	showDeleted, err := cmd.Flags().GetBool("deleted")
+	if err != nil {
+		return err
+	}
+
+	opts := &srsdk.GetSchemasOpts{SubjectPrefix: optional.NewString(subjectPrefix), Deleted: optional.NewBool(showDeleted)}
 	schemas, _, err := srClient.DefaultApi.GetSchemas(ctx, opts)
 	if err != nil {
 		return err


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- PLACEHOLDER

New Features
- Add a new `--deleted` flag to `confluent schema-registry schema list` to include soft-deleted schemas in the output

Bug Fixes
- Schemas can now be permanently deleted with `confluent schema-registry schema delete` when using `--version all`

Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
`GetSchemaByVersion` from `schema-registry-sdk-go` doesn't currently work with the `Deleted` optional argument when the version is `latest` or `all`, so until that issue is resolved I'm disabling the existence check.

I also added a flag to `sr schema list` to show soft deleted schemas in addition to everything else.

References
----------
n/a

Test & Review
-------------
Ran all tests
Made sure that all manual test cases from https://github.com/confluentinc/cli/pull/1796 still work as expected

Additionally tested the following case (payment is a soft-deleted subject):
```
confluent sr schema delete --subject payment --version all --permanent
Are you sure you want to permanently delete schema "payment (version all)"?
To confirm, type "payment". To cancel, press Ctrl-C: payment
Successfully hard deleted all versions for subject "payment"
  Version  
-----------
        1  
```

Open Questions / Follow-ups
---------------------------
<!--
Optional: Anything open to discussion for the reviewer, out of scope of this PR, or follow-ups.
-->
