### PR TITLE
FLINKCC-100: Create compute pool with wrong-env should fail with descriptive error

### DIFF
--- a/internal/cmd/organization/command_describe.go
+++ b/internal/cmd/organization/command_describe.go
@@ -31,7 +31,7 @@ func (c *command) newDescribeCommand() *cobra.Command {
 func (c *command) describe(cmd *cobra.Command, args []string) error {
 	organization, httpResp, err := c.V2Client.GetOrgOrganization(c.Context.GetCurrentOrganization())
 	if err != nil {
-		return errors.CatchOrgV2ResourceNotFoundError(err, resource.Organization, httpResp)
+		return errors.CatchCCloudV2ResourceNotFoundError(err, resource.Organization, httpResp)
 	}
 
 	table := output.NewTable(cmd)

--- a/internal/cmd/organization/command_update.go
+++ b/internal/cmd/organization/command_update.go
@@ -36,7 +36,7 @@ func (c *command) update(cmd *cobra.Command, args []string) error {
 	organization := orgv2.OrgV2Organization{DisplayName: orgv2.PtrString(name)}
 	organization, httpResp, err := c.V2Client.UpdateOrgOrganization(c.Context.GetCurrentOrganization(), organization)
 	if err != nil {
-		return errors.CatchOrgV2ResourceNotFoundError(err, resource.Organization, httpResp)
+		return errors.CatchCCloudV2ResourceNotFoundError(err, resource.Organization, httpResp)
 	}
 
 	table := output.NewTable(cmd)

--- a/internal/pkg/ccloudv2/flink.go
+++ b/internal/pkg/ccloudv2/flink.go
@@ -29,12 +29,12 @@ func (c *Client) CreateFlinkComputePool(computePool flinkv2.FcpmV2ComputePool) (
 
 func (c *Client) DeleteFlinkComputePool(id, environment string) error {
 	httpResp, err := c.FlinkClient.ComputePoolsFcpmV2Api.DeleteFcpmV2ComputePool(c.flinkApiContext(), id).Environment(environment).Execute()
-	return errors.CatchCCloudV2Error(err, httpResp)
+	return errors.CatchCCloudV2ResourceNotFoundError(err, environment, httpResp)
 }
 
 func (c *Client) DescribeFlinkComputePool(id, environment string) (flinkv2.FcpmV2ComputePool, error) {
 	res, httpResp, err := c.FlinkClient.ComputePoolsFcpmV2Api.GetFcpmV2ComputePool(c.flinkApiContext(), id).Environment(environment).Execute()
-	return res, errors.CatchCCloudV2Error(err, httpResp)
+	return res, errors.CatchCCloudV2ResourceNotFoundError(err, environment, httpResp)
 }
 
 func (c *Client) ListFlinkComputePools(environment, specRegion string) ([]flinkv2.FcpmV2ComputePool, error) {
@@ -43,7 +43,7 @@ func (c *Client) ListFlinkComputePools(environment, specRegion string) ([]flinkv
 		req = req.SpecRegion(specRegion)
 	}
 	res, httpResp, err := req.Execute()
-	return res.GetData(), errors.CatchCCloudV2Error(err, httpResp)
+	return res.GetData(), errors.CatchCCloudV2ResourceNotFoundError(err, environment, httpResp)
 }
 
 func (c *Client) ListFlinkRegions(cloud string) ([]flinkv2.FcpmV2Region, error) {
@@ -68,12 +68,12 @@ func (c *Client) CreateFlinkIAMBinding(region, cloud, environmentId, identityPoo
 		IdentityPool: flinkv2.NewGlobalObjectReference(identityPoolId, "", ""),
 	}
 	res, httpResp, err := c.FlinkClient.IamBindingsFcpmV2Api.CreateFcpmV2IamBinding(c.flinkApiContext()).FcpmV2IamBinding(iamBinding).Execute()
-	return res, errors.CatchCCloudV2Error(err, httpResp)
+	return res, errors.CatchCCloudV2ResourceNotFoundError(err, environmentId, httpResp)
 }
 
 func (c *Client) DeleteFlinkIAMBinding(id, environmentId string) error {
 	httpResp, err := c.FlinkClient.IamBindingsFcpmV2Api.DeleteFcpmV2IamBinding(c.flinkApiContext(), id).Environment(environmentId).Execute()
-	return errors.CatchCCloudV2Error(err, httpResp)
+	return errors.CatchCCloudV2ResourceNotFoundError(err, environmentId, httpResp)
 }
 
 func (c *Client) ListFlinkIAMBindings(environmentId, region, cloud, identityPoolId string) ([]flinkv2.FcpmV2IamBinding, error) {
@@ -88,5 +88,5 @@ func (c *Client) ListFlinkIAMBindings(environmentId, region, cloud, identityPool
 		req = req.IdentityPool(identityPoolId)
 	}
 	res, httpResp, err := req.Execute()
-	return res.GetData(), errors.CatchCCloudV2Error(err, httpResp)
+	return res.GetData(), errors.CatchCCloudV2ResourceNotFoundError(err, environmentId, httpResp)
 }

--- a/internal/pkg/ccloudv2/org.go
+++ b/internal/pkg/ccloudv2/org.go
@@ -30,7 +30,7 @@ func (c *Client) CreateOrgEnvironment(environment orgv2.OrgV2Environment) (orgv2
 
 func (c *Client) GetOrgEnvironment(envId string) (orgv2.OrgV2Environment, error) {
 	res, httpResp, err := c.OrgClient.EnvironmentsOrgV2Api.GetOrgV2Environment(c.orgApiContext(), envId).Execute()
-	return res, errors.CatchCCloudV2Error(err, httpResp)
+	return res, errors.CatchCCloudV2ResourceNotFoundError(err, envId, httpResp)
 }
 
 func (c *Client) UpdateOrgEnvironment(envId string, updateEnvironment orgv2.OrgV2Environment) (orgv2.OrgV2Environment, error) {

--- a/internal/pkg/errors/catcher.go
+++ b/internal/pkg/errors/catcher.go
@@ -195,7 +195,7 @@ func CatchResourceNotFoundError(err error, resourceId string) error {
 	return err
 }
 
-func CatchOrgV2ResourceNotFoundError(err error, resourceType string, r *http.Response) error {
+func CatchCCloudV2ResourceNotFoundError(err error, resourceType string, r *http.Response) error {
 	if err == nil {
 		return nil
 	}


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
Make sure all Flink related commands that get --environment as an argument (create, delete, describe and list compute pool) fail with a descriptive message, for example:

```
Tested on STAG: env-mzoyn2  does not exist

mbpro16 :: confluentinc/cli » ./dist/confluent_darwin_amd64_v1/confluent  flink compute-pool list --environment env-mzoyn2                                                    
Error: env-mzoyn2 not found or access forbidden: Forbidden Access: 403 Forbidden

Suggestions:
    List available env-mzoyn2s with `confluent env-mzoyn2 list`.
```
