### PR TITLE
Update `local kafka start` golden file

### DIFF
--- a/test/fixtures/output/local/start.golden
+++ b/test/fixtures/output/local/start.golden
@@ -2,6 +2,6 @@ The local commands are intended for a single-node development environment only, 
 
 Pulling from confluentinc/confluent-local
 Digest: sha256:[a-zA-Z0-9]*.
-Status: Image is up to date for confluentinc/confluent-local:latest
+Status: (?:Image is up to date|Downloaded newer image) for confluentinc/confluent-local:latest
 Started Confluent Local container [a-zA-Z0-9]*.
 To continue your Confluent Local experience, run `confluent local kafka topic create test` and `confluent local kafka topic produce test`.


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- PLACEHOLDER

New Features
- PLACEHOLDER

Bug Fixes
- PLACEHOLDER

Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
I noticed this while testing something else.

The `local kafka start` integration test can fail if you don't already have the latest image downloaded, because the string `Image is up to date for confluentinc/confluent-local:latest` is replaced with `Downloaded newer image for confluentinc/confluent-local:latest`.

So the test fails the first time you run it if you didn't run the `confluent local start` command before.

Since this golden file already uses regex, this PR just adds a bit more regex to allow for either string.

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
Tested on Darwin (I commented out `Skip()`) that both patterns give test success now.

Open Questions / Follow-ups
---------------------------
<!--
Optional: Anything open to discussion for the reviewer, out of scope of this PR, or follow-ups.
-->
