### PR TITLE
Upload Alpine binaries/archives to S3

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -174,6 +174,7 @@ archives:
     
 blobs:
   - ids:
+    - binary-alpine
     - binary
     provider: s3
     bucket: confluent.cloud
@@ -181,6 +182,7 @@ blobs:
     folder: "{{ .Env.S3FOLDER }}/binaries/{{ .Version }}"
     disable: "{{ .Env.DRY_RUN }}" 
   - ids:
+    - archive-alpine
     - archive
     provider: s3
     bucket: confluent.cloud


### PR DESCRIPTION
What
----
All binaries/archives except for alpine were being uploaded to S3, since alpine has a unique ID to avoid naming conflicts.