### PR TITLE
KFS-963 feat: use default terminal color for infos

### DIFF
--- a/internal/pkg/color/color.go
+++ b/internal/pkg/color/color.go
@@ -10,6 +10,5 @@ import (
 const PromptAccentColor = prompt.Cyan
 const AccentColor = color.FgCyan
 
-const InfoColor = color.FgWhite
 const ErrorColor = color.FgHiRed
 const WarnColor = color.FgHiYellow

--- a/internal/pkg/flink/internal/controller/input_controller_utils.go
+++ b/internal/pkg/flink/internal/controller/input_controller_utils.go
@@ -55,13 +55,11 @@ func outputErrf(s string, args ...any) {
 }
 
 func outputInfo(s string) {
-	c := fColor.New(color.InfoColor)
-	output.Println(c.Sprint(s))
+	output.Println(s)
 }
 
 func outputInfof(s string, args ...any) {
-	c := fColor.New(color.InfoColor)
-	output.Printf(c.Sprint(s), args...)
+	output.Printf(s, args...)
 }
 
 func outputWarn(s string) {

--- a/internal/pkg/flink/internal/highlighting/lexer.go
+++ b/internal/pkg/flink/internal/highlighting/lexer.go
@@ -57,8 +57,6 @@ func Lexer(line string) []prompt.LexerElement {
 			element.Color = color.PromptAccentColor
 		} else if wrappedInInvertedCommasOrBackticks(word) {
 			element.Color = prompt.Yellow
-		} else {
-			element.Color = prompt.White
 		}
 
 		// We have to maintain the spaces between words if not the last word

--- a/internal/pkg/flink/internal/highlighting/lexer_test.go
+++ b/internal/pkg/flink/internal/highlighting/lexer_test.go
@@ -25,21 +25,21 @@ func TestLexer(t *testing.T) {
 	require.Len(t, elements, 9)
 	require.Equal(t, prompt.Cyan, elements[0].Color)
 	require.Equal(t, "SELECT", elements[0].Text)
-	require.Equal(t, prompt.White, elements[1].Color)
+	require.Equal(t, prompt.DefaultColor, elements[1].Color)
 	require.Equal(t, " ", elements[1].Text)
-	require.Equal(t, prompt.White, elements[2].Color)
+	require.Equal(t, prompt.DefaultColor, elements[2].Color)
 	require.Equal(t, "FIELD", elements[2].Text)
-	require.Equal(t, prompt.White, elements[3].Color)
+	require.Equal(t, prompt.DefaultColor, elements[3].Color)
 	require.Equal(t, " ", elements[3].Text)
-	require.Equal(t, prompt.White, elements[4].Color)
+	require.Equal(t, prompt.DefaultColor, elements[4].Color)
 	require.Equal(t, "\n", elements[4].Text)
 	require.Equal(t, prompt.Cyan, elements[5].Color)
 	require.Equal(t, "FROM", elements[5].Text)
-	require.Equal(t, prompt.White, elements[6].Color)
+	require.Equal(t, prompt.DefaultColor, elements[6].Color)
 	require.Equal(t, " ", elements[6].Text)
 	require.Equal(t, prompt.Cyan, elements[7].Color)
 	require.Equal(t, "TABLE", elements[7].Text)
-	require.Equal(t, prompt.White, elements[8].Color)
+	require.Equal(t, prompt.DefaultColor, elements[8].Color)
 	require.Equal(t, ";", elements[8].Text)
 }
 
@@ -94,7 +94,7 @@ func TestExamplesWordLexer(t *testing.T) {
 			} else if wrappedInInvertedCommasOrBackticks(element.Text) {
 				require.Equalf(t, element.Color, prompt.Yellow, "wrong colour for element: %s", element.Text)
 			} else {
-				require.Equalf(t, element.Color, prompt.White, "wrong colour for element: %s", element.Text)
+				require.Equalf(t, element.Color, prompt.DefaultColor, "wrong colour for element: %s", element.Text)
 			}
 		}
 	}
@@ -142,7 +142,7 @@ func TestWordLexerForRandomStatements(t *testing.T) {
 			} else if wrappedInInvertedCommasOrBackticks(element.Text) {
 				require.Equalf(t, element.Color, prompt.Yellow, "wrong colour for element: %s", element.Text)
 			} else {
-				require.Equalf(t, element.Color, prompt.White, "wrong colour for element: %s", element.Text)
+				require.Equalf(t, element.Color, prompt.DefaultColor, "wrong colour for element: %s", element.Text)
 			}
 		}
 	})

--- a/internal/pkg/flink/internal/reverseisearch/reverse_i_search.go
+++ b/internal/pkg/flink/internal/reverseisearch/reverse_i_search.go
@@ -80,7 +80,7 @@ func (r reverseISearch) ReverseISearch(history []string) string {
 		prompt.OptionTitle("bck-i-search"),
 		prompt.OptionLivePrefix(reverseISearchLivePrefix(livePrefixState)),
 		prompt.OptionHistory(history),
-		prompt.OptionPrefixTextColor(prompt.White),
+		prompt.OptionPrefixTextColor(prompt.DefaultColor),
 		prompt.OptionSetStatementTerminator(func(lastKeyStroke prompt.Key, buffer *prompt.Buffer) bool {
 			if lastKeyStroke == prompt.ControlM {
 				livePrefixState.LivePrefix = ""


### PR DESCRIPTION
Release Notes
-------------
Bug Fixes
- Use the default terminal colours in flink shell to make them more readable on light backgrounds

Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->
### Some users were having a hard time reading some infos because we weren't using the default terminal color for text in some cases. **This should be solved now. More detail on coloring in the terminal:**

The only colors that are user-defined and we can use from the user config are: text, bold text and (text) selection - see picture at the bottom. That means, every time we use another color, we’re at risk that some user won’t be able to see some information properly, if the terminal doesn’t configure proper alternatives for the default colors. For example, ohmyzsh uses a bunch of colors and if I change my theme there are some things that I can’t read properly anymore, see last example:



The defined user colors can be used by basically not adding any hard coded color and they’ll be printed in the text color from the terminal by default. I’ll remove the default value for colors everywhere I can in the CLI, so the example from the picture above won’t be a problem for any user, for example. This should be then good for most of the users.

However, errors, warnings and accent (yellow, red and cyan) will still use the default yellow, red and cyan color configured in the terminal. That means, people with yellow/red or cyan background will have a hardtime using the CLI, if their terminals or themselves don’t configure the theme/colors properly. We have three ways of dealing with this:

1 - Remove coloring and all level of infos will have the same color - I’m not a fan.
2 - Add hard-coded background color at least to error - to make sure they will be readable - not optimal too.
3 - Using the default text colors and default yellow/red/cyan shades configured by the terminal and rely on people using theme managers in their terminals that adjust the colors or  properly set their terminal colors. Or just don't use these three colors as background (red, yellow, cyan). - I think that’s the solution we should go with.

![image](https://github.com/confluentinc/cli/assets/11739405/d5f0e213-bd91-43a4-b112-27c5acef5a07)

**Following my 3rd suggestion, that’s how it’s going to look like for the example above and other  (apparently most used terminal themes/colors):**

![image](https://github.com/confluentinc/cli/assets/11739405/2e606b3c-0d72-4ddf-8efe-df56e274401b)

![image](https://github.com/confluentinc/cli/assets/11739405/725303bd-b135-47d7-b108-525d016021ad)

![image](https://github.com/confluentinc/cli/assets/11739405/d6124bc9-c818-4151-9bab-05b15a53ea1d)

![image](https://github.com/confluentinc/cli/assets/11739405/3c2f145d-8474-4380-ac8c-9912ad347849)

![image](https://github.com/confluentinc/cli/assets/11739405/1a5da401-5975-4693-a97a-785e75cc8200)


References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
<!--
Has it been tested? How?
Copy and paste any instructions or steps that can save the reviewer time.
-->
Tests updated. 

Open Questions / Follow-ups
---------------------------
<!--
Optional: Anything open to discussion for the reviewer, out of scope of this PR, or follow-ups.
-->
