### PR TITLE
[CLI-2504] Use `UNKNOWN` as the default instead of `DEDICATED` for cluster type

### DIFF
--- a/internal/cmd/kafka/utils.go
+++ b/internal/cmd/kafka/utils.go
@@ -133,7 +133,10 @@ func getCmkClusterType(cluster *cmkv2.CmkV2Cluster) string {
 	if isStandard(cluster) {
 		return ccstructs.Sku_name[3]
 	}
-	return ccstructs.Sku_name[4]
+	if isDedicated(cluster) {
+		return ccstructs.Sku_name[4]
+	}
+	return ccstructs.Sku_name[0] // UNKNOWN
 }
 
 func getCmkClusterSize(cluster *cmkv2.CmkV2Cluster) int32 {

--- a/test/fixtures/output/kafka/describe-unknown-cluster-type.golden
+++ b/test/fixtures/output/kafka/describe-unknown-cluster-type.golden
@@ -1,0 +1,16 @@
++----------------------+---------------------------+
+| Current              | true                      |
+| ID                   | lkc-unknown-type          |
+| Name                 | kafka-cluster             |
+| Type                 | UNKNOWN                   |
+| Ingress Limit (MB/s) |                       250 |
+| Egress Limit (MB/s)  |                       750 |
+| Storage              | Infinite                  |
+| Provider             | aws                       |
+| Region               | us-west-2                 |
+| Availability         | single-zone               |
+| Status               | UP                        |
+| Endpoint             | SASL_SSL://kafka-endpoint |
+| REST Endpoint        | http://127.0.0.1:1025     |
+| Topic Count          |                         2 |
++----------------------+---------------------------+

--- a/test/kafka_test.go
+++ b/test/kafka_test.go
@@ -83,6 +83,7 @@ func (s *CLITestSuite) TestKafka() {
 		{args: "kafka cluster describe lkc-describe-dedicated-provisioning", fixture: "kafka/cluster-describe-dedicated-provisioning.golden"},
 
 		{args: "kafka cluster describe lkc-unknown", fixture: "kafka/48.golden", exitCode: 1},
+		{args: "kafka cluster describe lkc-unknown-type", fixture: "kafka/describe-unknown-cluster-type.golden"},
 
 		{args: "kafka acl list --cluster lkc-acls", fixture: "kafka/acl/list-cloud.golden"},
 		{args: "kafka acl list --cluster lkc-acls -o json", fixture: "kafka/acl/list-json-cloud.golden"},

--- a/test/test-server/cmk_handlers.go
+++ b/test/test-server/cmk_handlers.go
@@ -123,6 +123,8 @@ func handleCmkCluster(t *testing.T) http.HandlerFunc {
 			handleCmkKafkaDedicatedClusterShrinkMulti(t)(w, r)
 		case "lkc-unknown":
 			handleCmkKafkaUnknown(t)(w, r)
+		case "lkc-unknown-type":
+			handleCmkKafkaUnknownType(t)(w, r)
 		default:
 			handleCmkKafkaClusterGetListDeleteDescribe(t)(w, r)
 		}
@@ -306,6 +308,17 @@ func handleCmkKafkaDedicatedClusterShrinkMulti(t *testing.T) http.HandlerFunc {
 func handleCmkKafkaUnknown(t *testing.T) http.HandlerFunc {
 	return func(w http.ResponseWriter, _ *http.Request) {
 		err := writeResourceNotFoundError(w)
+		require.NoError(t, err)
+	}
+}
+
+// Handler for GET "/cmk/v2/clusters/lkc-unknown-type"
+func handleCmkKafkaUnknownType(t *testing.T) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		vars := mux.Vars(r)
+		id := vars["id"]
+		cluster := getCmkUnknownDescribeCluster(id, "kafka-cluster")
+		err := json.NewEncoder(w).Encode(cluster)
 		require.NoError(t, err)
 	}
 }

--- a/test/test-server/utils.go
+++ b/test/test-server/utils.go
@@ -315,9 +315,7 @@ func getCmkUnknownDescribeCluster(id string, name string) *cmkv2.CmkV2Cluster {
 			Availability:           cmkv2.PtrString("SINGLE_ZONE"),
 		},
 		Id: cmkv2.PtrString(id),
-		Status: &cmkv2.CmkV2ClusterStatus{
-			Phase: "PROVISIONED",
-		},
+		Status: &cmkv2.CmkV2ClusterStatus{Phase: "PROVISIONED"},
 	}
 }
 

--- a/test/test-server/utils.go
+++ b/test/test-server/utils.go
@@ -304,7 +304,7 @@ func getCmkDedicatedDescribeCluster(id string, name string, cku int32) *cmkv2.Cm
 	}
 }
 
-func getCmkUnknownDescribeCluster(id string, name string) *cmkv2.CmkV2Cluster {
+func getCmkUnknownDescribeCluster(id, name string) *cmkv2.CmkV2Cluster {
 	return &cmkv2.CmkV2Cluster{
 		Spec: &cmkv2.CmkV2ClusterSpec{
 			DisplayName:            cmkv2.PtrString(name),
@@ -314,7 +314,7 @@ func getCmkUnknownDescribeCluster(id string, name string) *cmkv2.CmkV2Cluster {
 			HttpEndpoint:           cmkv2.PtrString(TestKafkaRestProxyUrl.String()),
 			Availability:           cmkv2.PtrString("SINGLE_ZONE"),
 		},
-		Id: cmkv2.PtrString(id),
+		Id:     cmkv2.PtrString(id),
 		Status: &cmkv2.CmkV2ClusterStatus{Phase: "PROVISIONED"},
 	}
 }

--- a/test/test-server/utils.go
+++ b/test/test-server/utils.go
@@ -304,6 +304,23 @@ func getCmkDedicatedDescribeCluster(id string, name string, cku int32) *cmkv2.Cm
 	}
 }
 
+func getCmkUnknownDescribeCluster(id string, name string) *cmkv2.CmkV2Cluster {
+	return &cmkv2.CmkV2Cluster{
+		Spec: &cmkv2.CmkV2ClusterSpec{
+			DisplayName:            cmkv2.PtrString(name),
+			Cloud:                  cmkv2.PtrString("aws"),
+			Region:                 cmkv2.PtrString("us-west-2"),
+			KafkaBootstrapEndpoint: cmkv2.PtrString("SASL_SSL://kafka-endpoint"),
+			HttpEndpoint:           cmkv2.PtrString(TestKafkaRestProxyUrl.String()),
+			Availability:           cmkv2.PtrString("SINGLE_ZONE"),
+		},
+		Id: cmkv2.PtrString(id),
+		Status: &cmkv2.CmkV2ClusterStatus{
+			Phase: "PROVISIONED",
+		},
+	}
+}
+
 func buildUser(id int32, email, firstName, lastName, resourceId string) *ccloudv1.User {
 	return &ccloudv1.User{
 		Id:         id,


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- PLACEHOLDER

New Features
- PLACEHOLDER

Bug Fixes
- PLACEHOLDER

Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
An `UNKNOWN` value is already supported, so we should use that instead of assuming that `DEDICATED` is the default case.

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
Added an integration test.

Open Questions / Follow-ups
---------------------------
<!--
Optional: Anything open to discussion for the reviewer, out of scope of this PR, or follow-ups.
-->
