### PR TITLE
Fix dataplane token flow

### DIFF
--- a/internal/cmd/flink/command_shell.go
+++ b/internal/cmd/flink/command_shell.go
@@ -57,7 +57,7 @@ func (c *command) authenticated(authenticated func(*cobra.Command, []string) err
 
 		jwtCtx := &v1.Context{State: &v1.ContextState{AuthToken: flinkGatewayClient.AuthToken}}
 		if tokenErr := jwtValidator.Validate(jwtCtx); tokenErr != nil {
-			dataplaneToken, err := auth.GetDataplaneToken(cfg.Context().GetState(), cfg.Context().GetPlatformServer(), map[string]any{})
+			dataplaneToken, err := auth.GetDataplaneToken(cfg.Context().GetState(), cfg.Context().GetPlatformServer())
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/ksql/command.go
+++ b/internal/cmd/ksql/command.go
@@ -84,7 +84,7 @@ func (c *ksqlCommand) checkProvisioningFailed(clusterId, endpoint string) (bool,
 		return false, err
 	}
 
-	dataplaneToken, err := pauth.GetDataplaneToken(state, ctx.Platform.Server, map[string][]string{"clusterIds": {clusterId}})
+	dataplaneToken, err := pauth.GetDataplaneToken(state, ctx.Platform.Server)
 	if err != nil {
 		return false, err
 	}

--- a/internal/cmd/ksql/command_cluster_delete.go
+++ b/internal/cmd/ksql/command_cluster_delete.go
@@ -79,7 +79,7 @@ func (c *ksqlCommand) deleteTopics(clusterId, endpoint string) error {
 		return err
 	}
 
-	dataplaneToken, err := pauth.GetDataplaneToken(state, ctx.Platform.Server, map[string][]string{"clusterIds": {clusterId}})
+	dataplaneToken, err := pauth.GetDataplaneToken(state, ctx.Platform.Server)
 	if err != nil {
 		return err
 	}

--- a/internal/pkg/auth/auth.go
+++ b/internal/pkg/auth/auth.go
@@ -213,7 +213,7 @@ func generateCredentialName(username string) string {
 	return fmt.Sprintf("username-%s", username)
 }
 
-func GetDataplaneToken(authenticatedState *v1.ContextState, server string, body any) (string, error) {
+func GetDataplaneToken(authenticatedState *v1.ContextState, server string) (string, error) {
 	endpoint := strings.Trim(server, "/") + "/api/access_tokens"
 
 	res := &struct {
@@ -221,7 +221,7 @@ func GetDataplaneToken(authenticatedState *v1.ContextState, server string, body 
 		Error string `json:"error"`
 	}{}
 
-	if _, err := sling.New().Add("content", "application/json").Add("Content-Type", "application/json").Add("Authorization", "Bearer "+authenticatedState.AuthToken).BodyJSON(body).Post(endpoint).ReceiveSuccess(res); err != nil {
+	if _, err := sling.New().Add("Content-Type", "application/json").Add("Authorization", "Bearer "+authenticatedState.AuthToken).Post(endpoint).BodyJSON(map[string]any{}).ReceiveSuccess(res); err != nil {
 		return "", err
 	}
 	if res.Error != "" {

--- a/internal/pkg/cmd/authenticated_cli_command.go
+++ b/internal/pkg/cmd/authenticated_cli_command.go
@@ -74,7 +74,7 @@ func (c *AuthenticatedCLICommand) GetFlinkGatewayClient() (*ccloudv2.FlinkGatewa
 			return nil, err
 		}
 
-		dataplaneToken, err := auth.GetDataplaneToken(ctx.GetState(), ctx.GetPlatformServer(), map[string]any{})
+		dataplaneToken, err := auth.GetDataplaneToken(ctx.GetState(), ctx.GetPlatformServer())
 		if err != nil {
 			return nil, err
 		}
@@ -120,7 +120,7 @@ func (c *AuthenticatedCLICommand) GetMetricsClient() (*ccloudv2.MetricsClient, e
 			return nil, err
 		}
 
-		dataplaneToken, err := auth.GetDataplaneToken(ctx.GetState(), ctx.GetPlatformServer(), map[string]any{})
+		dataplaneToken, err := auth.GetDataplaneToken(ctx.GetState(), ctx.GetPlatformServer())
 		if err != nil {
 			return nil, err
 		}

--- a/internal/pkg/cmd/kafka_rest_test.go
+++ b/internal/pkg/cmd/kafka_rest_test.go
@@ -16,7 +16,7 @@ type KafkaRestTestSuite struct {
 func (suite *KafkaRestTestSuite) TestInvalidGetBearerToken() {
 	req := suite.Require()
 	emptyState := v1.ContextState{}
-	_, err := pauth.GetDataplaneToken(&emptyState, "invalidhost", map[string][]string{"clusterIds": {"lkc-123"}})
+	_, err := pauth.GetDataplaneToken(&emptyState, "invalidhost")
 	req.NotNil(err)
 }
 

--- a/internal/pkg/cmd/prerunner.go
+++ b/internal/pkg/cmd/prerunner.go
@@ -353,7 +353,7 @@ func (r *PreRun) setCCloudClient(c *AuthenticatedCLICommand) error {
 				return nil, err
 			}
 
-			dataplaneToken, err := pauth.GetDataplaneToken(state, ctx.Platform.Server, map[string]any{"clusterIds": lkc})
+			dataplaneToken, err := pauth.GetDataplaneToken(state, ctx.Platform.Server)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
#2002 passed `"clusterIds": "<cluster-id>"` instead of `"clusterIds": {"<cluster-id>"}` for Kafka REST, resulting in a backend error. I'm awaiting confirmation, but it looks like the body is no longer needed, so I deleted it entirely! Also, the header `"content": "application/json"` appears not to be needed as well.

Test & Review
-------------
Verified that system tests are fixed, also verified manually.