### PR TITLE
fix: token refresh not working

### DIFF
--- a/internal/cmd/flink/command_shell.go
+++ b/internal/cmd/flink/command_shell.go
@@ -41,9 +41,9 @@ func (c *command) authenticated(authenticated func(*cobra.Command, []string) err
 			return err
 		}
 
-		auth := cfg.Context().State.AuthToken
+		authToken := cfg.Context().State.AuthToken
 		authRefreshToken := cfg.Context().State.AuthRefreshToken
-		if err := c.Context.UpdateAuthTokens(auth, authRefreshToken); err != nil {
+		if err := c.Context.UpdateAuthTokens(authToken, authRefreshToken); err != nil {
 			return err
 		}
 
@@ -55,17 +55,16 @@ func (c *command) authenticated(authenticated func(*cobra.Command, []string) err
 		if err != nil {
 			return err
 		}
-		jwtToken := flinkGatewayClient.GetAuthToken()
 
-		jwtCtx := &v1.Context{State: &v1.ContextState{AuthToken: jwtToken}}
+		jwtCtx := &v1.Context{State: &v1.ContextState{AuthToken: flinkGatewayClient.AuthToken}}
 		if tokenErr := jwtValidator.Validate(jwtCtx); tokenErr != nil {
 			output.Println("Token expired. Refreshing token...")
-			authToken, err := pauth.GetJwtTokenForV2Client(cfg.Context().GetState(), cfg.Context().GetPlatformServer())
+			flinkGatewayAuthToken, err := pauth.GetJwtTokenForV2Client(cfg.Context().GetState(), cfg.Context().GetPlatformServer())
 			if err != nil {
 				output.Printf("Refreshing token failed. Error: %v\n", err)
 				return err
 			}
-			flinkGatewayClient.SetAuthToken(authToken)
+			flinkGatewayClient.AuthToken = flinkGatewayAuthToken
 		}
 
 		return nil

--- a/internal/cmd/flink/command_shell.go
+++ b/internal/cmd/flink/command_shell.go
@@ -5,12 +5,14 @@ import (
 
 	"github.com/spf13/cobra"
 
+	pauth "github.com/confluentinc/cli/internal/pkg/auth"
 	pcmd "github.com/confluentinc/cli/internal/pkg/cmd"
 	"github.com/confluentinc/cli/internal/pkg/config/load"
 	v1 "github.com/confluentinc/cli/internal/pkg/config/v1"
 	"github.com/confluentinc/cli/internal/pkg/errors"
 	client "github.com/confluentinc/cli/internal/pkg/flink/app"
 	"github.com/confluentinc/cli/internal/pkg/flink/types"
+	"github.com/confluentinc/cli/internal/pkg/output"
 )
 
 func (c *command) newShellCommand(prerunner pcmd.PreRunner) *cobra.Command {
@@ -32,18 +34,41 @@ func (c *command) newShellCommand(prerunner pcmd.PreRunner) *cobra.Command {
 	return cmd
 }
 
-func (c *command) authenticated(authenticated func(*cobra.Command, []string) error, cmd *cobra.Command) func() error {
+func (c *command) authenticated(authenticated func(*cobra.Command, []string) error, cmd *cobra.Command, jwtValidator pcmd.JWTValidator) func() error {
 	return func() error {
 		cfg, err := load.LoadAndMigrate(v1.New())
 		if err != nil {
 			return err
 		}
+
 		auth := cfg.Context().State.AuthToken
 		authRefreshToken := cfg.Context().State.AuthRefreshToken
 		if err := c.Context.UpdateAuthTokens(auth, authRefreshToken); err != nil {
 			return err
 		}
-		return authenticated(cmd, nil)
+
+		if err := authenticated(cmd, nil); err != nil {
+			return err
+		}
+
+		flinkGatewayClient, err := c.GetFlinkGatewayClient()
+		if err != nil {
+			return err
+		}
+		jwtToken := flinkGatewayClient.GetAuthToken()
+
+		jwtCtx := &v1.Context{State: &v1.ContextState{AuthToken: jwtToken}}
+		if tokenErr := jwtValidator.Validate(jwtCtx); tokenErr != nil {
+			output.Println("Token expired. Refreshing token...")
+			authToken, err := pauth.GetJwtTokenForV2Client(cfg.Context().GetState(), cfg.Context().GetPlatformServer())
+			if err != nil {
+				output.Printf("Refreshing token failed. Error: %v\n", err)
+				return err
+			}
+			flinkGatewayClient.SetAuthToken(authToken)
+		}
+
+		return nil
 	}
 }
 
@@ -109,8 +134,10 @@ func (c *command) startFlinkSqlClient(prerunner pcmd.PreRunner, cmd *cobra.Comma
 		return err
 	}
 
+	jwtValidator := pcmd.NewJWTValidator()
+
 	client.StartApp(flinkGatewayClient,
-		c.authenticated(prerunner.Authenticated(c.AuthenticatedCLICommand), cmd),
+		c.authenticated(prerunner.Authenticated(c.AuthenticatedCLICommand), cmd, jwtValidator),
 		types.ApplicationOptions{
 			DefaultProperties: map[string]string{"execution.runtime-mode": "streaming"},
 			FlinkGatewayUrl:   parsedUrl.String(),

--- a/internal/cmd/flink/command_shell.go
+++ b/internal/cmd/flink/command_shell.go
@@ -12,7 +12,6 @@ import (
 	"github.com/confluentinc/cli/internal/pkg/errors"
 	client "github.com/confluentinc/cli/internal/pkg/flink/app"
 	"github.com/confluentinc/cli/internal/pkg/flink/types"
-	"github.com/confluentinc/cli/internal/pkg/output"
 )
 
 func (c *command) newShellCommand(prerunner pcmd.PreRunner) *cobra.Command {
@@ -58,10 +57,8 @@ func (c *command) authenticated(authenticated func(*cobra.Command, []string) err
 
 		jwtCtx := &v1.Context{State: &v1.ContextState{AuthToken: flinkGatewayClient.AuthToken}}
 		if tokenErr := jwtValidator.Validate(jwtCtx); tokenErr != nil {
-			output.Println("Token expired. Refreshing token...")
 			flinkGatewayAuthToken, err := pauth.GetJwtTokenForV2Client(cfg.Context().GetState(), cfg.Context().GetPlatformServer())
 			if err != nil {
-				output.Printf("Refreshing token failed. Error: %v\n", err)
 				return err
 			}
 			flinkGatewayClient.AuthToken = flinkGatewayAuthToken

--- a/internal/pkg/ccloudv2/flink_gateway.go
+++ b/internal/pkg/ccloudv2/flink_gateway.go
@@ -37,6 +37,20 @@ func NewFlinkGatewayClient(url, userAgent string, unsafeTrace bool, authToken st
 	}
 }
 
+func (c *FlinkGatewayClient) SetAuthToken(authToken string) {
+	if c == nil {
+		return
+	}
+	c.authToken = authToken
+}
+
+func (c *FlinkGatewayClient) GetAuthToken() string {
+	if c == nil {
+		return ""
+	}
+	return c.authToken
+}
+
 func (c *FlinkGatewayClient) flinkGatewayApiContext() context.Context {
 	return context.WithValue(context.Background(), flinkgatewayv1alpha1.ContextAccessToken, c.authToken)
 }

--- a/internal/pkg/ccloudv2/flink_gateway.go
+++ b/internal/pkg/ccloudv2/flink_gateway.go
@@ -21,7 +21,7 @@ type GatewayClientInterface interface {
 
 type FlinkGatewayClient struct {
 	*flinkgatewayv1alpha1.APIClient
-	authToken string
+	AuthToken string
 }
 
 func NewFlinkGatewayClient(url, userAgent string, unsafeTrace bool, authToken string) *FlinkGatewayClient {
@@ -33,26 +33,12 @@ func NewFlinkGatewayClient(url, userAgent string, unsafeTrace bool, authToken st
 
 	return &FlinkGatewayClient{
 		APIClient: flinkgatewayv1alpha1.NewAPIClient(cfg),
-		authToken: authToken,
+		AuthToken: authToken,
 	}
-}
-
-func (c *FlinkGatewayClient) SetAuthToken(authToken string) {
-	if c == nil {
-		return
-	}
-	c.authToken = authToken
-}
-
-func (c *FlinkGatewayClient) GetAuthToken() string {
-	if c == nil {
-		return ""
-	}
-	return c.authToken
 }
 
 func (c *FlinkGatewayClient) flinkGatewayApiContext() context.Context {
-	return context.WithValue(context.Background(), flinkgatewayv1alpha1.ContextAccessToken, c.authToken)
+	return context.WithValue(context.Background(), flinkgatewayv1alpha1.ContextAccessToken, c.AuthToken)
 }
 
 func (c *FlinkGatewayClient) DeleteStatement(environmentId, statementName, orgId string) error {

--- a/internal/pkg/flink/internal/controller/input_controller.go
+++ b/internal/pkg/flink/internal/controller/input_controller.go
@@ -81,7 +81,7 @@ func (c *InputController) RunInteractiveInput() {
 
 		// Upon receiving user input, we check if user is authenticated and possibly a refresh the CCloud SSO token
 		if authErr := c.authenticated(); authErr != nil {
-			output.Println(authErr.Error())
+			output.Printf("Error: %v\n", authErr)
 			c.appController.ExitApplication()
 			continue
 		}


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->
The token refresh in the SQL client was not working correctly. If the client was left open for >= 15mins, the JWT would expire causing errors in subsequent statements. To fix it, you would need to close and reopen the SQL client.

In order for the token refresh to work, we need to first refresh the control plane token and then swap it for a data plane token. This token can then be used in the GatewayClient.
