### PR TITLE
Add confluentgov.com to list of cloud hostnames

### DIFF
--- a/internal/pkg/ccloudv2/utils.go
+++ b/internal/pkg/ccloudv2/utils.go
@@ -27,6 +27,7 @@ type NullableString interface {
 var Hostnames = []string{
 	"confluent.cloud",
 	"confluentgov-internal.com",
+	"confluentgov.com",
 	"cpdev.cloud",
 }
 


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
Forgot to add confluentgov.com to this list, only the internal environment existed until now.