### PR TITLE
Move command structs out of prerunner

### DIFF
--- a/internal/pkg/cmd/authenticated_cli_command.go
+++ b/internal/pkg/cmd/authenticated_cli_command.go
@@ -4,7 +4,12 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/spf13/cobra"
+
 	ccloudv1 "github.com/confluentinc/ccloud-sdk-go-v1-public"
+	mds "github.com/confluentinc/mds-sdk-go-public/mdsv1"
+	"github.com/confluentinc/mds-sdk-go-public/mdsv2alpha1"
+
 	"github.com/confluentinc/cli/internal/pkg/auth"
 	"github.com/confluentinc/cli/internal/pkg/ccloudv2"
 	v1 "github.com/confluentinc/cli/internal/pkg/config/v1"
@@ -12,9 +17,6 @@ import (
 	"github.com/confluentinc/cli/internal/pkg/errors"
 	"github.com/confluentinc/cli/internal/pkg/hub"
 	testserver "github.com/confluentinc/cli/test/test-server"
-	mds "github.com/confluentinc/mds-sdk-go-public/mdsv1"
-	"github.com/confluentinc/mds-sdk-go-public/mdsv2alpha1"
-	"github.com/spf13/cobra"
 )
 
 type AuthenticatedCLICommand struct {

--- a/internal/pkg/cmd/authenticated_cli_command.go
+++ b/internal/pkg/cmd/authenticated_cli_command.go
@@ -1,0 +1,134 @@
+package cmd
+
+import (
+	"net/url"
+	"strings"
+
+	ccloudv1 "github.com/confluentinc/ccloud-sdk-go-v1-public"
+	"github.com/confluentinc/cli/internal/pkg/auth"
+	"github.com/confluentinc/cli/internal/pkg/ccloudv2"
+	v1 "github.com/confluentinc/cli/internal/pkg/config/v1"
+	dynamicconfig "github.com/confluentinc/cli/internal/pkg/dynamic-config"
+	"github.com/confluentinc/cli/internal/pkg/errors"
+	"github.com/confluentinc/cli/internal/pkg/hub"
+	testserver "github.com/confluentinc/cli/test/test-server"
+	mds "github.com/confluentinc/mds-sdk-go-public/mdsv1"
+	"github.com/confluentinc/mds-sdk-go-public/mdsv2alpha1"
+	"github.com/spf13/cobra"
+)
+
+type AuthenticatedCLICommand struct {
+	*CLICommand
+
+	Client             *ccloudv1.Client
+	HubClient          *hub.Client
+	KafkaRESTProvider  *KafkaRESTProvider
+	MDSClient          *mds.APIClient
+	MDSv2Client        *mdsv2alpha1.APIClient
+	V2Client           *ccloudv2.Client
+	flinkGatewayClient *ccloudv2.FlinkGatewayClient
+	metricsClient      *ccloudv2.MetricsClient
+
+	Context *dynamicconfig.DynamicContext
+	State   *v1.ContextState
+}
+
+func NewAuthenticatedCLICommand(cmd *cobra.Command, prerunner PreRunner) *AuthenticatedCLICommand {
+	c := &AuthenticatedCLICommand{CLICommand: NewCLICommand(cmd, prerunner)}
+	cmd.PersistentPreRunE = Chain(prerunner.Authenticated(c), prerunner.ParseFlagsIntoContext(c))
+	c.Command = cmd
+	return c
+}
+
+func NewAuthenticatedWithMDSCLICommand(cmd *cobra.Command, prerunner PreRunner) *AuthenticatedCLICommand {
+	c := &AuthenticatedCLICommand{CLICommand: NewCLICommand(cmd, prerunner)}
+	cmd.PersistentPreRunE = Chain(prerunner.AuthenticatedWithMDS(c), prerunner.ParseFlagsIntoContext(c))
+	c.Command = cmd
+	return c
+}
+
+func (c *AuthenticatedCLICommand) GetFlinkGatewayClient() (*ccloudv2.FlinkGatewayClient, error) {
+	ctx := c.Config.Context()
+
+	if c.flinkGatewayClient == nil {
+		computePoolId := ctx.GetCurrentFlinkComputePool()
+		if computePoolId == "" {
+			return nil, errors.NewErrorWithSuggestions("no compute pool selected", "Select a compute pool with `confluent flink compute-pool use` or `--compute-pool`.")
+		}
+
+		computePool, err := c.V2Client.DescribeFlinkComputePool(computePoolId, ctx.GetCurrentEnvironment())
+		if err != nil {
+			return nil, err
+		}
+
+		u, err := url.Parse(computePool.Spec.GetHttpEndpoint())
+		if err != nil {
+			return nil, err
+		}
+		u.Path = ""
+
+		unsafeTrace, err := c.Command.Flags().GetBool("unsafe-trace")
+		if err != nil {
+			return nil, err
+		}
+
+		authToken, err := auth.GetJwtTokenForV2Client(ctx.GetState(), ctx.GetPlatformServer())
+		if err != nil {
+			return nil, err
+		}
+
+		c.flinkGatewayClient = ccloudv2.NewFlinkGatewayClient(u.String(), c.Version.UserAgent, unsafeTrace, authToken)
+	}
+
+	return c.flinkGatewayClient, nil
+}
+
+func (c *AuthenticatedCLICommand) GetHubClient() (*hub.Client, error) {
+	if c.HubClient == nil {
+		unsafeTrace, err := c.Flags().GetBool("unsafe-trace")
+		if err != nil {
+			return nil, err
+		}
+
+		c.HubClient = hub.NewClient(c.Config.Version.UserAgent, c.Config.IsTest, unsafeTrace)
+	}
+
+	return c.HubClient, nil
+}
+
+func (c *AuthenticatedCLICommand) GetKafkaREST() (*KafkaREST, error) {
+	return (*c.KafkaRESTProvider)()
+}
+
+func (c *AuthenticatedCLICommand) GetMetricsClient() (*ccloudv2.MetricsClient, error) {
+	ctx := c.Config.Context()
+
+	if c.metricsClient == nil {
+		url := "https://api.telemetry.confluent.cloud"
+		if c.Config.IsTest {
+			url = testserver.TestV2CloudUrl.String()
+		} else if strings.Contains(ctx.GetPlatformServer(), "devel") {
+			url = "https://devel-sandbox-api.telemetry.aws.confluent.cloud"
+		} else if strings.Contains(ctx.GetPlatformServer(), "stag") {
+			url = "https://stag-sandbox-api.telemetry.aws.confluent.cloud"
+		}
+
+		unsafeTrace, err := c.Command.Flags().GetBool("unsafe-trace")
+		if err != nil {
+			return nil, err
+		}
+
+		authToken, err := auth.GetJwtTokenForV2Client(ctx.GetState(), ctx.GetPlatformServer())
+		if err != nil {
+			return nil, err
+		}
+
+		c.metricsClient = ccloudv2.NewMetricsClient(url, c.Version.UserAgent, unsafeTrace, authToken)
+	}
+
+	return c.metricsClient, nil
+}
+
+func (c *AuthenticatedCLICommand) AuthToken() string {
+	return c.Context.GetAuthToken()
+}

--- a/internal/pkg/cmd/cli_command.go
+++ b/internal/pkg/cmd/cli_command.go
@@ -1,9 +1,10 @@
 package cmd
 
 import (
+	"github.com/spf13/cobra"
+
 	dynamicconfig "github.com/confluentinc/cli/internal/pkg/dynamic-config"
 	"github.com/confluentinc/cli/internal/pkg/version"
-	"github.com/spf13/cobra"
 )
 
 type CLICommand struct {

--- a/internal/pkg/cmd/cli_command.go
+++ b/internal/pkg/cmd/cli_command.go
@@ -1,0 +1,29 @@
+package cmd
+
+import (
+	dynamicconfig "github.com/confluentinc/cli/internal/pkg/dynamic-config"
+	"github.com/confluentinc/cli/internal/pkg/version"
+	"github.com/spf13/cobra"
+)
+
+type CLICommand struct {
+	*cobra.Command
+	Config    *dynamicconfig.DynamicConfig
+	Version   *version.Version
+	prerunner PreRunner
+}
+
+func NewCLICommand(cmd *cobra.Command, prerunner PreRunner) *CLICommand {
+	return &CLICommand{
+		Config:    &dynamicconfig.DynamicConfig{},
+		Command:   cmd,
+		prerunner: prerunner,
+	}
+}
+
+func NewAnonymousCLICommand(cmd *cobra.Command, prerunner PreRunner) *CLICommand {
+	c := NewCLICommand(cmd, prerunner)
+	cmd.PersistentPreRunE = Chain(prerunner.Anonymous(c, false), prerunner.AnonymousParseFlagsIntoContext(c))
+	c.Command = cmd
+	return c
+}

--- a/internal/pkg/cmd/has_api_key_cli_command.go
+++ b/internal/pkg/cmd/has_api_key_cli_command.go
@@ -1,0 +1,19 @@
+package cmd
+
+import "github.com/spf13/cobra"
+
+type HasAPIKeyCLICommand struct {
+	*CLICommand
+}
+
+func NewHasAPIKeyCLICommand(cmd *cobra.Command, prerunner PreRunner) *HasAPIKeyCLICommand {
+	c := &HasAPIKeyCLICommand{CLICommand: NewCLICommand(cmd, prerunner)}
+	cmd.PersistentPreRunE = prerunner.HasAPIKey(c)
+	c.Command = cmd
+	return c
+}
+
+func (h *HasAPIKeyCLICommand) AddCommand(cmd *cobra.Command) {
+	cmd.PersistentPreRunE = h.PersistentPreRunE
+	h.Command.AddCommand(cmd)
+}

--- a/internal/pkg/cmd/prerunner.go
+++ b/internal/pkg/cmd/prerunner.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"net/url"
 	"os"
 	"strings"
 
@@ -23,14 +22,12 @@ import (
 	"github.com/confluentinc/cli/internal/pkg/errors"
 	"github.com/confluentinc/cli/internal/pkg/featureflags"
 	"github.com/confluentinc/cli/internal/pkg/form"
-	"github.com/confluentinc/cli/internal/pkg/hub"
 	"github.com/confluentinc/cli/internal/pkg/log"
 	"github.com/confluentinc/cli/internal/pkg/netrc"
 	"github.com/confluentinc/cli/internal/pkg/output"
 	"github.com/confluentinc/cli/internal/pkg/update"
 	"github.com/confluentinc/cli/internal/pkg/utils"
 	"github.com/confluentinc/cli/internal/pkg/version"
-	testserver "github.com/confluentinc/cli/test/test-server"
 )
 
 // PreRun is a helper class for automatically setting up Cobra PersistentPreRun commands
@@ -57,146 +54,7 @@ type PreRun struct {
 	JWTValidator            JWTValidator
 }
 
-type CLICommand struct {
-	*cobra.Command
-	Config    *dynamicconfig.DynamicConfig
-	Version   *version.Version
-	prerunner PreRunner
-}
-
 type KafkaRESTProvider func() (*KafkaREST, error)
-
-type AuthenticatedCLICommand struct {
-	*CLICommand
-	Client             *ccloudv1.Client
-	V2Client           *ccloudv2.Client
-	MDSClient          *mds.APIClient
-	MDSv2Client        *mdsv2alpha1.APIClient
-	HubClient          *hub.Client
-	KafkaRESTProvider  *KafkaRESTProvider
-	flinkGatewayClient *ccloudv2.FlinkGatewayClient
-	metricsClient      *ccloudv2.MetricsClient
-	Context            *dynamicconfig.DynamicContext
-	State              *v1.ContextState
-}
-
-type HasAPIKeyCLICommand struct {
-	*CLICommand
-}
-
-func NewAuthenticatedCLICommand(cmd *cobra.Command, prerunner PreRunner) *AuthenticatedCLICommand {
-	c := &AuthenticatedCLICommand{CLICommand: NewCLICommand(cmd, prerunner)}
-	cmd.PersistentPreRunE = Chain(prerunner.Authenticated(c), prerunner.ParseFlagsIntoContext(c))
-	c.Command = cmd
-	return c
-}
-
-func NewAuthenticatedWithMDSCLICommand(cmd *cobra.Command, prerunner PreRunner) *AuthenticatedCLICommand {
-	c := &AuthenticatedCLICommand{CLICommand: NewCLICommand(cmd, prerunner)}
-	cmd.PersistentPreRunE = Chain(prerunner.AuthenticatedWithMDS(c), prerunner.ParseFlagsIntoContext(c))
-	c.Command = cmd
-	return c
-}
-
-func NewHasAPIKeyCLICommand(cmd *cobra.Command, prerunner PreRunner) *HasAPIKeyCLICommand {
-	c := &HasAPIKeyCLICommand{CLICommand: NewCLICommand(cmd, prerunner)}
-	cmd.PersistentPreRunE = prerunner.HasAPIKey(c)
-	c.Command = cmd
-	return c
-}
-
-func NewAnonymousCLICommand(cmd *cobra.Command, prerunner PreRunner) *CLICommand {
-	c := NewCLICommand(cmd, prerunner)
-	cmd.PersistentPreRunE = Chain(prerunner.Anonymous(c, false), prerunner.AnonymousParseFlagsIntoContext(c))
-	c.Command = cmd
-	return c
-}
-
-func NewCLICommand(cmd *cobra.Command, prerunner PreRunner) *CLICommand {
-	return &CLICommand{
-		Config:    &dynamicconfig.DynamicConfig{},
-		Command:   cmd,
-		prerunner: prerunner,
-	}
-}
-
-func (c *AuthenticatedCLICommand) GetKafkaREST() (*KafkaREST, error) {
-	return (*c.KafkaRESTProvider)()
-}
-
-func (c *AuthenticatedCLICommand) GetFlinkGatewayClient() (*ccloudv2.FlinkGatewayClient, error) {
-	ctx := c.Config.Context()
-
-	if c.flinkGatewayClient == nil {
-		computePoolId := ctx.GetCurrentFlinkComputePool()
-		if computePoolId == "" {
-			return nil, errors.NewErrorWithSuggestions("no compute pool selected", "Select a compute pool with `confluent flink compute-pool use` or `--compute-pool`.")
-		}
-
-		computePool, err := c.V2Client.DescribeFlinkComputePool(computePoolId, ctx.GetCurrentEnvironment())
-		if err != nil {
-			return nil, err
-		}
-
-		u, err := url.Parse(computePool.Spec.GetHttpEndpoint())
-		if err != nil {
-			return nil, err
-		}
-		u.Path = ""
-
-		unsafeTrace, err := c.Command.Flags().GetBool("unsafe-trace")
-		if err != nil {
-			return nil, err
-		}
-
-		authToken, err := pauth.GetJwtTokenForV2Client(ctx.GetState(), ctx.GetPlatformServer())
-		if err != nil {
-			return nil, err
-		}
-
-		c.flinkGatewayClient = ccloudv2.NewFlinkGatewayClient(u.String(), c.Version.UserAgent, unsafeTrace, authToken)
-	}
-
-	return c.flinkGatewayClient, nil
-}
-
-func (c *AuthenticatedCLICommand) GetMetricsClient() (*ccloudv2.MetricsClient, error) {
-	ctx := c.Config.Context()
-
-	if c.metricsClient == nil {
-		url := "https://api.telemetry.confluent.cloud"
-		if c.Config.IsTest {
-			url = testserver.TestV2CloudUrl.String()
-		} else if strings.Contains(ctx.GetPlatformServer(), "devel") {
-			url = "https://devel-sandbox-api.telemetry.aws.confluent.cloud"
-		} else if strings.Contains(ctx.GetPlatformServer(), "stag") {
-			url = "https://stag-sandbox-api.telemetry.aws.confluent.cloud"
-		}
-
-		unsafeTrace, err := c.Command.Flags().GetBool("unsafe-trace")
-		if err != nil {
-			return nil, err
-		}
-
-		authToken, err := pauth.GetJwtTokenForV2Client(ctx.GetState(), ctx.GetPlatformServer())
-		if err != nil {
-			return nil, err
-		}
-
-		c.metricsClient = ccloudv2.NewMetricsClient(url, c.Version.UserAgent, unsafeTrace, authToken)
-	}
-
-	return c.metricsClient, nil
-}
-
-func (c *AuthenticatedCLICommand) AuthToken() string {
-	return c.Context.GetAuthToken()
-}
-
-func (h *HasAPIKeyCLICommand) AddCommand(cmd *cobra.Command) {
-	cmd.PersistentPreRunE = h.PersistentPreRunE
-	h.Command.AddCommand(cmd)
-}
 
 // Anonymous provides PreRun operations for commands that may be run without a logged-in user
 func (r *PreRun) Anonymous(command *CLICommand, willAuthenticate bool) func(*cobra.Command, []string) error {
@@ -525,19 +383,6 @@ func (r *PreRun) setV2Clients(c *AuthenticatedCLICommand) error {
 	c.Config.V2Client = v2Client
 
 	return nil
-}
-
-func (c *AuthenticatedCLICommand) GetHubClient() (*hub.Client, error) {
-	if c.HubClient == nil {
-		unsafeTrace, err := c.Flags().GetBool("unsafe-trace")
-		if err != nil {
-			return nil, err
-		}
-
-		c.HubClient = hub.NewClient(c.Config.Version.UserAgent, c.Config.IsTest, unsafeTrace)
-	}
-
-	return c.HubClient, nil
 }
 
 func getKafkaRestEndpoint(ctx *dynamicconfig.DynamicContext) (string, string, error) {


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
Move `CLICommand`, `AuthenticatedCLICommand`, and others out of the (previously 1000+ LOC) prerunner.go file. This is set up for standardizing our clients (Confluent Cloud, Confluent Hub, Kafka REST, Flink Gateway, etc).