### PR TITLE
[DGS-6655] AsyncAPI Export: Pass a list of topics to export as input

### DIFF
--- a/internal/cmd/asyncapi/command_export.go
+++ b/internal/cmd/asyncapi/command_export.go
@@ -3,6 +3,7 @@ package asyncapi
 import (
 	"context"
 	"fmt"
+	"github.com/confluentinc/cli/internal/pkg/types"
 	"os"
 	"strings"
 	"time"
@@ -107,15 +108,10 @@ func (c *command) export(cmd *cobra.Command, _ []string) error {
 	}
 	channelCount := 0
 
-	topicMap := make(map[string]struct{})
-	for _, topic := range flags.topics {
-		topicMap[topic] = struct{}{}
-	}
-	topicsSpecified := len(topicMap) > 0
-
+	topicsSpecified := types.NewSet(flags.topics...)
 	for _, topic := range accountDetails.topics {
 		// Only use user-specified topics if parameter passed
-		if _, ok := topicMap[topic.GetTopicName()]; topicsSpecified && !ok {
+		if len(topicsSpecified) > 0 && !topicsSpecified.Contains(topic.GetTopicName()) {
 			continue
 		}
 		for _, subject := range accountDetails.subjects {

--- a/internal/cmd/asyncapi/command_export.go
+++ b/internal/cmd/asyncapi/command_export.go
@@ -51,6 +51,7 @@ type flags struct {
 	schemaRegistryApiSecret string
 	valueFormat             string
 	schemaContext           string
+	topics                  []string
 }
 
 // messageOffset is 5, as the schema ID is stored at the [1:5] bytes of a message as meta info (when valid)
@@ -76,6 +77,7 @@ func newExportCommand(prerunner pcmd.PreRunner) *cobra.Command {
 	cmd.Flags().String("schema-registry-api-key", "", "API key for Schema Registry.")
 	cmd.Flags().String("schema-registry-api-secret", "", "API secret for Schema Registry.")
 	cmd.Flags().String("schema-context", "default", "Use a specific schema context.")
+	cmd.Flags().StringSlice("topics", nil, "A comma-separated list of topics to export.")
 	pcmd.AddValueFormatFlag(cmd)
 	pcmd.AddClusterFlag(cmd, c.AuthenticatedCLICommand)
 	pcmd.AddEnvironmentFlag(cmd, c.AuthenticatedCLICommand)
@@ -104,7 +106,18 @@ func (c *command) export(cmd *cobra.Command, _ []string) error {
 		schemaContextPrefix = fmt.Sprintf(":.%s:", flags.schemaContext)
 	}
 	channelCount := 0
+
+	topicMap := make(map[string]struct{})
+	for _, topic := range flags.topics {
+		topicMap[topic] = struct{}{}
+	}
+	topicsSpecified := len(topicMap) > 0
+
 	for _, topic := range accountDetails.topics {
+		// Only use user-specified topics if parameter passed
+		if _, ok := topicMap[topic.GetTopicName()]; topicsSpecified && !ok {
+			continue
+		}
 		for _, subject := range accountDetails.subjects {
 			if subject != schemaContextPrefix+topic.GetTopicName()+"-value" || strings.HasPrefix(topic.GetTopicName(), "_") {
 				// Avoid internal topics or if subject does not follow topic naming strategy
@@ -389,6 +402,10 @@ func getFlags(cmd *cobra.Command) (*flags, error) {
 	if err != nil {
 		return nil, err
 	}
+	topics, err := cmd.Flags().GetStringSlice("topics")
+	if err != nil {
+		return nil, err
+	}
 	return &flags{
 		file:                    file,
 		groupId:                 groupId,
@@ -399,6 +416,7 @@ func getFlags(cmd *cobra.Command) (*flags, error) {
 		schemaRegistryApiSecret: schemaRegistryApiSecret,
 		valueFormat:             valueFormat,
 		schemaContext:           schemaContext,
+		topics:                  topics,
 	}, nil
 }
 

--- a/internal/cmd/asyncapi/command_export.go
+++ b/internal/cmd/asyncapi/command_export.go
@@ -3,7 +3,6 @@ package asyncapi
 import (
 	"context"
 	"fmt"
-	"github.com/confluentinc/cli/internal/pkg/types"
 	"os"
 	"strings"
 	"time"
@@ -25,6 +24,7 @@ import (
 	"github.com/confluentinc/cli/internal/pkg/log"
 	"github.com/confluentinc/cli/internal/pkg/output"
 	"github.com/confluentinc/cli/internal/pkg/serdes"
+	"github.com/confluentinc/cli/internal/pkg/types"
 )
 
 type command struct {

--- a/test/asyncapi_test.go
+++ b/test/asyncapi_test.go
@@ -17,6 +17,8 @@ func (s *CLITestSuite) TestAsyncApiExport() {
 		// Spec Generated
 		{args: "asyncapi export --schema-registry-api-key ASYNCAPIKEY --schema-registry-api-secret ASYNCAPISECRET", fixture: "asyncapi/export-success.golden", useKafka: "lkc-asyncapi", authKafka: "true", workflow: true},
 		{args: "asyncapi export --schema-registry-api-key ASYNCAPIKEY --schema-registry-api-secret ASYNCAPISECRET --schema-context dev --file asyncapi-with-context.yaml", useKafka: "lkc-asyncapi", authKafka: "true", workflow: true},
+		{args: "asyncapi export --schema-registry-api-key ASYNCAPIKEY --schema-registry-api-secret ASYNCAPISECRET --topics topic1 --file asyncapi-topic-specified.yaml", fixture: "asyncapi/export-topic-specified.golden", useKafka: "lkc-asyncapi", authKafka: "true", workflow: true},
+		{args: "asyncapi export --schema-registry-api-key ASYNCAPIKEY --schema-registry-api-secret ASYNCAPISECRET --topics topic2 --file asyncapi-no-topics.yaml", fixture: "asyncapi/export-no-topics.golden", useKafka: "lkc-asyncapi", authKafka: "true", workflow: true},
 	}
 	resetConfiguration(s.T(), false)
 	for _, test := range tests {
@@ -24,7 +26,7 @@ func (s *CLITestSuite) TestAsyncApiExport() {
 		s.runIntegrationTest(test)
 	}
 
-	for _, filename := range []string{"asyncapi-spec.yaml", "asyncapi-with-context.yaml"} {
+	for _, filename := range []string{"asyncapi-spec.yaml", "asyncapi-with-context.yaml", "asyncapi-topic-specified.yaml", "asyncapi-no-topics.yaml"} {
 		require.FileExists(s.T(), filename)
 		defer os.Remove(filename)
 

--- a/test/fixtures/output/asyncapi/asyncapi-no-topics.yaml
+++ b/test/fixtures/output/asyncapi/asyncapi-no-topics.yaml
@@ -1,0 +1,20 @@
+asyncapi: 2.4.0
+info:
+  title: API Document for Confluent Cluster
+  version: 1.0.0
+servers:
+  confluentSchemaRegistry: []
+channels: {}
+components:
+  securitySchemes:
+    confluentBroker:
+      type: userPassword
+      x-configs:
+        sasl.mechanisms: PLAIN
+        sasl.password: '{{CLUSTER_API_SECRET}}'
+        sasl.username: '{{CLUSTER_API_KEY}}'
+        security.protocol: sasl_ssl
+    confluentSchemaRegistry:
+      type: userPassword
+      x-configs:
+        basic.auth.user.info: '{{SCHEMA_REGISTRY_API_KEY}}:{{SCHEMA_REGISTRY_API_SECRET}}'

--- a/test/fixtures/output/asyncapi/asyncapi-topic-specified.yaml
+++ b/test/fixtures/output/asyncapi/asyncapi-topic-specified.yaml
@@ -1,0 +1,63 @@
+asyncapi: 2.4.0
+info:
+  title: API Document for Confluent Cluster
+  version: 1.0.0
+servers:
+  confluentSchemaRegistry: []
+channels:
+  topic1:
+    subscribe:
+      operationId: Topic1Subscribe
+      bindings:
+        kafka:
+          bindingVersion: 0.3.0
+          groupId:
+            type: string
+          clientId:
+            type: string
+      message:
+        $ref: '#/components/messages/Topic1Message'
+    bindings:
+      kafka:
+        x-partitions: 3
+        x-configs:
+          cleanup.policy: delete
+          delete.retention.ms: "86400000"
+    x-messageCompatibility: FORWARD
+components:
+  messages:
+    Topic1Message:
+      payload:
+        doc: Sample schema to help you get started.
+        fields:
+        - doc: The int type is a 32-bit signed integer.
+          name: my_field1
+          type: int
+        - doc: The double type is a double precision(64-bit) IEEE754 floating-point
+            number.
+          name: my_field2
+          type: double
+        - doc: The string is a unicode character sequence.
+          name: my_field3
+          type: string
+        name: sampleRecord
+        namespace: com.mycorp.mynamespace
+        type: AVRO
+      name: Topic1Message
+      bindings:
+        kafka:
+          bindingVersion: 0.3.0
+          key:
+            type: string
+  securitySchemes:
+    confluentBroker:
+      type: userPassword
+      x-configs:
+        sasl.mechanisms: PLAIN
+        sasl.password: '{{CLUSTER_API_SECRET}}'
+        sasl.username: '{{CLUSTER_API_KEY}}'
+        security.protocol: sasl_ssl
+    confluentSchemaRegistry:
+      type: userPassword
+      x-configs:
+        basic.auth.user.info: '{{SCHEMA_REGISTRY_API_KEY}}:{{SCHEMA_REGISTRY_API_SECRET}}'

--- a/test/fixtures/output/asyncapi/export-no-topics.golden
+++ b/test/fixtures/output/asyncapi/export-no-topics.golden
@@ -1,0 +1,1 @@
+AsyncAPI specification written to "asyncapi-no-topics.yaml".

--- a/test/fixtures/output/asyncapi/export-topic-specified.golden
+++ b/test/fixtures/output/asyncapi/export-topic-specified.golden
@@ -1,0 +1,2 @@
+Added topic "topic1".
+AsyncAPI specification written to "asyncapi-topic-specified.yaml".


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

New Features
- Add `--topics` flag to `confluent asyncapi export` to only export specified topics

Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->

- Added flag to allow user to specify a list of topics to export on asyncapi. If this parameter is set, we check that the topic is listed under `--topics` before exporting it
- Optional flag, default is still to export all topics

Test & Review
-------------
<!--
Has it been tested? How?
Copy and paste any instructions or steps that can save the reviewer time.
-->

Tested on prod confluent cloud, create topics and schemas (with TopicNamingStrategy) and export a subset of them with `--topics topic1,topic2...`
<!--
Optional: Anything open to discussion for the reviewer, out of scope of this PR, or follow-ups.
-->
