### PR TITLE
[cli-2532] fix npd panic when schema registry cluster info is not ready in config

### DIFF
--- a/internal/pkg/dynamic-config/dynamic_context.go
+++ b/internal/pkg/dynamic-config/dynamic_context.go
@@ -148,7 +148,7 @@ func (d *DynamicContext) SchemaRegistryCluster(cmd *cobra.Command) (*v1.SchemaRe
 	var clusterChanged bool
 	if resourceType == presource.SchemaRegistryCluster {
 		for _, srCluster := range d.SchemaRegistryClusters {
-			if srCluster.Id == resource {
+			if srCluster != nil && srCluster.Id == resource {
 				cluster = srCluster
 			}
 		}


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- PLACEHOLDER

New Features
- PLACEHOLDER

Bug Fixes
- Fix bug in getting schema registry cluster information when it's not present in configuration file

Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok 

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->
Check if sr cluster is nil. If user had deleted sr using cli, it would be nil and cause a panic when trying to get the cluster id.

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->
https://confluent.slack.com/archives/C9Y6NAM6X/p1686557957247439

Test & Review
-------------
<!--
Has it been tested? How?
Copy and paste any instructions or steps that can save the reviewer time.
-->
Delete sr cluster in cli. Create api-key will show `resource not found`. Enable sr in gui, and use the right lsrc id to create api-key, sr cluster info will be updated.

Open Questions / Follow-ups
---------------------------
<!--
Optional: Anything open to discussion for the reviewer, out of scope of this PR, or follow-ups.
-->
