### PR TITLE
DGS-7258 Async API Ability to only export topics with prefix

### DIFF
--- a/internal/cmd/asyncapi/command_export.go
+++ b/internal/cmd/asyncapi/command_export.go
@@ -20,6 +20,7 @@ import (
 	pcmd "github.com/confluentinc/cli/internal/pkg/cmd"
 	v1 "github.com/confluentinc/cli/internal/pkg/config/v1"
 	"github.com/confluentinc/cli/internal/pkg/errors"
+	"github.com/confluentinc/cli/internal/pkg/examples"
 	"github.com/confluentinc/cli/internal/pkg/kafkarest"
 	"github.com/confluentinc/cli/internal/pkg/log"
 	"github.com/confluentinc/cli/internal/pkg/output"
@@ -64,6 +65,12 @@ func newExportCommand(prerunner pcmd.PreRunner) *cobra.Command {
 		Short: "Export an AsyncAPI specification.",
 		Long:  "Export an AsyncAPI specification for a Kafka cluster and Schema Registry.",
 		Args:  cobra.NoArgs,
+		Example: examples.BuildExampleString(
+			examples.Example{
+				Text: `Export an AsyncAPI specification with topic "my-topic" and all topics starting with "prefix-".`,
+				Code: `confluent asyncapi export --topics "my-topic,prefix-*"`,
+			},
+		),
 	}
 
 	c := &command{pcmd.NewAuthenticatedCLICommand(cmd, prerunner)}
@@ -113,32 +120,31 @@ func (c *command) export(cmd *cobra.Command, _ []string) error {
 		}
 
 		for _, subject := range accountDetails.subjects {
-			if subject != schemaContextPrefix+topic.GetTopicName()+"-value" || strings.HasPrefix(topic.GetTopicName(), "_") {
+			if subject != fmt.Sprintf("%s%s-value", schemaContextPrefix, topic.GetTopicName()) || strings.HasPrefix(topic.GetTopicName(), "_") {
 				// Avoid internal topics or if subject does not follow topic naming strategy
 				continue
-			} else {
-				// Subject and Topic matches
-				// Reset channel details
-				accountDetails.channelDetails = channelDetails{
-					currentTopic:   topic,
-					currentSubject: subject,
+			}
+			// Subject and Topic matches
+			// Reset channel details
+			accountDetails.channelDetails = channelDetails{
+				currentTopic:   topic,
+				currentSubject: subject,
+			}
+			err := c.getChannelDetails(accountDetails, flags)
+			if err != nil {
+				if err.Error() == protobufErrorMessage {
+					log.CliLogger.Info(err.Error())
+					continue
 				}
-				err := c.getChannelDetails(accountDetails, flags)
-				if err != nil {
-					if err.Error() == protobufErrorMessage {
-						log.CliLogger.Info(err.Error())
-						continue
-					}
-					return err
-				}
-				channelCount++
-				messages[msgName(topic.GetTopicName())] = spec.Message{
-					OneOf1: &spec.MessageOneOf1{MessageEntity: accountDetails.buildMessageEntity()},
-				}
-				reflector, err = addChannel(reflector, accountDetails.channelDetails)
-				if err != nil {
-					return err
-				}
+				return err
+			}
+			channelCount++
+			messages[msgName(topic.GetTopicName())] = spec.Message{
+				OneOf1: &spec.MessageOneOf1{MessageEntity: accountDetails.buildMessageEntity()},
+			}
+			reflector, err = addChannel(reflector, accountDetails.channelDetails)
+			if err != nil {
+				return err
 			}
 		}
 	}
@@ -581,7 +587,7 @@ func topicMatch(topic string, userTopics []string) bool {
 	}
 
 	for _, userTopic := range userTopics {
-		if strings.HasSuffix(userTopic, "*") && strings.HasPrefix(topic, userTopic[:len(userTopic)-1]) || userTopic == topic {
+		if strings.HasSuffix(userTopic, "*") && strings.HasPrefix(topic, strings.TrimSuffix(userTopic, "*")) || userTopic == topic {
 			return true
 		}
 	}

--- a/internal/cmd/asyncapi/command_export.go
+++ b/internal/cmd/asyncapi/command_export.go
@@ -24,7 +24,6 @@ import (
 	"github.com/confluentinc/cli/internal/pkg/log"
 	"github.com/confluentinc/cli/internal/pkg/output"
 	"github.com/confluentinc/cli/internal/pkg/serdes"
-	"github.com/confluentinc/cli/internal/pkg/types"
 )
 
 type command struct {
@@ -107,20 +106,6 @@ func (c *command) export(cmd *cobra.Command, _ []string) error {
 		schemaContextPrefix = fmt.Sprintf(":.%s:", flags.schemaContext)
 	}
 	channelCount := 0
-
-	topicsSpecified := types.NewSet()
-	var prefixesSpecified []string
-	// Split user-specified topics into topics/topic prefixes
-	for _, userTopic := range flags.topics {
-		if len(userTopic) == 0 {
-			continue
-		}
-		if userTopic[len(userTopic)-1:] == "*" {
-			prefixesSpecified = append(prefixesSpecified, userTopic)
-		} else {
-			topicsSpecified.Add(userTopic)
-		}
-	}
 
 	for _, topic := range accountDetails.topics {
 		if !topicMatch(topic.GetTopicName(), flags.topics) {

--- a/internal/cmd/asyncapi/command_export.go
+++ b/internal/cmd/asyncapi/command_export.go
@@ -112,6 +112,9 @@ func (c *command) export(cmd *cobra.Command, _ []string) error {
 	var prefixesSpecified []string
 	// Split user-specified topics into topics/topic prefixes
 	for _, userTopic := range flags.topics {
+		if len(userTopic) == 0 {
+			continue
+		}
 		if userTopic[len(userTopic)-1:] == "*" {
 			prefixesSpecified = append(prefixesSpecified, userTopic)
 		} else {

--- a/internal/cmd/asyncapi/command_export_test.go
+++ b/internal/cmd/asyncapi/command_export_test.go
@@ -18,3 +18,24 @@ func TestHandlePrimitiveSchemas(t *testing.T) {
 func TestMsgName(t *testing.T) {
 	require.Equal(t, "TopicNameMessage", msgName("topic name"))
 }
+
+func TestTopicMatch(t *testing.T) {
+	userTopicInput := []string{"topic1", "test*"}
+
+	got := topicMatch("topic1", userTopicInput)
+	want := true
+	require.Equal(t, want, got)
+
+	got = topicMatch("test_topic", userTopicInput)
+	want = true
+	require.Equal(t, want, got)
+
+	got = topicMatch("topic2", userTopicInput)
+	want = false
+	require.Equal(t, want, got)
+
+	// User not setting --topics
+	got = topicMatch("topic2", []string{})
+	want = true
+	require.Equal(t, want, got)
+}

--- a/internal/cmd/asyncapi/command_export_test.go
+++ b/internal/cmd/asyncapi/command_export_test.go
@@ -20,22 +20,10 @@ func TestMsgName(t *testing.T) {
 }
 
 func TestTopicMatch(t *testing.T) {
-	userTopicInput := []string{"topic1", "test*"}
+	userTopics := []string{"topic1", "test*"}
 
-	got := topicMatch("topic1", userTopicInput)
-	want := true
-	require.Equal(t, want, got)
-
-	got = topicMatch("test_topic", userTopicInput)
-	want = true
-	require.Equal(t, want, got)
-
-	got = topicMatch("topic2", userTopicInput)
-	want = false
-	require.Equal(t, want, got)
-
-	// User not setting --topics
-	got = topicMatch("topic2", []string{})
-	want = true
-	require.Equal(t, want, got)
+	require.True(t, topicMatch("topic1", userTopics))
+	require.True(t, topicMatch("test_topic", userTopics))
+	require.False(t, topicMatch("topic2", userTopics))
+	require.True(t, topicMatch("topic2", []string{}))
 }

--- a/test/asyncapi_test.go
+++ b/test/asyncapi_test.go
@@ -19,6 +19,8 @@ func (s *CLITestSuite) TestAsyncApiExport() {
 		{args: "asyncapi export --schema-registry-api-key ASYNCAPIKEY --schema-registry-api-secret ASYNCAPISECRET --schema-context dev --file asyncapi-with-context.yaml", useKafka: "lkc-asyncapi", authKafka: "true", workflow: true},
 		{args: "asyncapi export --schema-registry-api-key ASYNCAPIKEY --schema-registry-api-secret ASYNCAPISECRET --topics topic1 --file asyncapi-topic-specified.yaml", fixture: "asyncapi/export-topic-specified.golden", useKafka: "lkc-asyncapi", authKafka: "true", workflow: true},
 		{args: "asyncapi export --schema-registry-api-key ASYNCAPIKEY --schema-registry-api-secret ASYNCAPISECRET --topics topic2 --file asyncapi-no-topics.yaml", fixture: "asyncapi/export-no-topics.golden", useKafka: "lkc-asyncapi", authKafka: "true", workflow: true},
+		{args: "asyncapi export --schema-registry-api-key ASYNCAPIKEY --schema-registry-api-secret ASYNCAPISECRET --topics topic* --file asyncapi-topic-specified.yaml", fixture: "asyncapi/export-topic-specified.golden", useKafka: "lkc-asyncapi", authKafka: "true", workflow: true},
+		{args: "asyncapi export --schema-registry-api-key ASYNCAPIKEY --schema-registry-api-secret ASYNCAPISECRET --topics no* --file asyncapi-no-topics.yaml", fixture: "asyncapi/export-no-topics.golden", useKafka: "lkc-asyncapi", authKafka: "true", workflow: true},
 	}
 	resetConfiguration(s.T(), false)
 	for _, test := range tests {

--- a/test/asyncapi_test.go
+++ b/test/asyncapi_test.go
@@ -19,8 +19,8 @@ func (s *CLITestSuite) TestAsyncApiExport() {
 		{args: "asyncapi export --schema-registry-api-key ASYNCAPIKEY --schema-registry-api-secret ASYNCAPISECRET --schema-context dev --file asyncapi-with-context.yaml", useKafka: "lkc-asyncapi", authKafka: "true", workflow: true},
 		{args: "asyncapi export --schema-registry-api-key ASYNCAPIKEY --schema-registry-api-secret ASYNCAPISECRET --topics topic1 --file asyncapi-topic-specified.yaml", fixture: "asyncapi/export-topic-specified.golden", useKafka: "lkc-asyncapi", authKafka: "true", workflow: true},
 		{args: "asyncapi export --schema-registry-api-key ASYNCAPIKEY --schema-registry-api-secret ASYNCAPISECRET --topics topic2 --file asyncapi-no-topics.yaml", fixture: "asyncapi/export-no-topics.golden", useKafka: "lkc-asyncapi", authKafka: "true", workflow: true},
-		{args: "asyncapi export --schema-registry-api-key ASYNCAPIKEY --schema-registry-api-secret ASYNCAPISECRET --topics topic* --file asyncapi-topic-specified.yaml", fixture: "asyncapi/export-topic-specified.golden", useKafka: "lkc-asyncapi", authKafka: "true", workflow: true},
-		{args: "asyncapi export --schema-registry-api-key ASYNCAPIKEY --schema-registry-api-secret ASYNCAPISECRET --topics no* --file asyncapi-no-topics.yaml", fixture: "asyncapi/export-no-topics.golden", useKafka: "lkc-asyncapi", authKafka: "true", workflow: true},
+		{args: `asyncapi export --schema-registry-api-key ASYNCAPIKEY --schema-registry-api-secret ASYNCAPISECRET --topics "topic*" --file asyncapi-topic-specified.yaml`, fixture: "asyncapi/export-topic-specified.golden", useKafka: "lkc-asyncapi", authKafka: "true", workflow: true},
+		{args: `asyncapi export --schema-registry-api-key ASYNCAPIKEY --schema-registry-api-secret ASYNCAPISECRET --topics "no*" --file asyncapi-no-topics.yaml`, fixture: "asyncapi/export-no-topics.golden", useKafka: "lkc-asyncapi", authKafka: "true", workflow: true},
 	}
 	resetConfiguration(s.T(), false)
 	for _, test := range tests {


### PR DESCRIPTION
Release Notes
-------------
New Features
- Support topic prefixes ending with a wildcard (*) in `confluent asyncapi export --topics`

Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->

If `--topics` specified, split into prefixes and regular topics. Then check that a topic is either present in the list of specified topics or has a prefix given by the user, otherwise don't export it.

For added tests, we only care about the CLI output (are topics correct?) so reusing files. File check is not useful here

Test & Review
-------------
<!--
Has it been tested? How?
Copy and paste any instructions or steps that can save the reviewer time.
-->

Tested on prod confluent cloud, create topics and schemas (with TopicNamingStrategy) and export a subset of them with `--topics topic1,topic2,prefix*...`