### PR TITLE
fix: use float64 type for op

### DIFF
--- a/internal/pkg/flink/internal/results/result_converter.go
+++ b/internal/pkg/flink/internal/results/result_converter.go
@@ -6,6 +6,7 @@ import (
 	flinkgatewayv1alpha1 "github.com/confluentinc/ccloud-sdk-go-v2/flink-gateway/v1alpha1"
 
 	"github.com/confluentinc/cli/internal/pkg/flink/types"
+	"github.com/confluentinc/cli/internal/pkg/log"
 )
 
 func convertToInternalField(field any, details flinkgatewayv1alpha1.ColumnDetails) types.StatementResultField {
@@ -33,7 +34,11 @@ func ConvertToInternalResults(results []any, resultSchema flinkgatewayv1alpha1.S
 			return nil, errors.New("given result item does not match op/row schema")
 		}
 
-		items, _ := resultItem["row"].([]any)
+		items, ok := resultItem["row"].([]any)
+		if !ok {
+			log.CliLogger.Error("Could not read 'row' from results as []any")
+		}
+
 		if len(items) != len(resultSchema.GetColumns()) {
 			return nil, errors.New("given result row does not match the provided schema")
 		}
@@ -44,7 +49,10 @@ func ConvertToInternalResults(results []any, resultSchema flinkgatewayv1alpha1.S
 			convertedFields[colIdx] = convertToInternalField(field, columnSchema)
 		}
 
-		op, _ := resultItem["op"].(int32)
+		op, ok := resultItem["op"].(float64)
+		if !ok {
+			log.CliLogger.Error("Could not read 'op' from results as float64")
+		}
 		convertedResults[rowIdx] = types.StatementResultRow{
 			Operation: types.StatementResultOperation(op),
 			Fields:    convertedFields,

--- a/internal/pkg/flink/internal/results/result_converter_test.go
+++ b/internal/pkg/flink/internal/results/result_converter_test.go
@@ -95,7 +95,7 @@ func (s *ResultConverterTestSuite) TestConvertResults() {
 		for rowIdx, row := range convertedResults.Rows {
 			expectedResultItem, ok := statementResults[rowIdx].(map[string]any)
 			require.True(t, ok)
-			op, ok := expectedResultItem["op"].(int32)
+			op, ok := expectedResultItem["op"].(float64)
 			require.True(t, ok)
 			items, ok := expectedResultItem["row"].([]any)
 			require.True(t, ok)

--- a/internal/pkg/flink/test/generators/results.go
+++ b/internal/pkg/flink/test/generators/results.go
@@ -128,7 +128,7 @@ func MockResultRow(columnDetails []flinkgatewayv1alpha1.ColumnDetails) *rapid.Ge
 			items = append(items, GetResultItemGeneratorForType(column.GetType()).Draw(t, "a field"))
 		}
 		return map[string]any{
-			"op":  rapid.Int32Range(0, 3).Draw(t, "an operation"),
+			"op":  rapid.Float64Range(0, 3).Draw(t, "an operation"),
 			"row": items,
 		}
 	})

--- a/internal/pkg/flink/types/statements.go
+++ b/internal/pkg/flink/types/statements.go
@@ -49,7 +49,7 @@ const (
 	DELETE        StatementResultOperation = 3
 )
 
-type StatementResultOperation int8
+type StatementResultOperation float64
 
 func (s StatementResultOperation) IsInsertOperation() bool {
 	return s == INSERT || s == UPDATE_AFTER


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok
   * no: DO NOT MERGE until the required features are live in prod  

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->
Fixes a bug where the table was not updated correctly and every row was just interpreted as an Insert operation.

We were using int32 to parse the op response from gateway, while it's actually a float64, leading to the value always being set to 0 -> Insert Operation +I. 