### PR TITLE
Remove `pipeline save` feature flag

### DIFF
--- a/internal/cmd/command.go
+++ b/internal/cmd/command.go
@@ -119,7 +119,7 @@ func NewConfluentCommand(cfg *v1.Config) *cobra.Command {
 	cmd.AddCommand(login.New(cfg, prerunner, ccloudClientFactory, mdsClientManager, netrcHandler, loginCredentialsManager, loginOrganizationManager, authTokenHandler))
 	cmd.AddCommand(logout.New(cfg, prerunner, netrcHandler))
 	cmd.AddCommand(organization.New(prerunner))
-	cmd.AddCommand(pipeline.New(cfg, prerunner))
+	cmd.AddCommand(pipeline.New(prerunner))
 	cmd.AddCommand(plugin.New(cfg, prerunner))
 	cmd.AddCommand(price.New(prerunner))
 	cmd.AddCommand(prompt.New(cfg))

--- a/internal/cmd/pipeline/command.go
+++ b/internal/cmd/pipeline/command.go
@@ -10,9 +10,6 @@ import (
 	streamdesignerv1 "github.com/confluentinc/ccloud-sdk-go-v2/stream-designer/v1"
 
 	pcmd "github.com/confluentinc/cli/internal/pkg/cmd"
-	v1 "github.com/confluentinc/cli/internal/pkg/config/v1"
-	dynamicconfig "github.com/confluentinc/cli/internal/pkg/dynamic-config"
-	launchdarkly "github.com/confluentinc/cli/internal/pkg/featureflags"
 	"github.com/confluentinc/cli/internal/pkg/output"
 )
 
@@ -49,7 +46,7 @@ type command struct {
 	*pcmd.AuthenticatedCLICommand
 }
 
-func New(cfg *v1.Config, prerunner pcmd.PreRunner) *cobra.Command {
+func New(prerunner pcmd.PreRunner) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:         "pipeline",
 		Short:       "Manage Stream Designer pipelines.",
@@ -58,18 +55,14 @@ func New(cfg *v1.Config, prerunner pcmd.PreRunner) *cobra.Command {
 
 	c := &command{pcmd.NewAuthenticatedCLICommand(cmd, prerunner)}
 
-	dc := dynamicconfig.New(cfg, nil, nil)
-	_ = dc.ParseFlagsIntoConfig(cmd)
-	enableSourceCode := launchdarkly.Manager.BoolVariation("cli.stream_designer.source_code.enable", dc.Context(), v1.CliLaunchDarklyClient, true, false)
-
 	cmd.AddCommand(c.newActivateCommand())
-	cmd.AddCommand(c.newCreateCommand(enableSourceCode))
+	cmd.AddCommand(c.newCreateCommand())
 	cmd.AddCommand(c.newDeactivateCommand())
 	cmd.AddCommand(c.newDeleteCommand())
 	cmd.AddCommand(c.newDescribeCommand())
 	cmd.AddCommand(c.newListCommand())
-	cmd.AddCommand(c.newSaveCommand(enableSourceCode))
-	cmd.AddCommand(c.newUpdateCommand(enableSourceCode))
+	cmd.AddCommand(c.newSaveCommand())
+	cmd.AddCommand(c.newUpdateCommand())
 
 	return cmd
 }

--- a/internal/cmd/pipeline/command_create.go
+++ b/internal/cmd/pipeline/command_create.go
@@ -15,7 +15,7 @@ import (
 	"github.com/confluentinc/cli/internal/pkg/examples"
 )
 
-func (c *command) newCreateCommand(enableSourceCode bool) *cobra.Command {
+func (c *command) newCreateCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create",
 		Short: "Create a new pipeline.",
@@ -32,21 +32,16 @@ func (c *command) newCreateCommand(enableSourceCode bool) *cobra.Command {
 	cmd.Flags().String("name", "", "Name of the pipeline.")
 	cmd.Flags().String("description", "", "Description of the pipeline.")
 	pcmd.AddKsqlClusterFlag(cmd, c.AuthenticatedCLICommand)
-	if enableSourceCode {
-		cmd.Flags().String("sql-file", "", "Path to a KSQL file containing the pipeline's source code.")
-		cmd.Flags().StringArray("secret", []string{}, "A named secret that can be referenced in pipeline source code, e.g. \"secret_name=secret_content\".\n"+
-			"This flag can be supplied multiple times. The secret mapping must have the format <secret-name>=<secret-value>,\n"+
-			"where <secret-name> consists of 1-128 lowercase, uppercase, numeric or underscore characters but may not begin with a digit.\n"+
-			"The <secret-value> can be of any format but may not be empty.")
-	}
+	cmd.Flags().String("sql-file", "", "Path to a KSQL file containing the pipeline's source code.")
+	cmd.Flags().StringArray("secret", []string{}, "A named secret that can be referenced in pipeline source code, e.g. \"secret_name=secret_content\".\n"+
+		"This flag can be supplied multiple times. The secret mapping must have the format <secret-name>=<secret-value>,\n"+
+		"where <secret-name> consists of 1-128 lowercase, uppercase, numeric or underscore characters but may not begin with a digit.\n"+
+		"The <secret-value> can be of any format but may not be empty.")
 	pcmd.AddOutputFlag(cmd)
 	pcmd.AddClusterFlag(cmd, c.AuthenticatedCLICommand)
 	pcmd.AddEnvironmentFlag(cmd, c.AuthenticatedCLICommand)
 
-	if enableSourceCode {
-		cobra.CheckErr(cmd.MarkFlagFilename("sql-file", "sql"))
-	}
-
+	cobra.CheckErr(cmd.MarkFlagFilename("sql-file", "sql"))
 	cobra.CheckErr(cmd.MarkFlagRequired("name"))
 
 	return cmd

--- a/internal/cmd/pipeline/command_save.go
+++ b/internal/cmd/pipeline/command_save.go
@@ -11,10 +11,12 @@ import (
 	"github.com/confluentinc/cli/internal/pkg/output"
 )
 
+const sqlFileTemplate = "./<pipeline-id>.sql"
+
 func (c *command) newSaveCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "save <id>",
-		Short:             "Save a Stream Designer pipeline's source code to a local file.",
+		Short:             "Save the source code of a Stream Designer pipeline locally.",
 		Args:              cobra.ExactArgs(1),
 		ValidArgsFunction: pcmd.NewValidArgsFunction(c.validArgs),
 		RunE:              c.save,
@@ -30,7 +32,7 @@ func (c *command) newSaveCommand() *cobra.Command {
 		),
 	}
 
-	cmd.Flags().String("sql-file", "", "Path to save the pipeline's source code at. (default \"./<pipeline-id>.sql\")")
+	cmd.Flags().String("sql-file", sqlFileTemplate, `Path to save the pipeline's source code at.`)
 	pcmd.AddClusterFlag(cmd, c.AuthenticatedCLICommand)
 	pcmd.AddEnvironmentFlag(cmd, c.AuthenticatedCLICommand)
 	pcmd.AddOutputFlag(cmd)
@@ -58,8 +60,11 @@ func (c *command) save(cmd *cobra.Command, args []string) error {
 
 	path := args[0] + ".sql"
 
-	sqlFile, _ := cmd.Flags().GetString("sql-file")
-	if sqlFile != "" {
+	sqlFile, err := cmd.Flags().GetString("sql-file")
+	if err != nil {
+		return err
+	}
+	if sqlFile != "" && sqlFile != sqlFileTemplate {
 		path = getPath(sqlFile)
 	}
 

--- a/internal/cmd/pipeline/command_save.go
+++ b/internal/cmd/pipeline/command_save.go
@@ -11,7 +11,7 @@ import (
 	"github.com/confluentinc/cli/internal/pkg/output"
 )
 
-func (c *command) newSaveCommand(enableSourceCode bool) *cobra.Command {
+func (c *command) newSaveCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "save <id>",
 		Short:             "Save a Stream Designer pipeline's source code to a local file.",
@@ -28,7 +28,6 @@ func (c *command) newSaveCommand(enableSourceCode bool) *cobra.Command {
 				Code: "confluent pipeline save pipe-12345 --sql-file /tmp/pipeline-source-code.sql",
 			},
 		),
-		Hidden: !enableSourceCode,
 	}
 
 	cmd.Flags().String("sql-file", "", "Path to save the pipeline's source code at. (default \"./<pipeline-id>.sql\")")

--- a/internal/cmd/pipeline/command_update.go
+++ b/internal/cmd/pipeline/command_update.go
@@ -12,7 +12,7 @@ import (
 	"github.com/confluentinc/cli/internal/pkg/examples"
 )
 
-func (c *command) newUpdateCommand(enableSourceCode bool) *cobra.Command {
+func (c *command) newUpdateCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "update <pipeline-id>",
 		Short:             "Update an existing pipeline.",
@@ -46,22 +46,18 @@ func (c *command) newUpdateCommand(enableSourceCode bool) *cobra.Command {
 	cmd.Flags().String("name", "", "Name of the pipeline.")
 	cmd.Flags().String("description", "", "Description of the pipeline.")
 	pcmd.AddKsqlClusterFlag(cmd, c.AuthenticatedCLICommand)
-	if enableSourceCode {
-		cmd.Flags().String("sql-file", "", "Path to a KSQL file containing the pipeline's source code.")
-		cmd.Flags().StringArray("secret", []string{}, "A named secret that can be referenced in pipeline source code, e.g. \"secret_name=secret_content\".\n"+
-			"This flag can be supplied multiple times. The secret mapping must have the format <secret-name>=<secret-value>,\n"+
-			"where <secret-name> consists of 1-128 lowercase, uppercase, numeric or underscore characters but may not begin with a digit.\n"+
-			"If <secret-value> is empty, the named secret will be removed from Stream Designer.")
-	}
+	cmd.Flags().String("sql-file", "", "Path to a KSQL file containing the pipeline's source code.")
+	cmd.Flags().StringArray("secret", []string{}, "A named secret that can be referenced in pipeline source code, e.g. \"secret_name=secret_content\".\n"+
+		"This flag can be supplied multiple times. The secret mapping must have the format <secret-name>=<secret-value>,\n"+
+		"where <secret-name> consists of 1-128 lowercase, uppercase, numeric or underscore characters but may not begin with a digit.\n"+
+		"If <secret-value> is empty, the named secret will be removed from Stream Designer.")
 	cmd.Flags().Bool("activation-privilege", true, "Grant or revoke the privilege to activate this pipeline.")
 	cmd.Flags().Bool("update-schema-registry", false, "Update the pipeline with the latest Schema Registry cluster.")
 	pcmd.AddOutputFlag(cmd)
 	pcmd.AddClusterFlag(cmd, c.AuthenticatedCLICommand)
 	pcmd.AddEnvironmentFlag(cmd, c.AuthenticatedCLICommand)
 
-	if enableSourceCode {
-		cobra.CheckErr(cmd.MarkFlagFilename("sql-file", "sql"))
-	}
+	cobra.CheckErr(cmd.MarkFlagFilename("sql-file", "sql"))
 
 	return cmd
 }

--- a/test/fixtures/output/pipeline/save-help.golden
+++ b/test/fixtures/output/pipeline/save-help.golden
@@ -1,4 +1,4 @@
-Save a Stream Designer pipeline's source code to a local file.
+Save the source code of a Stream Designer pipeline locally.
 
 Usage:
   confluent pipeline save <id> [flags]


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
The `confluent pipeline save` command has been enabled for a while, so we should be ok to remove the feature flag to give the command some more stability in case of a LaunchDarkly outage.