### PR TITLE
Fix/kfs 968 tackle zombie queries

### DIFF
--- a/internal/pkg/flink/app/application.go
+++ b/internal/pkg/flink/app/application.go
@@ -30,7 +30,7 @@ func StartApp(client ccloudv2.GatewayClientInterface, authenticated func() error
 	appController := controller.NewApplicationController(app, history)
 
 	// Store used to process statements and store local properties
-	store := store.NewStore(client, appController.ExitApplication, &appOptions)
+	store := store.NewStore(client, appController.ExitApplication, &appOptions, authenticated)
 
 	// Instantiate Component Controllers
 	fetchController := controller.NewFetchController(store)

--- a/internal/pkg/flink/internal/controller/fetch_controller_test.go
+++ b/internal/pkg/flink/internal/controller/fetch_controller_test.go
@@ -179,3 +179,24 @@ func (s *FetchControllerTestSuite) TestJumpToLiveResultsOnUserInput() {
 	require.Equal(s.T(), types.Paused, s.fetchController.GetFetchState())
 	require.Equal(s.T(), types.ProcessedStatement{PageToken: "LAST"}, s.fetchController.getStatement())
 }
+
+func (s *FetchControllerTestSuite) TestCloseShouldSetFetchStateToPaused() {
+	s.fetchController.setFetchState(types.Running)
+
+	s.fetchController.Close()
+
+	require.Equal(s.T(), types.Paused, s.fetchController.GetFetchState())
+}
+
+func (s *FetchControllerTestSuite) TestCloseShouldDeleteRunningStatements() {
+	statement := types.ProcessedStatement{
+		StatementName: "test-statement",
+		Status:        types.RUNNING,
+	}
+	s.fetchController.setStatement(statement)
+	s.mockStore.EXPECT().DeleteStatement(statement.StatementName)
+
+	s.fetchController.Close()
+
+	require.Equal(s.T(), types.Paused, s.fetchController.GetFetchState())
+}

--- a/internal/pkg/flink/internal/controller/fetch_controller_test.go
+++ b/internal/pkg/flink/internal/controller/fetch_controller_test.go
@@ -194,9 +194,14 @@ func (s *FetchControllerTestSuite) TestCloseShouldDeleteRunningStatements() {
 		Status:        types.RUNNING,
 	}
 	s.fetchController.setStatement(statement)
-	s.mockStore.EXPECT().DeleteStatement(statement.StatementName)
+	done := make(chan bool)
+	s.mockStore.EXPECT().DeleteStatement(statement.StatementName).Do(
+		func(statementName string) {
+			done <- true
+		})
 
 	s.fetchController.Close()
+	<-done
 
 	require.Equal(s.T(), types.Paused, s.fetchController.GetFetchState())
 }

--- a/internal/pkg/flink/internal/store/store.go
+++ b/internal/pkg/flink/internal/store/store.go
@@ -32,6 +32,14 @@ type Store struct {
 	exitApplication func()
 	client          ccloudv2.GatewayClientInterface
 	appOptions      *types.ApplicationOptions
+	authenticated   func() error
+}
+
+func (s *Store) authenticatedGatewayClient() ccloudv2.GatewayClientInterface {
+	if authErr := s.authenticated(); authErr != nil {
+		log.CliLogger.Warnf("Failed to refresh token: %v", authErr)
+	}
+	return s.client
 }
 
 func (s *Store) ProcessLocalStatement(statement string) (*types.ProcessedStatement, *types.StatementError) {
@@ -61,7 +69,7 @@ func (s *Store) ProcessStatement(statement string) (*types.ProcessedStatement, *
 	}
 
 	// Process remote statements
-	statementObj, err := s.client.CreateStatement(
+	statementObj, err := s.authenticatedGatewayClient().CreateStatement(
 		statement,
 		s.appOptions.GetComputePoolId(),
 		s.appOptions.GetIdentityPoolId(),
@@ -108,7 +116,7 @@ func (s *Store) FetchStatementResults(statement types.ProcessedStatement) (*type
 	}
 
 	// Process remote statements that are now running or completed
-	statementResultObj, err := s.client.GetStatementResults(s.appOptions.GetEnvironmentId(), statement.StatementName, s.appOptions.GetOrgResourceId(), statement.PageToken)
+	statementResultObj, err := s.authenticatedGatewayClient().GetStatementResults(s.appOptions.GetEnvironmentId(), statement.StatementName, s.appOptions.GetOrgResourceId(), statement.PageToken)
 	if err != nil {
 		return nil, &types.StatementError{Message: err.Error()}
 	}
@@ -130,7 +138,7 @@ func (s *Store) FetchStatementResults(statement types.ProcessedStatement) (*type
 }
 
 func (s *Store) DeleteStatement(statementName string) bool {
-	if err := s.client.DeleteStatement(s.appOptions.GetEnvironmentId(), statementName, s.appOptions.GetOrgResourceId()); err != nil {
+	if err := s.authenticatedGatewayClient().DeleteStatement(s.appOptions.GetEnvironmentId(), statementName, s.appOptions.GetOrgResourceId()); err != nil {
 		log.CliLogger.Warnf("Failed to delete the statement: %v", err)
 		return false
 	}
@@ -150,7 +158,7 @@ func (s *Store) waitForPendingStatement(ctx context.Context, statementName strin
 		case <-ctx.Done():
 			return nil, &types.StatementError{Message: "result retrieval aborted. Statement will be deleted", HttpResponseCode: 499}
 		default:
-			statementObj, err := s.client.GetStatement(s.appOptions.GetEnvironmentId(), statementName, s.appOptions.GetOrgResourceId())
+			statementObj, err := s.authenticatedGatewayClient().GetStatement(s.appOptions.GetEnvironmentId(), statementName, s.appOptions.GetOrgResourceId())
 			statusDetail := s.getStatusDetail(statementObj)
 			if err != nil {
 				return nil, &types.StatementError{
@@ -215,7 +223,7 @@ func (s *Store) getStatusDetail(statementObj flinkgatewayv1alpha1.SqlV1alpha1Sta
 	}
 
 	// if the statement is in FAILED or FAILING phase and the status detail field is empty we show the latest exception instead
-	exceptionsResponse, err := s.client.GetExceptions(s.appOptions.GetEnvironmentId(), statementObj.Spec.GetStatementName(), s.appOptions.GetOrgResourceId())
+	exceptionsResponse, err := s.authenticatedGatewayClient().GetExceptions(s.appOptions.GetEnvironmentId(), statementObj.Spec.GetStatementName(), s.appOptions.GetOrgResourceId())
 	if err != nil {
 		return ""
 	}
@@ -244,12 +252,13 @@ func extractPageToken(nextUrl string) (string, error) {
 	return params.Get("page_token"), nil
 }
 
-func NewStore(client ccloudv2.GatewayClientInterface, exitApplication func(), appOptions *types.ApplicationOptions) StoreInterface {
+func NewStore(client ccloudv2.GatewayClientInterface, exitApplication func(), appOptions *types.ApplicationOptions, authenticated func() error) StoreInterface {
 	return &Store{
 		Properties:      appOptions.GetDefaultProperties(),
 		client:          client,
 		exitApplication: exitApplication,
 		appOptions:      appOptions,
+		authenticated:   authenticated,
 	}
 }
 

--- a/internal/pkg/flink/internal/store/store.go
+++ b/internal/pkg/flink/internal/store/store.go
@@ -28,15 +28,15 @@ type StoreInterface interface {
 }
 
 type Store struct {
-	Properties      map[string]string
-	exitApplication func()
-	client          ccloudv2.GatewayClientInterface
-	appOptions      *types.ApplicationOptions
-	authenticated   func() error
+	Properties       map[string]string
+	exitApplication  func()
+	client           ccloudv2.GatewayClientInterface
+	appOptions       *types.ApplicationOptions
+	tokenRefreshFunc func() error
 }
 
 func (s *Store) authenticatedGatewayClient() ccloudv2.GatewayClientInterface {
-	if authErr := s.authenticated(); authErr != nil {
+	if authErr := s.tokenRefreshFunc(); authErr != nil {
 		log.CliLogger.Warnf("Failed to refresh token: %v", authErr)
 	}
 	return s.client
@@ -254,11 +254,11 @@ func extractPageToken(nextUrl string) (string, error) {
 
 func NewStore(client ccloudv2.GatewayClientInterface, exitApplication func(), appOptions *types.ApplicationOptions, authenticated func() error) StoreInterface {
 	return &Store{
-		Properties:      appOptions.GetDefaultProperties(),
-		client:          client,
-		exitApplication: exitApplication,
-		appOptions:      appOptions,
-		authenticated:   authenticated,
+		Properties:       appOptions.GetDefaultProperties(),
+		client:           client,
+		exitApplication:  exitApplication,
+		appOptions:       appOptions,
+		tokenRefreshFunc: authenticated,
 	}
 }
 

--- a/internal/pkg/flink/internal/store/store.go
+++ b/internal/pkg/flink/internal/store/store.go
@@ -134,6 +134,7 @@ func (s *Store) DeleteStatement(statementName string) bool {
 		log.CliLogger.Warnf("Failed to delete the statement: %v", err)
 		return false
 	}
+	log.CliLogger.Infof("Successfully deleted statement: %s", statementName)
 	return true
 }
 

--- a/internal/pkg/flink/internal/store/store_test.go
+++ b/internal/pkg/flink/internal/store/store_test.go
@@ -33,11 +33,15 @@ func TestStoreTestSuite(t *testing.T) {
 	suite.Run(t, new(StoreTestSuite))
 }
 
+func authenticated() error {
+	return nil
+}
+
 func TestStoreProcessLocalStatement(t *testing.T) {
 	// Create a new store
 	client := ccloudv2.NewFlinkGatewayClient("url", "userAgent", false, "authToken")
 	mockAppController := mock.NewMockApplicationControllerInterface(gomock.NewController(t))
-	s := NewStore(client, mockAppController.ExitApplication, nil).(*Store)
+	s := NewStore(client, mockAppController.ExitApplication, nil, authenticated).(*Store)
 
 	result, err := s.ProcessLocalStatement("SET 'foo'='bar';")
 	assert.Nil(t, err)
@@ -73,8 +77,9 @@ func TestWaitForPendingStatement3(t *testing.T) {
 		EnvironmentId: "envId",
 	}
 	s := &Store{
-		client:     client,
-		appOptions: &appOptions,
+		client:        client,
+		appOptions:    &appOptions,
+		authenticated: authenticated,
 	}
 
 	// Test case 1: Statement is not pending
@@ -102,8 +107,9 @@ func TestWaitForPendingTimesout(t *testing.T) {
 		EnvironmentId: "envId",
 	}
 	s := &Store{
-		client:     client,
-		appOptions: &appOptions,
+		client:        client,
+		appOptions:    &appOptions,
+		authenticated: authenticated,
 	}
 
 	statusDetailMessage := "test status detail message"
@@ -133,8 +139,9 @@ func TestWaitForPendingEventuallyCompletes(t *testing.T) {
 		EnvironmentId: "envId",
 	}
 	s := &Store{
-		client:     client,
-		appOptions: &appOptions,
+		client:        client,
+		appOptions:    &appOptions,
+		authenticated: authenticated,
 	}
 
 	transientStatusDetailMessage := "Transient status detail message"
@@ -170,8 +177,9 @@ func TestWaitForPendingStatementErrors(t *testing.T) {
 		EnvironmentId: "envId",
 	}
 	s := &Store{
-		client:     client,
-		appOptions: &appOptions,
+		client:        client,
+		appOptions:    &appOptions,
+		authenticated: authenticated,
 	}
 	statusDetailMessage := "Test status detail message"
 	statementObj := flinkgatewayv1alpha1.SqlV1alpha1Statement{
@@ -202,8 +210,9 @@ func TestCancelPendingStatement(t *testing.T) {
 		EnvironmentId: "envId",
 	}
 	s := &Store{
-		client:     client,
-		appOptions: &appOptions,
+		client:        client,
+		appOptions:    &appOptions,
+		authenticated: authenticated,
 	}
 
 	statementObj := flinkgatewayv1alpha1.SqlV1alpha1Statement{
@@ -724,7 +733,7 @@ func (s *StoreTestSuite) TestDeleteStatement() {
 		OrgResourceId: "orgId",
 		EnvironmentId: "envId",
 	}
-	store := NewStore(client, mockAppController.ExitApplication, &appOptions)
+	store := NewStore(client, mockAppController.ExitApplication, &appOptions, authenticated)
 
 	statementName := "TEST_STATEMENT"
 	client.EXPECT().DeleteStatement("envId", statementName, "orgId").Return(nil)
@@ -743,7 +752,7 @@ func (s *StoreTestSuite) TestDeleteStatementFailsOnError() {
 		OrgResourceId: "orgId",
 		EnvironmentId: "envId",
 	}
-	store := NewStore(client, mockAppController.ExitApplication, &appOptions)
+	store := NewStore(client, mockAppController.ExitApplication, &appOptions, authenticated)
 
 	statementName := "TEST_STATEMENT"
 	client.EXPECT().DeleteStatement("envId", statementName, "orgId").Return(errors.New("test error"))
@@ -762,7 +771,7 @@ func (s *StoreTestSuite) TestFetchResultsNoRetryWithCompletedStatement() {
 		OrgResourceId: "orgId",
 		EnvironmentId: "envId",
 	}
-	store := NewStore(client, mockAppController.ExitApplication, &appOptions)
+	store := NewStore(client, mockAppController.ExitApplication, &appOptions, authenticated)
 
 	statement := types.ProcessedStatement{
 		StatementName: "TEST_STATEMENT",
@@ -789,7 +798,7 @@ func (s *StoreTestSuite) TestFetchResultsWithRunningStatement() {
 		OrgResourceId: "orgId",
 		EnvironmentId: "envId",
 	}
-	store := NewStore(client, mockAppController.ExitApplication, &appOptions)
+	store := NewStore(client, mockAppController.ExitApplication, &appOptions, authenticated)
 
 	statement := types.ProcessedStatement{
 		StatementName: "TEST_STATEMENT",
@@ -816,7 +825,7 @@ func (s *StoreTestSuite) TestFetchResultsNoRetryWhenPageTokenExists() {
 		OrgResourceId: "orgId",
 		EnvironmentId: "envId",
 	}
-	store := NewStore(client, mockAppController.ExitApplication, &appOptions)
+	store := NewStore(client, mockAppController.ExitApplication, &appOptions, authenticated)
 
 	statement := types.ProcessedStatement{
 		StatementName: "TEST_STATEMENT",
@@ -844,7 +853,7 @@ func (s *StoreTestSuite) TestFetchResultsNoRetryWhenResultsExist() {
 		OrgResourceId: "orgId",
 		EnvironmentId: "envId",
 	}
-	store := NewStore(client, mockAppController.ExitApplication, &appOptions)
+	store := NewStore(client, mockAppController.ExitApplication, &appOptions, authenticated)
 
 	statement := types.ProcessedStatement{
 		StatementName: "TEST_STATEMENT",
@@ -934,8 +943,9 @@ func (s *StoreTestSuite) TestProcessStatement() {
 		Properties: map[string]string{
 			"TestProp": "TestVal",
 		},
-		client:     client,
-		appOptions: appOptions,
+		client:        client,
+		appOptions:    appOptions,
+		authenticated: authenticated,
 	}
 
 	statusDetailMessage := "Test status detail message"
@@ -967,8 +977,9 @@ func (s *StoreTestSuite) TestProcessStatementFailsOnError() {
 		Properties: map[string]string{
 			"TestProp": "TestVal",
 		},
-		client:     client,
-		appOptions: appOptions,
+		client:        client,
+		appOptions:    appOptions,
+		authenticated: authenticated,
 	}
 
 	statusDetailMessage := "test status detail message"
@@ -1002,8 +1013,9 @@ func (s *StoreTestSuite) TestWaitPendingStatement() {
 		Properties: map[string]string{
 			"TestProp": "TestVal",
 		},
-		client:     client,
-		appOptions: appOptions,
+		client:        client,
+		appOptions:    appOptions,
+		authenticated: authenticated,
 	}
 
 	statementName := "Test Statement"
@@ -1069,8 +1081,9 @@ func (s *StoreTestSuite) TestWaitPendingStatementFailsOnWaitError() {
 		Properties: map[string]string{
 			"TestProp": "TestVal",
 		},
-		client:     client,
-		appOptions: appOptions,
+		client:        client,
+		appOptions:    appOptions,
+		authenticated: authenticated,
 	}
 
 	statementName := "Test Statement"
@@ -1108,8 +1121,9 @@ func (s *StoreTestSuite) TestWaitPendingStatementFailsOnNonCompletedOrRunningSta
 		Properties: map[string]string{
 			"TestProp": "TestVal",
 		},
-		client:     client,
-		appOptions: appOptions,
+		client:        client,
+		appOptions:    appOptions,
+		authenticated: authenticated,
 	}
 
 	statementName := "Test Statement"
@@ -1148,8 +1162,9 @@ func (s *StoreTestSuite) TestWaitPendingStatementFetchesExceptionOnFailedStateme
 		Properties: map[string]string{
 			"TestProp": "TestVal",
 		},
-		client:     client,
-		appOptions: appOptions,
+		client:        client,
+		appOptions:    appOptions,
+		authenticated: authenticated,
 	}
 
 	statementName := "Test Statement"
@@ -1195,8 +1210,9 @@ func (s *StoreTestSuite) TestGetStatusDetail() {
 		Properties: map[string]string{
 			"TestProp": "TestVal",
 		},
-		client:     client,
-		appOptions: appOptions,
+		client:        client,
+		appOptions:    appOptions,
+		authenticated: authenticated,
 	}
 
 	statementName := "Test Statement"
@@ -1234,8 +1250,9 @@ func (s *StoreTestSuite) TestGetStatusDetailReturnsWhenStatusNoFailedOrFailing()
 		Properties: map[string]string{
 			"TestProp": "TestVal",
 		},
-		client:     client,
-		appOptions: appOptions,
+		client:        client,
+		appOptions:    appOptions,
+		authenticated: authenticated,
 	}
 
 	testStatusDetailMessage := "Test Status Detail Message"
@@ -1268,8 +1285,9 @@ func (s *StoreTestSuite) TestGetStatusDetailReturnsWhenStatusDetailFilled() {
 		Properties: map[string]string{
 			"TestProp": "TestVal",
 		},
-		client:     client,
-		appOptions: appOptions,
+		client:        client,
+		appOptions:    appOptions,
+		authenticated: authenticated,
 	}
 
 	testStatusDetailMessage := "Test Status Detail Message"
@@ -1296,8 +1314,9 @@ func (s *StoreTestSuite) TestGetStatusDetailReturnsEmptyWhenNoExceptionsAvailabl
 		Properties: map[string]string{
 			"TestProp": "TestVal",
 		},
-		client:     client,
-		appOptions: appOptions,
+		client:        client,
+		appOptions:    appOptions,
+		authenticated: authenticated,
 	}
 
 	statementName := "Test Statement"

--- a/internal/pkg/flink/internal/store/store_test.go
+++ b/internal/pkg/flink/internal/store/store_test.go
@@ -33,7 +33,7 @@ func TestStoreTestSuite(t *testing.T) {
 	suite.Run(t, new(StoreTestSuite))
 }
 
-func authenticated() error {
+func tokenRefreshFunc() error {
 	return nil
 }
 
@@ -41,7 +41,7 @@ func TestStoreProcessLocalStatement(t *testing.T) {
 	// Create a new store
 	client := ccloudv2.NewFlinkGatewayClient("url", "userAgent", false, "authToken")
 	mockAppController := mock.NewMockApplicationControllerInterface(gomock.NewController(t))
-	s := NewStore(client, mockAppController.ExitApplication, nil, authenticated).(*Store)
+	s := NewStore(client, mockAppController.ExitApplication, nil, tokenRefreshFunc).(*Store)
 
 	result, err := s.ProcessLocalStatement("SET 'foo'='bar';")
 	assert.Nil(t, err)
@@ -77,9 +77,9 @@ func TestWaitForPendingStatement3(t *testing.T) {
 		EnvironmentId: "envId",
 	}
 	s := &Store{
-		client:        client,
-		appOptions:    &appOptions,
-		authenticated: authenticated,
+		client:           client,
+		appOptions:       &appOptions,
+		tokenRefreshFunc: tokenRefreshFunc,
 	}
 
 	// Test case 1: Statement is not pending
@@ -107,9 +107,9 @@ func TestWaitForPendingTimesout(t *testing.T) {
 		EnvironmentId: "envId",
 	}
 	s := &Store{
-		client:        client,
-		appOptions:    &appOptions,
-		authenticated: authenticated,
+		client:           client,
+		appOptions:       &appOptions,
+		tokenRefreshFunc: tokenRefreshFunc,
 	}
 
 	statusDetailMessage := "test status detail message"
@@ -139,9 +139,9 @@ func TestWaitForPendingEventuallyCompletes(t *testing.T) {
 		EnvironmentId: "envId",
 	}
 	s := &Store{
-		client:        client,
-		appOptions:    &appOptions,
-		authenticated: authenticated,
+		client:           client,
+		appOptions:       &appOptions,
+		tokenRefreshFunc: tokenRefreshFunc,
 	}
 
 	transientStatusDetailMessage := "Transient status detail message"
@@ -177,9 +177,9 @@ func TestWaitForPendingStatementErrors(t *testing.T) {
 		EnvironmentId: "envId",
 	}
 	s := &Store{
-		client:        client,
-		appOptions:    &appOptions,
-		authenticated: authenticated,
+		client:           client,
+		appOptions:       &appOptions,
+		tokenRefreshFunc: tokenRefreshFunc,
 	}
 	statusDetailMessage := "Test status detail message"
 	statementObj := flinkgatewayv1alpha1.SqlV1alpha1Statement{
@@ -210,9 +210,9 @@ func TestCancelPendingStatement(t *testing.T) {
 		EnvironmentId: "envId",
 	}
 	s := &Store{
-		client:        client,
-		appOptions:    &appOptions,
-		authenticated: authenticated,
+		client:           client,
+		appOptions:       &appOptions,
+		tokenRefreshFunc: tokenRefreshFunc,
 	}
 
 	statementObj := flinkgatewayv1alpha1.SqlV1alpha1Statement{
@@ -733,7 +733,7 @@ func (s *StoreTestSuite) TestDeleteStatement() {
 		OrgResourceId: "orgId",
 		EnvironmentId: "envId",
 	}
-	store := NewStore(client, mockAppController.ExitApplication, &appOptions, authenticated)
+	store := NewStore(client, mockAppController.ExitApplication, &appOptions, tokenRefreshFunc)
 
 	statementName := "TEST_STATEMENT"
 	client.EXPECT().DeleteStatement("envId", statementName, "orgId").Return(nil)
@@ -752,7 +752,7 @@ func (s *StoreTestSuite) TestDeleteStatementFailsOnError() {
 		OrgResourceId: "orgId",
 		EnvironmentId: "envId",
 	}
-	store := NewStore(client, mockAppController.ExitApplication, &appOptions, authenticated)
+	store := NewStore(client, mockAppController.ExitApplication, &appOptions, tokenRefreshFunc)
 
 	statementName := "TEST_STATEMENT"
 	client.EXPECT().DeleteStatement("envId", statementName, "orgId").Return(errors.New("test error"))
@@ -771,7 +771,7 @@ func (s *StoreTestSuite) TestFetchResultsNoRetryWithCompletedStatement() {
 		OrgResourceId: "orgId",
 		EnvironmentId: "envId",
 	}
-	store := NewStore(client, mockAppController.ExitApplication, &appOptions, authenticated)
+	store := NewStore(client, mockAppController.ExitApplication, &appOptions, tokenRefreshFunc)
 
 	statement := types.ProcessedStatement{
 		StatementName: "TEST_STATEMENT",
@@ -798,7 +798,7 @@ func (s *StoreTestSuite) TestFetchResultsWithRunningStatement() {
 		OrgResourceId: "orgId",
 		EnvironmentId: "envId",
 	}
-	store := NewStore(client, mockAppController.ExitApplication, &appOptions, authenticated)
+	store := NewStore(client, mockAppController.ExitApplication, &appOptions, tokenRefreshFunc)
 
 	statement := types.ProcessedStatement{
 		StatementName: "TEST_STATEMENT",
@@ -825,7 +825,7 @@ func (s *StoreTestSuite) TestFetchResultsNoRetryWhenPageTokenExists() {
 		OrgResourceId: "orgId",
 		EnvironmentId: "envId",
 	}
-	store := NewStore(client, mockAppController.ExitApplication, &appOptions, authenticated)
+	store := NewStore(client, mockAppController.ExitApplication, &appOptions, tokenRefreshFunc)
 
 	statement := types.ProcessedStatement{
 		StatementName: "TEST_STATEMENT",
@@ -853,7 +853,7 @@ func (s *StoreTestSuite) TestFetchResultsNoRetryWhenResultsExist() {
 		OrgResourceId: "orgId",
 		EnvironmentId: "envId",
 	}
-	store := NewStore(client, mockAppController.ExitApplication, &appOptions, authenticated)
+	store := NewStore(client, mockAppController.ExitApplication, &appOptions, tokenRefreshFunc)
 
 	statement := types.ProcessedStatement{
 		StatementName: "TEST_STATEMENT",
@@ -943,9 +943,9 @@ func (s *StoreTestSuite) TestProcessStatement() {
 		Properties: map[string]string{
 			"TestProp": "TestVal",
 		},
-		client:        client,
-		appOptions:    appOptions,
-		authenticated: authenticated,
+		client:           client,
+		appOptions:       appOptions,
+		tokenRefreshFunc: tokenRefreshFunc,
 	}
 
 	statusDetailMessage := "Test status detail message"
@@ -977,9 +977,9 @@ func (s *StoreTestSuite) TestProcessStatementFailsOnError() {
 		Properties: map[string]string{
 			"TestProp": "TestVal",
 		},
-		client:        client,
-		appOptions:    appOptions,
-		authenticated: authenticated,
+		client:           client,
+		appOptions:       appOptions,
+		tokenRefreshFunc: tokenRefreshFunc,
 	}
 
 	statusDetailMessage := "test status detail message"
@@ -1013,9 +1013,9 @@ func (s *StoreTestSuite) TestWaitPendingStatement() {
 		Properties: map[string]string{
 			"TestProp": "TestVal",
 		},
-		client:        client,
-		appOptions:    appOptions,
-		authenticated: authenticated,
+		client:           client,
+		appOptions:       appOptions,
+		tokenRefreshFunc: tokenRefreshFunc,
 	}
 
 	statementName := "Test Statement"
@@ -1081,9 +1081,9 @@ func (s *StoreTestSuite) TestWaitPendingStatementFailsOnWaitError() {
 		Properties: map[string]string{
 			"TestProp": "TestVal",
 		},
-		client:        client,
-		appOptions:    appOptions,
-		authenticated: authenticated,
+		client:           client,
+		appOptions:       appOptions,
+		tokenRefreshFunc: tokenRefreshFunc,
 	}
 
 	statementName := "Test Statement"
@@ -1121,9 +1121,9 @@ func (s *StoreTestSuite) TestWaitPendingStatementFailsOnNonCompletedOrRunningSta
 		Properties: map[string]string{
 			"TestProp": "TestVal",
 		},
-		client:        client,
-		appOptions:    appOptions,
-		authenticated: authenticated,
+		client:           client,
+		appOptions:       appOptions,
+		tokenRefreshFunc: tokenRefreshFunc,
 	}
 
 	statementName := "Test Statement"
@@ -1162,9 +1162,9 @@ func (s *StoreTestSuite) TestWaitPendingStatementFetchesExceptionOnFailedStateme
 		Properties: map[string]string{
 			"TestProp": "TestVal",
 		},
-		client:        client,
-		appOptions:    appOptions,
-		authenticated: authenticated,
+		client:           client,
+		appOptions:       appOptions,
+		tokenRefreshFunc: tokenRefreshFunc,
 	}
 
 	statementName := "Test Statement"
@@ -1210,9 +1210,9 @@ func (s *StoreTestSuite) TestGetStatusDetail() {
 		Properties: map[string]string{
 			"TestProp": "TestVal",
 		},
-		client:        client,
-		appOptions:    appOptions,
-		authenticated: authenticated,
+		client:           client,
+		appOptions:       appOptions,
+		tokenRefreshFunc: tokenRefreshFunc,
 	}
 
 	statementName := "Test Statement"
@@ -1250,9 +1250,9 @@ func (s *StoreTestSuite) TestGetStatusDetailReturnsWhenStatusNoFailedOrFailing()
 		Properties: map[string]string{
 			"TestProp": "TestVal",
 		},
-		client:        client,
-		appOptions:    appOptions,
-		authenticated: authenticated,
+		client:           client,
+		appOptions:       appOptions,
+		tokenRefreshFunc: tokenRefreshFunc,
 	}
 
 	testStatusDetailMessage := "Test Status Detail Message"
@@ -1285,9 +1285,9 @@ func (s *StoreTestSuite) TestGetStatusDetailReturnsWhenStatusDetailFilled() {
 		Properties: map[string]string{
 			"TestProp": "TestVal",
 		},
-		client:        client,
-		appOptions:    appOptions,
-		authenticated: authenticated,
+		client:           client,
+		appOptions:       appOptions,
+		tokenRefreshFunc: tokenRefreshFunc,
 	}
 
 	testStatusDetailMessage := "Test Status Detail Message"
@@ -1314,9 +1314,9 @@ func (s *StoreTestSuite) TestGetStatusDetailReturnsEmptyWhenNoExceptionsAvailabl
 		Properties: map[string]string{
 			"TestProp": "TestVal",
 		},
-		client:        client,
-		appOptions:    appOptions,
-		authenticated: authenticated,
+		client:           client,
+		appOptions:       appOptions,
+		tokenRefreshFunc: tokenRefreshFunc,
 	}
 
 	statementName := "Test Statement"

--- a/internal/pkg/flink/internal/store/store_utils_test.go
+++ b/internal/pkg/flink/internal/store/store_utils_test.go
@@ -80,7 +80,7 @@ func TestRemoveWhiteSpaces(t *testing.T) {
 func TestProcessSetStatement(t *testing.T) {
 	// Create a new store
 	client := ccloudv2.NewFlinkGatewayClient("url", "userAgent", false, "authToken")
-	s := NewStore(client, nil, nil, authenticated).(*Store)
+	s := NewStore(client, nil, nil, tokenRefreshFunc).(*Store)
 
 	t.Run("should return an error message if statement is invalid", func(t *testing.T) {
 		_, err := s.processSetStatement("se key=value")
@@ -129,7 +129,7 @@ func TestProcessSetStatement(t *testing.T) {
 func TestProcessResetStatement(t *testing.T) {
 	// Create a new store
 	client := ccloudv2.NewFlinkGatewayClient("url", "userAgent", false, "authToken")
-	s := NewStore(client, nil, nil, authenticated).(*Store)
+	s := NewStore(client, nil, nil, tokenRefreshFunc).(*Store)
 
 	t.Run("should return an error message if statement is invalid", func(t *testing.T) {
 		_, err := s.processResetStatement("res key")
@@ -172,7 +172,7 @@ func TestProcessResetStatement(t *testing.T) {
 func TestProcessUseStatement(t *testing.T) {
 	// Create a new store
 	client := ccloudv2.NewFlinkGatewayClient("url", "userAgent", false, "authToken")
-	s := NewStore(client, nil, nil, authenticated).(*Store)
+	s := NewStore(client, nil, nil, tokenRefreshFunc).(*Store)
 
 	t.Run("should return an error message if statement is invalid", func(t *testing.T) {
 		_, err := s.processUseStatement("us")

--- a/internal/pkg/flink/internal/store/store_utils_test.go
+++ b/internal/pkg/flink/internal/store/store_utils_test.go
@@ -80,7 +80,7 @@ func TestRemoveWhiteSpaces(t *testing.T) {
 func TestProcessSetStatement(t *testing.T) {
 	// Create a new store
 	client := ccloudv2.NewFlinkGatewayClient("url", "userAgent", false, "authToken")
-	s := NewStore(client, nil, nil).(*Store)
+	s := NewStore(client, nil, nil, authenticated).(*Store)
 
 	t.Run("should return an error message if statement is invalid", func(t *testing.T) {
 		_, err := s.processSetStatement("se key=value")
@@ -129,7 +129,7 @@ func TestProcessSetStatement(t *testing.T) {
 func TestProcessResetStatement(t *testing.T) {
 	// Create a new store
 	client := ccloudv2.NewFlinkGatewayClient("url", "userAgent", false, "authToken")
-	s := NewStore(client, nil, nil).(*Store)
+	s := NewStore(client, nil, nil, authenticated).(*Store)
 
 	t.Run("should return an error message if statement is invalid", func(t *testing.T) {
 		_, err := s.processResetStatement("res key")
@@ -172,7 +172,7 @@ func TestProcessResetStatement(t *testing.T) {
 func TestProcessUseStatement(t *testing.T) {
 	// Create a new store
 	client := ccloudv2.NewFlinkGatewayClient("url", "userAgent", false, "authToken")
-	s := NewStore(client, nil, nil).(*Store)
+	s := NewStore(client, nil, nil, authenticated).(*Store)
 
 	t.Run("should return an error message if statement is invalid", func(t *testing.T) {
 		_, err := s.processUseStatement("us")


### PR DESCRIPTION

Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->
This should fix the issue where some statements would not be deleted correctly. It also fixes future issues, where a request to the Gateway would be made with an invalid token. 

We now ensure that before making a request to the Gateway we at least tried to refresh the token.
