### PR TITLE
[Draft] Various formatting updates

### DIFF
--- a/internal/cmd/api-key/command_create.go
+++ b/internal/cmd/api-key/command_create.go
@@ -136,8 +136,7 @@ func (c *command) create(cmd *cobra.Command, _ []string) error {
 		if resourceType != resource.KafkaCluster {
 			return errors.Wrap(errors.New(errors.NonKafkaNotImplementedErrorMsg), "`--use` set but ineffective")
 		}
-		err = c.Context.UseAPIKey(userKey.Key, clusterId)
-		if err != nil {
+		if err := c.Context.UseAPIKey(userKey.Key, clusterId); err != nil {
 			return errors.NewWrapErrorWithSuggestions(err, errors.APIKeyUseFailedErrorMsg, fmt.Sprintf(errors.APIKeyUseFailedSuggestions, userKey.Key))
 		}
 		output.Printf(errors.UseAPIKeyMsg, userKey.Key, clusterId)

--- a/internal/cmd/api-key/command_list.go
+++ b/internal/cmd/api-key/command_list.go
@@ -79,8 +79,7 @@ func (c *command) list(cmd *cobra.Command, _ []string) error {
 		if resource.LookupType(serviceAccount) != resource.ServiceAccount {
 			return errors.New(errors.BadServiceAccountIDErrorMsg)
 		}
-		_, ok := resourceIdToUserIdMap[serviceAccount]
-		if !ok {
+		if _, ok := resourceIdToUserIdMap[serviceAccount]; !ok {
 			return errors.NewErrorWithSuggestions(fmt.Sprintf(errors.ServiceAccountNotFoundErrorMsg, serviceAccount), errors.ServiceAccountNotFoundSuggestions)
 		}
 	}

--- a/internal/cmd/api-key/command_use.go
+++ b/internal/cmd/api-key/command_use.go
@@ -42,8 +42,7 @@ func (c *command) use(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	err = c.Context.UseAPIKey(apiKey, cluster.ID)
-	if err != nil {
+	if err := c.Context.UseAPIKey(apiKey, cluster.ID); err != nil {
 		return errors.NewWrapErrorWithSuggestions(err, errors.APIKeyUseFailedErrorMsg, fmt.Sprintf(errors.APIKeyUseFailedSuggestions, apiKey))
 	}
 	output.Printf(errors.UseAPIKeyMsg, apiKey, clusterId)

--- a/internal/cmd/asyncapi/account_details.go
+++ b/internal/cmd/asyncapi/account_details.go
@@ -87,8 +87,7 @@ func (d *accountDetails) getSchemaDetails() error {
 		return fmt.Errorf("protobuf is not supported")
 	}
 	// JSON or Avro Format
-	err = json.Unmarshal([]byte(schema.Schema), &d.channelDetails.unmarshalledSchema)
-	if err != nil {
+	if err := json.Unmarshal([]byte(schema.Schema), &d.channelDetails.unmarshalledSchema); err != nil {
 		d.channelDetails.unmarshalledSchema, err = handlePrimitiveSchemas(schema.Schema, err)
 		log.CliLogger.Warn(err)
 	}
@@ -120,8 +119,7 @@ func (d *accountDetails) getTopicDescription() error {
 }
 
 func (c *command) countAsyncApiUsage(details *accountDetails) error {
-	_, err := details.srClient.DefaultApi.AsyncapiPut(details.srContext)
-	if err != nil {
+	if _, err := details.srClient.DefaultApi.AsyncapiPut(details.srContext); err != nil {
 		return fmt.Errorf("failed to access AsyncAPI metric endpoint: %v", err)
 	}
 	return nil

--- a/internal/cmd/asyncapi/command_export.go
+++ b/internal/cmd/asyncapi/command_export.go
@@ -125,8 +125,7 @@ func (c *command) export(cmd *cobra.Command, _ []string) error {
 					currentTopic:   topic,
 					currentSubject: subject,
 				}
-				err := c.getChannelDetails(accountDetails, flags)
-				if err != nil {
+				if err := c.getChannelDetails(accountDetails, flags); err != nil {
 					if err.Error() == protobufErrorMessage {
 						log.CliLogger.Info(err.Error())
 						continue
@@ -163,8 +162,7 @@ func (c *command) export(cmd *cobra.Command, _ []string) error {
 }
 
 func (c *command) getChannelDetails(details *accountDetails, flags *flags) error {
-	err := details.getSchemaDetails()
-	if err != nil {
+	if err := details.getSchemaDetails(); err != nil {
 		if err.Error() == protobufErrorMessage {
 			return err
 		}
@@ -174,6 +172,7 @@ func (c *command) getChannelDetails(details *accountDetails, flags *flags) error
 		log.CliLogger.Warnf("Failed to get tags: %v", err)
 	}
 	details.channelDetails.example = nil
+	var err error
 	if flags.consumeExamples {
 		details.channelDetails.example, err = c.getMessageExamples(details.consumer, details.channelDetails.currentTopic.GetTopicName(), details.channelDetails.contentType, details.srClient, flags.valueFormat)
 		if err != nil {
@@ -198,14 +197,13 @@ func (c *command) getChannelDetails(details *accountDetails, flags *flags) error
 
 func (c *command) getAccountDetails(flags *flags) (*accountDetails, error) {
 	details := new(accountDetails)
-	err := c.getClusterDetails(details, flags)
-	if err != nil {
+	if err := c.getClusterDetails(details, flags); err != nil {
 		return nil, err
 	}
-	err = c.getSchemaRegistry(details, flags)
-	if err != nil {
+	if err := c.getSchemaRegistry(details, flags); err != nil {
 		return nil, err
 	}
+	var err error
 	details.subjects, _, err = details.srClient.DefaultApi.List(details.srContext, nil)
 	if err != nil {
 		return nil, err
@@ -242,8 +240,7 @@ func handlePanic() {
 
 func (c command) getMessageExamples(consumer *ckgo.Consumer, topicName, contentType string, srClient *schemaregistry.APIClient, valueFormatFlag string) (any, error) {
 	defer handlePanic()
-	err := consumer.Subscribe(topicName, nil)
-	if err != nil {
+	if err := consumer.Subscribe(topicName, nil); err != nil {
 		return nil, fmt.Errorf(`failed to subscribe to topic "%s": %v`, topicName, err)
 	}
 	message, err := consumer.ReadMessage(10 * time.Second)
@@ -275,8 +272,7 @@ func (c command) getMessageExamples(consumer *ckgo.Consumer, topicName, contentT
 		}
 		// Message body is encoded after 5 bytes of meta information.
 		value = value[messageOffset:]
-		err = deserializationProvider.LoadSchema(schemaPath, referencePathMap)
-		if err != nil {
+		if err := deserializationProvider.LoadSchema(schemaPath, referencePathMap); err != nil {
 			return nil, err
 		}
 	}

--- a/internal/cmd/asyncapi/command_import.go
+++ b/internal/cmd/asyncapi/command_import.go
@@ -174,8 +174,7 @@ func (c *command) asyncapiImport(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	for topicName, topicDetails := range spec.Channels {
-		err := c.addChannelToCluster(details, spec, topicName, topicDetails.Bindings.Kafka, flagsImp.overwrite)
-		if err != nil {
+		if err := c.addChannelToCluster(details, spec, topicName, topicDetails.Bindings.Kafka, flagsImp.overwrite); err != nil {
 			if err.Error() == parseErrorMessage {
 				output.Printf("WARNING: topic \"%s\" is already present and `--overwrite` is not set.\n", topicName)
 			} else {
@@ -423,8 +422,7 @@ func addSchemaTags(details *accountDetails, components Components, topicName str
 			})
 			tagNames = append(tagNames, tag.Name)
 		}
-		err := addTagsUtil(details, tagDefConfigs, tagConfigs)
-		if err != nil {
+		if err := addTagsUtil(details, tagDefConfigs, tagConfigs); err != nil {
 			return err
 		}
 		output.Printf("Tag(s) %s added to schema \"%d\".\n", utils.ArrayToCommaDelimitedString(tagNames, "and"), schemaId)
@@ -454,8 +452,7 @@ func addTopicTags(details *accountDetails, subscribe Operation, topicName string
 		})
 		tagNames = append(tagNames, tag.Name)
 	}
-	err := addTagsUtil(details, tagDefConfigs, tagConfigs)
-	if err != nil {
+	if err := addTagsUtil(details, tagDefConfigs, tagConfigs); err != nil {
 		return err
 	}
 	output.Printf("Tag(s) %s added to Kafka topic \"%s\".\n", utils.ArrayToCommaDelimitedString(tagNames, "and"), topicName)

--- a/internal/cmd/audit-log/command_config_update.go
+++ b/internal/cmd/audit-log/command_config_update.go
@@ -51,8 +51,7 @@ func (c *configCommand) update(cmd *cobra.Command, _ []string) error {
 	}
 
 	fileSpec := mds.AuditLogConfigSpec{}
-	err = json.Unmarshal(data, &fileSpec)
-	if err != nil {
+	if err := json.Unmarshal(data, &fileSpec); err != nil {
 		return err
 	}
 	putSpec := &fileSpec

--- a/internal/cmd/audit-log/migration.go
+++ b/internal/cmd/audit-log/migration.go
@@ -188,8 +188,7 @@ func jsonConfigsToAuditLogConfigSpecs(clusterConfigs map[string]string) (map[str
 	clusterAuditLogConfigSpecs := make(map[string]*mds.AuditLogConfigSpec)
 	for clusterId, auditConfig := range clusterConfigs {
 		var spec mds.AuditLogConfigSpec
-		err := json.Unmarshal([]byte(auditConfig), &spec)
-		if err != nil {
+		if err := json.Unmarshal([]byte(auditConfig), &spec); err != nil {
 			return nil, fmt.Errorf(warn.MalformedConfigErrorMsg, clusterId, err.Error())
 		}
 		clusterAuditLogConfigSpecs[clusterId] = &spec
@@ -213,9 +212,7 @@ func combineDestinationTopics(specs map[string]*mds.AuditLogConfigSpec, newSpec 
 				if destination.RetentionMs != newTopics[topicName].RetentionMs {
 					topicRetentionDiscrepancies[topicName] = retentionTime
 				}
-				newTopics[topicName] = mds.AuditLogConfigDestinationConfig{
-					RetentionMs: retentionTime,
-				}
+				newTopics[topicName] = mds.AuditLogConfigDestinationConfig{RetentionMs: retentionTime}
 			} else {
 				newTopics[topicName] = destination
 			}
@@ -248,9 +245,7 @@ func setDefaultTopic(newSpec *mds.AuditLogConfigSpec, defaultTopicName string) {
 	}
 
 	if _, ok := newSpec.Destinations.Topics[defaultTopicName]; !ok {
-		newSpec.Destinations.Topics[defaultTopicName] = mds.AuditLogConfigDestinationConfig{
-			RetentionMs: DefaultRetentionMs,
-		}
+		newSpec.Destinations.Topics[defaultTopicName] = mds.AuditLogConfigDestinationConfig{RetentionMs: DefaultRetentionMs}
 	}
 }
 

--- a/internal/cmd/cloud-signup/command.go
+++ b/internal/cmd/cloud-signup/command.go
@@ -24,13 +24,11 @@ func cloudSignup(cmd *cobra.Command, _ []string) error {
 	signupUrl := "https://www.confluent.io/get-started/"
 
 	output.Printf("You will now be redirected to the Confluent Cloud sign up page in your browser. If you are not redirected, please use the following link: %s\n", signupUrl)
-	err := form.ConfirmEnter()
-	if err != nil {
+	if err := form.ConfirmEnter(); err != nil {
 		return err
 	}
 
-	err = browser.OpenURL(signupUrl)
-	if err != nil {
+	if err := browser.OpenURL(signupUrl); err != nil {
 		return errors.Wrap(err, "unable to open web browser for cloud signup")
 	}
 

--- a/internal/cmd/cluster/scoped_id_service.go
+++ b/internal/cmd/cluster/scoped_id_service.go
@@ -30,9 +30,7 @@ type Scope struct {
 }
 
 func newScopedIdService(userAgent string) *ScopedIdService {
-	return &ScopedIdService{
-		userAgent: userAgent,
-	}
+	return &ScopedIdService{userAgent: userAgent}
 }
 
 func (s *ScopedIdService) DescribeCluster(url string, caCertPath string) (*ScopedId, error) {

--- a/internal/cmd/iam/command_rbac_role_binding.go
+++ b/internal/cmd/iam/command_rbac_role_binding.go
@@ -115,8 +115,7 @@ func (c *roleBindingCommand) parseCommon(cmd *cobra.Command) (*roleBindingOption
 	}
 
 	if cmd.Flags().Changed("principal") {
-		err = c.validatePrincipalFormat(principal)
-		if err != nil {
+		if err := c.validatePrincipalFormat(principal); err != nil {
 			return nil, err
 		}
 	}
@@ -456,8 +455,7 @@ func (c *roleBindingCommand) parseV2RoleBinding(cmd *cobra.Command) (*mdsv2.IamV
 		return nil, err
 	}
 	if cmd.Flags().Changed("principal") {
-		err = c.validatePrincipalFormat(principal)
-		if err != nil {
+		if err = c.validatePrincipalFormat(principal); err != nil {
 			return nil, err
 		}
 	}

--- a/internal/cmd/iam/command_rbac_role_binding_create.go
+++ b/internal/cmd/iam/command_rbac_role_binding_create.go
@@ -81,8 +81,7 @@ func (c *roleBindingCommand) create(cmd *cobra.Command, _ []string) error {
 			return err
 		}
 
-		_, err = c.V2Client.CreateIamRoleBinding(createRoleBinding)
-		if err != nil {
+		if _, err := c.V2Client.CreateIamRoleBinding(createRoleBinding); err != nil {
 			return err
 		}
 

--- a/internal/cmd/iam/command_rbac_role_binding_delete.go
+++ b/internal/cmd/iam/command_rbac_role_binding_delete.go
@@ -56,8 +56,7 @@ func (c *roleBindingCommand) delete(cmd *cobra.Command, _ []string) error {
 			return err
 		}
 
-		err = c.ccloudDelete(cmd, deleteRoleBinding)
-		if err != nil {
+		if err := c.ccloudDelete(cmd, deleteRoleBinding); err != nil {
 			return err
 		}
 

--- a/internal/cmd/iam/command_rbac_role_binding_list.go
+++ b/internal/cmd/iam/command_rbac_role_binding_list.go
@@ -119,8 +119,7 @@ func (c *roleBindingCommand) list(cmd *cobra.Command, _ []string) error {
 		if err != nil {
 			return err
 		}
-		err = c.ccloudList(cmd, listRoleBinding)
-		return err
+		return c.ccloudList(cmd, listRoleBinding)
 	} else {
 		options, err := c.parseCommon(cmd)
 		if err != nil {

--- a/internal/cmd/iam/command_service_account_delete.go
+++ b/internal/cmd/iam/command_service_account_delete.go
@@ -50,8 +50,7 @@ func (c *serviceAccountCommand) delete(cmd *cobra.Command, args []string) error 
 		return err
 	}
 
-	err = c.V2Client.DeleteIamServiceAccount(serviceAccountId)
-	if err != nil {
+	if err := c.V2Client.DeleteIamServiceAccount(serviceAccountId); err != nil {
 		return errors.Errorf(errors.DeleteResourceErrorMsg, resource.ServiceAccount, serviceAccountId, err)
 	}
 

--- a/internal/cmd/kafka/command_cluster_test.go
+++ b/internal/cmd/kafka/command_cluster_test.go
@@ -42,9 +42,7 @@ var (
 
 var cmkByokCluster = cmkv2.CmkV2Cluster{
 	Spec: &cmkv2.CmkV2ClusterSpec{
-		Environment: &cmkv2.EnvScopedObjectReference{
-			Id: environmentId,
-		},
+		Environment: &cmkv2.EnvScopedObjectReference{Id: environmentId},
 		DisplayName:  cmkv2.PtrString("gcp-byok-test"),
 		Cloud:        cmkv2.PtrString("gcp"),
 		Region:       cmkv2.PtrString("us-central1"),
@@ -60,9 +58,7 @@ var cmkByokCluster = cmkv2.CmkV2Cluster{
 
 var cmkExpandCluster = cmkv2.CmkV2Cluster{
 	Spec: &cmkv2.CmkV2ClusterSpec{
-		Environment: &cmkv2.EnvScopedObjectReference{
-			Id: environmentId,
-		},
+		Environment: &cmkv2.EnvScopedObjectReference{Id: environmentId},
 		DisplayName:  cmkv2.PtrString("gcp-shrink-test"),
 		Cloud:        cmkv2.PtrString("gcp"),
 		Region:       cmkv2.PtrString("us-central1"),

--- a/internal/cmd/kafka/command_topic_consume.go
+++ b/internal/cmd/kafka/command_topic_consume.go
@@ -130,8 +130,7 @@ func (c *hasAPIKeyTopicCommand) consume(cmd *cobra.Command, args []string) error
 	}
 	defer adminClient.Close()
 
-	err = c.validateTopic(adminClient, topic, cluster)
-	if err != nil {
+	if err := c.validateTopic(adminClient, topic, cluster); err != nil {
 		return err
 	}
 

--- a/internal/cmd/kafka/command_topic_consume_onprem.go
+++ b/internal/cmd/kafka/command_topic_consume_onprem.go
@@ -107,8 +107,7 @@ func (c *authenticatedTopicCommand) consumeOnPrem(cmd *cobra.Command, args []str
 	}
 	log.CliLogger.Tracef("Create consumer succeeded")
 
-	err = c.refreshOAuthBearerToken(cmd, consumer)
-	if err != nil {
+	if err := c.refreshOAuthBearerToken(cmd, consumer); err != nil {
 		return err
 	}
 
@@ -119,8 +118,7 @@ func (c *authenticatedTopicCommand) consumeOnPrem(cmd *cobra.Command, args []str
 	defer adminClient.Close()
 
 	topicName := args[0]
-	err = c.validateTopic(adminClient, topicName)
-	if err != nil {
+	if err := c.validateTopic(adminClient, topicName); err != nil {
 		return err
 	}
 

--- a/internal/cmd/kafka/command_topic_onprem.go
+++ b/internal/cmd/kafka/command_topic_onprem.go
@@ -21,8 +21,7 @@ func getClusterIdForRestRequests(client *kafkarestv3.APIClient, ctx context.Cont
 	if clusters.Data == nil || len(clusters.Data) == 0 {
 		return "", errors.NewErrorWithSuggestions(errors.NoClustersFoundErrorMsg, errors.NoClustersFoundSuggestions)
 	}
-	clusterId := clusters.Data[0].ClusterId
-	return clusterId, nil
+	return clusters.Data[0].ClusterId, nil
 }
 
 // validate that a topic exists before attempting to produce/consume messages

--- a/internal/cmd/kafka/command_topic_produce.go
+++ b/internal/cmd/kafka/command_topic_produce.go
@@ -154,8 +154,7 @@ func (c *hasAPIKeyTopicCommand) produce(cmd *cobra.Command, args []string) error
 		if err != nil {
 			return err
 		}
-		err = producer.Produce(msg, deliveryChan)
-		if err != nil {
+		if err := producer.Produce(msg, deliveryChan); err != nil {
 			isProduceToCompactedTopicError, err := errors.CatchProduceToCompactedTopicError(err, topic)
 			if isProduceToCompactedTopicError {
 				scanErr = err
@@ -340,8 +339,7 @@ func (c *hasAPIKeyTopicCommand) initSchemaAndGetInfo(cmd *cobra.Command, topic s
 		}
 	}
 
-	err = serializationProvider.LoadSchema(schemaPath, referencePathMap)
-	if err != nil {
+	if err := serializationProvider.LoadSchema(schemaPath, referencePathMap); err != nil {
 		return nil, nil, errors.NewWrapErrorWithSuggestions(err, "failed to load schema", errors.FailedToLoadSchemaSuggestions)
 	}
 

--- a/internal/cmd/kafka/command_topic_produce_onprem.go
+++ b/internal/cmd/kafka/command_topic_produce_onprem.go
@@ -82,8 +82,7 @@ func (c *authenticatedTopicCommand) produceOnPrem(cmd *cobra.Command, args []str
 	defer producer.Close()
 	log.CliLogger.Tracef("Create producer succeeded")
 
-	err = c.refreshOAuthBearerToken(cmd, producer)
-	if err != nil {
+	if err := c.refreshOAuthBearerToken(cmd, producer); err != nil {
 		return err
 	}
 
@@ -94,8 +93,7 @@ func (c *authenticatedTopicCommand) produceOnPrem(cmd *cobra.Command, args []str
 	defer adminClient.Close()
 
 	topicName := args[0]
-	err = c.validateTopic(adminClient, topicName)
-	if err != nil {
+	if err := c.validateTopic(adminClient, topicName); err != nil {
 		return err
 	}
 
@@ -181,8 +179,7 @@ func (c *authenticatedTopicCommand) produceOnPrem(cmd *cobra.Command, args []str
 		if err != nil {
 			return err
 		}
-		err = producer.Produce(msg, deliveryChan)
-		if err != nil {
+		if err := producer.Produce(msg, deliveryChan); err != nil {
 			output.ErrPrintf(errors.FailedToProduceErrorMsg, msg.TopicPartition.Offset, err)
 		}
 

--- a/internal/cmd/kafka/confluent_kafka.go
+++ b/internal/cmd/kafka/confluent_kafka.go
@@ -195,8 +195,7 @@ func consumeMessage(e *ckafka.Message, h *GroupHandler) error {
 		} else {
 			keyString = string(key)
 		}
-		_, err := fmt.Fprint(h.Out, keyString+h.Properties.Delimiter)
-		if err != nil {
+		if _, err := fmt.Fprint(h.Out, keyString+h.Properties.Delimiter); err != nil {
 			return err
 		}
 	}
@@ -213,8 +212,7 @@ func consumeMessage(e *ckafka.Message, h *GroupHandler) error {
 		}
 		// Message body is encoded after 5 bytes of meta information.
 		value = value[messageOffset:]
-		err = deserializationProvider.LoadSchema(schemaPath, referencePathMap)
-		if err != nil {
+		if err := deserializationProvider.LoadSchema(schemaPath, referencePathMap); err != nil {
 			return err
 		}
 	}
@@ -227,8 +225,7 @@ func consumeMessage(e *ckafka.Message, h *GroupHandler) error {
 		jsonMessage = fmt.Sprintf("Timestamp: %d\t%s", e.Timestamp.UnixMilli(), jsonMessage)
 	}
 
-	_, err = fmt.Fprintln(h.Out, jsonMessage)
-	if err != nil {
+	if _, err := fmt.Fprintln(h.Out, jsonMessage); err != nil {
 		return err
 	}
 
@@ -263,8 +260,7 @@ func runConsumer(consumer *ckafka.Consumer, groupHandler *GroupHandler) error {
 			}
 			switch e := event.(type) {
 			case *ckafka.Message:
-				err := consumeMessage(e, groupHandler)
-				if err != nil {
+				if err := consumeMessage(e, groupHandler); err != nil {
 					return err
 				}
 			case ckafka.Error:
@@ -299,8 +295,7 @@ func (h *GroupHandler) RequestSchema(value []byte) (string, map[string]string, e
 		if err != nil {
 			return "", nil, err
 		}
-		err = os.WriteFile(tempStorePath, []byte(schemaString.Schema), 0644)
-		if err != nil {
+		if err := os.WriteFile(tempStorePath, []byte(schemaString.Schema), 0644); err != nil {
 			return "", nil, err
 		}
 
@@ -308,8 +303,7 @@ func (h *GroupHandler) RequestSchema(value []byte) (string, map[string]string, e
 		if err != nil {
 			return "", nil, err
 		}
-		err = os.WriteFile(tempRefStorePath, refBytes, 0644)
-		if err != nil {
+		if err := os.WriteFile(tempRefStorePath, refBytes, 0644); err != nil {
 			return "", nil, err
 		}
 		references = schemaString.References
@@ -318,8 +312,7 @@ func (h *GroupHandler) RequestSchema(value []byte) (string, map[string]string, e
 		if err != nil {
 			return "", nil, err
 		}
-		err = json.Unmarshal(refBlob, &references)
-		if err != nil {
+		if err := json.Unmarshal(refBlob, &references); err != nil {
 			return "", nil, err
 		}
 	}

--- a/internal/cmd/kafka/confluent_kafka_configs.go
+++ b/internal/cmd/kafka/confluent_kafka_configs.go
@@ -295,8 +295,7 @@ func setConsumerDebugOption(configMap *ckafka.ConfigMap) error {
 }
 
 func newProducerWithOverwrittenConfigs(configMap *ckafka.ConfigMap, configPath string, configStrings []string) (*ckafka.Producer, error) {
-	err := overwriteKafkaClientConfigs(configMap, configPath, configStrings)
-	if err != nil {
+	if err := overwriteKafkaClientConfigs(configMap, configPath, configStrings); err != nil {
 		return nil, err
 	}
 
@@ -304,8 +303,7 @@ func newProducerWithOverwrittenConfigs(configMap *ckafka.ConfigMap, configPath s
 }
 
 func newConsumerWithOverwrittenConfigs(configMap *ckafka.ConfigMap, configPath string, configStrings []string) (*ckafka.Consumer, error) {
-	err := overwriteKafkaClientConfigs(configMap, configPath, configStrings)
-	if err != nil {
+	if err := overwriteKafkaClientConfigs(configMap, configPath, configStrings); err != nil {
 		return nil, err
 	}
 

--- a/internal/cmd/kafka/metrics_utils.go
+++ b/internal/cmd/kafka/metrics_utils.go
@@ -71,8 +71,7 @@ func (c *clusterCommand) validateClusterLoad(clusterId string, isLatestMetric bo
 		return errors.Errorf("could not retrieve cluster load metrics to validate request to shrink cluster, please try again in a few minutes: %v", err)
 	}
 
-	err = ccloudv2.UnmarshalFlatQueryResponseIfDataSchemaMatchError(err, clusterLoadResponse, httpResp)
-	if err != nil {
+	if err := ccloudv2.UnmarshalFlatQueryResponseIfDataSchemaMatchError(err, clusterLoadResponse, httpResp); err != nil {
 		return err
 	}
 	maxClusterLoad := maxApiDataValue(clusterLoadResponse.FlatQueryResponse.GetData())

--- a/internal/cmd/ksql/command_test.go
+++ b/internal/cmd/ksql/command_test.go
@@ -64,9 +64,7 @@ func (suite *KSQLTestSuite) SetupTest() {
 			KafkaCluster: &ksqlv2.ObjectReference{
 				Id: suite.conf.Context().KafkaClusterContext.GetActiveKafkaClusterId(),
 			},
-			CredentialIdentity: &ksqlv2.ObjectReference{
-				Id: serviceAcctResourceID,
-			},
+			CredentialIdentity: &ksqlv2.ObjectReference{Id: serviceAcctResourceID},
 			UseDetailedProcessingLog: &useDetailedProcessingLog,
 		},
 		Status: &ksqlv2.KsqldbcmV2ClusterStatus{

--- a/internal/cmd/local/command_service_connect.go
+++ b/internal/cmd/local/command_service_connect.go
@@ -410,8 +410,7 @@ func formatJSONResponse(res *http.Response) (string, error) {
 
 	buf := new(bytes.Buffer)
 	if len(out) > 0 {
-		err = json.Indent(buf, out, "", "  ")
-		if err != nil {
+		if err := json.Indent(buf, out, "", "  "); err != nil {
 			return "", err
 		}
 	}

--- a/internal/cmd/schema-registry/command_cluster_delete.go
+++ b/internal/cmd/schema-registry/command_cluster_delete.go
@@ -54,8 +54,7 @@ func (c *command) clusterDelete(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	err = c.Client.SchemaRegistry.DeleteSchemaRegistryCluster(cluster)
-	if err != nil {
+	if err := c.Client.SchemaRegistry.DeleteSchemaRegistryCluster(cluster); err != nil {
 		return err
 	}
 

--- a/internal/cmd/schema-registry/command_cluster_test.go
+++ b/internal/cmd/schema-registry/command_cluster_test.go
@@ -48,9 +48,7 @@ func (suite *ClusterTestSuite) SetupSuite() {
 		Name:       cluster.Name,
 		Enterprise: true,
 	}
-	suite.srCluster = &ccloudv1.SchemaRegistryCluster{
-		Id: srClusterID,
-	}
+	suite.srCluster = &ccloudv1.SchemaRegistryCluster{Id: srClusterID}
 	suite.srClientMock = &srsdk.APIClient{
 		DefaultApi: &srMock.DefaultApi{
 			GetTopLevelConfigFunc: func(_ context.Context) (srsdk.Config, *http.Response, error) {

--- a/internal/cmd/schema-registry/command_cluster_update.go
+++ b/internal/cmd/schema-registry/command_cluster_update.go
@@ -112,8 +112,7 @@ func (c *command) getConfigUpdateRequest(cmd *cobra.Command) (srsdk.ConfigUpdate
 	}
 	if metadataDefaults != "" {
 		updateReq.DefaultMetadata = new(srsdk.Metadata)
-		err := read(metadataDefaults, updateReq.DefaultMetadata)
-		if err != nil {
+		if err := read(metadataDefaults, updateReq.DefaultMetadata); err != nil {
 			return srsdk.ConfigUpdateRequest{}, err
 		}
 	}
@@ -124,8 +123,7 @@ func (c *command) getConfigUpdateRequest(cmd *cobra.Command) (srsdk.ConfigUpdate
 	}
 	if metadataOverrides != "" {
 		updateReq.OverrideMetadata = new(srsdk.Metadata)
-		err := read(metadataOverrides, updateReq.OverrideMetadata)
-		if err != nil {
+		if err := read(metadataOverrides, updateReq.OverrideMetadata); err != nil {
 			return srsdk.ConfigUpdateRequest{}, err
 		}
 	}
@@ -136,8 +134,7 @@ func (c *command) getConfigUpdateRequest(cmd *cobra.Command) (srsdk.ConfigUpdate
 	}
 	if rulesetDefaults != "" {
 		updateReq.DefaultRuleSet = new(srsdk.RuleSet)
-		err := read(rulesetDefaults, updateReq.DefaultRuleSet)
-		if err != nil {
+		if err := read(rulesetDefaults, updateReq.DefaultRuleSet); err != nil {
 			return srsdk.ConfigUpdateRequest{}, err
 		}
 	}
@@ -148,8 +145,7 @@ func (c *command) getConfigUpdateRequest(cmd *cobra.Command) (srsdk.ConfigUpdate
 	}
 	if rulesetOverrides != "" {
 		updateReq.OverrideRuleSet = new(srsdk.RuleSet)
-		err := read(rulesetOverrides, updateReq.OverrideRuleSet)
-		if err != nil {
+		if err := read(rulesetOverrides, updateReq.OverrideRuleSet); err != nil {
 			return srsdk.ConfigUpdateRequest{}, err
 		}
 	}

--- a/internal/cmd/schema-registry/command_schema_create.go
+++ b/internal/cmd/schema-registry/command_schema_create.go
@@ -119,8 +119,7 @@ func (c *command) schemaCreate(cmd *cobra.Command, _ []string) error {
 	}
 	if metadata != "" {
 		request.Metadata = new(srsdk.Metadata)
-		err := read(metadata, request.Metadata)
-		if err != nil {
+		if err := read(metadata, request.Metadata); err != nil {
 			return err
 		}
 	}
@@ -131,8 +130,7 @@ func (c *command) schemaCreate(cmd *cobra.Command, _ []string) error {
 	}
 	if ruleset != "" {
 		request.RuleSet = new(srsdk.RuleSet)
-		err := read(ruleset, request.RuleSet)
-		if err != nil {
+		if err := read(ruleset, request.RuleSet); err != nil {
 			return err
 		}
 	}

--- a/internal/cmd/schema-registry/command_schema_create_onprem.go
+++ b/internal/cmd/schema-registry/command_schema_create_onprem.go
@@ -101,8 +101,7 @@ func (c *command) schemaCreateOnPrem(cmd *cobra.Command, _ []string) error {
 	}
 	if metadata != "" {
 		schemaCfg.Metadata = new(srsdk.Metadata)
-		err := read(metadata, schemaCfg.Metadata)
-		if err != nil {
+		if err := read(metadata, schemaCfg.Metadata); err != nil {
 			return err
 		}
 	}
@@ -113,8 +112,7 @@ func (c *command) schemaCreateOnPrem(cmd *cobra.Command, _ []string) error {
 	}
 	if ruleset != "" {
 		schemaCfg.Ruleset = new(srsdk.RuleSet)
-		err := read(ruleset, schemaCfg.Ruleset)
-		if err != nil {
+		if err := read(ruleset, schemaCfg.Ruleset); err != nil {
 			return err
 		}
 	}

--- a/internal/cmd/schema-registry/command_schema_test.go
+++ b/internal/cmd/schema-registry/command_schema_test.go
@@ -59,9 +59,7 @@ func (suite *SchemaTestSuite) SetupSuite() {
 		Name:       cluster.Name,
 		Enterprise: true,
 	}
-	suite.srCluster = &ccloudv1.SchemaRegistryCluster{
-		Id: srClusterID,
-	}
+	suite.srCluster = &ccloudv1.SchemaRegistryCluster{Id: srClusterID}
 }
 
 func (suite *SchemaTestSuite) SetupTest() {
@@ -98,8 +96,7 @@ func (suite *SchemaTestSuite) newCMD() *cobra.Command {
 	client := &ccloudv1.Client{
 		SchemaRegistry: suite.srMothershipMock,
 	}
-	cmd := New(suite.conf, climock.NewPreRunnerMock(client, nil, nil, nil, suite.conf), suite.srClientMock)
-	return cmd
+	return New(suite.conf, climock.NewPreRunnerMock(client, nil, nil, nil, suite.conf), suite.srClientMock)
 }
 
 func (suite *SchemaTestSuite) TestGetSchemaMetaInfo() {

--- a/internal/cmd/schema-registry/command_subject_test.go
+++ b/internal/cmd/schema-registry/command_subject_test.go
@@ -43,9 +43,7 @@ func (suite *SubjectTestSuite) SetupSuite() {
 		Name:       cluster.Name,
 		Enterprise: true,
 	}
-	suite.srCluster = &ccloudv1.SchemaRegistryCluster{
-		Id: srClusterID,
-	}
+	suite.srCluster = &ccloudv1.SchemaRegistryCluster{Id: srClusterID}
 }
 
 func (suite *SubjectTestSuite) SetupTest() {
@@ -80,8 +78,7 @@ func (suite *SubjectTestSuite) newCMD() *cobra.Command {
 	client := &ccloudv1.Client{
 		SchemaRegistry: suite.srMothershipMock,
 	}
-	cmd := New(suite.conf, climock.NewPreRunnerMock(client, nil, nil, nil, suite.conf), suite.srClientMock)
-	return cmd
+	return New(suite.conf, climock.NewPreRunnerMock(client, nil, nil, nil, suite.conf), suite.srClientMock)
 }
 
 func (suite *SubjectTestSuite) TestSubjectList() {

--- a/internal/cmd/schema-registry/schema_utilities.go
+++ b/internal/cmd/schema-registry/schema_utilities.go
@@ -79,8 +79,7 @@ func ReadSchemaRefs(cmd *cobra.Command) ([]srsdk.SchemaReference, error) {
 		if err != nil {
 			return nil, err
 		}
-		err = json.Unmarshal(refBlob, &refs)
-		if err != nil {
+		if err := json.Unmarshal(refBlob, &refs); err != nil {
 			return nil, err
 		}
 	}
@@ -96,12 +95,10 @@ func StoreSchemaReferences(schemaDir string, refs []srsdk.SchemaReference, srCli
 			if err != nil {
 				return nil, err
 			}
-			err = os.MkdirAll(filepath.Dir(tempStorePath), 0755)
-			if err != nil {
+			if err := os.MkdirAll(filepath.Dir(tempStorePath), 0755); err != nil {
 				return nil, err
 			}
-			err = os.WriteFile(tempStorePath, []byte(schema.Schema), 0644)
-			if err != nil {
+			if err := os.WriteFile(tempStorePath, []byte(schema.Schema), 0644); err != nil {
 				return nil, err
 			}
 		}
@@ -137,8 +134,7 @@ func SetSchemaPathRef(schemaString srsdk.SchemaString, dir string, subject strin
 
 	if !utils.FileExists(tempStorePath) || !utils.FileExists(tempRefStorePath) {
 		// TODO: add handler for writing schema failure
-		err := os.WriteFile(tempStorePath, []byte(schemaString.Schema), 0644)
-		if err != nil {
+		if err := os.WriteFile(tempStorePath, []byte(schemaString.Schema), 0644); err != nil {
 			return "", nil, err
 		}
 
@@ -146,8 +142,7 @@ func SetSchemaPathRef(schemaString srsdk.SchemaString, dir string, subject strin
 		if err != nil {
 			return "", nil, err
 		}
-		err = os.WriteFile(tempRefStorePath, refBytes, 0644)
-		if err != nil {
+		if err := os.WriteFile(tempRefStorePath, refBytes, 0644); err != nil {
 			return "", nil, err
 		}
 		references = schemaString.References
@@ -156,8 +151,7 @@ func SetSchemaPathRef(schemaString srsdk.SchemaString, dir string, subject strin
 		if err != nil {
 			return "", nil, err
 		}
-		err = json.Unmarshal(refBlob, &references)
-		if err != nil {
+		if err := json.Unmarshal(refBlob, &references); err != nil {
 			return "", nil, err
 		}
 	}

--- a/internal/pkg/auth/auth.go
+++ b/internal/pkg/auth/auth.go
@@ -63,8 +63,7 @@ func PersistLogout(config *v1.Config) error {
 	}
 
 	delete(ctx.Config.SavedCredentials, ctx.Name)
-	err := ctx.DeleteUserAuth()
-	if err != nil {
+	if err := ctx.DeleteUserAuth(); err != nil {
 		return err
 	}
 	ctx.Config.CurrentContext = ""
@@ -226,8 +225,7 @@ func GetBearerToken(authenticatedState *v1.ContextState, server, clusterId strin
 
 	// Configure and send post request with session token to Auth Service to get access token
 	responses := new(response)
-	_, err := sling.New().Add("content", "application/json").Add("Content-Type", "application/json").Add("Authorization", bearerSessionToken).BodyJSON(clusterIds).Post(accessTokenEndpoint).ReceiveSuccess(responses)
-	if err != nil {
+	if _, err := sling.New().Add("content", "application/json").Add("Content-Type", "application/json").Add("Authorization", bearerSessionToken).BodyJSON(clusterIds).Post(accessTokenEndpoint).ReceiveSuccess(responses); err != nil {
 		return "", err
 	}
 	return responses.Token, nil

--- a/internal/pkg/auth/ccloud_client_factory.go
+++ b/internal/pkg/auth/ccloud_client_factory.go
@@ -19,9 +19,7 @@ type CCloudClientFactoryImpl struct {
 }
 
 func NewCCloudClientFactory(userAgent string) CCloudClientFactory {
-	return &CCloudClientFactoryImpl{
-		UserAgent: userAgent,
-	}
+	return &CCloudClientFactoryImpl{UserAgent: userAgent}
 }
 
 func (c *CCloudClientFactoryImpl) AnonHTTPClientFactory(baseURL string) *ccloudv1.Client {

--- a/internal/pkg/auth/sso/auth_sso_flow.go
+++ b/internal/pkg/auth/sso/auth_sso_flow.go
@@ -45,26 +45,22 @@ func Login(authURL string, noBrowser bool, connectionName string) (string, strin
 		// we need to start a background HTTP server to support the authorization code flow with PKCE
 		// described at https://auth0.com/docs/flows/guides/auth-code-pkce/call-api-auth-code-pkce
 		server := newServer(state)
-		err = server.startServer()
-		if err != nil {
+		if err := server.startServer(); err != nil {
 			return "", "", errors.Wrap(err, errors.StartHTTPServerErrorMsg)
 		}
 
 		// Get authorization code for making subsequent token request
-		err := browser.OpenURL(state.getAuthorizationCodeUrl(connectionName, isOkta))
-		if err != nil {
+		if err := browser.OpenURL(state.getAuthorizationCodeUrl(connectionName, isOkta)); err != nil {
 			return "", "", errors.Wrap(err, errors.OpenWebBrowserErrorMsg)
 		}
 
-		err = server.awaitAuthorizationCode(30 * time.Second)
-		if err != nil {
+		if err = server.awaitAuthorizationCode(30 * time.Second); err != nil {
 			return "", "", err
 		}
 	}
 
 	// Exchange authorization code for OAuth token from SSO provider
-	err = state.getOAuthToken()
-	if err != nil {
+	if err := state.getOAuthToken(); err != nil {
 		return "", "", err
 	}
 

--- a/internal/pkg/auth/sso/auth_state.go
+++ b/internal/pkg/auth/sso/auth_state.go
@@ -115,8 +115,7 @@ func newState(authURL string, noBrowser bool) (*authState, error) {
 		state.SSOProviderCallbackUrl = ssoProviderCallbackLocalURL
 	}
 
-	err := state.generateCodes()
-	if err != nil {
+	if err := state.generateCodes(); err != nil {
 		return nil, err
 	}
 
@@ -127,23 +126,20 @@ func newState(authURL string, noBrowser bool) (*authState, error) {
 func (s *authState) generateCodes() error {
 	randomBytes := make([]byte, 32)
 
-	_, err := rand.Read(randomBytes)
-	if err != nil {
+	if _, err := rand.Read(randomBytes); err != nil {
 		return errors.Wrap(err, errors.GenerateRandomSSOProviderErrorMsg)
 	}
 
 	s.SSOProviderState = base64.RawURLEncoding.EncodeToString(randomBytes)
 
-	_, err = rand.Read(randomBytes)
-	if err != nil {
+	if _, err := rand.Read(randomBytes); err != nil {
 		return errors.Wrap(err, errors.GenerateRandomCodeVerifierErrorMsg)
 	}
 
 	s.CodeVerifier = base64.RawURLEncoding.EncodeToString(randomBytes)
 
 	hasher := sha256.New()
-	_, err = hasher.Write([]byte(s.CodeVerifier))
-	if err != nil {
+	if _, err := hasher.Write([]byte(s.CodeVerifier)); err != nil {
 		return errors.Wrap(err, errors.ComputeHashErrorMsg)
 	}
 	s.CodeChallenge = base64.RawURLEncoding.EncodeToString(hasher.Sum(nil))
@@ -214,8 +210,7 @@ func (s *authState) getOAuthTokenResponse(payload *strings.Reader) (map[string]a
 	defer res.Body.Close()
 	errorResponseBody, _ := io.ReadAll(res.Body)
 	var data map[string]any
-	err = json.Unmarshal(errorResponseBody, &data)
-	if err != nil {
+	if err := json.Unmarshal(errorResponseBody, &data); err != nil {
 		log.CliLogger.Debugf("Failed oauth token response body: %s", errorResponseBody)
 		return nil, errors.Wrap(err, errors.UnmarshalOAuthTokenErrorMsg)
 	}

--- a/internal/pkg/ccloudv2/metrics.go
+++ b/internal/pkg/ccloudv2/metrics.go
@@ -60,8 +60,7 @@ func UnmarshalFlatQueryResponseIfDataSchemaMatchError(err error, metricsResponse
 			return err
 		}
 		var resBody flatQueryResponse
-		err = json.Unmarshal(body, &resBody)
-		if err != nil {
+		if err := json.Unmarshal(body, &resBody); err != nil {
 			return err
 		}
 

--- a/internal/pkg/cmd/prerunner.go
+++ b/internal/pkg/cmd/prerunner.go
@@ -592,8 +592,7 @@ func (r *PreRun) confluentAutoLogin(cmd *cobra.Command, netrcMachineName string)
 		log.CliLogger.Debug("Non-interactive login failed: no credentials")
 		return nil
 	}
-	err = pauth.PersistConfluentLoginToConfig(r.Config, credentials, credentials.PrerunLoginURL, token, credentials.PrerunLoginCaCertPath, false, false)
-	if err != nil {
+	if err := pauth.PersistConfluentLoginToConfig(r.Config, credentials, credentials.PrerunLoginURL, token, credentials.PrerunLoginCaCertPath, false, false); err != nil {
 		return err
 	}
 	log.CliLogger.Debug(errors.AutoLoginMsg)

--- a/internal/pkg/config/base_config.go
+++ b/internal/pkg/config/base_config.go
@@ -23,11 +23,11 @@ func (v *Version) MarshalJSON() ([]byte, error) {
 
 func (v *Version) UnmarshalJSON(data []byte) error {
 	var s string
-	err := json.Unmarshal(data, &s)
-	if err != nil {
+	if err := json.Unmarshal(data, &s); err != nil {
 		return err
 	}
 
+	var err error
 	v.Version, err = version.NewVersion(s)
 	return err
 }

--- a/internal/pkg/config/v1/config.go
+++ b/internal/pkg/config/v1/config.go
@@ -134,12 +134,10 @@ func (c *Config) DecryptContextStates() error {
 	if context := c.Context(); context != nil {
 		state := c.ContextStates[context.Name]
 		if state != nil {
-			err := state.DecryptContextStateAuthToken(context.Name)
-			if err != nil {
+			if err := state.DecryptContextStateAuthToken(context.Name); err != nil {
 				return err
 			}
-			err = state.DecryptContextStateAuthRefreshToken(context.Name)
-			if err != nil {
+			if err := state.DecryptContextStateAuthRefreshToken(context.Name); err != nil {
 				return err
 			}
 		}
@@ -215,8 +213,7 @@ func (c *Config) Save() error {
 	if c.Context() != nil {
 		tempAuthToken = c.Context().GetState().AuthToken
 		tempAuthRefreshToken = c.Context().GetState().AuthRefreshToken
-		err := c.encryptContextStateTokens(tempAuthToken, tempAuthRefreshToken)
-		if err != nil {
+		if err := c.encryptContextStateTokens(tempAuthToken, tempAuthRefreshToken); err != nil {
 			return err
 		}
 	}
@@ -367,8 +364,7 @@ func (c *Config) Validate() error {
 	// 1. Has no hanging references between the context and the config.
 	// 2. Is mapped by name correctly in the config.
 	for _, context := range c.Contexts {
-		err := context.validate()
-		if err != nil {
+		if err := context.validate(); err != nil {
 			log.CliLogger.Trace("context validation error")
 			return err
 		}

--- a/internal/pkg/config/v1/context.go
+++ b/internal/pkg/config/v1/context.go
@@ -47,8 +47,7 @@ func newContext(name string, platform *Platform, credential *Credential, kafkaCl
 		LastOrgId:              orgResourceId,
 	}
 	ctx.KafkaClusterContext = NewKafkaClusterContext(ctx, kafka, kafkaClusters)
-	err := ctx.validate()
-	if err != nil {
+	if err := ctx.validate(); err != nil {
 		return nil, err
 	}
 	return ctx, nil

--- a/internal/pkg/config/v1/kafka_cluster_context.go
+++ b/internal/pkg/config/v1/kafka_cluster_context.go
@@ -132,8 +132,7 @@ func (k *KafkaClusterContext) GetCurrentKafkaEnvContext() *KafkaEnvContext {
 			ActiveKafkaCluster:  "",
 			KafkaClusterConfigs: map[string]*KafkaClusterConfig{},
 		}
-		err := k.Context.Save()
-		if err != nil {
+		if err := k.Context.Save(); err != nil {
 			panic(fmt.Sprintf("Unable to save new KafkaEnvContext to config for context '%s' environment '%s'.", k.Context.Name, curEnv))
 		}
 	}
@@ -145,8 +144,7 @@ func (k *KafkaClusterContext) Validate() {
 	if !k.EnvContext {
 		if k.KafkaClusterConfigs == nil {
 			k.KafkaClusterConfigs = map[string]*KafkaClusterConfig{}
-			err := k.Context.Save()
-			if err != nil {
+			if err := k.Context.Save(); err != nil {
 				panic(fmt.Sprintf("Unable to save new KafkaClusterConfigs map to config for context '%s'.", k.Context.Name))
 			}
 		}
@@ -156,16 +154,14 @@ func (k *KafkaClusterContext) Validate() {
 	} else {
 		if k.KafkaEnvContexts == nil {
 			k.KafkaEnvContexts = map[string]*KafkaEnvContext{}
-			err := k.Context.Save()
-			if err != nil {
+			if err := k.Context.Save(); err != nil {
 				panic(fmt.Sprintf("Unable to save new KafkaEnvContexts map to config for context '%s'.", k.Context.Name))
 			}
 		}
 		for env, kafkaEnvContexts := range k.KafkaEnvContexts {
 			if kafkaEnvContexts.KafkaClusterConfigs == nil {
 				kafkaEnvContexts.KafkaClusterConfigs = map[string]*KafkaClusterConfig{}
-				err := k.Context.Save()
-				if err != nil {
+				if err := k.Context.Save(); err != nil {
 					panic(fmt.Sprintf("Unable to save new KafkaClusterConfigs map to config for context '%s', environment '%s'.", k.Context.Name, env))
 				}
 			}
@@ -184,8 +180,7 @@ func (k *KafkaClusterContext) validateActiveKafka() {
 		if _, ok := k.KafkaClusterConfigs[k.ActiveKafkaCluster]; k.ActiveKafkaCluster != "" && !ok {
 			output.ErrPrintf(errMsg, k.ActiveKafkaCluster, k.Context.Name)
 			k.ActiveKafkaCluster = ""
-			err := k.Context.Save()
-			if err != nil {
+			if err := k.Context.Save(); err != nil {
 				panic(fmt.Sprintf("Unable to reset ActiveKafkaCluster in context '%s'.", k.Context.Name))
 			}
 		}
@@ -194,8 +189,7 @@ func (k *KafkaClusterContext) validateActiveKafka() {
 			if _, ok := kafkaEnvContext.KafkaClusterConfigs[kafkaEnvContext.ActiveKafkaCluster]; kafkaEnvContext.ActiveKafkaCluster != "" && !ok {
 				output.ErrPrintf(errMsg, kafkaEnvContext.ActiveKafkaCluster, k.Context.Name)
 				kafkaEnvContext.ActiveKafkaCluster = ""
-				err := k.Context.Save()
-				if err != nil {
+				if err := k.Context.Save(); err != nil {
 					panic(fmt.Sprintf("Unable to reset ActiveKafkaCluster in context '%s', environment '%s'.", k.Context.Name, env))
 				}
 			}
@@ -209,16 +203,14 @@ func (k *KafkaClusterContext) validateKafkaClusterConfig(cluster *KafkaClusterCo
 	}
 	if cluster.APIKeys == nil {
 		cluster.APIKeys = map[string]*APIKeyPair{}
-		err := k.Context.Save()
-		if err != nil {
+		if err := k.Context.Save(); err != nil {
 			panic(fmt.Sprintf("Unable to save new APIKeys map in context '%s', for cluster '%s'.", k.Context.Name, cluster.ID))
 		}
 	}
 	if _, ok := cluster.APIKeys[cluster.APIKey]; cluster.APIKey != "" && !ok {
 		output.ErrPrintf(errors.CurrentAPIKeyAutofixMsg, cluster.APIKey, cluster.ID, k.Context.Name, cluster.ID)
 		cluster.APIKey = ""
-		err := k.Context.Save()
-		if err != nil {
+		if err := k.Context.Save(); err != nil {
 			panic(fmt.Sprintf("Unable to reset current APIKey for cluster '%s' in context '%s'.", cluster.ID, k.Context.Name))
 		}
 	}
@@ -247,8 +239,7 @@ func (k *KafkaClusterContext) validateApiKeysDict(cluster *KafkaClusterConfig) {
 	}
 	if missingKey || mismatchKey || missingSecret {
 		printApiKeysDictErrorMessage(missingKey, mismatchKey, missingSecret, cluster, k.Context.Name)
-		err := k.Context.Save()
-		if err != nil {
+		if err := k.Context.Save(); err != nil {
 			panic("Unable to save new KafkaEnvContext to config.")
 		}
 	}

--- a/internal/pkg/errors/catcher.go
+++ b/internal/pkg/errors/catcher.go
@@ -49,8 +49,7 @@ func catchTypedErrors(err error) error {
 func parseMDSOpenAPIErrorType1(err error) (*MDSV2Alpha1ErrorType1, error) {
 	if openAPIError, ok := err.(mdsv2alpha1.GenericOpenAPIError); ok {
 		var decodedError MDSV2Alpha1ErrorType1
-		err = json.Unmarshal(openAPIError.Body(), &decodedError)
-		if err != nil {
+		if err := json.Unmarshal(openAPIError.Body(), &decodedError); err != nil {
 			return nil, err
 		}
 		if reflect.DeepEqual(decodedError, MDSV2Alpha1ErrorType1{}) {
@@ -64,8 +63,7 @@ func parseMDSOpenAPIErrorType1(err error) (*MDSV2Alpha1ErrorType1, error) {
 func parseMDSOpenAPIErrorType2(err error) (*MDSV2Alpha1ErrorType2Array, error) {
 	if openAPIError, ok := err.(mdsv2alpha1.GenericOpenAPIError); ok {
 		var decodedError MDSV2Alpha1ErrorType2Array
-		err = json.Unmarshal(openAPIError.Body(), &decodedError)
-		if err != nil {
+		if err := json.Unmarshal(openAPIError.Body(), &decodedError); err != nil {
 			return nil, err
 		}
 		if reflect.DeepEqual(decodedError, MDSV2Alpha1ErrorType2Array{}) {

--- a/internal/pkg/featureflags/feature_flags.go
+++ b/internal/pkg/featureflags/feature_flags.go
@@ -126,8 +126,7 @@ func (ld *launchDarklyManager) IntVariation(key string, ctx *dynamicconfig.Dynam
 }
 
 func (ld *launchDarklyManager) JsonVariation(key string, ctx *dynamicconfig.DynamicContext, client v1.LaunchDarklyClient, shouldCache bool, defaultVal any) any {
-	flagVal := ld.generalVariation(key, ctx, client, shouldCache, defaultVal)
-	return flagVal
+	return ld.generalVariation(key, ctx, client, shouldCache, defaultVal)
 }
 
 func (ld *launchDarklyManager) generalVariation(key string, ctx *dynamicconfig.DynamicContext, client v1.LaunchDarklyClient, shouldCache bool, defaultVal any) any {

--- a/internal/pkg/kafkarest/kafkarest.go
+++ b/internal/pkg/kafkarest/kafkarest.go
@@ -61,8 +61,7 @@ func NewError(url string, err error, httpResp *http.Response) error {
 func ParseOpenAPIErrorCloud(err error) (*V3Error, error) {
 	if openAPIError, ok := err.(cckafkarestv3.GenericOpenAPIError); ok {
 		var decodedError V3Error
-		err = json.Unmarshal(openAPIError.Body(), &decodedError)
-		if err != nil {
+		if err := json.Unmarshal(openAPIError.Body(), &decodedError); err != nil {
 			return nil, err
 		}
 		return &decodedError, nil
@@ -79,8 +78,7 @@ func kafkaRestHttpError(httpResp *http.Response) error {
 func parseOpenAPIError(err error) (*V3Error, error) {
 	if openAPIError, ok := err.(kafkarestv3.GenericOpenAPIError); ok {
 		var decodedError V3Error
-		err = json.Unmarshal(openAPIError.Body(), &decodedError)
-		if err != nil {
+		if err := json.Unmarshal(openAPIError.Body(), &decodedError); err != nil {
 			return nil, err
 		}
 		return &decodedError, nil

--- a/internal/pkg/keychain/keychain_darwin.go
+++ b/internal/pkg/keychain/keychain_darwin.go
@@ -50,8 +50,7 @@ func Delete(isCloud bool, ctxName string) error {
 	for _, entry := range results {
 		if strings.Contains(ctxName, entry.Account) {
 			username, _, _ := parseCredentialsFromKeychain(entry.Data)
-			err := keychain.DeleteGenericPasswordItem(service, entry.Account)
-			if err != nil {
+			if err := keychain.DeleteGenericPasswordItem(service, entry.Account); err != nil {
 				return err
 			}
 

--- a/internal/pkg/linter/linter.go
+++ b/internal/pkg/linter/linter.go
@@ -17,8 +17,7 @@ type Linter struct {
 func (l *Linter) Lint(cmd *cobra.Command) error {
 	var issues *multierror.Error
 
-	err := l.lintRules(cmd)
-	if err != nil {
+	if err := l.lintRules(cmd); err != nil {
 		issues = multierror.Append(issues, err)
 	}
 

--- a/internal/pkg/netrc/netrc_handler.go
+++ b/internal/pkg/netrc/netrc_handler.go
@@ -71,8 +71,7 @@ func (n *NetrcHandlerImpl) RemoveNetrcCredentials(isCloud bool, ctxName string) 
 	machineName := GetLocalCredentialName(isCloud, ctxName)
 	machine := netrcFile.FindMachine(machineName)
 	if machine != nil {
-		err := removeCredentials(machineName, netrcFile, n.FileName)
-		if err != nil {
+		if err := removeCredentials(machineName, netrcFile, n.FileName); err != nil {
 			return "", err
 		}
 		return machine.Login, nil
@@ -116,8 +115,7 @@ func removeCredentials(machineName string, netrcFile *gonetrc.Netrc, filename st
 		return err
 	}
 	filemode := info.Mode()
-	err = os.WriteFile(filename, buf, filemode)
-	if err != nil {
+	if err := os.WriteFile(filename, buf, filemode); err != nil {
 		return errors.Wrapf(err, errors.WriteToNetrcFileErrorMsg, filename)
 	}
 	return nil

--- a/internal/pkg/netrc/netrc_handler_test.go
+++ b/internal/pkg/netrc/netrc_handler_test.go
@@ -156,9 +156,7 @@ func TestGetMatchingNetrcMachineNameFromURL(t *testing.T) {
 		{
 			name: "ccloud login no url",
 			want: ccloudDiffURLMachine,
-			params: NetrcMachineParams{
-				IsCloud: true,
-			},
+			params: NetrcMachineParams{IsCloud: true},
 			file: netrcFilePath,
 		},
 		{
@@ -172,9 +170,7 @@ func TestGetMatchingNetrcMachineNameFromURL(t *testing.T) {
 		},
 		{
 			name: "No file error",
-			params: NetrcMachineParams{
-				IsCloud: false,
-			},
+			params: NetrcMachineParams{IsCloud: false},
 			wantErr: true,
 			file:    "wrong-file",
 		},

--- a/internal/pkg/secret/encryption_other.go
+++ b/internal/pkg/secret/encryption_other.go
@@ -25,11 +25,10 @@ const (
 
 func GenerateRandomBytes(n int) ([]byte, error) {
 	b := make([]byte, n)
-	_, err := rand.Read(b)
-	if err != nil {
+	if _, err := rand.Read(b); err != nil {
 		return []byte{}, err
 	}
-	return b, err
+	return b, nil
 }
 
 func DeriveEncryptionKey(salt []byte) ([]byte, error) {
@@ -38,8 +37,7 @@ func DeriveEncryptionKey(salt []byte) ([]byte, error) {
 		return []byte{}, err
 	}
 	userId := strconv.Itoa(os.Getuid())
-	encryptionKey := pbkdf2.Key([]byte(machineId+userId), salt, iterationNumber, keyLength, sha256.New)
-	return encryptionKey, nil
+	return pbkdf2.Key([]byte(machineId+userId), salt, iterationNumber, keyLength, sha256.New), nil
 }
 
 func Encrypt(username, password string, salt, nonce []byte) (string, error) {

--- a/internal/pkg/secret/jaas_config_parser.go
+++ b/internal/pkg/secret/jaas_config_parser.go
@@ -96,8 +96,7 @@ func (j *JAASParser) parseConfig(specialChar rune) (string, int, error) {
 			offset = j.tokenizer.Pos().Offset
 		}
 	}
-	err := validateConfig(configName)
-	if err != nil {
+	if err := validateConfig(configName); err != nil {
 		return "", offset, err
 	}
 	return configName, offset, nil
@@ -138,8 +137,7 @@ func (j *JAASParser) ParseJAASConfigurationEntry(jaasConfig string, key string) 
 		return nil, err
 	}
 	j.JaasOriginalConfigKeys.DisableExpansion = true
-	_, _, err = j.JaasOriginalConfigKeys.Set(key+KeySeparator+parentKey, jaasConfig)
-	if err != nil {
+	if _, _, err := j.JaasOriginalConfigKeys.Set(key+KeySeparator+parentKey, jaasConfig); err != nil {
 		return nil, err
 	}
 
@@ -166,12 +164,10 @@ func (j *JAASParser) ConvertPropertiesToJAAS(props *properties.Properties, op st
 		if err != nil {
 			return nil, err
 		}
-		_, _, err = j.JaasOriginalConfigKeys.Set(configKey, jaas)
-		if err != nil {
+		if _, _, err := j.JaasOriginalConfigKeys.Set(configKey, jaas); err != nil {
 			return nil, err
 		}
-		_, _, err = result.Set(keys[ClassId], jaas)
-		if err != nil {
+		if _, _, err := result.Set(keys[ClassId], jaas); err != nil {
 			return nil, err
 		}
 	}
@@ -189,8 +185,7 @@ func (j *JAASParser) parseConfigurationEntry(prefixKey string) (int, int, *prope
 	}
 
 	// Parse Control Flag
-	err = j.parseControlFlag()
-	if err != nil {
+	if err := j.parseControlFlag(); err != nil {
 		return 0, 0, nil, "", err
 	}
 
@@ -218,8 +213,7 @@ func (j *JAASParser) parseConfigurationEntry(prefixKey string) (int, int, *prope
 			return 0, 0, nil, "", err
 		}
 		newKey := prefixKey + KeySeparator + parentKey + KeySeparator + key
-		_, _, err := parsedConfigs.Set(newKey, value)
-		if err != nil {
+		if _, _, err := parsedConfigs.Set(newKey, value); err != nil {
 			return 0, 0, nil, "", err
 		}
 		j.ignoreBackslash()

--- a/internal/pkg/secret/password_protection_plugin.go
+++ b/internal/pkg/secret/password_protection_plugin.go
@@ -76,19 +76,16 @@ func (c *PasswordProtectionSuite) CreateMasterKey(passphrase string, localSecure
 	}
 
 	// save the master key salt
-	_, _, err = secureConfigProps.Set(MetadataMEKSalt, salt)
-	if err != nil {
+	if _, _, err := secureConfigProps.Set(MetadataMEKSalt, salt); err != nil {
 		return "", err
 	}
 
 	now := c.Clock.Now()
-	_, _, err = secureConfigProps.Set(MetadataKeyTimestamp, now.String())
-	if err != nil {
+	if _, _, err := secureConfigProps.Set(MetadataKeyTimestamp, now.String()); err != nil {
 		return "", err
 	}
 
-	err = WritePropertiesFile(localSecureConfigPath, secureConfigProps, true)
-	if err != nil {
+	if err := WritePropertiesFile(localSecureConfigPath, secureConfigProps, true); err != nil {
 		return "", err
 	}
 
@@ -139,8 +136,7 @@ func (c *PasswordProtectionSuite) EncryptConfigFileSecrets(configFilePath string
 	configProps.DisableExpansion = true
 
 	// Encrypt the secrets with DEK. Save the encrypted secrets in secure config file.
-	err = c.encryptConfigValues(configProps, localSecureConfigPath, configFilePath, remoteSecureConfigPath)
-	if err != nil {
+	if err := c.encryptConfigValues(configProps, localSecureConfigPath, configFilePath, remoteSecureConfigPath); err != nil {
 		return err
 	}
 
@@ -203,8 +199,7 @@ func (c *PasswordProtectionSuite) DecryptConfigFileSecrets(configFilePath string
 					log.CliLogger.Debug(err)
 					return errors.Errorf(errors.DecryptConfigErrorMsg, key)
 				}
-				_, _, err = configProps.Set(key, plainSecret)
-				if err != nil {
+				if _, _, err := configProps.Set(key, plainSecret); err != nil {
 					return err
 				}
 			} else {
@@ -294,20 +289,16 @@ func (c *PasswordProtectionSuite) RotateDataKey(masterPassphrase string, localSe
 
 	// Save new DEK and re-encrypted ciphers.
 	now := c.Clock.Now()
-	_, _, err = secureConfigProps.Set(MetadataKeyTimestamp, now.String())
-	if err != nil {
+	if _, _, err := secureConfigProps.Set(MetadataKeyTimestamp, now.String()); err != nil {
 		return err
 	}
-	_, _, err = secureConfigProps.Set(MetadataDataKey, wrappedNewDK)
-	if err != nil {
+	if _, _, err := secureConfigProps.Set(MetadataDataKey, wrappedNewDK); err != nil {
 		return err
 	}
-	_, _, err = secureConfigProps.Set(MetadataDEKSalt, salt)
-	if err != nil {
+	if _, _, err := secureConfigProps.Set(MetadataDEKSalt, salt); err != nil {
 		return err
 	}
-	err = WritePropertiesFile(localSecureConfigPath, secureConfigProps, true)
-	if err != nil {
+	if err := WritePropertiesFile(localSecureConfigPath, secureConfigProps, true); err != nil {
 		return err
 	}
 
@@ -376,23 +367,19 @@ func (c *PasswordProtectionSuite) RotateMasterKey(oldPassphrase string, newPassp
 
 	// Save DEK
 	now := c.Clock.Now()
-	_, _, err = secureConfigProps.Set(MetadataKeyTimestamp, now.String())
-	if err != nil {
+	if _, _, err := secureConfigProps.Set(MetadataKeyTimestamp, now.String()); err != nil {
 		return "", err
 	}
-	_, _, err = secureConfigProps.Set(MetadataDataKey, newEncodedDataKey)
-	if err != nil {
+	if _, _, err := secureConfigProps.Set(MetadataDataKey, newEncodedDataKey); err != nil {
 		return "", err
 	}
 
 	// save the master key salt
-	_, _, err = secureConfigProps.Set(MetadataMEKSalt, salt)
-	if err != nil {
+	if _, _, err := secureConfigProps.Set(MetadataMEKSalt, salt); err != nil {
 		return "", err
 	}
 
-	err = WritePropertiesFile(localSecureConfigPath, secureConfigProps, true)
-	if err != nil {
+	if err := WritePropertiesFile(localSecureConfigPath, secureConfigProps, true); err != nil {
 		return "", err
 	}
 
@@ -414,12 +401,7 @@ func (c *PasswordProtectionSuite) AddEncryptedPasswords(configFilePath string, l
 		return errors.New(errors.EmptyNewConfigListErrorMsg)
 	}
 
-	err = c.encryptConfigValues(newConfigProps, localSecureConfigPath, configFilePath, remoteSecureConfigPath)
-	if err != nil {
-		return err
-	}
-
-	return err
+	return c.encryptConfigValues(newConfigProps, localSecureConfigPath, configFilePath, remoteSecureConfigPath)
 }
 
 // This function updates a the value of existing keys in the configFilePath property file. The original 'value' is
@@ -443,9 +425,7 @@ func (c *PasswordProtectionSuite) UpdateEncryptedPasswords(configFilePath string
 	}
 	configProps.DisableExpansion = true
 
-	err = c.encryptConfigValues(newConfigProps, localSecureConfigPath, configFilePath, remoteSecureConfigPath)
-
-	return err
+	return c.encryptConfigValues(newConfigProps, localSecureConfigPath, configFilePath, remoteSecureConfigPath)
 }
 
 func (c *PasswordProtectionSuite) RemoveEncryptedPasswords(configFilePath string, localSecureConfigPath string, removeConfigs string) error {
@@ -473,8 +453,7 @@ func (c *PasswordProtectionSuite) RemoveEncryptedPasswords(configFilePath string
 			pathKey = strings.ReplaceAll(pathKey, "\\.", ".")
 		}
 		// Check if config is removed from secrets files
-		_, ok := secureConfigProps.Get(pathKey)
-		if !ok {
+		if _, ok := secureConfigProps.Get(pathKey); !ok {
 			return errors.Errorf(errors.ConfigKeyNotEncryptedErrorMsg, key)
 		}
 		secureConfigProps.Delete(pathKey)
@@ -493,8 +472,7 @@ func (c *PasswordProtectionSuite) RemoveEncryptedPasswords(configFilePath string
 		return err
 	}
 
-	err = WritePropertiesFile(localSecureConfigPath, secureConfigProps, true)
-	return err
+	return WritePropertiesFile(localSecureConfigPath, secureConfigProps, true)
 }
 
 // Helper Functions
@@ -530,9 +508,7 @@ func (c *PasswordProtectionSuite) wrapDataKey(engine EncryptionEngine, dataKey [
 		return "", err
 	}
 
-	encodedDataKey := c.formatCipherValue(wrappedDataKey, iv)
-
-	return encodedDataKey, nil
+	return c.formatCipherValue(wrappedDataKey, iv), nil
 }
 
 func (c *PasswordProtectionSuite) loadCipherSuiteFromLocalFile(localSecureConfigPath string) (*Cipher, error) {
@@ -603,31 +579,25 @@ func (c *PasswordProtectionSuite) fetchSecureConfigProps(localSecureConfigPath s
 
 	// Add DEK Metadata to secureConfigProps
 	now := c.Clock.Now()
-	_, _, err = secureConfigProps.Set(MetadataKeyTimestamp, now.String())
-	if err != nil {
+	if _, _, err := secureConfigProps.Set(MetadataKeyTimestamp, now.String()); err != nil {
 		return nil, nil, err
 	}
-	_, _, err = secureConfigProps.Set(MetadataKeyEnvVar, ConfluentKeyEnvVar)
-	if err != nil {
+	if _, _, err := secureConfigProps.Set(MetadataKeyEnvVar, ConfluentKeyEnvVar); err != nil {
 		return nil, nil, err
 	}
-	_, _, err = secureConfigProps.Set(MetadataKeyLength, strconv.Itoa(cipherSuites.KeyLength))
-	if err != nil {
+	if _, _, err := secureConfigProps.Set(MetadataKeyLength, strconv.Itoa(cipherSuites.KeyLength)); err != nil {
 		return nil, nil, err
 	}
-	_, _, err = secureConfigProps.Set(MetadataKeyIterations, strconv.Itoa(cipherSuites.Iterations))
-	if err != nil {
+	if _, _, err := secureConfigProps.Set(MetadataKeyIterations, strconv.Itoa(cipherSuites.Iterations)); err != nil {
 		return nil, nil, err
 	}
-	_, _, err = secureConfigProps.Set(MetadataDEKSalt, cipherSuites.SaltDEK)
-	if err != nil {
+	if _, _, err := secureConfigProps.Set(MetadataDEKSalt, cipherSuites.SaltDEK); err != nil {
 		return nil, nil, err
 	}
-	_, _, err = secureConfigProps.Set(MetadataDataKey, cipherSuites.EncryptedDataKey)
-	if err != nil {
+	if _, _, err := secureConfigProps.Set(MetadataDataKey, cipherSuites.EncryptedDataKey); err != nil {
 		return nil, nil, err
 	}
-	return secureConfigProps, cipherSuites, err
+	return secureConfigProps, cipherSuites, nil
 }
 
 func (c *PasswordProtectionSuite) loadMasterKey() (string, error) {
@@ -682,13 +652,11 @@ func (c *PasswordProtectionSuite) encryptConfigValues(matchProps *properties.Pro
 		}
 	}
 
-	err = SaveConfiguration(configFilePath, configProps, true)
-	if err != nil {
+	if err := SaveConfiguration(configFilePath, configProps, true); err != nil {
 		return err
 	}
 
-	err = WritePropertiesFile(localSecureConfigPath, secureConfigProps, true)
-	if err != nil {
+	if err := WritePropertiesFile(localSecureConfigPath, secureConfigProps, true); err != nil {
 		return err
 	}
 

--- a/internal/pkg/secret/password_protection_test.go
+++ b/internal/pkg/secret/password_protection_test.go
@@ -1346,8 +1346,7 @@ func createMasterKey(passphrase string, localSecretsFile string, plugin *Passwor
 }
 
 func createNewConfigFile(path string, contents string) error {
-	err := os.WriteFile(path, []byte(contents), 0644)
-	return err
+	return os.WriteFile(path, []byte(contents), 0644)
 }
 
 func validateTextFileContents(path string, expectedFileContent string, req *require.Assertions) {
@@ -1371,13 +1370,11 @@ func validateJSONFileContents(path string, expectedFileContent string, req *requ
 func generateCorruptedData(cipher string) (string, error) {
 	data, _, _ := ParseCipherValue(cipher)
 	randomBytes := make([]byte, 32)
-	_, err := rand.Read(randomBytes)
-	if err != nil {
+	if _, err := rand.Read(randomBytes); err != nil {
 		return "", err
 	}
 	corruptedData := base32.StdEncoding.EncodeToString(randomBytes)[:32]
-	result := strings.Replace(cipher, data, corruptedData, 1)
-	return result, nil
+	return strings.Replace(cipher, data, corruptedData, 1), nil
 }
 
 func corruptEncryptedDEK(localSecureConfigPath string) error {
@@ -1390,13 +1387,11 @@ func corruptEncryptedDEK(localSecureConfigPath string) error {
 	if err != nil {
 		return err
 	}
-	_, _, err = secretsProps.Set(MetadataDataKey, corruptedCipher)
-	if err != nil {
+	if _, _, err := secretsProps.Set(MetadataDataKey, corruptedCipher); err != nil {
 		return err
 	}
 
-	err = WritePropertiesFile(localSecureConfigPath, secretsProps, true)
-	return err
+	return WritePropertiesFile(localSecureConfigPath, secretsProps, true)
 }
 
 func verifyConfigsRemoved(configFilePath string, localSecureConfigPath string, removedConfigs string) error {
@@ -1414,8 +1409,7 @@ func verifyConfigsRemoved(configFilePath string, localSecureConfigPath string, r
 		pathKey := GenerateConfigKey(configFilePath, key)
 
 		// Check if config is removed from secrets files
-		_, ok := secretsProps.Get(pathKey)
-		if ok {
+		if _, ok := secretsProps.Get(pathKey); ok {
 			return fmt.Errorf("failed to remove config from secrets file")
 		}
 	}
@@ -1424,8 +1418,7 @@ func verifyConfigsRemoved(configFilePath string, localSecureConfigPath string, r
 }
 
 func validateUsingDecryption(configFilePath string, localSecureConfigPath string, outputConfigPath string, origConfigs string, plugin *PasswordProtectionSuite) error {
-	err := plugin.DecryptConfigFileSecrets(configFilePath, localSecureConfigPath, outputConfigPath, "")
-	if err != nil {
+	if err := plugin.DecryptConfigFileSecrets(configFilePath, localSecureConfigPath, outputConfigPath, ""); err != nil {
 		return fmt.Errorf("failed to decrypt config file")
 	}
 
@@ -1454,21 +1447,18 @@ func validateUsingDecryption(configFilePath string, localSecureConfigPath string
 }
 
 func setUpDir(masterKeyPassphrase string, secureDir string, configFile string, localSecureConfigPath string, contents string) (*PasswordProtectionSuite, error) {
-	err := os.MkdirAll(secureDir, os.ModePerm)
-	if err != nil {
+	if err := os.MkdirAll(secureDir, os.ModePerm); err != nil {
 		return nil, fmt.Errorf("failed to create password protection directory")
 	}
 	plugin := NewPasswordProtectionPlugin()
 	plugin.Clock = clockwork.NewFakeClock()
 
 	// Set master key
-	err = createMasterKey(masterKeyPassphrase, localSecureConfigPath, plugin)
-	if err != nil {
+	if err := createMasterKey(masterKeyPassphrase, localSecureConfigPath, plugin); err != nil {
 		return nil, fmt.Errorf("failed to create master key")
 	}
 
-	err = createNewConfigFile(configFile, contents)
-	if err != nil {
+	if err := createNewConfigFile(configFile, contents); err != nil {
 		return nil, fmt.Errorf("failed to create config file")
 	}
 

--- a/internal/pkg/secret/rng.go
+++ b/internal/pkg/secret/rng.go
@@ -31,8 +31,7 @@ func (s *cryptoSource) Int63() int64 {
 
 func (s *cryptoSource) Uint64() uint64 {
 	var v uint64
-	err := binary.Read(crand.Reader, binary.BigEndian, &v)
-	if err != nil {
+	if err := binary.Read(crand.Reader, binary.BigEndian, &v); err != nil {
 		log.CliLogger.Error(err)
 	}
 	return v

--- a/internal/pkg/secret/utils.go
+++ b/internal/pkg/secret/utils.go
@@ -60,19 +60,16 @@ func SaveConfiguration(path string, configuration *properties.Properties, addSec
 func WritePropertiesFile(path string, property *properties.Properties, writeComments bool) error {
 	buf := new(bytes.Buffer)
 	if writeComments {
-		_, err := property.WriteFormattedComment(buf, properties.UTF8)
-		if err != nil {
+		if _, err := property.WriteFormattedComment(buf, properties.UTF8); err != nil {
 			return err
 		}
 	} else {
-		_, err := property.Write(buf, properties.UTF8)
-		if err != nil {
+		if _, err := property.Write(buf, properties.UTF8); err != nil {
 			return err
 		}
 	}
 
-	err := WriteFile(path, buf.Bytes())
-	return err
+	return WriteFile(path, buf.Bytes())
 }
 
 func addSecureConfigProviderProperty(property *properties.Properties) (*properties.Properties, error) {
@@ -84,12 +81,10 @@ func addSecureConfigProviderProperty(property *properties.Properties) (*properti
 		configProviders = configProviders + "," + SecureConfigProvider
 	}
 
-	_, _, err := property.Set(ConfigProviderKey, configProviders)
-	if err != nil {
+	if _, _, err := property.Set(ConfigProviderKey, configProviders); err != nil {
 		return nil, err
 	}
-	_, _, err = property.Set(SecureConfigProviderClassKey, SecureConfigProviderClass)
-	if err != nil {
+	if _, _, err := property.Set(SecureConfigProviderClassKey, SecureConfigProviderClass); err != nil {
 		return nil, err
 	}
 	return property, nil
@@ -120,8 +115,7 @@ func filterProperties(configProps *properties.Properties, configKeys []string, f
 			value, ok := configProps.Get(key)
 			// If key present in config file
 			if ok {
-				_, _, err := matchProps.Set(key, value)
-				if err != nil {
+				if _, _, err := matchProps.Set(key, value); err != nil {
 					return nil, err
 				}
 			} else {
@@ -193,12 +187,10 @@ func convertPropertiesJAAS(props *properties.Properties, originalConfigs *proper
 			origKey := parentKeys[ClassId]
 			origVal, ok := originalConfigs.Get(origKey)
 			if ok {
-				_, _, err = jaasProps.Set(key, value)
-				if err != nil {
+				if _, _, err := jaasProps.Set(key, value); err != nil {
 					return props, nil
 				}
-				_, _, err = jaasOriginal.Set(parentKeys[ClassId]+KeySeparator+parentKeys[ParentId], origVal)
-				if err != nil {
+				if _, _, err := jaasOriginal.Set(parentKeys[ClassId]+KeySeparator+parentKeys[ParentId], origVal); err != nil {
 					return props, nil
 				}
 				props.Delete(key)
@@ -252,8 +244,7 @@ func loadJSONConfig(path string, configKeys []string) (*properties.Properties, e
 		// If key present in config file
 		if gjson.Get(jsonConfig, key).Exists() {
 			configValue := gjson.Get(jsonConfig, key)
-			_, _, err = matchProps.Set(key, configValue.String())
-			if err != nil {
+			if _, _, err := matchProps.Set(key, configValue.String()); err != nil {
 				return nil, err
 			}
 		} else {
@@ -277,8 +268,7 @@ func writePropertiesConfig(path string, configs *properties.Properties, addSecur
 	}
 
 	for key, value := range configs.Map() {
-		_, _, err = configProps.Set(key, value)
-		if err != nil {
+		if _, _, err := configProps.Set(key, value); err != nil {
 			return err
 		}
 	}
@@ -290,8 +280,7 @@ func writePropertiesConfig(path string, configs *properties.Properties, addSecur
 		}
 	}
 
-	err = WritePropertiesFile(path, configProps, true)
-	return err
+	return WritePropertiesFile(path, configProps, true)
 }
 
 func RemovePropertiesConfig(removeConfigs []string, path string) error {
@@ -306,13 +295,11 @@ func RemovePropertiesConfig(removeConfigs []string, path string) error {
 	for _, key := range removeConfigs {
 		// check if config is present
 		if pattern.MatchString(key) {
-			_, _, err = removeJAASConfig.Set(key, "")
-			if err != nil {
+			if _, _, err := removeJAASConfig.Set(key, ""); err != nil {
 				return err
 			}
 		} else {
-			_, ok := configProps.Get(key)
-			if !ok {
+			if _, ok := configProps.Get(key); !ok {
 				return errors.Errorf(errors.ConfigKeyNotPresentErrorMsg, key)
 			}
 			configProps.Delete(key)
@@ -325,14 +312,12 @@ func RemovePropertiesConfig(removeConfigs []string, path string) error {
 	}
 
 	for key, value := range configs.Map() {
-		_, _, err = configProps.Set(key, value)
-		if err != nil {
+		if _, _, err := configProps.Set(key, value); err != nil {
 			return err
 		}
 	}
 
-	err = WritePropertiesFile(path, configProps, true)
-	return err
+	return WritePropertiesFile(path, configProps, true)
 }
 
 func writeJSONConfig(path string, configs *properties.Properties, addSecureConfig bool) error {
@@ -343,8 +328,7 @@ func writeJSONConfig(path string, configs *properties.Properties, addSecureConfi
 
 	if gjson.Get(jsonConfig, ConfigProviderKey).Exists() {
 		configValue := gjson.Get(jsonConfig, ConfigProviderKey)
-		_, _, err = configs.Set(ConfigProviderKey, configValue.String())
-		if err != nil {
+		if _, _, err := configs.Set(ConfigProviderKey, configValue.String()); err != nil {
 			return err
 		}
 	}
@@ -378,8 +362,7 @@ func writeJSONConfig(path string, configs *properties.Properties, addSecureConfi
 	}
 
 	result := pretty.Pretty([]byte(jsonConfig))
-	err = WriteFile(path, result)
-	return err
+	return WriteFile(path, result)
 }
 
 func WriteFile(path string, data []byte) error {

--- a/internal/pkg/serdes/jsonserdes.go
+++ b/internal/pkg/serdes/jsonserdes.go
@@ -44,8 +44,7 @@ func (jsonProvider *JsonSerializationProvider) encode(str string) ([]byte, error
 
 	// Compact Json string, i.e. remove redundant space, etc.
 	compactedBuffer := new(bytes.Buffer)
-	err = json.Compact(compactedBuffer, data)
-	if err != nil {
+	if err := json.Compact(compactedBuffer, data); err != nil {
 		return nil, err
 	}
 	return compactedBuffer.Bytes(), nil
@@ -87,8 +86,7 @@ func (jsonProvider *JsonDeserializationProvider) decode(data []byte) (string, er
 
 	// Compact Json string, i.e. remove redundant space, etc.
 	compactedBuffer := new(bytes.Buffer)
-	err = json.Compact(compactedBuffer, data)
-	if err != nil {
+	if err := json.Compact(compactedBuffer, data); err != nil {
 		return "", err
 	}
 	return compactedBuffer.String(), nil
@@ -102,8 +100,7 @@ func parseSchema(schemaPath string, referencePathMap map[string]string) (*gojson
 			return nil, err
 		}
 		referenceLoader := gojsonschema.NewStringLoader(string(refSchema))
-		err = sl.AddSchema("/"+referenceName, referenceLoader)
-		if err != nil {
+		if err := sl.AddSchema("/"+referenceName, referenceLoader); err != nil {
 			return nil, err
 		}
 	}

--- a/internal/pkg/serdes/protoserdes.go
+++ b/internal/pkg/serdes/protoserdes.go
@@ -71,8 +71,7 @@ func (protoProvider *ProtoDeserializationProvider) decode(data []byte) (string, 
 	data = data[1:]
 
 	// Convert from binary format to proto message type.
-	err := proto.Unmarshal(data, protoProvider.message)
-	if err != nil {
+	if err := proto.Unmarshal(data, protoProvider.message); err != nil {
 		return "", errors.New(errors.ProtoDocumentInvalidErrorMsg)
 	}
 
@@ -108,7 +107,5 @@ func parseMessage(schemaPath string, referencePathMap map[string]string) (proto.
 	// We're always using the outermost first message.
 	messageDescriptor := messageDescriptors[0]
 	messageFactory := dynamic.NewMessageFactoryWithDefaults()
-	message := messageFactory.NewMessage(messageDescriptor)
-
-	return message, nil
+	return messageFactory.NewMessage(messageDescriptor), nil
 }

--- a/internal/pkg/update/client.go
+++ b/internal/pkg/update/client.go
@@ -197,8 +197,7 @@ func (c *client) UpdateBinary(cliName, version, path string, noVerify bool) erro
 		return errors.Wrapf(err, errors.GetTempDirErrorMsg, cliName)
 	}
 	defer func() {
-		err = c.fs.RemoveAll(downloadDir)
-		if err != nil {
+		if err := c.fs.RemoveAll(downloadDir); err != nil {
 			log.CliLogger.Warnf("unable to clean up temp download dir %s: %s", downloadDir, err)
 		}
 	}()

--- a/internal/pkg/update/s3/object_key_test.go
+++ b/internal/pkg/update/s3/object_key_test.go
@@ -296,9 +296,7 @@ func TestPrefixedKey_URLFor(t *testing.T) {
 		},
 		{
 			name: "with empty prefix and with version prefix",
-			fields: fields{
-				VersionPrefixed: true,
-			},
+			fields: fields{VersionPrefixed: true},
 			args: args{
 				name:    "fancy-cli",
 				version: "0.1.2",

--- a/internal/pkg/update/s3/public.go
+++ b/internal/pkg/update/s3/public.go
@@ -127,8 +127,7 @@ func (r *PublicRepo) getListBucketResultFromDir(s3DirPrefix string) (*ListBucket
 			return nil, err
 		}
 		var result ListBucketResult
-		err = xml.Unmarshal(body, &result)
-		if err != nil {
+		if err := xml.Unmarshal(body, &result); err != nil {
 			return nil, err
 		}
 		results = append(results, result)

--- a/internal/pkg/utils/cert_utils.go
+++ b/internal/pkg/utils/cert_utils.go
@@ -23,8 +23,7 @@ func GetCAClient(caCertPath string) (*http.Client, error) {
 	caCertPool.AppendCertsFromPEM(caCert)
 	transport := DefaultTransport()
 	transport.TLSClientConfig.RootCAs = caCertPool
-	client := DefaultClientWithTransport(transport)
-	return client, nil
+	return DefaultClientWithTransport(transport), nil
 }
 
 func SelfSignedCertClientFromPath(caCertPath string) (*http.Client, error) {
@@ -159,7 +158,5 @@ func DefaultClient() *http.Client {
 }
 
 func DefaultClientWithTransport(transport *http.Transport) *http.Client {
-	return &http.Client{
-		Transport: transport,
-	}
+	return &http.Client{Transport: transport}
 }

--- a/internal/pkg/utils/stripe_utils.go
+++ b/internal/pkg/utils/stripe_utils.go
@@ -19,9 +19,7 @@ func setStripeKey(isTest bool) {
 	} else {
 		stripe.Key = stripeLiveKey
 	}
-	stripe.DefaultLeveledLogger = &stripe.LeveledLogger{
-		Level: 0,
-	}
+	stripe.DefaultLeveledLogger = &stripe.LeveledLogger{Level: 0}
 }
 
 func NewStripeToken(cardNumber, expiration, cvc, name string, isTest bool) (*stripe.Token, error) {

--- a/internal/pkg/utils/utils.go
+++ b/internal/pkg/utils/utils.go
@@ -93,8 +93,7 @@ func NormalizeByteArrayNewLines(raw []byte) []byte {
 
 func ValidateEmail(email string) bool {
 	rgxEmail := regexp.MustCompile("^[a-zA-Z0-9.!#$%&'*+\\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$")
-	matched := rgxEmail.MatchString(email)
-	return matched
+	return rgxEmail.MatchString(email)
 }
 
 func Abbreviate(s string, maxLength int) string {

--- a/mock/commander.go
+++ b/mock/commander.go
@@ -125,8 +125,7 @@ func (c *Commander) HasAPIKey(command *pcmd.HasAPIKeyCLICommand) func(*cobra.Com
 // UseKafkaRest - The PreRun function registered by the mock prerunner for UseKafkaRestCLICommand
 func (c *Commander) InitializeOnPremKafkaRest(command *pcmd.AuthenticatedCLICommand) func(*cobra.Command, []string) error {
 	return func(cmd *cobra.Command, args []string) error {
-		err := c.AuthenticatedWithMDS(command)(cmd, args)
-		if err != nil {
+		if err := c.AuthenticatedWithMDS(command)(cmd, args); err != nil {
 			return err
 		}
 		command.KafkaRESTProvider = c.KafkaRESTProvider

--- a/test/test-server/iam_handlers.go
+++ b/test/test-server/iam_handlers.go
@@ -186,9 +186,7 @@ func handleIamUsers(t *testing.T) http.HandlerFunc {
 					users = []iamv2.IamV2User{}
 				}
 			}
-			res := iamv2.IamV2UserList{
-				Data: users,
-			}
+			res := iamv2.IamV2UserList{Data: users}
 			email := r.URL.Query().Get("email")
 			if email != "" {
 				for _, u := range users {


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- PLACEHOLDER

New Features
- PLACEHOLDER

Bug Fixes
- PLACEHOLDER

Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
We keep modifying the following patterns as we come across them, so I figured I would just get the majority of them in one go. I've included the regexes I've used to find them:

1. Multiline err blocks that could be single line `^[\t ,_]*err :?= [\w\.\(\)," -:\[\];]+\n[\t ]*if err !=`
Includes any number of underscores before `err`.
```
err := Foo()
if err != nil {
```
to
```
if err := Foo(); err != nil {
```

2. Multiline ok blocks that could be single line `^[\t ,_]*ok :?= [\w\.\(\)," -:\[\];]+\n[\t ]*if !?ok`
Includes both `ok` and `!ok`.
```
_, ok := Map[key]
if ok {
```
to
```
if _, ok := Map[key]; ok {
```

3. Declarations of a variable followed immediately by a return of that variable `^[\t ]*([\w]+) := [\w\.\(\)," -:\[\];\{\}]+\s*return (\1|nil|\1, |nil )*\n`
Includes `nil`s with the returned variable.
```
result := Bar()
return result, nil
```
to
```
return Bar(), nil
```

4. Multiline struct literals that only set one field `[\w]+\{\n[\t ]*[\w]+:[\t ]*[\w]+,\n[\t ]*\},*\n`
```
foo := Bar{
  a: b,
}
```
to
```
foo := Bar{a: b}
```
References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
All tests pass, but I want to carefully double check that I didn't introduce any subtle bugs, hence why I marked this as a draft PR.

Open Questions / Follow-ups
---------------------------
<!--
Optional: Anything open to discussion for the reviewer, out of scope of this PR, or follow-ups.
-->
