### PR TITLE
[KFS-950] Fix 404 after role binding create pools

### DIFF
--- a/internal/cmd/iam/command_rbac_role_binding.go
+++ b/internal/cmd/iam/command_rbac_role_binding.go
@@ -384,7 +384,8 @@ func (c *roleBindingCommand) displayCCloudCreateAndDeleteOutput(cmd *cobra.Comma
 	}
 
 	var fields []string
-	if presource.LookupType(userResourceId) == presource.ServiceAccount {
+	principalType := presource.LookupType(userResourceId)
+	if principalType == presource.ServiceAccount || principalType == presource.IdentityPool {
 		if resource != "" {
 			fields = resourcePatternListFields
 		} else {

--- a/test/cli_test.go
+++ b/test/cli_test.go
@@ -83,8 +83,8 @@ func (s *CLITestSuite) SetupSuite() {
 	err := os.Chdir("..")
 	req.NoError(err)
 
-	err = exec.Command("make", "build-for-integration-test").Run()
-	req.NoError(err)
+	output, err := exec.Command("make", "build-for-integration-test").CombinedOutput()
+	req.NoError(err, string(output))
 
 	if runtime.GOOS == "windows" {
 		testBin += ".exe"

--- a/test/fixtures/output/iam/rbac/role-binding/create-identity-pool-developer-read.golden
+++ b/test/fixtures/output/iam/rbac/role-binding/create-identity-pool-developer-read.golden
@@ -1,0 +1,7 @@
++---------------+-----------------+
+| Principal     | User:pool-12345 |
+| Role          | DeveloperRead   |
+| Resource Type | Topic           |
+| Name          | payroll         |
+| Pattern Type  | LITERAL         |
++---------------+-----------------+

--- a/test/iam_test.go
+++ b/test/iam_test.go
@@ -52,6 +52,7 @@ func (s *CLITestSuite) TestIAMRBACRoleBindingCRUDCloud() {
 	tests := []CLITest{
 		{args: "iam rbac role-binding create --help", fixture: "iam/rbac/role-binding/create-help-cloud.golden"},
 		{args: "iam rbac role-binding create --principal User:sa-12345 --role DeveloperRead --resource Topic:payroll --kafka-cluster lkc-1111aaa --current-environment --cloud-cluster lkc-1111aaa", fixture: "iam/rbac/role-binding/create-service-account-developer-read.golden"},
+		{args: "iam rbac role-binding create --principal User:pool-12345 --role DeveloperRead --resource Topic:payroll --kafka-cluster lkc-1111aaa --current-environment --cloud-cluster lkc-1111aaa", fixture: "iam/rbac/role-binding/create-identity-pool-developer-read.golden"},
 		{args: "iam rbac role-binding create --principal User:u-11aaa --role CloudClusterAdmin --current-environment --cloud-cluster lkc-1111aaa"},
 		{args: "iam rbac role-binding create --principal User:u-11aaa --role CloudClusterAdmin --environment a-595 --cloud-cluster lkc-1111aaa"},
 		{args: "iam rbac role-binding create --principal User:u-11aaa --role CloudClusterAdmin", fixture: "iam/rbac/role-binding/missing-cloud-cluster-cloud.golden", exitCode: 1},


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->
Bug Fixes
- Fixes the 404 error when creating a role binding attached to an identity pool

Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
Granting roles on identityPool was returning 404 but the role was actually granted. This because the cli was trying to fetch the email for identityPool and failing

References
----------
https://confluentinc.atlassian.net/browse/KFS-950

Test & Review
-------------
Added integration 
Open Questions / Follow-ups
---------------------------
<!--
Optional: Anything open to discussion for the reviewer, out of scope of this PR, or follow-ups.
-->
