### PR TITLE
Feat/kfs 985 change table eviction logic

### DIFF
--- a/internal/pkg/flink/internal/controller/.snapshots/TestTableControllerTestSuite-TestTableTitleDisplaysPageSizeAndCacheSizeWithUnsafeTrace
+++ b/internal/pkg/flink/internal/controller/.snapshots/TestTableControllerTestSuite-TestTableTitleDisplaysPageSizeAndCacheSizeWithUnsafeTrace
@@ -1,1 +1,1 @@
- Table mode (unknown error) | last page size: 10 | current cache size: 10/10 | table size: 10
+ Table mode (unknown error) | Last page size: 10 | Current cache size: 10/10 | Table size: 10 

--- a/internal/pkg/flink/internal/controller/fetch_controller.go
+++ b/internal/pkg/flink/internal/controller/fetch_controller.go
@@ -20,7 +20,7 @@ type FetchController struct {
 }
 
 const (
-	maxResultsCapacity     int  = 1000000
+	maxResultsCapacity     int  = 10000
 	defaultRefreshInterval uint = 1000 // in milliseconds
 	minColumnWidth         int  = 4    // min characters displayed in a column
 )
@@ -104,12 +104,10 @@ func (t *FetchController) fetchNextPage() {
 		t.setFetchState(types.Failed)
 		return
 	}
-	rows := newResults.StatementResults.GetRows()
-	t.materializedStatementResults.SetMaxResults(len(rows) * 5)
 
 	// update data
 	t.setStatement(*newResults)
-	t.materializedStatementResults.Append(rows...)
+	t.materializedStatementResults.Append(newResults.StatementResults.GetRows()...)
 	if newResults.PageToken == "" {
 		t.setFetchState(types.Completed)
 		return
@@ -130,10 +128,6 @@ func (t *FetchController) GetHeaders() []string {
 
 func (t *FetchController) GetMaxWidthPerColumn() []int {
 	return t.materializedStatementResults.GetMaxWidthPerColum()
-}
-
-func (t *FetchController) GetResultsIterator(startFromBack bool) types.MaterializedStatementResultsIterator {
-	return t.materializedStatementResults.Iterator(startFromBack)
 }
 
 func (t *FetchController) ForEach(f func(rowIdx int, row *types.StatementResultRow)) {

--- a/internal/pkg/flink/internal/controller/table_controller.go
+++ b/internal/pkg/flink/internal/controller/table_controller.go
@@ -43,8 +43,8 @@ func (t *TableController) SetRunInteractiveInputCallback(runInteractiveInput fun
 
 func (t *TableController) Init(statement types.ProcessedStatement) {
 	t.isRowViewOpen = false
-	t.fetchController.Init(statement)
 	t.fetchController.SetAutoRefreshCallback(t.renderTableAsync)
+	t.fetchController.Init(statement)
 	t.renderTable()
 }
 
@@ -200,14 +200,15 @@ func (t *TableController) renderTitle() {
 	}
 
 	if t.debug {
+		materializedResults := t.fetchController.GetMaterializedStatementResults()
 		t.table.SetTitle(fmt.Sprintf(
-			" %s (%s) | last page size: %d | current cache size: %d/%d | table size: %d ",
+			" %s (%s) | Last page size: %d | Current cache size: %d/%d | Table size: %d ",
 			mode,
 			state,
 			t.fetchController.GetStatement().GetPageSize(),
-			t.fetchController.GetMaterializedStatementResults().GetChangelogSize(),
-			t.fetchController.GetMaterializedStatementResults().GetMaxResults(),
-			t.fetchController.GetMaterializedStatementResults().GetTableSize(),
+			materializedResults.GetChangelogSize(),
+			materializedResults.GetMaxResults(),
+			materializedResults.GetTableSize(),
 		))
 	} else {
 		t.table.SetTitle(fmt.Sprintf(" %s (%s) ", mode, state))

--- a/internal/pkg/flink/types/controllers.go
+++ b/internal/pkg/flink/types/controllers.go
@@ -45,7 +45,6 @@ type FetchControllerInterface interface {
 	IsAutoRefreshRunning() bool
 	GetHeaders() []string
 	GetMaxWidthPerColumn() []int
-	GetResultsIterator(bool) MaterializedStatementResultsIterator
 	ForEach(func(rowIdx int, row *StatementResultRow))
 	Init(statement ProcessedStatement)
 	Close()

--- a/internal/pkg/flink/types/materialized_results.go
+++ b/internal/pkg/flink/types/materialized_results.go
@@ -220,10 +220,6 @@ func (s *MaterializedStatementResults) GetMaxWidthPerColum() []int {
 	return columnWidths
 }
 
-func (s *MaterializedStatementResults) SetMaxResults(size int) {
-	s.maxCapacity = size
-}
-
 func (s *MaterializedStatementResults) GetMaxResults() int {
 	return s.maxCapacity
 }

--- a/internal/pkg/flink/types/materialized_results.go
+++ b/internal/pkg/flink/types/materialized_results.go
@@ -118,14 +118,13 @@ func (s *MaterializedStatementResults) Iterator(startFromBack bool) Materialized
 
 func (s *MaterializedStatementResults) cleanup() {
 	if s.changelog.Len() > s.maxCapacity {
-		removedRow := s.changelog.RemoveFront()
-		removedRowKey := removedRow.GetRowKey()
+		s.changelog.RemoveFront()
+	}
 
-		listPtr, ok := s.cache[removedRowKey]
-		if ok {
-			s.table.Remove(listPtr)
-			delete(s.cache, removedRowKey)
-		}
+	if s.table.Len() > s.maxCapacity {
+		removedRow := s.table.RemoveFront()
+		removedRowKey := removedRow.GetRowKey()
+		delete(s.cache, removedRowKey)
 	}
 }
 


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->
- we no longer remove already registered events from the result table, in case something is popped from the changelog (so the table always represents the current state of the event stream up to this point instead of representing the state of the stream we have in memory)
- I set the cache size to a fixed value again (10k rows) because once the page size gets smaller when the stream catches up, the cache will be tiny (e.g. page size = 3 -> cache size = 15)
- we no longer need the iterator for selected rows, because you can back a table cell with a custom struct
