### PR TITLE
Fix/kfs 909 remove ctrl finish

### DIFF
--- a/internal/pkg/flink/internal/controller/input_controller_test.go
+++ b/internal/pkg/flink/internal/controller/input_controller_test.go
@@ -19,7 +19,7 @@ func TestRenderError(t *testing.T) {
 	err := &types.StatementError{HttpResponseCode: http.StatusUnauthorized}
 
 	// Test unauthorized error - should exit application
-	mockAppController.EXPECT().ExitApplication().Times(1)
+	mockAppController.EXPECT().ExitApplication()
 	result := inputController.isSessionValid(err)
 	require.False(t, result)
 

--- a/internal/pkg/flink/internal/controller/table_controller_test.go
+++ b/internal/pkg/flink/internal/controller/table_controller_test.go
@@ -45,7 +45,7 @@ func (s *TableControllerTestSuite) TestQ() {
 	}
 	tableController.SetRunInteractiveInputCallback(s.mockInputController.RunInteractiveInput)
 	input := tcell.NewEventKey(tcell.KeyRune, 'Q', tcell.ModNone)
-	s.mockAppController.EXPECT().SuspendOutputMode(gomock.Any()).Times(1)
+	s.mockAppController.EXPECT().SuspendOutputMode(gomock.Any())
 
 	// When
 	result := tableController.AppInputCapture(input)
@@ -64,7 +64,7 @@ func (s *TableControllerTestSuite) TestCtrlQ() {
 	}
 	tableController.SetRunInteractiveInputCallback(s.mockInputController.RunInteractiveInput)
 	input := tcell.NewEventKey(tcell.KeyCtrlQ, rune(0), tcell.ModNone)
-	s.mockAppController.EXPECT().SuspendOutputMode(gomock.Any()).Times(1)
+	s.mockAppController.EXPECT().SuspendOutputMode(gomock.Any())
 
 	// When
 	result := tableController.AppInputCapture(input)
@@ -83,7 +83,7 @@ func (s *TableControllerTestSuite) TestEscape() {
 	}
 	tableController.SetRunInteractiveInputCallback(s.mockInputController.RunInteractiveInput)
 	input := tcell.NewEventKey(tcell.KeyEscape, rune(0), tcell.ModNone)
-	s.mockAppController.EXPECT().SuspendOutputMode(gomock.Any()).Times(1)
+	s.mockAppController.EXPECT().SuspendOutputMode(gomock.Any())
 
 	// When
 	result := tableController.AppInputCapture(input)

--- a/internal/pkg/flink/internal/controller/table_controller_test.go
+++ b/internal/pkg/flink/internal/controller/table_controller_test.go
@@ -1,10 +1,10 @@
 package controller
 
 import (
-	"github.com/confluentinc/cli/internal/pkg/flink/components"
-	"github.com/confluentinc/cli/internal/pkg/flink/internal/results"
-	"github.com/confluentinc/cli/internal/pkg/flink/test/mock"
-	"github.com/confluentinc/cli/internal/pkg/flink/types"
+	"strconv"
+	"testing"
+	"time"
+
 	"github.com/gdamore/tcell/v2"
 	"github.com/golang/mock/gomock"
 	"github.com/rivo/tview"
@@ -12,9 +12,11 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"pgregory.net/rapid"
-	"strconv"
-	"testing"
-	"time"
+
+	"github.com/confluentinc/cli/internal/pkg/flink/components"
+	"github.com/confluentinc/cli/internal/pkg/flink/internal/results"
+	"github.com/confluentinc/cli/internal/pkg/flink/test/mock"
+	"github.com/confluentinc/cli/internal/pkg/flink/types"
 )
 
 type TableControllerTestSuite struct {

--- a/internal/pkg/flink/internal/store/store_test.go
+++ b/internal/pkg/flink/internal/store/store_test.go
@@ -58,7 +58,7 @@ func TestStoreProcessLocalStatement(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Nil(t, result)
 
-	mockAppController.EXPECT().ExitApplication().Times(1)
+	mockAppController.EXPECT().ExitApplication()
 	result, err = s.ProcessLocalStatement("EXIT;")
 	assert.Nil(t, err)
 	assert.Nil(t, result)
@@ -84,7 +84,7 @@ func TestWaitForPendingStatement3(t *testing.T) {
 			Detail: flinkgatewayv1alpha1.PtrString("Test status detail message"),
 		},
 	}
-	client.EXPECT().GetStatement("orgId", "envId", statementName).Return(statementObj, nil).Times(1)
+	client.EXPECT().GetStatement("orgId", "envId", statementName).Return(statementObj, nil)
 
 	processedStatement, err := s.waitForPendingStatement(context.Background(), statementName, time.Duration(10))
 	assert.Nil(t, err)
@@ -153,7 +153,7 @@ func TestWaitForPendingEventuallyCompletes(t *testing.T) {
 		},
 	}
 	client.EXPECT().GetStatement("orgId", "envId", statementName).Return(statementObj, nil).Times(3)
-	client.EXPECT().GetStatement("orgId", "envId", statementName).Return(statementObjCompleted, nil).Times(1)
+	client.EXPECT().GetStatement("orgId", "envId", statementName).Return(statementObjCompleted, nil)
 
 	processedStatement, err := s.waitForPendingStatement(context.Background(), statementName, time.Duration(10)*time.Second)
 	assert.Nil(t, err)
@@ -186,7 +186,7 @@ func TestWaitForPendingStatementErrors(t *testing.T) {
 		Message:        returnedError.Error(),
 		FailureMessage: statusDetailMessage,
 	}
-	client.EXPECT().GetStatement("orgId", "envId", statementName).Return(statementObj, returnedError).Times(1)
+	client.EXPECT().GetStatement("orgId", "envId", statementName).Return(statementObj, returnedError)
 	_, err := s.waitForPendingStatement(context.Background(), statementName, waitTime)
 	assert.Equal(t, expectedError, err)
 }
@@ -914,7 +914,7 @@ func (s *StoreTestSuite) TestWaitPendingStatement() {
 			Detail: &statusDetailMessage,
 		},
 	}
-	client.EXPECT().GetStatement("orgId", "envId", statementName).Return(statementObj, nil).Times(1)
+	client.EXPECT().GetStatement("orgId", "envId", statementName).Return(statementObj, nil)
 
 	processedStatement, err := store.WaitPendingStatement(context.Background(), types.ProcessedStatement{
 		StatementName: statementName,
@@ -981,7 +981,7 @@ func (s *StoreTestSuite) TestWaitPendingStatementFailsOnWaitError() {
 		},
 	}
 	returnedErr := errors.New("test error")
-	client.EXPECT().GetStatement("orgId", "envId", statementName).Return(statementObj, returnedErr).Times(1)
+	client.EXPECT().GetStatement("orgId", "envId", statementName).Return(statementObj, returnedErr)
 	expectedError := &types.StatementError{
 		Message:        returnedErr.Error(),
 		FailureMessage: statusDetailMessage,

--- a/internal/pkg/flink/internal/store/store_test.go
+++ b/internal/pkg/flink/internal/store/store_test.go
@@ -603,7 +603,6 @@ func generateCloserFromObject(obj interface{}) io.ReadCloser {
 
 func (s *StoreTestSuite) TestDeleteStatement() {
 	ctrl := gomock.NewController(s.T())
-	defer ctrl.Finish()
 
 	// create objects
 	client := mock.NewMockGatewayClientInterface(ctrl)
@@ -623,7 +622,6 @@ func (s *StoreTestSuite) TestDeleteStatement() {
 
 func (s *StoreTestSuite) TestDeleteStatementFailsOnError() {
 	ctrl := gomock.NewController(s.T())
-	defer ctrl.Finish()
 
 	// create objects
 	client := mock.NewMockGatewayClientInterface(ctrl)
@@ -643,7 +641,6 @@ func (s *StoreTestSuite) TestDeleteStatementFailsOnError() {
 
 func (s *StoreTestSuite) TestFetchResultsNoRetryWithCompletedStatement() {
 	ctrl := gomock.NewController(s.T())
-	defer ctrl.Finish()
 
 	// create objects
 	client := mock.NewMockGatewayClientInterface(ctrl)
@@ -671,7 +668,6 @@ func (s *StoreTestSuite) TestFetchResultsNoRetryWithCompletedStatement() {
 
 func (s *StoreTestSuite) TestFetchResultsWithRunningStatement() {
 	ctrl := gomock.NewController(s.T())
-	defer ctrl.Finish()
 
 	// create objects
 	client := mock.NewMockGatewayClientInterface(ctrl)
@@ -699,7 +695,6 @@ func (s *StoreTestSuite) TestFetchResultsWithRunningStatement() {
 
 func (s *StoreTestSuite) TestFetchResultsNoRetryWhenPageTokenExists() {
 	ctrl := gomock.NewController(s.T())
-	defer ctrl.Finish()
 
 	// create objects
 	client := mock.NewMockGatewayClientInterface(ctrl)
@@ -728,7 +723,6 @@ func (s *StoreTestSuite) TestFetchResultsNoRetryWhenPageTokenExists() {
 
 func (s *StoreTestSuite) TestFetchResultsNoRetryWhenResultsExist() {
 	ctrl := gomock.NewController(s.T())
-	defer ctrl.Finish()
 
 	// create objects
 	client := mock.NewMockGatewayClientInterface(ctrl)


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->
As of Go version 1.14+ and mockgen version 1.5.0+ you no longer need to call ctrl.Finish() see here: https://github.com/golang/mock#building-mocks

We call that function in a couple of tests, but when you remove the call, some test cases start failing due to too many or too little expected mock calls. This PR aims to fix that.
