### PR TITLE
[CLI-2496] Resolve issue causing users to log into the wrong SSO org

### DIFF
--- a/internal/pkg/auth/auth_token_handler.go
+++ b/internal/pkg/auth/auth_token_handler.go
@@ -94,7 +94,10 @@ func (a *AuthTokenHandlerImpl) getCCloudSSOToken(client *ccloudv1.Client, noBrow
 		return "", "", err
 	}
 
-	req := &ccloudv1.AuthenticateRequest{IdToken: idToken}
+	req := &ccloudv1.AuthenticateRequest{
+		IdToken:       idToken,
+		OrgResourceId: orgResourceId,
+	}
 	res, err := login(client, req)
 	if err != nil {
 		return "", "", err


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- PLACEHOLDER

New Features
- PLACEHOLDER

Bug Fixes
- Prevent `confluent login --organization-id` from logging users into the wrong SSO-enabled organization

Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
After logging in with SSO and obtaining the idp id, the organization resource id was not being sent in the final login request. Without the organization resource id, the backend interprets this as a request to log into the default organization. If that organization also uses the same idp, that request will succeed (*single* sign on), and inadvertently ignore the `organization-id` flag.

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
Manually tested w/ @ivanhyf 's help (successfully logged into the correct organization using this fix).

Open Questions / Follow-ups
---------------------------
<!--
Optional: Anything open to discussion for the reviewer, out of scope of this PR, or follow-ups.
-->
