### PR TITLE
Autocomplete `api-key create --resource`

### DIFF
--- a/internal/cmd/api-key/command.go
+++ b/internal/cmd/api-key/command.go
@@ -74,7 +74,12 @@ func (c *command) addResourceFlag(cmd *cobra.Command) {
 			return nil
 		}
 
-		suggestions := make([]string, 1+len(kafkaClusters)+len(schemaRegistryClusters))
+		ksqlClusters, err := c.V2Client.ListKsqlClusters(environmentId)
+		if err != nil {
+			return nil
+		}
+
+		suggestions := make([]string, 1+len(kafkaClusters)+len(schemaRegistryClusters)+len(ksqlClusters))
 		i := 0
 
 		suggestions[i] = "cloud"
@@ -86,6 +91,11 @@ func (c *command) addResourceFlag(cmd *cobra.Command) {
 		}
 
 		for _, cluster := range schemaRegistryClusters {
+			suggestions[i] = fmt.Sprintf("%s\t%s", cluster.GetId(), cluster.Spec.GetDisplayName())
+			i++
+		}
+
+		for _, cluster := range ksqlClusters {
 			suggestions[i] = fmt.Sprintf("%s\t%s", cluster.GetId(), cluster.Spec.GetDisplayName())
 			i++
 		}

--- a/internal/cmd/api-key/command.go
+++ b/internal/cmd/api-key/command.go
@@ -21,8 +21,6 @@ type command struct {
 	flagResolver pcmd.FlagResolver
 }
 
-const resourceFlagName = "resource"
-
 const (
 	deleteOperation = "deleting"
 	getOperation    = "getting"
@@ -51,6 +49,49 @@ func New(prerunner pcmd.PreRunner, keystore keystore.KeyStore, resolver pcmd.Fla
 	cmd.AddCommand(c.newUseCommand())
 
 	return cmd
+}
+
+func (c *command) addResourceFlag(cmd *cobra.Command) {
+	cmd.Flags().String("resource", "", `The ID of the resource the API key is for. Use "cloud" for a Cloud API key.`)
+
+	pcmd.RegisterFlagCompletionFunc(cmd, "resource", func(cmd *cobra.Command, args []string) []string {
+		if err := c.PersistentPreRunE(cmd, args); err != nil {
+			return nil
+		}
+
+		environmentId, err := c.Context.EnvironmentId()
+		if err != nil {
+			return nil
+		}
+
+		kafkaClusters, err := c.V2Client.ListKafkaClusters(environmentId)
+		if err != nil {
+			return nil
+		}
+
+		schemaRegistryClusters, err := c.V2Client.GetSchemaRegistryClustersByEnvironment(environmentId)
+		if err != nil {
+			return nil
+		}
+
+		suggestions := make([]string, 1+len(kafkaClusters)+len(schemaRegistryClusters))
+		i := 0
+
+		suggestions[i] = "cloud"
+		i++
+
+		for _, cluster := range kafkaClusters {
+			suggestions[i] = fmt.Sprintf("%s\t%s", cluster.GetId(), cluster.Spec.GetDisplayName())
+			i++
+		}
+
+		for _, cluster := range schemaRegistryClusters {
+			suggestions[i] = fmt.Sprintf("%s\t%s", cluster.GetId(), cluster.Spec.GetDisplayName())
+			i++
+		}
+
+		return suggestions
+	})
 }
 
 func (c *command) setKeyStoreIfNil() {

--- a/internal/cmd/api-key/command_create.go
+++ b/internal/cmd/api-key/command_create.go
@@ -41,13 +41,21 @@ func (c *command) newCreateCommand() *cobra.Command {
 				Code: "confluent api-key create --resource lkc-123456",
 			},
 			examples.Example{
-				Text: `Create an API key for cluster "lkc-123456" and service account "sa-123456":`,
+				Text: `Create an API key for Kafka cluster "lkc-123456" and service account "sa-123456":`,
 				Code: "confluent api-key create --resource lkc-123456 --service-account sa-123456",
+			},
+			examples.Example{
+				Text: `Create an API key for Schema Registry cluster "lsrc-123456":`,
+				Code: "confluent api-key create --resource lsrc-123456",
+			},
+			examples.Example{
+				Text: "Create a Cloud API key:",
+				Code: "confluent api-key create --resource cloud",
 			},
 		),
 	}
 
-	cmd.Flags().String(resourceFlagName, "", `The resource ID. Use "cloud" to create a Cloud API key.`)
+	c.addResourceFlag(cmd)
 	cmd.Flags().String("description", "", "Description of API key.")
 	cmd.Flags().Bool("use", false, "Use the created API key for the provided resource.")
 	pcmd.AddContextFlag(cmd, c.CLICommand)
@@ -55,14 +63,15 @@ func (c *command) newCreateCommand() *cobra.Command {
 	pcmd.AddServiceAccountFlag(cmd, c.AuthenticatedCLICommand)
 	pcmd.AddOutputFlag(cmd)
 
-	cobra.CheckErr(cmd.MarkFlagRequired(resourceFlagName))
+	cobra.CheckErr(cmd.MarkFlagRequired("resource"))
 
 	return cmd
 }
 
 func (c *command) create(cmd *cobra.Command, _ []string) error {
 	c.setKeyStoreIfNil()
-	resourceType, clusterId, _, err := c.resolveResourceId(cmd, c.V2Client)
+
+	description, err := cmd.Flags().GetString("description")
 	if err != nil {
 		return err
 	}
@@ -72,28 +81,28 @@ func (c *command) create(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	description, err := cmd.Flags().GetString("description")
+	owner := serviceAccount
+	if owner == "" {
+		userId, err := c.getCurrentUserId()
+		if err != nil {
+			return err
+		}
+		owner = userId
+	}
+
+	resourceType, clusterId, _, err := c.resolveResourceId(cmd, c.V2Client)
 	if err != nil {
 		return err
 	}
 
-	if serviceAccount == "" {
-		serviceAccount, err = c.getCurrentUserId()
-		if err != nil {
-			return err
-		}
-	}
-
-	key := apikeysv2.IamV2ApiKey{
-		Spec: &apikeysv2.IamV2ApiKeySpec{
-			Description: apikeysv2.PtrString(description),
-			Owner:       &apikeysv2.ObjectReference{Id: serviceAccount},
-			Resource: &apikeysv2.ObjectReference{
-				Id:   clusterId,
-				Kind: apikeysv2.PtrString(resourceTypeToKind[resourceType]),
-			},
+	key := apikeysv2.IamV2ApiKey{Spec: &apikeysv2.IamV2ApiKeySpec{
+		Description: apikeysv2.PtrString(description),
+		Owner:       &apikeysv2.ObjectReference{Id: owner},
+		Resource: &apikeysv2.ObjectReference{
+			Id:   clusterId,
+			Kind: apikeysv2.PtrString(resourceTypeToKind[resourceType]),
 		},
-	}
+	}}
 	if resourceType == resource.Cloud {
 		key.Spec.Resource.Id = "cloud"
 	}

--- a/internal/cmd/api-key/command_create.go
+++ b/internal/cmd/api-key/command_create.go
@@ -49,6 +49,10 @@ func (c *command) newCreateCommand() *cobra.Command {
 				Code: "confluent api-key create --resource lsrc-123456",
 			},
 			examples.Example{
+				Text: `Create an API key for KSQL cluster "lksqlc-123456":`,
+				Code: "confluent api-key create --resource lksqlc-123456",
+			},
+			examples.Example{
 				Text: "Create a Cloud API key:",
 				Code: "confluent api-key create --resource cloud",
 			},

--- a/internal/cmd/api-key/command_list.go
+++ b/internal/cmd/api-key/command_list.go
@@ -40,7 +40,7 @@ func (c *command) newListCommand() *cobra.Command {
 		),
 	}
 
-	cmd.Flags().String(resourceFlagName, "", `The resource ID to filter by. Use "cloud" to show only Cloud API keys.`)
+	c.addResourceFlag(cmd)
 	cmd.Flags().Bool("current-user", false, "Show only API keys belonging to current user.")
 	pcmd.AddEnvironmentFlag(cmd, c.AuthenticatedCLICommand)
 	pcmd.AddServiceAccountFlag(cmd, c.AuthenticatedCLICommand)

--- a/internal/cmd/api-key/command_store.go
+++ b/internal/cmd/api-key/command_store.go
@@ -47,7 +47,7 @@ func (c *command) newStoreCommand() *cobra.Command {
 		),
 	}
 
-	cmd.Flags().String(resourceFlagName, "", "The resource ID of the resource the API key is for.")
+	c.addResourceFlag(cmd)
 	cmd.Flags().BoolP("force", "f", false, "Force overwrite existing secret for this key.")
 	pcmd.AddContextFlag(cmd, c.CLICommand)
 	pcmd.AddEnvironmentFlag(cmd, c.AuthenticatedCLICommand)

--- a/internal/cmd/api-key/command_use.go
+++ b/internal/cmd/api-key/command_use.go
@@ -21,9 +21,9 @@ func (c *command) newUseCommand() *cobra.Command {
 		RunE:              c.use,
 	}
 
-	cmd.Flags().String(resourceFlagName, "", "The resource ID.")
+	c.addResourceFlag(cmd)
 
-	cobra.CheckErr(cmd.MarkFlagRequired(resourceFlagName))
+	cobra.CheckErr(cmd.MarkFlagRequired("resource"))
 
 	return cmd
 }

--- a/test/api_key_test.go
+++ b/test/api_key_test.go
@@ -179,10 +179,10 @@ func (s *CLITestSuite) TestApiKey_EnvironmentNotValid() {
 	s.runIntegrationTest(tt)
 }
 
-func (s *CLITestSuite) TestApiKeyAutocomplete() {
+func (s *CLITestSuite) TestApiKey_Autocomplete() {
 	tests := []CLITest{
-		{args: `__complete api-key describe ""`, fixture: "api-key/describe-autocomplete.golden"},
 		{args: `__complete api-key create --resource ""`, fixture: "api-key/create-resource-autocomplete.golden"},
+		{args: `__complete api-key describe ""`, fixture: "api-key/describe-autocomplete.golden"},
 	}
 
 	for _, test := range tests {

--- a/test/api_key_test.go
+++ b/test/api_key_test.go
@@ -180,6 +180,13 @@ func (s *CLITestSuite) TestApiKey_EnvironmentNotValid() {
 }
 
 func (s *CLITestSuite) TestApiKeyAutocomplete() {
-	test := CLITest{args: `__complete api-key describe ""`, login: "cloud", fixture: "api-key/describe-autocomplete.golden"}
-	s.runIntegrationTest(test)
+	tests := []CLITest{
+		{args: `__complete api-key describe ""`, fixture: "api-key/describe-autocomplete.golden"},
+		{args: `__complete api-key create --resource ""`, fixture: "api-key/create-resource-autocomplete.golden"},
+	}
+
+	for _, test := range tests {
+		test.login = "cloud"
+		s.runIntegrationTest(test)
+	}
 }

--- a/test/fixtures/output/api-key/53.golden
+++ b/test/fixtures/output/api-key/53.golden
@@ -3,7 +3,7 @@ Usage:
   confluent api-key use <api-key> [flags]
 
 Flags:
-      --resource string   REQUIRED: The resource ID.
+      --resource string   REQUIRED: The ID of the resource the API key is for. Use "cloud" for a Cloud API key.
 
 Global Flags:
   -h, --help            Show help for this command.

--- a/test/fixtures/output/api-key/54.golden
+++ b/test/fixtures/output/api-key/54.golden
@@ -7,12 +7,24 @@ Create an API key with full access to cluster "lkc-123456":
 
   $ confluent api-key create --resource lkc-123456
 
-Create an API key for cluster "lkc-123456" and service account "sa-123456":
+Create an API key for Kafka cluster "lkc-123456" and service account "sa-123456":
 
   $ confluent api-key create --resource lkc-123456 --service-account sa-123456
 
+Create an API key for Schema Registry cluster "lsrc-123456":
+
+  $ confluent api-key create --resource lsrc-123456
+
+Create an API key for KSQL cluster "lksqlc-123456":
+
+  $ confluent api-key create --resource lksqlc-123456
+
+Create a Cloud API key:
+
+  $ confluent api-key create --resource cloud
+
 Flags:
-      --resource string          REQUIRED: The resource ID. Use "cloud" to create a Cloud API key.
+      --resource string          REQUIRED: The ID of the resource the API key is for. Use "cloud" for a Cloud API key.
       --description string       Description of API key.
       --use                      Use the created API key for the provided resource.
       --context string           CLI context name.

--- a/test/fixtures/output/api-key/create-help.golden
+++ b/test/fixtures/output/api-key/create-help.golden
@@ -8,12 +8,24 @@ Create an API key with full access to cluster "lkc-123456":
 
   $ confluent api-key create --resource lkc-123456
 
-Create an API key for cluster "lkc-123456" and service account "sa-123456":
+Create an API key for Kafka cluster "lkc-123456" and service account "sa-123456":
 
   $ confluent api-key create --resource lkc-123456 --service-account sa-123456
 
+Create an API key for Schema Registry cluster "lsrc-123456":
+
+  $ confluent api-key create --resource lsrc-123456
+
+Create an API key for KSQL cluster "lksqlc-123456":
+
+  $ confluent api-key create --resource lksqlc-123456
+
+Create a Cloud API key:
+
+  $ confluent api-key create --resource cloud
+
 Flags:
-      --resource string          REQUIRED: The resource ID. Use "cloud" to create a Cloud API key.
+      --resource string          REQUIRED: The ID of the resource the API key is for. Use "cloud" for a Cloud API key.
       --description string       Description of API key.
       --use                      Use the created API key for the provided resource.
       --context string           CLI context name.

--- a/test/fixtures/output/api-key/create-resource-autocomplete.golden
+++ b/test/fixtures/output/api-key/create-resource-autocomplete.golden
@@ -1,0 +1,8 @@
+cloud
+lkc-123	abc
+lkc-456	def
+lsrc-1234	account schema-registry
+lksqlc-ksql5	account ksql
+lksqlc-woooo	kay cee queue elle
+:4
+Completion ended with directive: ShellCompDirectiveNoFileComp

--- a/test/fixtures/output/api-key/describe-autocomplete.golden
+++ b/test/fixtures/output/api-key/describe-autocomplete.golden
@@ -2,8 +2,21 @@ DEACTIVATEDUSERKEY
 MULTICLUSTERKEY1	works for two clusters
 MULTICLUSTERKEY2	works for two clusters but on a different sr cluster
 MULTICLUSTERKEY3	works for two clusters and owned by service account
-MYKEY1	Example description
+MYKEY1	first-key
+MYKEY10
+MYKEY11	auditlog-key
+MYKEY12	auditlog-key
+MYKEY13	human-output
+MYKEY14	json-output
+MYKEY15	yaml-output
+MYKEY16	my-cool-app
 MYKEY2
+MYKEY3
+MYKEY4	my-cool-app
+MYKEY6	my-ksql-app
+MYKEY7
+MYKEY8
+MYKEY9
 SERVICEACCOUNTKEY1
 UIAPIKEY100
 UIAPIKEY101

--- a/test/fixtures/output/api-key/describe-autocomplete.golden
+++ b/test/fixtures/output/api-key/describe-autocomplete.golden
@@ -2,21 +2,8 @@ DEACTIVATEDUSERKEY
 MULTICLUSTERKEY1	works for two clusters
 MULTICLUSTERKEY2	works for two clusters but on a different sr cluster
 MULTICLUSTERKEY3	works for two clusters and owned by service account
-MYKEY1	first-key
-MYKEY10
-MYKEY11	auditlog-key
-MYKEY12	auditlog-key
-MYKEY13	human-output
-MYKEY14	json-output
-MYKEY15	yaml-output
-MYKEY16	my-cool-app
+MYKEY1	Example description
 MYKEY2
-MYKEY3
-MYKEY4	my-cool-app
-MYKEY6	my-ksql-app
-MYKEY7
-MYKEY8
-MYKEY9
 SERVICEACCOUNTKEY1
 UIAPIKEY100
 UIAPIKEY101

--- a/test/fixtures/output/api-key/list-help.golden
+++ b/test/fixtures/output/api-key/list-help.golden
@@ -9,7 +9,7 @@ List the API keys that belong to service account "sa-123456" on cluster "lkc-123
   $ confluent api-key list --resource lkc-123456 --service-account sa-123456
 
 Flags:
-      --resource string          The resource ID to filter by. Use "cloud" to show only Cloud API keys.
+      --resource string          The ID of the resource the API key is for. Use "cloud" for a Cloud API key.
       --current-user             Show only API keys belonging to current user.
       --environment string       Environment ID.
       --service-account string   Service account ID.

--- a/test/fixtures/output/api-key/store-help.golden
+++ b/test/fixtures/output/api-key/store-help.golden
@@ -26,7 +26,7 @@ Get prompted for both the API key and secret
   $ confluent api-key store
 
 Flags:
-      --resource string      The resource ID of the resource the API key is for.
+      --resource string      The ID of the resource the API key is for. Use "cloud" for a Cloud API key.
   -f, --force                Force overwrite existing secret for this key.
       --context string       CLI context name.
       --environment string   Environment ID.

--- a/test/fixtures/output/api-key/use-help.golden
+++ b/test/fixtures/output/api-key/use-help.golden
@@ -4,7 +4,7 @@ Usage:
   confluent api-key use <api-key> [flags]
 
 Flags:
-      --resource string   REQUIRED: The resource ID.
+      --resource string   REQUIRED: The ID of the resource the API key is for. Use "cloud" for a Cloud API key.
 
 Global Flags:
   -h, --help            Show help for this command.


### PR DESCRIPTION
Release Notes
-------------
New Features
- Autocompletion for `confluent api-key create --resource`

Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
Autocomplete the `--resource` flag with "cloud", the list of Kafka cluster IDs, KSQL cluster IDs, and the Schema Registry cluster ID (if it exists). Improve examples to include "cloud" and Schema Registry API keys.

```
% confluent api-key create --resource
lkc-8mm8z0     -- my-kafka-cluster
lksqlc-wzzvnm  -- my-ksql-cluster
lsrc-6oomr2    -- Stream Governance Package
cloud
```

Test & Review
-------------
Integration test