### PR TITLE
Remove `stream-share` feature flag

### DIFF
--- a/cmd/docs/main.go
+++ b/cmd/docs/main.go
@@ -59,7 +59,6 @@ func main() {
 // removeUnreleasedDocs hides documentation for unreleased features
 func removeUnreleasedDocs() {
 	removeUnreleasedCommands("flink")
-	removeUnreleasedCommands("stream-share")
 }
 
 func removeUnreleasedCommands(command string) {

--- a/internal/cmd/command.go
+++ b/internal/cmd/command.go
@@ -128,7 +128,7 @@ func NewConfluentCommand(cfg *v1.Config) *cobra.Command {
 	cmd.AddCommand(schemaregistry.New(cfg, prerunner, nil))
 	cmd.AddCommand(secret.New(prerunner, flagResolver, secrets.NewPasswordProtectionPlugin()))
 	cmd.AddCommand(shell.New(cmd, func() *cobra.Command { return NewConfluentCommand(cfg) }))
-	cmd.AddCommand(streamshare.New(cfg, prerunner))
+	cmd.AddCommand(streamshare.New(prerunner))
 	cmd.AddCommand(version.New(prerunner, cfg.Version))
 
 	dc := dynamicconfig.New(cfg, nil, nil)

--- a/internal/cmd/command.go
+++ b/internal/cmd/command.go
@@ -128,14 +128,12 @@ func NewConfluentCommand(cfg *v1.Config) *cobra.Command {
 	cmd.AddCommand(schemaregistry.New(cfg, prerunner, nil))
 	cmd.AddCommand(secret.New(prerunner, flagResolver, secrets.NewPasswordProtectionPlugin()))
 	cmd.AddCommand(shell.New(cmd, func() *cobra.Command { return NewConfluentCommand(cfg) }))
+	cmd.AddCommand(streamshare.New(cfg, prerunner))
 	cmd.AddCommand(version.New(prerunner, cfg.Version))
 
 	dc := dynamicconfig.New(cfg, nil, nil)
 	_ = dc.ParseFlagsIntoConfig(cmd)
 
-	if cfg.IsTest || featureflags.Manager.BoolVariation("cli.cdx", dc.Context(), v1.CliLaunchDarklyClient, true, false) {
-		cmd.AddCommand(streamshare.New(cfg, prerunner))
-	}
 	if cfg.IsTest || featureflags.Manager.BoolVariation("cli.flink", dc.Context(), v1.CliLaunchDarklyClient, true, false) {
 		cmd.AddCommand(flink.New(cfg, prerunner))
 	}

--- a/internal/cmd/stream-share/command.go
+++ b/internal/cmd/stream-share/command.go
@@ -4,24 +4,18 @@ import (
 	"github.com/spf13/cobra"
 
 	pcmd "github.com/confluentinc/cli/internal/pkg/cmd"
-	v1 "github.com/confluentinc/cli/internal/pkg/config/v1"
-	dynamicconfig "github.com/confluentinc/cli/internal/pkg/dynamic-config"
-	"github.com/confluentinc/cli/internal/pkg/featureflags"
 )
 
 type command struct {
 	*pcmd.AuthenticatedCLICommand
 }
 
-func New(cfg *v1.Config, prerunner pcmd.PreRunner) *cobra.Command {
-	ctx := dynamicconfig.NewDynamicContext(cfg.Context(), nil, nil)
-
+func New(prerunner pcmd.PreRunner) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:         "stream-share",
 		Aliases:     []string{"ss"},
 		Short:       "Manage stream shares.",
 		Annotations: map[string]string{pcmd.RunRequirement: pcmd.RequireCloudLogin},
-		Hidden:      !cfg.IsTest && !featureflags.Manager.BoolVariation("cli.cdx", ctx, v1.CliLaunchDarklyClient, true, false),
 	}
 
 	c := &command{pcmd.NewAuthenticatedCLICommand(cmd, prerunner)}


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
Stream sharing has been GA for a while. Remove the feature flag to increase stability in case of a Launch Darkly outage, and generate documentation.