### PR TITLE
fix: use new GetDataplaneToken function

### DIFF
--- a/internal/cmd/flink/command_shell.go
+++ b/internal/cmd/flink/command_shell.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	pauth "github.com/confluentinc/cli/internal/pkg/auth"
+	"github.com/confluentinc/cli/internal/pkg/auth"
 	pcmd "github.com/confluentinc/cli/internal/pkg/cmd"
 	"github.com/confluentinc/cli/internal/pkg/config/load"
 	v1 "github.com/confluentinc/cli/internal/pkg/config/v1"
@@ -57,11 +57,11 @@ func (c *command) authenticated(authenticated func(*cobra.Command, []string) err
 
 		jwtCtx := &v1.Context{State: &v1.ContextState{AuthToken: flinkGatewayClient.AuthToken}}
 		if tokenErr := jwtValidator.Validate(jwtCtx); tokenErr != nil {
-			flinkGatewayAuthToken, err := pauth.GetJwtTokenForV2Client(cfg.Context().GetState(), cfg.Context().GetPlatformServer())
+			dataplaneToken, err := auth.GetDataplaneToken(cfg.Context().GetState(), cfg.Context().GetPlatformServer(), map[string]any{})
 			if err != nil {
 				return err
 			}
-			flinkGatewayClient.AuthToken = flinkGatewayAuthToken
+			flinkGatewayClient.AuthToken = dataplaneToken
 		}
 
 		return nil

--- a/internal/pkg/flink/internal/controller/input_controller_test.go
+++ b/internal/pkg/flink/internal/controller/input_controller_test.go
@@ -359,7 +359,7 @@ func (s *InputControllerTestSuite) TestRunInteractiveInputExitsWhenNotAuthentica
 	actual := s.runMainLoop(inputController, false)
 
 	// Then
-	expected := fmt.Sprintf("%s\n", inputController.authenticated().Error())
+	expected := fmt.Sprintf("Error: %s\n", inputController.authenticated().Error())
 	require.Equal(s.T(), expected, actual)
 }
 


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->
Function GetJwtTokenForV2Client was removed in #2002 causing the build on main to fail after #1991 was merged

