### PR TITLE
Fix `confluent update` for alpine

### DIFF
--- a/internal/pkg/update/client.go
+++ b/internal/pkg/update/client.go
@@ -221,7 +221,7 @@ func (c *client) UpdateBinary(cliName, version, path string, noVerify bool) erro
 			return errors.Wrapf(err, "failed to download checksums file")
 		}
 
-		binary := getBinaryName(version, runtime.GOOS, runtime.GOARCH)
+		binary := getBinaryName(version, GetOs(), runtime.GOARCH)
 		checksum, err := findChecksum(content, binary)
 		if err != nil {
 			return err

--- a/internal/pkg/update/client.go
+++ b/internal/pkg/update/client.go
@@ -57,7 +57,7 @@ func NewClient(params *ClientParams) *client {
 		params.CheckInterval = 24 * time.Hour
 	}
 	if params.OS == "" {
-		params.OS = runtime.GOOS
+		params.OS = GetOs()
 	}
 	return &client{
 		ClientParams: params,
@@ -221,7 +221,7 @@ func (c *client) UpdateBinary(cliName, version, path string, noVerify bool) erro
 			return errors.Wrapf(err, "failed to download checksums file")
 		}
 
-		binary := getBinaryName(version, GetOs(), runtime.GOARCH)
+		binary := getBinaryName(version, c.OS, runtime.GOARCH)
 		checksum, err := findChecksum(content, binary)
 		if err != nil {
 			return err

--- a/internal/pkg/update/os.go
+++ b/internal/pkg/update/os.go
@@ -1,0 +1,25 @@
+package update
+
+import (
+	"bytes"
+	"os/exec"
+	"runtime"
+	"strings"
+)
+
+func GetOs() string {
+	if runtime.GOOS == "linux" {
+		cmd := exec.Command("ldd", "--version")
+
+		stderr := new(bytes.Buffer)
+		cmd.Stderr = stderr
+
+		_ = cmd.Run()
+
+		if strings.Contains(stderr.String(), "musl") {
+			return "alpine"
+		}
+	}
+
+	return runtime.GOOS
+}

--- a/internal/pkg/update/os.go
+++ b/internal/pkg/update/os.go
@@ -9,11 +9,10 @@ import (
 
 func GetOs() string {
 	if runtime.GOOS == "linux" {
-		cmd := exec.Command("ldd", "--version")
-
 		stderr := new(bytes.Buffer)
-		cmd.Stderr = stderr
 
+		cmd := exec.Command("ldd", "--version")
+		cmd.Stderr = stderr
 		_ = cmd.Run()
 
 		if strings.Contains(stderr.String(), "musl") {

--- a/internal/pkg/update/s3/object_key.go
+++ b/internal/pkg/update/s3/object_key.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/go-version" // This "version" alias is require for go:generate go run github.com/travisjeffery/mocker/cmd/mocker to work
 
 	"github.com/confluentinc/cli/internal/pkg/errors"
+	"github.com/confluentinc/cli/internal/pkg/update"
 )
 
 // ObjectKey represents an S3 Key for a versioned package
@@ -46,7 +47,7 @@ func NewPrefixedKey(prefix, sep string, prefixVersion bool) (*PrefixedKey, error
 		Prefix:        prefix,
 		PrefixVersion: prefixVersion,
 		Separator:     sep,
-		goos:          runtime.GOOS,
+		goos:          update.GetOs(),
 		goarch:        runtime.GOARCH,
 	}, nil
 }

--- a/internal/pkg/update/s3/public.go
+++ b/internal/pkg/update/s3/public.go
@@ -59,7 +59,7 @@ func NewPublicRepo(params *PublicRepoParams) *PublicRepo {
 		PublicRepoParams: params,
 		endpoint:         fmt.Sprintf("https://s3-%s.amazonaws.com/%s", params.S3BinRegion, params.S3BinBucket),
 		fs:               &pio.RealFileSystem{},
-		goos:             runtime.GOOS,
+		goos:             update.GetOs(),
 		goarch:           runtime.GOARCH,
 	}
 }

--- a/internal/pkg/update/s3/public.go
+++ b/internal/pkg/update/s3/public.go
@@ -1,12 +1,10 @@
 package s3
 
 import (
-	"bytes"
 	"encoding/xml"
 	"fmt"
 	"io"
 	"net/http"
-	"os/exec"
 	"runtime"
 	"sort"
 	"strings"
@@ -16,6 +14,7 @@ import (
 	"github.com/confluentinc/cli/internal/pkg/errors"
 	pio "github.com/confluentinc/cli/internal/pkg/io"
 	"github.com/confluentinc/cli/internal/pkg/log"
+	"github.com/confluentinc/cli/internal/pkg/update"
 )
 
 var S3ReleaseNotesFile = "release-notes.rst"
@@ -295,12 +294,8 @@ func (r *PublicRepo) getHttpResponse(url string) (*http.Response, error) {
 
 func (r *PublicRepo) getDownloadVersion(s3URL string) string {
 	downloadVersion := fmt.Sprintf("%s/%s", r.endpoint, s3URL)
-	cmd := exec.Command("ldd", "--version")
-	var stderr bytes.Buffer
-	cmd.Stderr = &stderr
-	_ = cmd.Run()
-	if strings.Contains(stderr.String(), "musl") {
-		return strings.Replace(downloadVersion, "linux", "alpine", 1)
+	if update.GetOs() == "alpine" {
+		downloadVersion = strings.Replace(downloadVersion, "linux", "alpine", 1)
 	}
 	return downloadVersion
 }

--- a/internal/pkg/update/s3/public.go
+++ b/internal/pkg/update/s3/public.go
@@ -293,9 +293,5 @@ func (r *PublicRepo) getHttpResponse(url string) (*http.Response, error) {
 }
 
 func (r *PublicRepo) getDownloadVersion(s3URL string) string {
-	downloadVersion := fmt.Sprintf("%s/%s", r.endpoint, s3URL)
-	if update.GetOs() == "alpine" {
-		downloadVersion = strings.Replace(downloadVersion, "linux", "alpine", 1)
-	}
-	return downloadVersion
+	return fmt.Sprintf("%s/%s", r.endpoint, s3URL)
 }


### PR DESCRIPTION
Release Notes
-------------
Bug Fixes
- Fix `confluent update` checksum validation for Alpine Linux

Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
The checksum validation code was inferring the OS as "linux" instead of "alpine" when downloading the correct checksum.

Test & Review
-------------
Manual verification, since we don't have alpine-specific CI.