### PR TITLE
KFS-906: chore: remove statement cleanup

### DIFF
--- a/internal/pkg/flink/config/results.go
+++ b/internal/pkg/flink/config/results.go
@@ -3,7 +3,8 @@ package config
 import "time"
 
 const (
-	InitialWaitTime        = time.Millisecond * 300
-	WaitTimeIncrease       = 300
-	DefaultTimeoutDuration = 10 * time.Minute
+	InitialWaitTime         = time.Millisecond * 300
+	WaitTimeIncrease        = 300
+	DefaultTimeoutDuration  = 10 * time.Minute
+	ShouldCleanupStatements = false
 )

--- a/internal/pkg/flink/config/results.go
+++ b/internal/pkg/flink/config/results.go
@@ -3,7 +3,7 @@ package config
 import "time"
 
 const (
-	InitialWaitTime         = time.Millisecond * 300
+	InitialWaitTime         = 300 * time.Millisecond
 	WaitTimeIncrease        = 300
 	DefaultTimeoutDuration  = 10 * time.Minute
 	ShouldCleanupStatements = false

--- a/internal/pkg/flink/internal/controller/input_controller.go
+++ b/internal/pkg/flink/internal/controller/input_controller.go
@@ -3,7 +3,6 @@ package controller
 import (
 	"context"
 	"errors"
-	"github.com/confluentinc/cli/internal/pkg/flink/config"
 	"net/http"
 	"os"
 	"reflect"
@@ -16,6 +15,7 @@ import (
 	"github.com/confluentinc/go-prompt"
 
 	"github.com/confluentinc/cli/internal/pkg/flink/components"
+	"github.com/confluentinc/cli/internal/pkg/flink/config"
 	"github.com/confluentinc/cli/internal/pkg/flink/internal/autocomplete"
 	lexer "github.com/confluentinc/cli/internal/pkg/flink/internal/highlighting"
 	"github.com/confluentinc/cli/internal/pkg/flink/internal/history"

--- a/internal/pkg/flink/internal/controller/input_controller.go
+++ b/internal/pkg/flink/internal/controller/input_controller.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"context"
 	"errors"
+	"github.com/confluentinc/cli/internal/pkg/flink/config"
 	"net/http"
 	"os"
 	"reflect"
@@ -133,10 +134,10 @@ func (c *InputController) RunInteractiveInput() {
 		}
 
 		c.printResultToSTDOUT(processedStatement.StatementResults)
-		// We already printed the results using plain text and will delete the statement. When using TView this will happen upon leaving the interactive view.
-		// TODO - this is currently used only to save system resources, To be removed once the API Server becomes scalable.
-		// We want to maintain a "completed" statement in the backend
-		if !processedStatement.IsLocalStatement && processedStatement.Status != types.RUNNING {
+		// This was used to delete statements after their execution to save system resources, which should not be
+		// an issue anymore. We don't want to remove it completely just yet, but will disable it by default for now.
+		// TODO: remove this completely once we are sure we won't need it in the future
+		if config.ShouldCleanupStatements && !processedStatement.IsLocalStatement && processedStatement.Status != types.RUNNING {
 			go c.store.DeleteStatement(processedStatement.StatementName)
 		}
 	}

--- a/internal/pkg/flink/internal/controller/table_controller.go
+++ b/internal/pkg/flink/internal/controller/table_controller.go
@@ -60,7 +60,7 @@ func (t *TableController) exitTViewMode() {
 	// This was used to delete statements after their execution to save system resources, which should not be
 	// an issue anymore. We don't want to remove it completely just yet, but will disable it by default for now.
 	// TODO: remove this completely once we are sure we won't need it in the future
-	if config.ShouldCleanupStatements {
+	if config.ShouldCleanupStatements || t.statement.Status == types.RUNNING {
 		go t.store.DeleteStatement(t.statement.StatementName)
 	}
 	t.appController.SuspendOutputMode(func() {
@@ -197,6 +197,7 @@ func (t *TableController) refreshResults(ctx context.Context, statement types.Pr
 		for {
 			select {
 			case <-ctx.Done():
+				t.statement = statement
 				return
 			default:
 				t.renderTable()

--- a/internal/pkg/flink/internal/controller/table_controller.go
+++ b/internal/pkg/flink/internal/controller/table_controller.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"github.com/confluentinc/cli/internal/pkg/flink/config"
 	"strings"
 	"sync"
 	"time"
@@ -56,7 +57,12 @@ func (t *TableController) SetRunInteractiveInputCallback(runInteractiveInput fun
 
 func (t *TableController) exitTViewMode() {
 	t.stopAutoRefresh()
-	go t.store.DeleteStatement(t.statement.StatementName)
+	// This was used to delete statements after their execution to save system resources, which should not be
+	// an issue anymore. We don't want to remove it completely just yet, but will disable it by default for now.
+	// TODO: remove this completely once we are sure we won't need it in the future
+	if config.ShouldCleanupStatements {
+		go t.store.DeleteStatement(t.statement.StatementName)
+	}
 	t.appController.SuspendOutputMode(func() {
 		output.Println("Result retrieval aborted. Statement will be deleted.")
 		t.runInteractiveInput()

--- a/internal/pkg/flink/internal/controller/table_controller.go
+++ b/internal/pkg/flink/internal/controller/table_controller.go
@@ -3,7 +3,6 @@ package controller
 import (
 	"context"
 	"fmt"
-	"github.com/confluentinc/cli/internal/pkg/flink/config"
 	"strings"
 	"sync"
 	"time"
@@ -14,6 +13,7 @@ import (
 	"github.com/samber/lo"
 
 	"github.com/confluentinc/cli/internal/pkg/flink/components"
+	"github.com/confluentinc/cli/internal/pkg/flink/config"
 	"github.com/confluentinc/cli/internal/pkg/flink/internal/results"
 	"github.com/confluentinc/cli/internal/pkg/flink/internal/store"
 	"github.com/confluentinc/cli/internal/pkg/flink/types"

--- a/internal/pkg/flink/internal/controller/table_controller.go
+++ b/internal/pkg/flink/internal/controller/table_controller.go
@@ -64,7 +64,7 @@ func (t *TableController) exitTViewMode() {
 		go t.store.DeleteStatement(t.statement.StatementName)
 	}
 	t.appController.SuspendOutputMode(func() {
-		output.Println("Result retrieval aborted. Statement will be deleted.")
+		output.Println("Result retrieval aborted.")
 		t.runInteractiveInput()
 	})
 }

--- a/internal/pkg/flink/internal/store/store.go
+++ b/internal/pkg/flink/internal/store/store.go
@@ -147,7 +147,7 @@ func (s *Store) waitForPendingStatement(ctx context.Context, statementName strin
 	for {
 		select {
 		case <-ctx.Done():
-			return nil, &types.StatementError{Message: "result retrieval aborted. Statement will be deleted.", HttpResponseCode: 499}
+			return nil, &types.StatementError{Message: "result retrieval aborted. Statement will be deleted", HttpResponseCode: 499}
 		default:
 			statementObj, err := s.client.GetStatement(s.appOptions.GetEnvironmentId(), statementName, s.appOptions.GetOrgResourceId())
 			statusDetail := s.getStatusDetail(statementObj)

--- a/internal/pkg/flink/internal/store/store_test.go
+++ b/internal/pkg/flink/internal/store/store_test.go
@@ -212,7 +212,7 @@ func TestCancelPendingStatement(t *testing.T) {
 		},
 	}
 
-	expectedErr := &types.StatementError{Message: "result retrieval aborted. Statement will be deleted."}
+	expectedErr := &types.StatementError{Message: "result retrieval aborted. Statement will be deleted"}
 	client.EXPECT().GetStatement("orgId", "envId", statementName).Return(statementObj, nil).AnyTimes()
 
 	// Schedule routine to cancel context


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->
We used to delete statements after their execution to save system resources, which should not be an issue anymore. This change introduces a config variable that allows to switch this behavior back on if we need it, but disables it by default.

