### PR TITLE
Set up GoReleaser Pro

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,8 +1,5 @@
 project_name: confluent
 
-partial:
-  by: target
-
 builds:
   - binary: confluent
     id: confluent-alpine-amd64
@@ -115,6 +112,18 @@ builds:
       post:
         - cmd: scripts/gon_filepath_editor.sh {{ .Path }} arm64
         - cmd: gon dist/gon_confluent_arm64.hcl
+  - builder: prebuilt
+    goos:
+      - linux
+    goarch:
+      - amd64
+      - arm64
+    goamd64:
+      - v1
+    
+    prebuilt:
+      path: dist/confluent_{{ .Os }}_{{ .Arch }}_{{ with .Amd64 }}_v1{{ end }}/confluent
+
 
 release:
   disable: "{{.Env.DRY_RUN}}"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,5 +1,8 @@
 project_name: confluent
 
+partial:
+  by: target
+
 builds:
   - binary: confluent
     id: confluent-alpine-amd64

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -120,10 +120,8 @@ builds:
       - arm64
     goamd64:
       - v1
-    
     prebuilt:
       path: dist/confluent_{{ .Os }}_{{ .Arch }}_{{ with .Amd64 }}_v1{{ end }}/confluent
-
 
 release:
   disable: "{{.Env.DRY_RUN}}"

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL              := /bin/bash
 ALL_SRC            := $(shell find . -name "*.go" | grep -v -e vendor)
-GORELEASER_VERSION := v1.16.3-0.20230323115904-f82a32cd3a59
+GORELEASER_VERSION := v1.17.2
 
 .PHONY: build # compile natively based on the system
 build:

--- a/debian/patches/standard_build_layout.patch
+++ b/debian/patches/standard_build_layout.patch
@@ -1,9 +1,9 @@
---- cli/Makefile	2023-03-31 16:37:17.842362310 -0700
+--- cli/Makefile	2023-05-01 10:40:17.301155288 -0700
 +++ debian/Makefile	2023-03-31 13:35:33.741910522 -0700
 @@ -1,121 +1,130 @@
 -SHELL              := /bin/bash
 -ALL_SRC            := $(shell find . -name "*.go" | grep -v -e vendor)
--GORELEASER_VERSION := v1.16.3-0.20230323115904-f82a32cd3a59
+-GORELEASER_VERSION := v1.17.2
 -
 -.PHONY: build # compile natively based on the system
 -build:

--- a/mk-files/release.mk
+++ b/mk-files/release.mk
@@ -57,16 +57,16 @@ endef
 # The glibc container doesn't need to publish to S3 so it doesn't need to $(caasenv-authenticate)
 .PHONY: gorelease-linux-glibc
 gorelease-linux-glibc:
-	go install github.com/goreleaser/goreleaser@$(GORELEASER_VERSION) && \
+	brew install goreleaser/tap/goreleaser-pro && \
 	VERSION=$(VERSION) GOEXPERIMENT=boringcrypto goreleaser release --clean -f .goreleaser-linux-glibc.yml
 
 .PHONY: gorelease-linux-glibc-arm64
 gorelease-linux-glibc-arm64:
 ifneq (,$(findstring x86_64,$(shell uname -m)))
-	go install github.com/goreleaser/goreleaser@$(GORELEASER_VERSION) && \
+	brew install goreleaser/tap/goreleaser-pro && \
 	VERSION=$(VERSION) CGO_ENABLED=1 CC=aarch64-linux-gnu-gcc CXX=aarch64-linux-gnu-g++ GOEXPERIMENT=boringcrypto goreleaser release --clean -f .goreleaser-linux-glibc-arm64.yml
 else
-	go install github.com/goreleaser/goreleaser@$(GORELEASER_VERSION) && \
+	brew install goreleaser/tap/goreleaser-pro && \
 	VERSION=$(VERSION) GOEXPERIMENT=boringcrypto goreleaser release --clean -f .goreleaser-linux-glibc-arm64.yml
 endif
 
@@ -76,10 +76,9 @@ endif
 gorelease:
 	$(eval token := $(shell (grep github.com ~/.netrc -A 2 | grep password || grep github.com ~/.netrc -A 2 | grep login) | head -1 | awk -F' ' '{ print $$2 }'))
 	
-	# $(aws-authenticate) && \
-
-	go install github.com/goreleaser/goreleaser@$(GORELEASER_VERSION) && \
-	VERSION=$(VERSION) GOEXPERIMENT=boringcrypto DRY_RUN=$(DRY_RUN) goreleaser release --clean --split --timeout 60m && \
+	$(aws-authenticate) && \
+	brew install goreleaser/tap/goreleaser-pro && \
+	GORELEASER_KEY=$(GORELEASER_KEY) VERSION=$(VERSION) GOEXPERIMENT=boringcrypto DRY_RUN=$(DRY_RUN) goreleaser release --clean --split --timeout 60m && \
 	scripts/build_linux_glibc.sh && \
 	GITHUB_TOKEN=$(token) S3FOLDER=$(S3_STAG_FOLDER_NAME)/confluent-cli DRY_RUN=$(DRY_RUN) goreleaser continue --merge --release-notes release-notes/latest-release
 


### PR DESCRIPTION
What
----
Add prebuilt Linux binaries to the GoReleaser pipeline. This is a first step before we can easily release to various package managers.

References
----------
https://goreleaser.com/customization/builds/#import-pre-built-binaries

Test & Review
-------------
Tested with `DRY_RUN=true`