### PR TITLE
Fix `make release-notes` for out-of-order releases

### DIFF
--- a/internal/pkg/releasenotes/by_version.go
+++ b/internal/pkg/releasenotes/by_version.go
@@ -1,0 +1,23 @@
+package releasenotes
+
+import (
+	"github.com/google/go-github/v50/github"
+	"github.com/hashicorp/go-version"
+)
+
+type byVersion []*github.RepositoryTag
+
+func (v byVersion) Len() int      { return len(v) }
+func (v byVersion) Swap(i, j int) { v[i], v[j] = v[j], v[i] }
+func (v byVersion) Less(i, j int) bool {
+	vi, err := version.NewSemver(v[i].GetName())
+	if err != nil {
+		return true
+	}
+	vj, err := version.NewSemver(v[j].GetName())
+	if err != nil {
+		return false
+	}
+
+	return vi.LessThan(vj)
+}

--- a/internal/pkg/releasenotes/by_version.go
+++ b/internal/pkg/releasenotes/by_version.go
@@ -7,8 +7,10 @@ import (
 
 type byVersion []*github.RepositoryTag
 
-func (v byVersion) Len() int      { return len(v) }
+func (v byVersion) Len() int { return len(v) }
+
 func (v byVersion) Swap(i, j int) { v[i], v[j] = v[j], v[i] }
+
 func (v byVersion) Less(i, j int) bool {
 	vi, err := version.NewSemver(v[i].GetName())
 	if err != nil {


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
`make release-notes` fails if the last release was out-of-order. Determine the latest release by sorting tags by semver.