### PR TITLE
Fix dist folder management for `make gorelease`

### DIFF
--- a/mk-files/release.mk
+++ b/mk-files/release.mk
@@ -77,10 +77,10 @@ gorelease:
 	$(eval token := $(shell (grep github.com ~/.netrc -A 2 | grep password || grep github.com ~/.netrc -A 2 | grep login) | head -1 | awk -F' ' '{ print $$2 }'))
 	
 	$(aws-authenticate) && \
-	rm -r dist/ && \
+	if [ -d dist/ ]; rm -r dist/; fi && \
 	mkdir dist/ && \
 	scripts/build_linux_glibc.sh && \
-	GORELEASER_KEY=$(GORELEASER_KEY) VERSION=$(VERSION) GOEXPERIMENT=boringcrypto S3FOLDER=$(S3_STAG_FOLDER_NAME)/confluent-cli GITHUB_TOKEN=$(token) DRY_RUN=$(DRY_RUN) goreleaser release --clean --release-notes release-notes/latest-release --timeout 60m
+	GORELEASER_KEY=$(GORELEASER_KEY) VERSION=$(VERSION) GOEXPERIMENT=boringcrypto S3FOLDER=$(S3_STAG_FOLDER_NAME)/confluent-cli GITHUB_TOKEN=$(token) DRY_RUN=$(DRY_RUN) goreleaser release --release-notes release-notes/latest-release --timeout 60m
 
 # Current goreleaser still has some shortcomings for the our use, and the target patches those issues
 # As new goreleaser versions allow more customization, we may be able to reduce the work for this make target

--- a/mk-files/release.mk
+++ b/mk-files/release.mk
@@ -77,7 +77,7 @@ gorelease:
 	$(eval token := $(shell (grep github.com ~/.netrc -A 2 | grep password || grep github.com ~/.netrc -A 2 | grep login) | head -1 | awk -F' ' '{ print $$2 }'))
 	
 	$(aws-authenticate) && \
-	if [ -d dist/ ]; rm -r dist/; fi && \
+	rm -rf dist && \
 	mkdir dist/ && \
 	scripts/build_linux_glibc.sh && \
 	GORELEASER_KEY=$(GORELEASER_KEY) VERSION=$(VERSION) GOEXPERIMENT=boringcrypto S3FOLDER=$(S3_STAG_FOLDER_NAME)/confluent-cli GITHUB_TOKEN=$(token) DRY_RUN=$(DRY_RUN) goreleaser release --release-notes release-notes/latest-release --timeout 60m

--- a/mk-files/release.mk
+++ b/mk-files/release.mk
@@ -77,7 +77,7 @@ gorelease:
 	$(eval token := $(shell (grep github.com ~/.netrc -A 2 | grep password || grep github.com ~/.netrc -A 2 | grep login) | head -1 | awk -F' ' '{ print $$2 }'))
 	
 	$(aws-authenticate) && \
-	rm -rf dist && \
+	rm -rf dist/ && \
 	mkdir dist/ && \
 	scripts/build_linux_glibc.sh && \
 	GORELEASER_KEY=$(GORELEASER_KEY) VERSION=$(VERSION) GOEXPERIMENT=boringcrypto S3FOLDER=$(S3_STAG_FOLDER_NAME)/confluent-cli GITHUB_TOKEN=$(token) DRY_RUN=$(DRY_RUN) goreleaser release --release-notes release-notes/latest-release --timeout 60m


### PR DESCRIPTION
What
----
The `dist/` folder should only be deleted if it exists, and it shouldn't be cleaned at the start of `goreleaser release` since it contains the Linux binaries.