### PR TITLE
[internal] [confluent-local] build with the correct arch for different platforms

### DIFF
--- a/.goreleaser-build.yml
+++ b/.goreleaser-build.yml
@@ -5,3 +5,5 @@ builds:
     main: cmd/confluent/main.go
     flags:
       - -tags={{.Env.TAGS}}
+    ldflags:
+      - "-X local.GetLocalArch={{.Env.LOCAL_ARCH}}"

--- a/.goreleaser-build.yml
+++ b/.goreleaser-build.yml
@@ -6,4 +6,4 @@ builds:
     flags:
       - -tags={{.Env.TAGS}}
     ldflags:
-      - "-X local.GetLocalArch={{.Env.LOCAL_ARCH}}"
+      - "-X github.com/confluentinc/cli/internal/cmd/local.localArch={{.Env.LOCAL_ARCH}}"

--- a/.goreleaser-linux-amd64.yml
+++ b/.goreleaser-linux-amd64.yml
@@ -9,7 +9,7 @@ builds:
     flags:
       - -mod=vendor
     ldflags:
-      - -s -w -X main.version={{.Version}} -X main.commit={{.ShortCommit}} -X main.date={{.Date}} -X local.GetLocalArch=amd64
+      - -s -w -X main.version={{.Version}} -X main.commit={{.ShortCommit}} -X main.date={{.Date}} -X github.com/confluentinc/cli/internal/cmd/local.localArch=amd64
     gcflags:
       - all=-trimpath={{.Env.HOME}}/git
     asmflags:
@@ -24,7 +24,7 @@ builds:
     flags:
       - -mod=vendor
     ldflags:
-      - -s -w -X main.version={{.Version}} -X main.commit={{.ShortCommit}} -X main.date={{.Date}} -X main.disableUpdates=true -X local.GetLocalArch=amd64
+      - -s -w -X main.version={{.Version}} -X main.commit={{.ShortCommit}} -X main.date={{.Date}} -X main.disableUpdates=true -X github.com/confluentinc/cli/internal/cmd/local.localArch=amd64
     gcflags:
       - all=-trimpath={{.Env.HOME}}/git
     asmflags:

--- a/.goreleaser-linux-amd64.yml
+++ b/.goreleaser-linux-amd64.yml
@@ -9,7 +9,7 @@ builds:
     flags:
       - -mod=vendor
     ldflags:
-      - -s -w -X main.version={{.Version}} -X main.commit={{.ShortCommit}} -X main.date={{.Date}}
+      - -s -w -X main.version={{.Version}} -X main.commit={{.ShortCommit}} -X main.date={{.Date}} -X local.GetLocalArch=amd64
     gcflags:
       - all=-trimpath={{.Env.HOME}}/git
     asmflags:
@@ -24,7 +24,7 @@ builds:
     flags:
       - -mod=vendor
     ldflags:
-      - -s -w -X main.version={{.Version}} -X main.commit={{.ShortCommit}} -X main.date={{.Date}} -X main.disableUpdates=true
+      - -s -w -X main.version={{.Version}} -X main.commit={{.ShortCommit}} -X main.date={{.Date}} -X main.disableUpdates=true -X local.GetLocalArch=amd64
     gcflags:
       - all=-trimpath={{.Env.HOME}}/git
     asmflags:

--- a/.goreleaser-linux-arm64.yml
+++ b/.goreleaser-linux-arm64.yml
@@ -9,7 +9,7 @@ builds:
     flags:
       - -mod=vendor
     ldflags:
-      - -s -w -X main.version={{.Version}} -X main.commit={{.ShortCommit}} -X main.date={{.Date}} -X local.GetLocalArch=arm64
+      - -s -w -X main.version={{.Version}} -X main.commit={{.ShortCommit}} -X main.date={{.Date}} -X github.com/confluentinc/cli/internal/cmd/local.localArch=arm64
     gcflags:
       - all=-trimpath={{.Env.HOME}}/git
     asmflags:
@@ -24,7 +24,7 @@ builds:
     flags:
       - -mod=vendor
     ldflags:
-      - -s -w -X main.version={{.Version}} -X main.commit={{.ShortCommit}} -X main.date={{.Date}} -X main.disableUpdates=true -X local.GetLocalArch=arm64
+      - -s -w -X main.version={{.Version}} -X main.commit={{.ShortCommit}} -X main.date={{.Date}} -X main.disableUpdates=true -X github.com/confluentinc/cli/internal/cmd/local.localArch=arm64
     gcflags:
       - all=-trimpath={{.Env.HOME}}/git
     asmflags:

--- a/.goreleaser-linux-arm64.yml
+++ b/.goreleaser-linux-arm64.yml
@@ -9,7 +9,7 @@ builds:
     flags:
       - -mod=vendor
     ldflags:
-      - -s -w -X main.version={{.Version}} -X main.commit={{.ShortCommit}} -X main.date={{.Date}}
+      - -s -w -X main.version={{.Version}} -X main.commit={{.ShortCommit}} -X main.date={{.Date}} -X local.GetLocalArch=arm64
     gcflags:
       - all=-trimpath={{.Env.HOME}}/git
     asmflags:
@@ -24,7 +24,7 @@ builds:
     flags:
       - -mod=vendor
     ldflags:
-      - -s -w -X main.version={{.Version}} -X main.commit={{.ShortCommit}} -X main.date={{.Date}} -X main.disableUpdates=true
+      - -s -w -X main.version={{.Version}} -X main.commit={{.ShortCommit}} -X main.date={{.Date}} -X main.disableUpdates=true -X local.GetLocalArch=arm64
     gcflags:
       - all=-trimpath={{.Env.HOME}}/git
     asmflags:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -7,7 +7,7 @@ builds:
     flags:
       - -tags=musl
     ldflags:
-      - -s -w -X main.version={{.Version}} -X main.commit={{.ShortCommit}} -X main.date={{.Date}} -X local.GetLocalArch=amd64
+      - -s -w -X main.version={{.Version}} -X main.commit={{.ShortCommit}} -X main.date={{.Date}} -X github.com/confluentinc/cli/internal/cmd/local.localArch=amd64
     gcflags:
       - all=-trimpath={{.Env.HOME}}/git
     asmflags:
@@ -27,7 +27,7 @@ builds:
     flags:
       - -tags=musl
     ldflags:
-      - -s -w -X main.version={{.Version}} -X main.commit={{.ShortCommit}} -X main.date={{.Date}} -X local.GetLocalArch=arm64
+      - -s -w -X main.version={{.Version}} -X main.commit={{.ShortCommit}} -X main.date={{.Date}} -X github.com/confluentinc/cli/internal/cmd/local.localArch=arm64
     gcflags:
       - all=-trimpath={{.Env.HOME}}/git
     asmflags:
@@ -45,7 +45,7 @@ builds:
     binary: confluent
     main: cmd/confluent/main.go
     ldflags:
-      - -s -w -X main.version={{.Version}} -X main.commit={{.ShortCommit}} -X main.date={{.Date}} -X local.GetLocalArch=amd64
+      - -s -w -X main.version={{.Version}} -X main.commit={{.ShortCommit}} -X main.date={{.Date}} -X github.com/confluentinc/cli/internal/cmd/local.localArch=amd64
     gcflags:
       - all=-trimpath={{.Env.HOME}}/git
     asmflags:
@@ -66,7 +66,7 @@ builds:
     flags:
       - -mod=readonly
     ldflags:
-      - -s -w -X main.version={{.Version}} -X main.commit={{.ShortCommit}} -X main.date={{.Date}} -X main.disableUpdates=true -X local.GetLocalArch=amd64
+      - -s -w -X main.version={{.Version}} -X main.commit={{.ShortCommit}} -X main.date={{.Date}} -X main.disableUpdates=true -X github.com/confluentinc/cli/internal/cmd/local.localArch=amd64
     gcflags:
       - all=-trimpath={{.Env.HOME}}/git
     asmflags:
@@ -86,7 +86,7 @@ builds:
     env:
       - CGO_ENABLED=1
     ldflags:
-      - -s -w -X main.version={{.Version}} -X main.commit={{.ShortCommit}} -X main.date={{.Date}} -X local.GetLocalArch=arm64
+      - -s -w -X main.version={{.Version}} -X main.commit={{.ShortCommit}} -X main.date={{.Date}} -X github.com/confluentinc/cli/internal/cmd/local.localArch=arm64
     gcflags:
       - all=-trimpath={{.Env.HOME}}/git
     asmflags:
@@ -108,7 +108,7 @@ builds:
     env:
       - CGO_ENABLED=1
     ldflags:
-      - -s -w -X main.version={{.Version}} -X main.commit={{.ShortCommit}} -X main.date={{.Date}} -X main.disableUpdates=true -X local.GetLocalArch=arm64
+      - -s -w -X main.version={{.Version}} -X main.commit={{.ShortCommit}} -X main.date={{.Date}} -X main.disableUpdates=true -X github.com/confluentinc/cli/internal/cmd/local.localArch=arm64
     gcflags:
       - all=-trimpath={{.Env.HOME}}/git
     asmflags:
@@ -148,7 +148,7 @@ builds:
     binary: confluent
     main: cmd/confluent/main.go
     ldflags:
-      - -s -w -X main.version={{.Version}} -X main.commit={{.ShortCommit}} -X main.date={{.Date}} -buildmode=exe -X local.GetLocalArch=amd64 
+      - -s -w -X main.version={{.Version}} -X main.commit={{.ShortCommit}} -X main.date={{.Date}} -buildmode=exe -X github.com/confluentinc/cli/internal/cmd/local.localArch=amd64 
     gcflags:
       - all=-trimpath={{.Env.HOME}}/git
     asmflags:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -7,7 +7,7 @@ builds:
     flags:
       - -tags=musl
     ldflags:
-      - -s -w -X main.version={{.Version}} -X main.commit={{.ShortCommit}} -X main.date={{.Date}}
+      - -s -w -X main.version={{.Version}} -X main.commit={{.ShortCommit}} -X main.date={{.Date}} -X local.GetLocalArch=amd64
     gcflags:
       - all=-trimpath={{.Env.HOME}}/git
     asmflags:
@@ -27,7 +27,7 @@ builds:
     flags:
       - -tags=musl
     ldflags:
-      - -s -w -X main.version={{.Version}} -X main.commit={{.ShortCommit}} -X main.date={{.Date}}
+      - -s -w -X main.version={{.Version}} -X main.commit={{.ShortCommit}} -X main.date={{.Date}} -X local.GetLocalArch=arm64
     gcflags:
       - all=-trimpath={{.Env.HOME}}/git
     asmflags:
@@ -45,7 +45,7 @@ builds:
     binary: confluent
     main: cmd/confluent/main.go
     ldflags:
-      - -s -w -X main.version={{.Version}} -X main.commit={{.ShortCommit}} -X main.date={{.Date}}
+      - -s -w -X main.version={{.Version}} -X main.commit={{.ShortCommit}} -X main.date={{.Date}} -X local.GetLocalArch=amd64
     gcflags:
       - all=-trimpath={{.Env.HOME}}/git
     asmflags:
@@ -66,7 +66,7 @@ builds:
     flags:
       - -mod=readonly
     ldflags:
-      - -s -w -X main.version={{.Version}} -X main.commit={{.ShortCommit}} -X main.date={{.Date}} -X main.disableUpdates=true
+      - -s -w -X main.version={{.Version}} -X main.commit={{.ShortCommit}} -X main.date={{.Date}} -X main.disableUpdates=true -X local.GetLocalArch=amd64
     gcflags:
       - all=-trimpath={{.Env.HOME}}/git
     asmflags:
@@ -86,7 +86,7 @@ builds:
     env:
       - CGO_ENABLED=1
     ldflags:
-      - -s -w -X main.version={{.Version}} -X main.commit={{.ShortCommit}} -X main.date={{.Date}}
+      - -s -w -X main.version={{.Version}} -X main.commit={{.ShortCommit}} -X main.date={{.Date}} -X local.GetLocalArch=arm64
     gcflags:
       - all=-trimpath={{.Env.HOME}}/git
     asmflags:
@@ -108,7 +108,7 @@ builds:
     env:
       - CGO_ENABLED=1
     ldflags:
-      - -s -w -X main.version={{.Version}} -X main.commit={{.ShortCommit}} -X main.date={{.Date}} -X main.disableUpdates=true
+      - -s -w -X main.version={{.Version}} -X main.commit={{.ShortCommit}} -X main.date={{.Date}} -X main.disableUpdates=true -X local.GetLocalArch=arm64
     gcflags:
       - all=-trimpath={{.Env.HOME}}/git
     asmflags:
@@ -148,7 +148,7 @@ builds:
     binary: confluent
     main: cmd/confluent/main.go
     ldflags:
-      - -s -w -X main.version={{.Version}} -X main.commit={{.ShortCommit}} -X main.date={{.Date}} -buildmode=exe  
+      - -s -w -X main.version={{.Version}} -X main.commit={{.ShortCommit}} -X main.date={{.Date}} -buildmode=exe -X local.GetLocalArch=amd64 
     gcflags:
       - all=-trimpath={{.Env.HOME}}/git
     asmflags:

--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,10 @@ endif
 cross-build:
 ifeq ($(GOARCH),arm64)
     ifeq ($(GOOS),linux) # linux/arm64
+		export LOCAL_ARCH=arm64 && \
 		CGO_ENABLED=1 CC=aarch64-linux-musl-gcc CXX=aarch64-linux-musl-g++ CGO_LDFLAGS="-static" TAGS=musl $(MAKE) cli-builder
     else # darwin/arm64
+		export LOCAL_ARCH=arm64 && \
 		CGO_ENABLED=1 $(MAKE) cli-builder
     endif
 else

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,13 @@
 SHELL := /bin/bash
 GORELEASER_VERSION := v1.17.2
 
+.PHONY: set-local-arch
+set-local-arch:
+export LOCAL_ARCH=$(shell go env GOARCH)
+
 # Compile natively based on the current system
 .PHONY: build 
-build:
+build: set-local-arch
 ifneq "" "$(findstring NT,$(shell uname))" # windows
 	CC=gcc CXX=g++ $(MAKE) cli-builder
 else ifneq (,$(findstring Linux,$(shell uname)))
@@ -20,14 +24,14 @@ endif
 .PHONY: cross-build
 cross-build:
 ifeq ($(GOARCH),arm64)
+	export LOCAL_ARCH=arm64
     ifeq ($(GOOS),linux) # linux/arm64
-		export LOCAL_ARCH=arm64 && \
 		CGO_ENABLED=1 CC=aarch64-linux-musl-gcc CXX=aarch64-linux-musl-g++ CGO_LDFLAGS="-static" TAGS=musl $(MAKE) cli-builder
     else # darwin/arm64
-		export LOCAL_ARCH=arm64 && \
 		CGO_ENABLED=1 $(MAKE) cli-builder
     endif
 else
+	export LOCAL_ARCH=amd64
     ifeq ($(GOOS),windows) # windows/amd64
 		CGO_ENABLED=1 CC=x86_64-w64-mingw32-gcc CXX=x86_64-w64-mingw32-g++ CGO_LDFLAGS="-static" $(MAKE) cli-builder
     else ifeq ($(GOOS),linux) # linux/amd64

--- a/debian/patches/standard_build_layout.patch
+++ b/debian/patches/standard_build_layout.patch
@@ -1,13 +1,17 @@
---- cli/Makefile	2023-06-12 10:41:30.495232513 -0700
-+++ debian/Makefile	2023-05-12 09:01:07.702951301 -0700
-@@ -1,120 +1,130 @@
+--- cli/Makefile	2023-06-28 12:33:17.000000000 -0700
++++ debian/Makefile	2023-05-18 13:22:09.000000000 -0700
+@@ -1,126 +1,130 @@
 -SHELL := /bin/bash
 -GORELEASER_VERSION := v1.17.2
 +SHELL=/bin/bash
  
+-.PHONY: set-local-arch
+-set-local-arch:
+-export LOCAL_ARCH=$(shell go env GOARCH)
+-
 -# Compile natively based on the current system
 -.PHONY: build 
--build:
+-build: set-local-arch
 -ifneq "" "$(findstring NT,$(shell uname))" # windows
 -	CC=gcc CXX=g++ $(MAKE) cli-builder
 -else ifneq (,$(findstring Linux,$(shell uname)))
@@ -24,6 +28,7 @@
 -.PHONY: cross-build
 -cross-build:
 -ifeq ($(GOARCH),arm64)
+-	export LOCAL_ARCH=arm64
 -    ifeq ($(GOOS),linux) # linux/arm64
 -		CGO_ENABLED=1 CC=aarch64-linux-musl-gcc CXX=aarch64-linux-musl-g++ CGO_LDFLAGS="-static" TAGS=musl $(MAKE) cli-builder
 -    else # darwin/arm64
@@ -52,6 +57,7 @@
 +PREFIX=$(PACKAGE_NAME)
 +SYSCONFDIR=$(PREFIX)/etc/$(PACKAGE_TITLE)
  else
+-	export LOCAL_ARCH=amd64
 -    ifeq ($(GOOS),windows) # windows/amd64
 -		CGO_ENABLED=1 CC=x86_64-w64-mingw32-gcc CXX=x86_64-w64-mingw32-g++ CGO_LDFLAGS="-static" $(MAKE) cli-builder
 -    else ifeq ($(GOOS),linux) # linux/amd64

--- a/internal/cmd/local/command_kafka_start.go
+++ b/internal/cmd/local/command_kafka_start.go
@@ -25,7 +25,7 @@ import (
 
 var (
 	statusBlacklist = []string{"Pulling fs layer", "Waiting", "Downloading", "Download complete", "Verifying Checksum", "Extracting", "Pull complete"}
-	localArch       = "unknown"
+	localArch       = "amd64"
 )
 
 type imagePullOut struct {
@@ -82,7 +82,7 @@ func (c *command) kafkaStart(cmd *cobra.Command, args []string) error {
 
 	log.CliLogger.Tracef("Pull confluent-local image success")
 
-	platform := &specsv1.Platform{OS: "linux", Architecture: getLocalArch()}
+	platform := &specsv1.Platform{OS: "linux", Architecture: localArch}
 
 	if err := c.prepareAndSaveLocalPorts(c.Config.IsTest); err != nil {
 		return err
@@ -188,8 +188,4 @@ func getContainerEnvironmentWithPorts(ports *v1.LocalPorts) []string {
 		fmt.Sprintf("KAFKA_REST_BOOTSTRAP_SERVERS=broker:%s", ports.BrokerPort),
 		fmt.Sprintf("KAFKA_REST_LISTENERS=http://0.0.0.0:%s", ports.KafkaRestPort),
 	}
-}
-
-func getLocalArch() string {
-	return localArch
 }


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- PLACEHOLDER

New Features
- PLACEHOLDER

Bug Fixes
- Users will be able to use `confluent local` on arm64 machines

Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->
Used to use `goarch` to specify the arch of confluent local container when building, but even when building for arm64, it's still using amd64 which is the arch of the machine i'm using. Change it to use a env var when running make build, and specify a flag for release process,

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->
https://confluent.slack.com/archives/C044D4HRQKB/p1687967588547289

Test & Review
-------------
<!--
Has it been tested? How?
Copy and paste any instructions or steps that can save the reviewer time.
-->

Open Questions / Follow-ups
---------------------------
<!--
Optional: Anything open to discussion for the reviewer, out of scope of this PR, or follow-ups.
-->
