### PR TITLE
Release to DockerHub with GoReleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -194,7 +194,26 @@ dockers:
   - ids:
       - confluent-alpine-amd64
     image_templates:
-      - "confluentinc/confluent-cli:{{ .Version }}"
-      - "confluentinc/confluent-cli:latest"
+      - "confluentinc/confluent-cli:{{ .Version }}-amd64"
+      - "confluentinc/confluent-cli:latest-amd64"
     skip_push: "{{ .Env.DRY_RUN }}"
     dockerfile: "dockerfiles/Dockerfile"
+  - ids:
+      - confluent-alpine-arm64
+    image_templates:
+      - "confluentinc/confluent-cli:{{ .Version }}-arm64"
+      - "confluentinc/confluent-cli:latest-arm64"
+    skip_push: "{{ .Env.DRY_RUN }}"
+    dockerfile: "dockerfiles/Dockerfile"
+
+docker_manifests:
+  - name_template: "confluentinc/confluent-cli:{{ .Version }}"
+    image_templates:
+      - "confluentinc/confluent-cli:{{ .Version }}-amd64"
+      - "confluentinc/confluent-cli:{{ .Version }}-arm64"
+    skip_push: "{{ .Env.DRY_RUN }}"
+  - name_template: "confluentinc/confluent-cli:latest"
+    image_templates:
+      - "confluentinc/confluent-cli:latest-amd64"
+      - "confluentinc/confluent-cli:latest-arm64"
+    skip_push: "{{ .Env.DRY_RUN }}"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -194,7 +194,7 @@ dockers:
   - ids:
       - confluent-alpine-amd64
     image_templates:
+      - "confluentinc/confluent-cli:{{ .Version }}"
       - "confluentinc/confluent-cli:latest"
-      - "confluentinc/confluent-cli:{{ .Tag }}"
     skip_push: "{{ .Env.DRY_RUN }}"
     dockerfile: "dockerfiles/Dockerfile"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -189,3 +189,12 @@ blobs:
     region: us-west-2
     folder: "{{ .Env.S3FOLDER }}/archives/{{ .Version }}"
     disable: "{{ .Env.DRY_RUN }}" 
+
+dockers:
+  - ids:
+      - confluent-alpine-amd64
+    image_templates:
+      - "confluentinc/confluent-cli:latest"
+      - "confluentinc/confluent-cli:{{ .Tag }}"
+    skip_push: "{{ .Env.DRY_RUN }}"
+    dockerfile: "dockerfiles/Dockerfile"

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,6 @@ cli-builder:
 	TAGS=$(TAGS) CGO_ENABLED=$(CGO_ENABLED) CC=$(CC) CXX=$(CXX) CGO_LDFLAGS=$(CGO_LDFLAGS) VERSION=$(VERSION) GOEXPERIMENT=boringcrypto goreleaser build -f .goreleaser-build.yml --clean --single-target --snapshot
 
 include ./mk-files/cc-cli-service.mk
-include ./mk-files/dockerhub.mk
 include ./mk-files/semver.mk
 include ./mk-files/docs.mk
 include ./mk-files/dry-run.mk

--- a/debian/patches/standard_build_layout.patch
+++ b/debian/patches/standard_build_layout.patch
@@ -1,6 +1,6 @@
---- cli/Makefile	2023-05-05 09:20:15.874939333 -0700
+--- cli/Makefile	2023-05-05 13:52:14.246574940 -0700
 +++ debian/Makefile	2023-03-31 13:35:33.741910522 -0700
-@@ -1,121 +1,130 @@
+@@ -1,120 +1,130 @@
 -SHELL              := /bin/bash
 -ALL_SRC            := $(shell find . -name "*.go" | grep -v -e vendor)
 -GORELEASER_VERSION := v1.17.2
@@ -43,7 +43,6 @@
 -	TAGS=$(TAGS) CGO_ENABLED=$(CGO_ENABLED) CC=$(CC) CXX=$(CXX) CGO_LDFLAGS=$(CGO_LDFLAGS) VERSION=$(VERSION) GOEXPERIMENT=boringcrypto goreleaser build -f .goreleaser-build.yml --clean --single-target --snapshot
 -
 -include ./mk-files/cc-cli-service.mk
--include ./mk-files/dockerhub.mk
 -include ./mk-files/semver.mk
 -include ./mk-files/docs.mk
 -include ./mk-files/dry-run.mk

--- a/mk-files/dockerhub.mk
+++ b/mk-files/dockerhub.mk
@@ -1,7 +1,0 @@
-.PHONY: publish-dockerhub
-publish-dockerhub:
-	# Dockerfile must be in same or subdirectory of this file
-	docker images | grep "confluentinc/confluent-cli" | awk '{system("docker rmi -f " "'"confluentinc/confluent-cli:"'" $$2)}'
-	docker build --no-cache -f ./dockerfiles/Dockerfile -t confluentinc/confluent-cli:$(CLEAN_VERSION) -t confluentinc/confluent-cli:latest ./mk-files/
-	$(call dry-run,docker push confluentinc/confluent-cli:$(CLEAN_VERSION))
-	$(call dry-run,docker push confluentinc/confluent-cli:latest)


### PR DESCRIPTION
Release Notes
-------------
New Features
- Publish linux/arm64 Docker image

What
----
Use GoReleaser to release to DockerHub, instead of mk-files/dockerhub.mk

Test & Review
-------------
Tested with `DRY_RUN=true` and the release was "successfully" published to DockerHub (due to https://github.com/goreleaser/goreleaser/issues/3988) 😬
