### PR TITLE
Fix base64 decoding error

### DIFF
--- a/internal/pkg/secret/encryption_other.go
+++ b/internal/pkg/secret/encryption_other.go
@@ -81,7 +81,7 @@ func Decrypt(username, encrypted string, salt, nonce []byte) (string, error) {
 
 	cipherText, err := base64.RawStdEncoding.DecodeString(encrypted)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("failed to decode base64: %v", err)
 	}
 
 	if len(nonce) != NonceLength {

--- a/internal/pkg/secret/encryption_other.go
+++ b/internal/pkg/secret/encryption_other.go
@@ -10,6 +10,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/panta/machineid"
 	"golang.org/x/crypto/pbkdf2"
@@ -60,7 +61,7 @@ func Encrypt(username, password string, salt, nonce []byte) (string, error) {
 	}
 	encryptedPassword := aesgcm.Seal(nil, nonce, []byte(password), []byte(username))
 
-	return base64.RawStdEncoding.EncodeToString(encryptedPassword), nil
+	return AesGcm + ":" + base64.RawStdEncoding.EncodeToString(encryptedPassword), nil
 }
 
 func Decrypt(username, encrypted string, salt, nonce []byte) (string, error) {
@@ -78,6 +79,8 @@ func Decrypt(username, encrypted string, salt, nonce []byte) (string, error) {
 	if err != nil {
 		return "", err
 	}
+
+	encrypted = strings.TrimPrefix(encrypted, AesGcm+":")
 
 	cipherText, err := base64.RawStdEncoding.DecodeString(encrypted)
 	if err != nil {

--- a/test/login_test.go
+++ b/test/login_test.go
@@ -72,6 +72,8 @@ func (s *CLITestSuite) TestLogin_VariousOrgSuspensionStatus() {
 }
 
 func (s *CLITestSuite) TestCcloudErrors() {
+	resetConfiguration(s.T(), false)
+
 	args := fmt.Sprintf("login --url %s -vvv", s.TestBackend.GetCloudUrl())
 
 	s.T().Run("invalid user or pass", func(t *testing.T) {

--- a/test/test-server/ccloud_handlers.go
+++ b/test/test-server/ccloud_handlers.go
@@ -118,6 +118,9 @@ func handleLogin(t *testing.T) http.HandlerFunc {
 		res := new(ccloudv1.AuthenticateReply)
 
 		switch req.Email {
+		case "":
+			// Refresh auth token
+			res.Token = req.RefreshToken
 		case "incorrect@user.com":
 			w.WriteHeader(http.StatusForbidden)
 		case "suspended@user.com":
@@ -136,6 +139,9 @@ func handleLogin(t *testing.T) http.HandlerFunc {
 			res.Token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpbmUgSldUIEJ1aWxkZXIiLCJpYXQiOjE1NjE2NjA4NTcsImV4cCI6MjUzMzg2MDM4NDU3LCJhdWQiOiJ3d3cuZXhhbXBsZS5jb20iLCJzdWIiOiJqcm9ja2V0QGV4YW1wbGUuY29tIn0.G6IgrFm5i0mN7Lz9tkZQ2tZvuZ2U7HKnvxMuZAooPmE"
 			res.Organization = RegularOrg
 		}
+
+		// Make it trivial to refresh the auth token
+		res.RefreshToken = res.Token
 
 		err = json.NewEncoder(w).Encode(res)
 		require.NoError(t, err)

--- a/test/test-server/ccloud_handlers.go
+++ b/test/test-server/ccloud_handlers.go
@@ -118,9 +118,6 @@ func handleLogin(t *testing.T) http.HandlerFunc {
 		res := new(ccloudv1.AuthenticateReply)
 
 		switch req.Email {
-		case "":
-			// Refresh auth token
-			res.Token = req.RefreshToken
 		case "incorrect@user.com":
 			w.WriteHeader(http.StatusForbidden)
 		case "suspended@user.com":
@@ -139,9 +136,6 @@ func handleLogin(t *testing.T) http.HandlerFunc {
 			res.Token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpbmUgSldUIEJ1aWxkZXIiLCJpYXQiOjE1NjE2NjA4NTcsImV4cCI6MjUzMzg2MDM4NDU3LCJhdWQiOiJ3d3cuZXhhbXBsZS5jb20iLCJzdWIiOiJqcm9ja2V0QGV4YW1wbGUuY29tIn0.G6IgrFm5i0mN7Lz9tkZQ2tZvuZ2U7HKnvxMuZAooPmE"
 			res.Organization = RegularOrg
 		}
-
-		// Make it trivial to refresh the auth token
-		res.RefreshToken = res.Token
 
 		err = json.NewEncoder(w).Encode(res)
 		require.NoError(t, err)


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
The new FedRAMP environment returns refresh tokens that have a different format, so the `v1\..*` regex no longer works. This PR prefixes all encrypted strings with "AES/GCM/NoPadding:" (encryption algorithm name) so we know if a refresh token is encrypted or not. The existence of that prefix + the correct platform name (i.e. "confluentgov.com") should be enough to know if we should encrypt a refresh token or not.

Test & Review
-------------
Manual testing with a FedRAMP test account.