### PR TITLE
[DGS-5681] Add ability to update network type for SR from CLI

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -173,3 +173,5 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
+
+replace github.com/confluentinc/ccloud-sdk-go-v1-public v0.0.0-20230427001341-5f8d2cce5ad9 => /Users/ksrinivasan/git/go/src/github.com/confluentinc/ccloud-sdk-go-v1-public

--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/confluentinc/ccloud-sdk-go-v2/metrics v0.2.0
 	github.com/confluentinc/ccloud-sdk-go-v2/org v0.6.0
 	github.com/confluentinc/ccloud-sdk-go-v2/service-quota v0.2.0
-	github.com/confluentinc/ccloud-sdk-go-v2/srcm v0.4.0
+	github.com/confluentinc/ccloud-sdk-go-v2/srcm v0.5.0
 	github.com/confluentinc/ccloud-sdk-go-v2/stream-designer v0.3.0
 	github.com/confluentinc/confluent-kafka-go v1.9.3-RC3
 	github.com/confluentinc/go-editor v0.11.0

--- a/go.sum
+++ b/go.sum
@@ -130,6 +130,8 @@ github.com/confluentinc/ccloud-sdk-go-v2/service-quota v0.2.0 h1:xVSmwdycExze1E2
 github.com/confluentinc/ccloud-sdk-go-v2/service-quota v0.2.0/go.mod h1:zZWZoGWJuO0Qm4lO6H2KlXMx4OoB/yhD8y6J1ZB/97Q=
 github.com/confluentinc/ccloud-sdk-go-v2/srcm v0.4.0 h1:k9pB+WBVn3pEIZ2r+LIi7c0mefb/5cVMUI5NmjJLegk=
 github.com/confluentinc/ccloud-sdk-go-v2/srcm v0.4.0/go.mod h1:qY4Y/QCDKI0eR+HLVJWGFstsTAiI83+sowKOyoRFhF0=
+github.com/confluentinc/ccloud-sdk-go-v2/srcm v0.5.0 h1:Axck11PErBK7rNUJKf8lM3/dBVXzum4oxzl6P++IW4U=
+github.com/confluentinc/ccloud-sdk-go-v2/srcm v0.5.0/go.mod h1:qY4Y/QCDKI0eR+HLVJWGFstsTAiI83+sowKOyoRFhF0=
 github.com/confluentinc/ccloud-sdk-go-v2/stream-designer v0.3.0 h1:zI59UpVm88hQn+dG4KO3TRxD2xdSVQbg5aqSm9/3LXo=
 github.com/confluentinc/ccloud-sdk-go-v2/stream-designer v0.3.0/go.mod h1:29HYKS91pkCre55OPNGRIWpkKSBLUDlzXbrxZ291Xhk=
 github.com/confluentinc/confluent-kafka-go v1.9.3-RC3 h1:urDeBIsNr0hgRf3nZn66SHtdBO/4DmEDSsMWquaolmo=

--- a/internal/cmd/schema-registry/command_cluster_enable.go
+++ b/internal/cmd/schema-registry/command_cluster_enable.go
@@ -40,6 +40,7 @@ func (c *command) newClusterEnableCommand() *cobra.Command {
 	pcmd.AddCloudFlag(cmd)
 	cmd.Flags().String("geo", "", fmt.Sprintf("Specify the geo as %s.", utils.ArrayToCommaDelimitedString(availableGeos, "or")))
 	addPackageFlag(cmd, essentialsPackage)
+	addNetworkTypeFlag(cmd, publicNetworkType)
 	pcmd.AddContextFlag(cmd, c.CLICommand)
 	pcmd.AddEnvironmentFlag(cmd, c.AuthenticatedCLICommand)
 	pcmd.AddOutputFlag(cmd)
@@ -80,6 +81,15 @@ func (c *command) clusterEnable(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
+	networkTypeDisplayName, err := cmd.Flags().GetString("networkType")
+	if err != nil {
+		return err
+	}
+	networkTypeInternal, err := getNetworkTypeInternal(networkTypeDisplayName)
+	if err != nil {
+		return err
+	}
+
 	environmentId, err := c.Context.EnvironmentId()
 	if err != nil {
 		return err
@@ -94,7 +104,8 @@ func (c *command) clusterEnable(cmd *cobra.Command, _ []string) error {
 		// Name is a special string that everyone expects. Originally, this field was added to support
 		// multiple SR instances, but for now there's a contract between our services that it will be
 		// this hardcoded string constant
-		Name: "account schema-registry",
+		Name:        "account schema-registry",
+		NetworkType: networkTypeInternal,
 	}
 
 	var out *enableOut

--- a/internal/cmd/schema-registry/command_cluster_update.go
+++ b/internal/cmd/schema-registry/command_cluster_update.go
@@ -1,11 +1,11 @@
 package schemaregistry
 
 import (
-	srcmv2 "github.com/confluentinc/ccloud-sdk-go-v2/srcm/v2"
 	"strings"
 
 	"github.com/spf13/cobra"
 
+	srcmv2 "github.com/confluentinc/ccloud-sdk-go-v2/srcm/v2"
 	srsdk "github.com/confluentinc/schema-registry-sdk-go"
 
 	pcmd "github.com/confluentinc/cli/internal/pkg/cmd"
@@ -101,24 +101,26 @@ func (c *command) updateNetworkType(cmd *cobra.Command) error {
 	}
 
 	cluster := clusters[0]
-	//clusterSpec := cluster.GetSpec()
+	clusterSpec := cluster.GetSpec()
 
 	networkTypeDisplayName, err := cmd.Flags().GetString("networkType")
 	if err != nil {
 		return err
 	}
-	//networkTypeInternal, err := getNetworkTypeInternal(networkTypeDisplayName)
-	//if err != nil {
-	//	return err
-	//}
+
+	if strings.ToLower(clusterSpec.GetNetworkType()) == networkTypeDisplayName {
+		output.ErrPrintf(errors.SRInvalidNetworkTypeUpgrade, environmentId, networkTypeDisplayName)
+		return nil
+	}
 
 	clusterUpdateRequest := &srcmv2.SrcmV2ClusterUpdate{
 		Spec: &srcmv2.SrcmV2ClusterSpecUpdate{
 			Environment: &srcmv2.GlobalObjectReference{Id: environmentId},
+			NetworkType: srcmv2.PtrString(networkTypeDisplayName),
 		},
 	}
 
-	if _, err := c.V2Client.UpgradeSchemaRegistryCluster(*clusterUpdateRequest, cluster.GetId()); err != nil {
+	if _, err := c.V2Client.UpdateSchemaRegistryCluster(*clusterUpdateRequest, cluster.GetId()); err != nil {
 		return err
 	}
 

--- a/internal/cmd/schema-registry/command_cluster_update.go
+++ b/internal/cmd/schema-registry/command_cluster_update.go
@@ -1,6 +1,7 @@
 package schemaregistry
 
 import (
+	srcmv2 "github.com/confluentinc/ccloud-sdk-go-v2/srcm/v2"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -16,7 +17,7 @@ import (
 func (c *command) newClusterUpdateCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:         "update",
-		Short:       "Update global mode or compatibility of Schema Registry.",
+		Short:       "Update global mode, network type  or compatibility of Schema Registry.",
 		Args:        cobra.NoArgs,
 		RunE:        c.clusterUpdate,
 		Annotations: map[string]string{pcmd.RunRequirement: pcmd.RequireCloudLogin},
@@ -33,6 +34,10 @@ func (c *command) newClusterUpdateCommand() *cobra.Command {
 				Text: "Update top-level mode of Schema Registry.",
 				Code: "confluent schema-registry cluster update --mode readwrite",
 			},
+			examples.Example{
+				Text: "Update network type Schema Registry.",
+				Code: "confluent schema-registry cluster update --networkType private",
+			},
 		),
 	}
 
@@ -43,6 +48,7 @@ func (c *command) newClusterUpdateCommand() *cobra.Command {
 	addRulesetDefaultsFlag(cmd)
 	addRulesetOverridesFlag(cmd)
 	addModeFlag(cmd)
+	addNetworkTypeFlag(cmd, "")
 	pcmd.AddApiKeyFlag(cmd, c.AuthenticatedCLICommand)
 	pcmd.AddApiSecretFlag(cmd)
 	pcmd.AddContextFlag(cmd, c.CLICommand)
@@ -68,7 +74,56 @@ func (c *command) clusterUpdate(cmd *cobra.Command, _ []string) error {
 		return c.updateTopLevelMode(cmd)
 	}
 
+	networkType, err := cmd.Flags().GetString("networkType")
+	if err != nil {
+		return err
+	}
+	if networkType != "" {
+		return c.updateNetworkType(cmd)
+	}
+
 	return errors.New(errors.CompatibilityOrModeErrorMsg)
+}
+
+func (c *command) updateNetworkType(cmd *cobra.Command) error {
+	environmentId, err := c.Context.EnvironmentId()
+	if err != nil {
+		return err
+	}
+
+	clusters, err := c.V2Client.GetSchemaRegistryClustersByEnvironment(environmentId)
+	if err != nil {
+		return err
+	}
+
+	if len(clusters) == 0 {
+		return errors.NewSRNotEnabledError()
+	}
+
+	cluster := clusters[0]
+	//clusterSpec := cluster.GetSpec()
+
+	networkTypeDisplayName, err := cmd.Flags().GetString("networkType")
+	if err != nil {
+		return err
+	}
+	//networkTypeInternal, err := getNetworkTypeInternal(networkTypeDisplayName)
+	//if err != nil {
+	//	return err
+	//}
+
+	clusterUpdateRequest := &srcmv2.SrcmV2ClusterUpdate{
+		Spec: &srcmv2.SrcmV2ClusterSpecUpdate{
+			Environment: &srcmv2.GlobalObjectReference{Id: environmentId},
+		},
+	}
+
+	if _, err := c.V2Client.UpgradeSchemaRegistryCluster(*clusterUpdateRequest, cluster.GetId()); err != nil {
+		return err
+	}
+
+	output.Printf(errors.UpdatedToNetworkTypeMsg, environmentId, networkTypeDisplayName)
+	return nil
 }
 
 func (c *command) updateTopLevelCompatibility(cmd *cobra.Command) error {

--- a/internal/cmd/schema-registry/command_cluster_upgrade.go
+++ b/internal/cmd/schema-registry/command_cluster_upgrade.go
@@ -77,7 +77,7 @@ func (c *command) clusterUpgrade(cmd *cobra.Command, _ []string) error {
 		},
 	}
 
-	if _, err := c.V2Client.UpgradeSchemaRegistryCluster(*clusterUpdateRequest, cluster.GetId()); err != nil {
+	if _, err := c.V2Client.UpdateSchemaRegistryCluster(*clusterUpdateRequest, cluster.GetId()); err != nil {
 		return err
 	}
 

--- a/internal/cmd/schema-registry/utils.go
+++ b/internal/cmd/schema-registry/utils.go
@@ -2,11 +2,11 @@ package schemaregistry
 
 import (
 	"fmt"
-	ccloudv1 "github.com/confluentinc/ccloud-sdk-go-v1-public"
 	"strings"
 
 	"github.com/spf13/cobra"
 
+	ccloudv1 "github.com/confluentinc/ccloud-sdk-go-v1-public"
 	"github.com/confluentinc/cli/internal/pkg/errors"
 	"github.com/confluentinc/cli/internal/pkg/utils"
 )

--- a/internal/cmd/schema-registry/utils.go
+++ b/internal/cmd/schema-registry/utils.go
@@ -2,6 +2,7 @@ package schemaregistry
 
 import (
 	"fmt"
+	ccloudv1 "github.com/confluentinc/ccloud-sdk-go-v1-public"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -15,6 +16,8 @@ const (
 	OnPremAuthenticationMsg   = "--ca-location <ca-file-location> --schema-registry-endpoint <schema-registry-endpoint>"
 	essentialsPackage         = "essentials"
 	advancedPackage           = "advanced"
+	privateNetworkType        = "private"
+	publicNetworkType         = "public"
 	essentialsPackageInternal = "free"
 	advancedPackageInternal   = "paid"
 )
@@ -25,6 +28,7 @@ var packageDisplayNameMapping = map[string]string{
 }
 
 var packageDisplayNames = []string{essentialsPackage, advancedPackage}
+var networkTypeDisplayNames = []string{privateNetworkType, publicNetworkType}
 
 func getPackageInternalName(inputPackageDisplayName string) (string, error) {
 	inputPackageDisplayName = strings.ToLower(inputPackageDisplayName)
@@ -38,10 +42,32 @@ func getPackageInternalName(inputPackageDisplayName string) (string, error) {
 		fmt.Sprintf(errors.SRInvalidPackageSuggestions, getCommaDelimitedPackagesString()))
 }
 
+func getNetworkTypeInternal(inputNetworkType string) (ccloudv1.SchemaRegistryNetworkType, error) {
+	inputNetworkType = strings.ToLower(inputNetworkType)
+	if inputNetworkType == publicNetworkType {
+		return ccloudv1.SchemaRegistryNetworkType_SR_PUBLIC, nil
+	} else if inputNetworkType == privateNetworkType {
+		return ccloudv1.SchemaRegistryNetworkType_SR_PRIVATE, nil
+	} else if inputNetworkType == "" {
+		return ccloudv1.SchemaRegistryNetworkType_SR_UNKNOWN, nil
+	}
+	return ccloudv1.SchemaRegistryNetworkType_SR_PUBLIC,
+		errors.NewErrorWithSuggestions(fmt.Sprintf(errors.SRInvalidNetworkTypeErrorMsg, inputNetworkType),
+			fmt.Sprintf(errors.SRInvalidNetworkTypeSuggestions, getCommaDelimitedNetworkTypeString()))
+}
+
 func getCommaDelimitedPackagesString() string {
 	return utils.ArrayToCommaDelimitedString(packageDisplayNames, "or")
 }
 
 func addPackageFlag(cmd *cobra.Command, defaultPackage string) {
 	cmd.Flags().String("package", defaultPackage, fmt.Sprintf("Specify the type of Stream Governance package as %s.", getCommaDelimitedPackagesString()))
+}
+
+func getCommaDelimitedNetworkTypeString() string {
+	return utils.ArrayToCommaDelimitedString(networkTypeDisplayNames, "or")
+}
+
+func addNetworkTypeFlag(cmd *cobra.Command, defaultNetworkType string) {
+	cmd.Flags().String("networkType", defaultNetworkType, fmt.Sprintf("Specify the network type as %s.", getCommaDelimitedNetworkTypeString()))
 }

--- a/internal/pkg/ccloudv2/schema_registry.go
+++ b/internal/pkg/ccloudv2/schema_registry.go
@@ -77,7 +77,7 @@ func (c *Client) DeleteSchemaRegistryCluster(clusterId, environment string) erro
 	return errors.CatchCCloudV2Error(err, httpResp)
 }
 
-func (c *Client) UpgradeSchemaRegistryCluster(srcmV2ClusterUpdate srcmv2.SrcmV2ClusterUpdate, clusterId string) (srcmv2.SrcmV2Cluster, error) {
+func (c *Client) UpdateSchemaRegistryCluster(srcmV2ClusterUpdate srcmv2.SrcmV2ClusterUpdate, clusterId string) (srcmv2.SrcmV2Cluster, error) {
 	cluster, httpResp, err := c.SchemaRegistryClient.ClustersSrcmV2Api.UpdateSrcmV2Cluster(c.SchemaRegistryApiContext(), clusterId).SrcmV2ClusterUpdate(srcmV2ClusterUpdate).Execute()
 	return cluster, errors.CatchCCloudV2Error(err, httpResp)
 }

--- a/internal/pkg/errors/error_message.go
+++ b/internal/pkg/errors/error_message.go
@@ -231,6 +231,7 @@ const (
 	SRInvalidPackageTypeErrorMsg    = `"%s" is an invalid package type`
 	SRInvalidPackageSuggestions     = "Allowed values for `--package` flag are: %s."
 	SRInvalidPackageUpgrade         = "Environment \"%s\" is already using the Stream Governance \"%s\" package.\n"
+	SRInvalidNetworkTypeUpgrade     = "Environment \"%s\" is already using the network type \"%s\".\n"
 	SRInvalidNetworkTypeErrorMsg    = `"%s" is an invalid network type`
 	SRInvalidNetworkTypeSuggestions = "Allowed values for `--networkType` flag are: %s."
 

--- a/internal/pkg/errors/error_message.go
+++ b/internal/pkg/errors/error_message.go
@@ -227,10 +227,12 @@ const (
 	SchemaNotFoundErrorMsg                   = "Schema Registry subject or version not found"
 	SchemaNotFoundSuggestions                = "List available subjects with `confluent schema-registry subject list`.\n" +
 		"List available versions with `confluent schema-registry subject describe`."
-	NoSubjectLevelConfigErrorMsg = `subject "%s" does not have subject-level compatibility configured`
-	SRInvalidPackageTypeErrorMsg = `"%s" is an invalid package type`
-	SRInvalidPackageSuggestions  = "Allowed values for `--package` flag are: %s."
-	SRInvalidPackageUpgrade      = "Environment \"%s\" is already using the Stream Governance \"%s\" package.\n"
+	NoSubjectLevelConfigErrorMsg    = `subject "%s" does not have subject-level compatibility configured`
+	SRInvalidPackageTypeErrorMsg    = `"%s" is an invalid package type`
+	SRInvalidPackageSuggestions     = "Allowed values for `--package` flag are: %s."
+	SRInvalidPackageUpgrade         = "Environment \"%s\" is already using the Stream Governance \"%s\" package.\n"
+	SRInvalidNetworkTypeErrorMsg    = `"%s" is an invalid network type`
+	SRInvalidNetworkTypeSuggestions = "Allowed values for `--networkType` flag are: %s."
 
 	// secret commands
 	EnterInputTypeErrorMsg    = "enter %s"

--- a/internal/pkg/errors/strings.go
+++ b/internal/pkg/errors/strings.go
@@ -58,6 +58,7 @@ const (
 	KsqlDBNotBackedByKafkaMsg = "The ksqlDB cluster \"%s\" is backed by \"%s\" which is not the current Kafka cluster \"%s\".\nTo switch to the correct cluster, use `confluent kafka cluster use %s`.\n"
 
 	// schema-registry commands
+	UpdatedToNetworkTypeMsg             = "Successfully updated network type to \"%s\"\n"
 	UpdatedToLevelCompatibilityMsg      = "Successfully updated Top Level compatibility to \"%s\"\n"
 	UpdatedTopLevelModeMsg              = "Successfully updated Top Level mode to \"%s\"\n"
 	RegisteredSchemaMsg                 = "Successfully registered schema with ID %v\n"


### PR DESCRIPTION
Release Notes
-------------
New Features
- Support for private link in Schema Registry

Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * No

What
----
 Add ability to update network type for SR from CLI. This is required to for enabling private link access to SR cluster in ccloud. Network type can be specified with `--networkType` in `enable` and `update` schemaregistry commands. Accepted values for networkType are `private` or `public`

References
----------
https://confluentinc.atlassian.net/browse/DGS-5681

Test & Review
-------------
TDB

Open Questions / Follow-ups
---------------------------
None
