### PR TITLE
fix: reset iterator and selected row idx correctly

### DIFF
--- a/internal/pkg/flink/internal/controller/table_controller.go
+++ b/internal/pkg/flink/internal/controller/table_controller.go
@@ -187,7 +187,7 @@ func (t *TableController) openRowView() {
 
 		headers := t.fetchController.GetHeaders()
 		sb := strings.Builder{}
-		for rowIdx, field := range row.Fields {
+		for rowIdx, field := range row.GetFields() {
 			sb.WriteString(fmt.Sprintf("[yellow]%s:\n[white]%s\n\n", tview.Escape(headers[rowIdx]), tview.Escape(field.ToString())))
 		}
 		textView := tview.NewTextView().SetText(sb.String())
@@ -291,10 +291,8 @@ func (t *TableController) resizeTable(columnWidths []int) func(screen tcell.Scre
 }
 
 func (t *TableController) selectLastRow() {
-	if !t.fetchController.IsAutoRefreshRunning() {
-		t.materializedStatementResultsIterator = t.fetchController.GetResultsIterator(true)
-	}
-
-	t.table.SetSelectable(!t.fetchController.IsAutoRefreshRunning(), false).Select(t.table.GetRowCount()-1, 0)
+	t.selectedRowIdx = t.table.GetRowCount() - 1
+	t.materializedStatementResultsIterator = t.fetchController.GetResultsIterator(true)
+	t.table.SetSelectable(!t.fetchController.IsAutoRefreshRunning(), false).Select(t.selectedRowIdx, 0)
 	t.table.ScrollToEnd()
 }

--- a/internal/pkg/flink/types/statements.go
+++ b/internal/pkg/flink/types/statements.go
@@ -34,12 +34,20 @@ type StatementResultRow struct {
 	Fields    []StatementResultField
 }
 
-func (r StatementResultRow) GetRowKey() string {
+func (r *StatementResultRow) GetRowKey() string {
 	rowKey := strings.Builder{}
-	for _, field := range r.Fields {
+	for _, field := range r.GetFields() {
 		rowKey.WriteString(field.ToString())
 	}
 	return rowKey.String()
+}
+
+func (r *StatementResultRow) GetFields() []StatementResultField {
+	if r == nil {
+		var fields []StatementResultField
+		return fields
+	}
+	return r.Fields
 }
 
 const (


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->
This fixes a NPE when opening up the row view after having moved the table row iterator. This bug was happening for instance when you moved the cursor to the top most row, then hit a key that triggers a rerender of the table (e.g. toggle auto refresh or toggle table mode) and then hit enter on that row. 

The NPE then happened because the iterator was moved out of bounds because it was reset too early. E.g.: 
1. user has first row selected 
2. user toggles auto refresh 
3. selectLastRow() is called and reset the iterator to the last row, but selectedRowIdx is still at 1! 
4. then the rowSelectionHandler is triggered thinks the selected row is still at 1, and then moves the iterator the amount of distance between 1 and the last row 
5. however the iterator is already at the end (because it was reset in step 3) causing it to move out of bounds
6. openRowView() is called with the iterator being out of bounds causing it to return nil
7. panic!

By resetting both the iterator and the selectedRowIdx variable, this is fixed.


I added a GetFields() method that returns an empty array to avoid the panic in case the iterator might still return nil in some odd cases and I've added a test case to cover that case.