### PR TITLE
Fix/kfs 978 remove jump to live

### DIFF
--- a/internal/pkg/flink/components/shortcuts.go
+++ b/internal/pkg/flink/components/shortcuts.go
@@ -14,7 +14,6 @@ var appShortcuts = []types.Shortcut{
 	{KeyText: "Q", Text: "Quit"},
 	{KeyText: "M", Text: "Toggle Result Mode"},
 	{KeyText: "A", Text: "Toggle Auto Refresh"},
-	{KeyText: "R", Text: "Live results"},
 	{KeyText: "H/L", Text: "Fast scroll ▲/▼"},
 }
 

--- a/internal/pkg/flink/internal/controller/fetch_controller.go
+++ b/internal/pkg/flink/internal/controller/fetch_controller.go
@@ -76,7 +76,7 @@ func (t *FetchController) startAutoRefresh(refreshInterval uint) {
 		t.setFetchState(types.Running)
 		go func() {
 			for t.IsAutoRefreshRunning() {
-				t.FetchNextPage()
+				t.fetchNextPage()
 				t.autoRefreshCallback()
 				time.Sleep(time.Millisecond * time.Duration(refreshInterval))
 			}
@@ -92,7 +92,7 @@ func (t *FetchController) setFetchState(state types.FetchState) {
 	atomic.StoreInt32(&t.fetchState, int32(state))
 }
 
-func (t *FetchController) FetchNextPage() {
+func (t *FetchController) fetchNextPage() {
 	// don't fetch if we're already at the last page, otherwise we would fetch the first page again
 	if t.GetFetchState() == types.Completed {
 		return

--- a/internal/pkg/flink/internal/controller/fetch_controller.go
+++ b/internal/pkg/flink/internal/controller/fetch_controller.go
@@ -122,21 +122,6 @@ func (t *FetchController) FetchNextPage() {
 	t.setFetchState(types.Running)
 }
 
-func (t *FetchController) JumpToLastPage() {
-	for {
-		t.FetchNextPage()
-		if !t.hasMoreResults() {
-			break
-		}
-		// minimal wait to avoid rate limiting
-		time.Sleep(time.Millisecond * 50)
-	}
-}
-
-func (t *FetchController) hasMoreResults() bool {
-	return len(t.getStatement().StatementResults.GetRows()) > 0 && t.GetFetchState() != types.Failed && t.GetFetchState() != types.Completed
-}
-
 func (t *FetchController) GetHeaders() []string {
 	return t.materializedStatementResults.GetHeaders()
 }

--- a/internal/pkg/flink/internal/controller/fetch_controller_test.go
+++ b/internal/pkg/flink/internal/controller/fetch_controller_test.go
@@ -148,38 +148,6 @@ func (s *FetchControllerTestSuite) TestFetchNextPageOnUserInput() {
 	require.Equal(s.T(), types.Completed, s.fetchController.GetFetchState())
 }
 
-func (s *FetchControllerTestSuite) TestJumpToLiveResultsOnUserInput() {
-	mockStatement := types.ProcessedStatement{
-		StatementResults: &types.StatementResults{
-			Headers: []string{"Test"},
-			Rows: []types.StatementResultRow{{
-				Operation: 0,
-				Fields: []types.StatementResultField{
-					types.AtomicStatementResultField{
-						Type:  "INTEGER",
-						Value: "1",
-					},
-				},
-			}},
-		},
-		PageToken: "NOT_EMPTY",
-	}
-	s.mockStore.EXPECT().FetchStatementResults(mockStatement).Return(&mockStatement, nil)
-	s.mockStore.EXPECT().FetchStatementResults(mockStatement).Return(&mockStatement, nil)
-	s.mockStore.EXPECT().FetchStatementResults(mockStatement).Return(&types.ProcessedStatement{PageToken: "LAST"}, nil)
-
-	// When
-	s.fetchController.setFetchState(types.Completed) // need to manually set this so auto refresh doesn't start
-	s.fetchController.Init(mockStatement)
-	s.fetchController.setFetchState(types.Paused)
-
-	// Then
-	s.fetchController.JumpToLastPage()
-
-	require.Equal(s.T(), types.Paused, s.fetchController.GetFetchState())
-	require.Equal(s.T(), types.ProcessedStatement{PageToken: "LAST"}, s.fetchController.getStatement())
-}
-
 func (s *FetchControllerTestSuite) TestCloseShouldSetFetchStateToPaused() {
 	s.fetchController.setFetchState(types.Running)
 

--- a/internal/pkg/flink/internal/controller/fetch_controller_test.go
+++ b/internal/pkg/flink/internal/controller/fetch_controller_test.go
@@ -86,7 +86,7 @@ func (s *FetchControllerTestSuite) TestFetchNextPageSetsFailedState() {
 	s.fetchController.setStatement(mockStatement)
 	s.mockStore.EXPECT().FetchStatementResults(mockStatement).Return(nil, &types.StatementError{})
 
-	s.fetchController.FetchNextPage()
+	s.fetchController.fetchNextPage()
 
 	require.Equal(s.T(), types.Failed, s.fetchController.GetFetchState())
 }
@@ -96,7 +96,7 @@ func (s *FetchControllerTestSuite) TestFetchNextPageSetsCompletedState() {
 	s.fetchController.setStatement(mockStatement)
 	s.mockStore.EXPECT().FetchStatementResults(mockStatement).Return(&types.ProcessedStatement{}, nil)
 
-	s.fetchController.FetchNextPage()
+	s.fetchController.fetchNextPage()
 
 	require.Equal(s.T(), types.Completed, s.fetchController.GetFetchState())
 }
@@ -104,7 +104,7 @@ func (s *FetchControllerTestSuite) TestFetchNextPageSetsCompletedState() {
 func (s *FetchControllerTestSuite) TestFetchNextPageReturnsWhenAlreadyCompleted() {
 	s.fetchController.setFetchState(types.Completed)
 
-	s.fetchController.FetchNextPage()
+	s.fetchController.fetchNextPage()
 
 	require.Equal(s.T(), types.Completed, s.fetchController.GetFetchState())
 }
@@ -115,7 +115,7 @@ func (s *FetchControllerTestSuite) TestFetchNextPageChangesFailedToPausedState()
 	s.fetchController.setStatement(mockStatement)
 	s.mockStore.EXPECT().FetchStatementResults(mockStatement).Return(&mockStatement, nil)
 
-	s.fetchController.FetchNextPage()
+	s.fetchController.fetchNextPage()
 
 	require.Equal(s.T(), types.Paused, s.fetchController.GetFetchState())
 }
@@ -126,12 +126,12 @@ func (s *FetchControllerTestSuite) TestFetchNextPagePreservesRunningState() {
 	s.fetchController.setStatement(mockStatement)
 	s.mockStore.EXPECT().FetchStatementResults(mockStatement).Return(&mockStatement, nil)
 
-	s.fetchController.FetchNextPage()
+	s.fetchController.fetchNextPage()
 
 	require.Equal(s.T(), types.Running, s.fetchController.GetFetchState())
 }
 
-func (s *FetchControllerTestSuite) TestFetchNextPageOnUserInput() {
+func (s *FetchControllerTestSuite) TestFetchNextPage() {
 	mockStatement := types.ProcessedStatement{PageToken: "NOT_EMPTY"}
 	s.mockStore.EXPECT().FetchStatementResults(mockStatement).Return(&mockStatement, nil)
 	s.mockStore.EXPECT().FetchStatementResults(mockStatement).Return(&types.ProcessedStatement{}, nil)
@@ -139,11 +139,11 @@ func (s *FetchControllerTestSuite) TestFetchNextPageOnUserInput() {
 	s.fetchController.Init(mockStatement)
 	s.fetchController.setFetchState(types.Paused)
 
-	s.fetchController.FetchNextPage()
+	s.fetchController.fetchNextPage()
 	// First nextPage returns statement with page token
 	require.Equal(s.T(), types.Paused, s.fetchController.GetFetchState())
 
-	s.fetchController.FetchNextPage()
+	s.fetchController.fetchNextPage()
 	// Second nextPage returns statement with empty page token, so state should be completed
 	require.Equal(s.T(), types.Completed, s.fetchController.GetFetchState())
 }

--- a/internal/pkg/flink/internal/controller/table_controller.go
+++ b/internal/pkg/flink/internal/controller/table_controller.go
@@ -132,8 +132,6 @@ func (t *TableController) getActionForShortcut(shortcut string) func() {
 		return t.toggleAutoRefreshAndRender
 	case "N":
 		return t.fetchNextPageAndRender
-	case "R":
-		return t.goToLastPageAndRender
 	case "H":
 		return t.fastScrollUp
 	case "L":
@@ -162,11 +160,6 @@ func (t *TableController) toggleAutoRefreshAndRender() {
 
 func (t *TableController) fetchNextPageAndRender() {
 	t.fetchController.FetchNextPage()
-	t.renderTable()
-}
-
-func (t *TableController) goToLastPageAndRender() {
-	t.fetchController.JumpToLastPage()
 	t.renderTable()
 }
 

--- a/internal/pkg/flink/internal/controller/table_controller.go
+++ b/internal/pkg/flink/internal/controller/table_controller.go
@@ -130,8 +130,6 @@ func (t *TableController) getActionForShortcut(shortcut string) func() {
 		return t.toggleTableModeAndRender
 	case "A":
 		return t.toggleAutoRefreshAndRender
-	case "N":
-		return t.fetchNextPageAndRender
 	case "H":
 		return t.fastScrollUp
 	case "L":
@@ -155,11 +153,6 @@ func (t *TableController) toggleTableModeAndRender() {
 
 func (t *TableController) toggleAutoRefreshAndRender() {
 	t.fetchController.ToggleAutoRefresh()
-	t.renderTable()
-}
-
-func (t *TableController) fetchNextPageAndRender() {
-	t.fetchController.FetchNextPage()
 	t.renderTable()
 }
 

--- a/internal/pkg/flink/internal/controller/table_controller_test.go
+++ b/internal/pkg/flink/internal/controller/table_controller_test.go
@@ -96,16 +96,6 @@ func (s *TableControllerTestSuite) TestToggleRefreshResultsOnUserInput() {
 	require.Nil(s.T(), result)
 }
 
-func (s *TableControllerTestSuite) TestFetchNextPageOnUserInput() {
-	input := tcell.NewEventKey(tcell.KeyRune, 'N', tcell.ModNone)
-	s.fetchController.EXPECT().FetchNextPage()
-	s.renderTableMockCalls()
-
-	result := s.tableController.AppInputCapture(input)
-
-	require.Nil(s.T(), result)
-}
-
 func (s *TableControllerTestSuite) TestNonSupportedUserInput() {
 	// Test a case when the event is neither 'Q', 'N', Ctrl-C, nor Escape
 	// When we return the event, it's forwarded to tview

--- a/internal/pkg/flink/internal/controller/table_controller_test.go
+++ b/internal/pkg/flink/internal/controller/table_controller_test.go
@@ -106,16 +106,6 @@ func (s *TableControllerTestSuite) TestFetchNextPageOnUserInput() {
 	require.Nil(s.T(), result)
 }
 
-func (s *TableControllerTestSuite) TestJumpToLastPageOnUserInput() {
-	input := tcell.NewEventKey(tcell.KeyRune, 'R', tcell.ModNone)
-	s.fetchController.EXPECT().JumpToLastPage()
-	s.renderTableMockCalls()
-
-	result := s.tableController.AppInputCapture(input)
-
-	require.Nil(s.T(), result)
-}
-
 func (s *TableControllerTestSuite) TestNonSupportedUserInput() {
 	// Test a case when the event is neither 'Q', 'N', Ctrl-C, nor Escape
 	// When we return the event, it's forwarded to tview

--- a/internal/pkg/flink/test/generators/results.go
+++ b/internal/pkg/flink/test/generators/results.go
@@ -128,7 +128,7 @@ func MockResultRow(columnDetails []flinkgatewayv1alpha1.ColumnDetails) *rapid.Ge
 			items = append(items, GetResultItemGeneratorForType(column.GetType()).Draw(t, "a field"))
 		}
 		return map[string]any{
-			"op":  rapid.Float64Range(0, 3).Draw(t, "an operation"),
+			"op":  float64(rapid.IntRange(0, 3).Draw(t, "an operation")),
 			"row": items,
 		}
 	})

--- a/internal/pkg/flink/test/mock/fetch_controller_mock.go
+++ b/internal/pkg/flink/test/mock/fetch_controller_mock.go
@@ -46,18 +46,6 @@ func (mr *MockFetchControllerInterfaceMockRecorder) Close() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockFetchControllerInterface)(nil).Close))
 }
 
-// FetchNextPage mocks base method.
-func (m *MockFetchControllerInterface) FetchNextPage() {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "FetchNextPage")
-}
-
-// FetchNextPage indicates an expected call of FetchNextPage.
-func (mr *MockFetchControllerInterfaceMockRecorder) FetchNextPage() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchNextPage", reflect.TypeOf((*MockFetchControllerInterface)(nil).FetchNextPage))
-}
-
 // ForEach mocks base method.
 func (m *MockFetchControllerInterface) ForEach(arg0 func(int, *types.StatementResultRow)) {
 	m.ctrl.T.Helper()
@@ -164,18 +152,6 @@ func (m *MockFetchControllerInterface) IsTableMode() bool {
 func (mr *MockFetchControllerInterfaceMockRecorder) IsTableMode() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsTableMode", reflect.TypeOf((*MockFetchControllerInterface)(nil).IsTableMode))
-}
-
-// JumpToLastPage mocks base method.
-func (m *MockFetchControllerInterface) JumpToLastPage() {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "JumpToLastPage")
-}
-
-// JumpToLastPage indicates an expected call of JumpToLastPage.
-func (mr *MockFetchControllerInterfaceMockRecorder) JumpToLastPage() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "JumpToLastPage", reflect.TypeOf((*MockFetchControllerInterface)(nil).JumpToLastPage))
 }
 
 // SetAutoRefreshCallback mocks base method.

--- a/internal/pkg/flink/test/mock/gateway_client_fake.go
+++ b/internal/pkg/flink/test/mock/gateway_client_fake.go
@@ -142,14 +142,14 @@ func (c *FakeFlinkGatewayClient) getFakeResultsRunningCounter() ([]any, string) 
 	for i := 0; i < c.fakeCount; i++ {
 		// update before
 		results = append(results, map[string]any{
-			"op":  int32(1),
+			"op":  float64(1),
 			"row": []any{fmt.Sprintf("%v", i)},
 		})
 	}
 
 	// update after (add latest entry)
 	results = append(results, map[string]any{
-		"op":  int32(2),
+		"op":  float64(2),
 		"row": []any{fmt.Sprintf("%v", c.fakeCount)},
 	})
 	c.fakeCount++

--- a/internal/pkg/flink/types/controllers.go
+++ b/internal/pkg/flink/types/controllers.go
@@ -44,7 +44,6 @@ type FetchControllerInterface interface {
 	ToggleAutoRefresh()
 	IsAutoRefreshRunning() bool
 	FetchNextPage()
-	JumpToLastPage()
 	GetHeaders() []string
 	GetMaxWidthPerColumn() []int
 	GetResultsIterator(bool) MaterializedStatementResultsIterator

--- a/internal/pkg/flink/types/controllers.go
+++ b/internal/pkg/flink/types/controllers.go
@@ -43,7 +43,6 @@ type FetchControllerInterface interface {
 	ToggleTableMode()
 	ToggleAutoRefresh()
 	IsAutoRefreshRunning() bool
-	FetchNextPage()
 	GetHeaders() []string
 	GetMaxWidthPerColumn() []int
 	GetResultsIterator(bool) MaterializedStatementResultsIterator


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok
   * no: DO NOT MERGE until the required features are live in prod  

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->
- removed jump to live, because it does not work when there are too many results 
- removed manually fetching the next page, as it is not really needed 
- fixed fake gateway client because it was still using int32 type for operation
