### PR TITLE
Fix diff in `update-db`

### DIFF
--- a/mk-files/cc-cli-service.mk
+++ b/mk-files/cc-cli-service.mk
@@ -19,7 +19,7 @@ update-db:
 	a=$$(ls | grep up | tail -n 2 | head -n 1) && \
 	b=$$(ls | grep up | tail -n 1) && \
 	sed -i "" "s/v[0-9]*\.[0-9]*\.[0-9]*/v$${version}/" $$a && \
-	diff=$$(diff -u $$a $$b) && \
+	diff=$$(diff -u $$a $$b); [ $$? -lt 2 ] && \
 	body=$$(echo -e "\`\`\`diff$${diff}\n\n\`\`\`") && \
 	if [ "$${diff}" = "" ]; then \
 		body="No changes."; \


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- PLACEHOLDER

New Features
- PLACEHOLDER

Bug Fixes
- PLACEHOLDER

Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok
   * no: DO NOT MERGE until the required features are live in prod  

What
----
`diff`'s exit status is `0` for no differences, `1` for differences, and `>1` for errors. But bash interprets `1` as an error, so the script fails if there are differences.

The fix is to check that the exit code `$?` is less than 2.

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
Manually tested with `DRY_RUN=true`. 

Since that run had a difference, I also changed the diff command to `diff=$$(diff -u $$a $$a)` to check success for no changes and `diff=$$(diff -u $$a)` to check failure for errors.

Open Questions / Follow-ups
---------------------------
<!--
Optional: Anything open to discussion for the reviewer, out of scope of this PR, or follow-ups.
-->
