### PR TITLE
Fix GoReleaser Pro

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -121,7 +121,7 @@ builds:
     goamd64:
       - v1
     prebuilt:
-      path: dist/confluent_{{ .Os }}_{{ .Arch }}_{{ with .Amd64 }}_v1{{ end }}/confluent
+      path: dist/confluent_{{ .Os }}_{{ .Arch }}_{{ with .Amd64 }}_{{ . }}{{ end }}/confluent
 
 release:
   disable: "{{.Env.DRY_RUN}}"

--- a/mk-files/release.mk
+++ b/mk-files/release.mk
@@ -77,9 +77,10 @@ gorelease:
 	$(eval token := $(shell (grep github.com ~/.netrc -A 2 | grep password || grep github.com ~/.netrc -A 2 | grep login) | head -1 | awk -F' ' '{ print $$2 }'))
 	
 	$(aws-authenticate) && \
-	GORELEASER_KEY=$(GORELEASER_KEY) VERSION=$(VERSION) GOEXPERIMENT=boringcrypto DRY_RUN=$(DRY_RUN) goreleaser release --clean --prepare --release-notes release-notes/latest-release --timeout 60m && \
+	rm -r dist/ && \
+	mkdir dist/ && \
 	scripts/build_linux_glibc.sh && \
-	GORELEASER_KEY=$(GORELEASER_KEY) GITHUB_TOKEN=$(token) S3FOLDER=$(S3_STAG_FOLDER_NAME)/confluent-cli DRY_RUN=$(DRY_RUN) goreleaser continue
+	GORELEASER_KEY=$(GORELEASER_KEY) VERSION=$(VERSION) GOEXPERIMENT=boringcrypto S3FOLDER=$(S3_STAG_FOLDER_NAME)/confluent-cli GITHUB_TOKEN=$(token) DRY_RUN=$(DRY_RUN) goreleaser release --clean --release-notes release-notes/latest-release --timeout 60m
 
 # Current goreleaser still has some shortcomings for the our use, and the target patches those issues
 # As new goreleaser versions allow more customization, we may be able to reduce the work for this make target

--- a/scripts/build_linux_glibc.sh
+++ b/scripts/build_linux_glibc.sh
@@ -20,4 +20,5 @@ fi
 docker container create --name cli-linux-glibc-arm64-builder cli-linux-glibc-arm64-builder-image
 docker container cp cli-linux-glibc-arm64-builder:/cli/dist/. ./dist/
 docker container rm cli-linux-glibc-arm64-builder
+
 rm -rf vendor


### PR DESCRIPTION
What
----
No need to break the GoReleaser run into two separate commands. We can build the Linux binaries first and add them as `prebuilt`. Also fixed some small bugs.