### PR TITLE
Allow `confluent update` in Docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -24,8 +24,7 @@ RUN apk update --no-cache && \
 
 COPY confluent /bin
 
-RUN chmod +x /bin/confluent
-RUN chown $USER:$USER /bin/confluent
+RUN chown $USER:$USER /bin
 RUN chown $USER:$USER /etc
 
 # This symbolic link exists for backwards compatibility reasons

--- a/internal/pkg/errors/strings.go
+++ b/internal/pkg/errors/strings.go
@@ -107,7 +107,8 @@ const (
 	PromptToDownloadDescriptionMsg = "New version of %s is available\n" +
 		"Current Version: %s\n" +
 		"Latest Version:  %s\n" +
-		"%s\n\n\n"
+		"\n" +
+		"%s"
 	InvalidChoiceMsg = "%s is not a valid choice"
 
 	// General


### PR DESCRIPTION
Release Notes
-------------
Bug Fixes
- Fix permission issue while running `confluent update` in Docker image

Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
`confluent update` has never worked on Docker due to the following error:
```
Error: update client failure: error updating CLI binary: open /bin/.confluent.new: permission denied

Suggestions:
    Please submit a support ticket.
    In the meantime, see link for other ways to download the latest CLI version:
    https://docs.confluent.io/current/cli/installing.html
```

Also fix stylistic output while printing release notes.

Test & Review
-------------
Manual verification