### PR TITLE
feat: use different colors for different types of information

### DIFF
--- a/internal/pkg/color/color.go
+++ b/internal/pkg/color/color.go
@@ -1,4 +1,4 @@
-package config
+package color
 
 import (
 	"github.com/fatih/color"

--- a/internal/pkg/flink/components/interactive_input.go
+++ b/internal/pkg/flink/components/interactive_input.go
@@ -3,9 +3,9 @@ package components
 import (
 	"strings"
 
-	"github.com/fatih/color"
+	fColor "github.com/fatih/color"
 
-	"github.com/confluentinc/cli/internal/pkg/flink/config"
+	"github.com/confluentinc/cli/internal/pkg/color"
 	"github.com/confluentinc/cli/internal/pkg/output"
 )
 
@@ -25,7 +25,7 @@ func PrintOptionState(prefix string, isEnabled bool, maxCol int) {
 		stateMsg = "enabled"
 	}
 
-	output.Printf("\n" + prefix + color.CyanString(stateMsg))
+	output.Printf("\n" + prefix + fColor.CyanString(stateMsg))
 
 	// This prints to the console the exact amount of empty characters to fill the line might have autocompletions before
 	output.Println(strings.Repeat(" ", maxCol-len(prefix+stateMsg)))
@@ -37,6 +37,6 @@ func PrintWelcomeHeader() {
 	output.Printf("To exit, press Ctrl-Q or type \"exit\". \n\n")
 
 	// Print shortcuts
-	c := color.New(config.AccentColor)
+	c := fColor.New(color.AccentColor)
 	output.Printf("[Ctrl-Q] %s [Ctrl-S] %s \n", c.Sprint("Quit"), c.Sprint("Toggle Smart Completion"))
 }

--- a/internal/pkg/flink/components/interactive_input.go
+++ b/internal/pkg/flink/components/interactive_input.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/fatih/color"
 
+	"github.com/confluentinc/cli/internal/pkg/flink/config"
 	"github.com/confluentinc/cli/internal/pkg/output"
 )
 
@@ -36,5 +37,6 @@ func PrintWelcomeHeader() {
 	output.Printf("To exit, press Ctrl-Q or type \"exit\". \n\n")
 
 	// Print shortcuts
-	output.Printf("[Ctrl-Q] %s [Ctrl-S] %s \n", color.CyanString("Quit"), color.CyanString("Toggle Smart Completion"))
+	c := color.New(config.AccentColor)
+	output.Printf("[Ctrl-Q] %s [Ctrl-S] %s \n", c.Sprint("Quit"), c.Sprint("Toggle Smart Completion"))
 }

--- a/internal/pkg/flink/config/color.go
+++ b/internal/pkg/flink/config/color.go
@@ -1,6 +1,14 @@
 package config
 
-import "github.com/confluentinc/go-prompt"
+import (
+	"github.com/confluentinc/go-prompt"
+	"github.com/fatih/color"
+)
 
-// We should use this package as a root for coloring variables
-const HighlightColor = prompt.Cyan
+// Package used as a root for color used accross the application
+const PromptAccentColor = prompt.Cyan
+const AccentColor = color.FgCyan
+
+const InfoColor = color.FgWhite
+const ErrorColor = color.FgHiRed
+const WarnColor = color.FgHiYellow

--- a/internal/pkg/flink/config/color.go
+++ b/internal/pkg/flink/config/color.go
@@ -1,14 +1,15 @@
 package config
 
 import (
-	"github.com/confluentinc/go-prompt"
 	"github.com/fatih/color"
+
+	"github.com/confluentinc/go-prompt"
 )
 
-// Package used as a root for color used accross the application
+// Package used as a root for color used across the application
 const PromptAccentColor = prompt.Cyan
 const AccentColor = color.FgCyan
 
 const InfoColor = color.FgWhite
 const ErrorColor = color.FgHiRed
-const WarnColor = color.FgHiYellow
+const WarnColor = color.FgCyan

--- a/internal/pkg/flink/config/color.go
+++ b/internal/pkg/flink/config/color.go
@@ -12,4 +12,4 @@ const AccentColor = color.FgCyan
 
 const InfoColor = color.FgWhite
 const ErrorColor = color.FgHiRed
-const WarnColor = color.FgCyan
+const WarnColor = color.FgHiYellow

--- a/internal/pkg/flink/internal/controller/input_controller.go
+++ b/internal/pkg/flink/internal/controller/input_controller.go
@@ -24,7 +24,6 @@ import (
 	"github.com/confluentinc/cli/internal/pkg/flink/internal/store"
 	"github.com/confluentinc/cli/internal/pkg/flink/types"
 	"github.com/confluentinc/cli/internal/pkg/log"
-	"github.com/confluentinc/cli/internal/pkg/output"
 )
 
 type InputController struct {
@@ -90,7 +89,7 @@ func (c *InputController) RunInteractiveInput() {
 
 		// Upon receiving user input, we check if user is authenticated and possibly a refresh the CCloud SSO token
 		if authErr := c.authenticated(); authErr != nil {
-			output.Printf("Error: %v\n", authErr)
+			outputErrf("Error: %v\n", authErr)
 			c.appController.ExitApplication()
 			return
 		}
@@ -107,7 +106,7 @@ func (c *InputController) RunInteractiveInput() {
 
 		renderMsgAndStatus(processedStatement)
 		if err != nil {
-			output.Println(err.Error())
+			outputErr(err.Error())
 			if !c.isSessionValid(err) {
 				c.appController.ExitApplication()
 				return
@@ -127,7 +126,7 @@ func (c *InputController) RunInteractiveInput() {
 		processedStatement, err = c.store.WaitPendingStatement(ctx, *processedStatement)
 		if err != nil {
 			cancelListenToUserInput()
-			output.Println(err.Error())
+			outputErr(err.Error())
 			if !c.isSessionValid(err) {
 				c.appController.ExitApplication()
 				return
@@ -139,7 +138,7 @@ func (c *InputController) RunInteractiveInput() {
 		processedStatement, err = c.store.FetchStatementResults(*processedStatement)
 		cancelListenToUserInput()
 		if err != nil {
-			output.Println(err.Error())
+			outputErr(err.Error())
 			continue
 		}
 
@@ -199,25 +198,26 @@ func (c *InputController) isSessionValid(err *types.StatementError) bool {
 }
 
 func renderMsgAndStatus(processedStatement *types.ProcessedStatement) {
+
 	if processedStatement == nil {
 		return
 	}
 
 	if processedStatement.IsLocalStatement {
 		if processedStatement.Status == "FAILED" {
-			output.Println("Error: Couldn't process statement. Please check your statement and try again")
+			outputErr("Error: Couldn't process statement. Please check your statement and try again.")
 		} else {
-			output.Println("Statement successfully submitted.")
+			outputInfo("Statement successfully submitted.")
 		}
 	} else {
 		if processedStatement.StatementName != "" {
-			output.Printf("Statement name: %s\n", processedStatement.StatementName)
+			outputInfof("Statement name: %s\n", processedStatement.StatementName)
 		}
 		if processedStatement.Status == "FAILED" {
-			output.Println("Error: Statement submission failed. There could a problem with the server right now. Check your statement and try again")
+			outputErr("Error: Statement submission failed. There could a problem with the server right now. Check your statement and try again.")
 		} else {
-			output.Println("Statement successfully submitted.")
-			output.Println("Fetching results...")
+			outputInfo("Statement successfully submitted.")
+			outputInfo("Fetching results...")
 		}
 		processedStatement.PrintStatusDetail()
 	}
@@ -249,7 +249,7 @@ func (c *InputController) toggleOutputMode() {
 
 func (c *InputController) printResultToSTDOUT(statementResults *types.StatementResults) {
 	if statementResults == nil || len(statementResults.Headers) == 0 || len(statementResults.Rows) == 0 {
-		output.Println("\nThe server returned empty rows for this statement.")
+		outputWarn("\nThe server returned empty rows for this statement.")
 		return
 	}
 

--- a/internal/pkg/flink/internal/controller/input_controller.go
+++ b/internal/pkg/flink/internal/controller/input_controller.go
@@ -204,7 +204,8 @@ func renderMsgAndStatus(processedStatement *types.ProcessedStatement) {
 
 	if processedStatement.IsLocalStatement {
 		if processedStatement.Status == "FAILED" {
-			outputErr("Error: Couldn't process statement. Please check your statement and try again.")
+			err := types.StatementError{Message: "couldn't process statement, please check your statement and try again"}
+			outputErr(err.Error())
 		} else {
 			outputInfo("Statement successfully submitted.")
 		}
@@ -213,7 +214,8 @@ func renderMsgAndStatus(processedStatement *types.ProcessedStatement) {
 			outputInfof("Statement name: %s\n", processedStatement.StatementName)
 		}
 		if processedStatement.Status == "FAILED" {
-			outputErr("Error: Statement submission failed. There could a problem with the server right now. Check your statement and try again.")
+			err := types.StatementError{Message: "statement submission failed"}
+			outputErr(err.Error())
 		} else {
 			outputInfo("Statement successfully submitted.")
 			outputInfo("Fetching results...")

--- a/internal/pkg/flink/internal/controller/input_controller.go
+++ b/internal/pkg/flink/internal/controller/input_controller.go
@@ -198,7 +198,6 @@ func (c *InputController) isSessionValid(err *types.StatementError) bool {
 }
 
 func renderMsgAndStatus(processedStatement *types.ProcessedStatement) {
-
 	if processedStatement == nil {
 		return
 	}

--- a/internal/pkg/flink/internal/controller/input_controller_test.go
+++ b/internal/pkg/flink/internal/controller/input_controller_test.go
@@ -204,7 +204,7 @@ func (s *InputControllerTestSuite) TestRenderMsgAndStatusLocalStatements() {
 		{
 			name:      "local failed statement",
 			statement: &types.ProcessedStatement{IsLocalStatement: true, Status: types.FAILED},
-			want:      "Error: Couldn't process statement. Please check your statement and try again.\n",
+			want:      "Error: couldn't process statement, please check your statement and try again\n",
 		},
 		{
 			name:      "local non-failed statement",
@@ -236,22 +236,22 @@ func (s *InputControllerTestSuite) TestRenderMsgAndStatusNonLocalFailedStatement
 		{
 			name:      "statement with name",
 			statement: &types.ProcessedStatement{StatementName: "test-statement", Status: types.FAILED},
-			want:      "Statement name: test-statement\nError: Statement submission failed. There could a problem with the server right now. Check your statement and try again.\n",
+			want:      "Statement name: test-statement\nError: statement submission failed\n",
 		},
 		{
 			name:      "statement with name and status detail",
 			statement: &types.ProcessedStatement{StatementName: "test-statement", Status: types.FAILED, StatusDetail: "status-detail"},
-			want:      "Statement name: test-statement\nError: Statement submission failed. There could a problem with the server right now. Check your statement and try again.\nstatus-detail.\n",
+			want:      "Statement name: test-statement\nError: statement submission failed\nstatus-detail.\n",
 		},
 		{
 			name:      "statement without name",
 			statement: &types.ProcessedStatement{Status: types.FAILED},
-			want:      "Error: Statement submission failed. There could a problem with the server right now. Check your statement and try again.\n",
+			want:      "Error: statement submission failed\n",
 		},
 		{
 			name:      "statement without name but with status detail",
 			statement: &types.ProcessedStatement{Status: types.FAILED, StatusDetail: "status-detail"},
-			want:      "Error: Statement submission failed. There could a problem with the server right now. Check your statement and try again.\nstatus-detail.\n",
+			want:      "Error: statement submission failed\nstatus-detail.\n",
 		},
 	}
 	for _, tt := range tests {

--- a/internal/pkg/flink/internal/controller/input_controller_test.go
+++ b/internal/pkg/flink/internal/controller/input_controller_test.go
@@ -204,7 +204,7 @@ func (s *InputControllerTestSuite) TestRenderMsgAndStatusLocalStatements() {
 		{
 			name:      "local failed statement",
 			statement: &types.ProcessedStatement{IsLocalStatement: true, Status: types.FAILED},
-			want:      "Error: Couldn't process statement. Please check your statement and try again\n",
+			want:      "Error: Couldn't process statement. Please check your statement and try again.\n",
 		},
 		{
 			name:      "local non-failed statement",
@@ -236,22 +236,22 @@ func (s *InputControllerTestSuite) TestRenderMsgAndStatusNonLocalFailedStatement
 		{
 			name:      "statement with name",
 			statement: &types.ProcessedStatement{StatementName: "test-statement", Status: types.FAILED},
-			want:      "Statement name: test-statement\nError: Statement submission failed. There could a problem with the server right now. Check your statement and try again\n",
+			want:      "Statement name: test-statement\nError: Statement submission failed. There could a problem with the server right now. Check your statement and try again.\n",
 		},
 		{
 			name:      "statement with name and status detail",
 			statement: &types.ProcessedStatement{StatementName: "test-statement", Status: types.FAILED, StatusDetail: "status-detail"},
-			want:      "Statement name: test-statement\nError: Statement submission failed. There could a problem with the server right now. Check your statement and try again\nstatus-detail.\n",
+			want:      "Statement name: test-statement\nError: Statement submission failed. There could a problem with the server right now. Check your statement and try again.\nstatus-detail.\n",
 		},
 		{
 			name:      "statement without name",
 			statement: &types.ProcessedStatement{Status: types.FAILED},
-			want:      "Error: Statement submission failed. There could a problem with the server right now. Check your statement and try again\n",
+			want:      "Error: Statement submission failed. There could a problem with the server right now. Check your statement and try again.\n",
 		},
 		{
 			name:      "statement without name but with status detail",
 			statement: &types.ProcessedStatement{Status: types.FAILED, StatusDetail: "status-detail"},
-			want:      "Error: Statement submission failed. There could a problem with the server right now. Check your statement and try again\nstatus-detail.\n",
+			want:      "Error: Statement submission failed. There could a problem with the server right now. Check your statement and try again.\nstatus-detail.\n",
 		},
 	}
 	for _, tt := range tests {

--- a/internal/pkg/flink/internal/controller/input_controller_utils.go
+++ b/internal/pkg/flink/internal/controller/input_controller_utils.go
@@ -6,8 +6,11 @@ import (
 	"golang.org/x/term"
 
 	"github.com/confluentinc/go-prompt"
+	"github.com/fatih/color"
 
+	"github.com/confluentinc/cli/internal/pkg/flink/config"
 	"github.com/confluentinc/cli/internal/pkg/log"
+	"github.com/confluentinc/cli/internal/pkg/output"
 )
 
 func getConsoleParser() prompt.ConsoleParser {
@@ -39,4 +42,34 @@ func restoreStdin(state *term.State) {
 	if state != nil {
 		_ = term.Restore(int(os.Stdin.Fd()), state)
 	}
+}
+
+func outputErr(s string) {
+	c := color.New(config.ErrorColor)
+	output.Println(c.Sprintf(s))
+}
+
+func outputErrf(s string, args ...any) {
+	c := color.New(config.ErrorColor)
+	output.Printf(c.Sprint(s), args...)
+}
+
+func outputInfo(s string) {
+	c := color.New(config.InfoColor)
+	output.Println(c.Sprint(s))
+}
+
+func outputInfof(s string, args ...any) {
+	c := color.New(config.InfoColor)
+	output.Printf(c.Sprint(s), args...)
+}
+
+func outputWarn(s string) {
+	c := color.New(config.WarnColor)
+	output.Println(c.Sprint(s))
+}
+
+func outputWarnf(s string, args ...any) {
+	c := color.New(config.WarnColor)
+	output.Printf(c.Sprint(s), args...)
 }

--- a/internal/pkg/flink/internal/controller/input_controller_utils.go
+++ b/internal/pkg/flink/internal/controller/input_controller_utils.go
@@ -3,12 +3,12 @@ package controller
 import (
 	"os"
 
-	"github.com/fatih/color"
+	fColor "github.com/fatih/color"
 	"golang.org/x/term"
 
 	"github.com/confluentinc/go-prompt"
 
-	"github.com/confluentinc/cli/internal/pkg/flink/config"
+	"github.com/confluentinc/cli/internal/pkg/color"
 	"github.com/confluentinc/cli/internal/pkg/log"
 	"github.com/confluentinc/cli/internal/pkg/output"
 )
@@ -45,26 +45,26 @@ func restoreStdin(state *term.State) {
 }
 
 func outputErr(s string) {
-	c := color.New(config.ErrorColor)
+	c := fColor.New(color.ErrorColor)
 	output.Println(c.Sprintf(s))
 }
 
 func outputErrf(s string, args ...any) {
-	c := color.New(config.ErrorColor)
+	c := fColor.New(color.ErrorColor)
 	output.Printf(c.Sprint(s), args...)
 }
 
 func outputInfo(s string) {
-	c := color.New(config.InfoColor)
+	c := fColor.New(color.InfoColor)
 	output.Println(c.Sprint(s))
 }
 
 func outputInfof(s string, args ...any) {
-	c := color.New(config.InfoColor)
+	c := fColor.New(color.InfoColor)
 	output.Printf(c.Sprint(s), args...)
 }
 
 func outputWarn(s string) {
-	c := color.New(config.WarnColor)
+	c := fColor.New(color.WarnColor)
 	output.Println(c.Sprint(s))
 }

--- a/internal/pkg/flink/internal/controller/input_controller_utils.go
+++ b/internal/pkg/flink/internal/controller/input_controller_utils.go
@@ -49,6 +49,11 @@ func outputErr(s string) {
 	output.Println(c.Sprintf(s))
 }
 
+func outputErrf(s string, args ...any) {
+	c := color.New(config.ErrorColor)
+	output.Printf(c.Sprint(s), args...)
+}
+
 func outputInfo(s string) {
 	c := color.New(config.InfoColor)
 	output.Println(c.Sprint(s))

--- a/internal/pkg/flink/internal/controller/input_controller_utils.go
+++ b/internal/pkg/flink/internal/controller/input_controller_utils.go
@@ -3,10 +3,10 @@ package controller
 import (
 	"os"
 
+	"github.com/fatih/color"
 	"golang.org/x/term"
 
 	"github.com/confluentinc/go-prompt"
-	"github.com/fatih/color"
 
 	"github.com/confluentinc/cli/internal/pkg/flink/config"
 	"github.com/confluentinc/cli/internal/pkg/log"
@@ -49,11 +49,6 @@ func outputErr(s string) {
 	output.Println(c.Sprintf(s))
 }
 
-func outputErrf(s string, args ...any) {
-	c := color.New(config.ErrorColor)
-	output.Printf(c.Sprint(s), args...)
-}
-
 func outputInfo(s string) {
 	c := color.New(config.InfoColor)
 	output.Println(c.Sprint(s))
@@ -67,9 +62,4 @@ func outputInfof(s string, args ...any) {
 func outputWarn(s string) {
 	c := color.New(config.WarnColor)
 	output.Println(c.Sprint(s))
-}
-
-func outputWarnf(s string, args ...any) {
-	c := color.New(config.WarnColor)
-	output.Printf(c.Sprint(s), args...)
 }

--- a/internal/pkg/flink/internal/highlighting/lexer.go
+++ b/internal/pkg/flink/internal/highlighting/lexer.go
@@ -5,6 +5,7 @@ import (
 
 	prompt "github.com/confluentinc/go-prompt"
 
+	"github.com/confluentinc/cli/internal/pkg/color"
 	"github.com/confluentinc/cli/internal/pkg/flink/config"
 )
 
@@ -53,7 +54,7 @@ func Lexer(line string) []prompt.LexerElement {
 
 		isKeyword := config.SQLKeywords.Contains(strings.ToUpper(strings.TrimSpace(word)))
 		if isKeyword {
-			element.Color = config.PromptAccentColor
+			element.Color = color.PromptAccentColor
 		} else if wrappedInInvertedCommasOrBackticks(word) {
 			element.Color = prompt.Yellow
 		} else {

--- a/internal/pkg/flink/internal/highlighting/lexer.go
+++ b/internal/pkg/flink/internal/highlighting/lexer.go
@@ -53,7 +53,7 @@ func Lexer(line string) []prompt.LexerElement {
 
 		isKeyword := config.SQLKeywords.Contains(strings.ToUpper(strings.TrimSpace(word)))
 		if isKeyword {
-			element.Color = config.HighlightColor
+			element.Color = config.PromptAccentColor
 		} else if wrappedInInvertedCommasOrBackticks(word) {
 			element.Color = prompt.Yellow
 		} else {

--- a/internal/pkg/flink/internal/highlighting/lexer_test.go
+++ b/internal/pkg/flink/internal/highlighting/lexer_test.go
@@ -89,7 +89,7 @@ func TestExamplesWordLexer(t *testing.T) {
 			}
 
 			if isKeyWord {
-				require.Equalf(t, element.Color, config.HighlightColor, "wrong colour for element: %s", element.Text)
+				require.Equalf(t, element.Color, config.PromptAccentColor, "wrong colour for element: %s", element.Text)
 			} else if wrappedInInvertedCommasOrBackticks(element.Text) {
 				require.Equalf(t, element.Color, prompt.Yellow, "wrong colour for element: %s", element.Text)
 			} else {
@@ -137,7 +137,7 @@ func TestWordLexerForRandomStatements(t *testing.T) {
 			}
 
 			if isKeyWord {
-				require.Equalf(t, element.Color, config.HighlightColor, "wrong colour for element: %s", element.Text)
+				require.Equalf(t, element.Color, config.PromptAccentColor, "wrong colour for element: %s", element.Text)
 			} else if wrappedInInvertedCommasOrBackticks(element.Text) {
 				require.Equalf(t, element.Color, prompt.Yellow, "wrong colour for element: %s", element.Text)
 			} else {

--- a/internal/pkg/flink/internal/highlighting/lexer_test.go
+++ b/internal/pkg/flink/internal/highlighting/lexer_test.go
@@ -9,6 +9,7 @@ import (
 
 	prompt "github.com/confluentinc/go-prompt"
 
+	"github.com/confluentinc/cli/internal/pkg/color"
 	"github.com/confluentinc/cli/internal/pkg/flink/config"
 	"github.com/confluentinc/cli/internal/pkg/flink/test/generators"
 )
@@ -89,7 +90,7 @@ func TestExamplesWordLexer(t *testing.T) {
 			}
 
 			if isKeyWord {
-				require.Equalf(t, element.Color, config.PromptAccentColor, "wrong colour for element: %s", element.Text)
+				require.Equalf(t, element.Color, color.PromptAccentColor, "wrong colour for element: %s", element.Text)
 			} else if wrappedInInvertedCommasOrBackticks(element.Text) {
 				require.Equalf(t, element.Color, prompt.Yellow, "wrong colour for element: %s", element.Text)
 			} else {
@@ -137,7 +138,7 @@ func TestWordLexerForRandomStatements(t *testing.T) {
 			}
 
 			if isKeyWord {
-				require.Equalf(t, element.Color, config.PromptAccentColor, "wrong colour for element: %s", element.Text)
+				require.Equalf(t, element.Color, color.PromptAccentColor, "wrong colour for element: %s", element.Text)
 			} else if wrappedInInvertedCommasOrBackticks(element.Text) {
 				require.Equalf(t, element.Color, prompt.Yellow, "wrong colour for element: %s", element.Text)
 			} else {


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- PLACEHOLDER

New Features
- PLACEHOLDER

Bug Fixes
- PLACEHOLDER

Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->

Product wanted us to use different colors in the client for different purposes. Erros should be red, info white and and warnings yellow.

This is now also configurable from a central file.

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
<!--
Has it been tested? How?
Copy and paste any instructions or steps that can save the reviewer time.
-->

Open Questions / Follow-ups
---------------------------
<!--
Optional: Anything open to discussion for the reviewer, out of scope of this PR, or follow-ups.
-->
