### PR TITLE
feat: pause refresh when user triggers scroll event

### DIFF
--- a/internal/pkg/flink/components/.snapshots/TestTableViewTestSuite-TestTableShortcutsShouldDisplayChangelogMode
+++ b/internal/pkg/flink/components/.snapshots/TestTableViewTestSuite-TestTableShortcutsShouldDisplayChangelogMode
@@ -1,0 +1,18 @@
+([]types.Shortcut) (len=4) {
+  (types.Shortcut) {
+    KeyText: (string) (len=1) "Q",
+    Text: (string) (len=4) "Quit"
+  },
+  (types.Shortcut) {
+    KeyText: (string) (len=1) "M",
+    Text: (string) (len=14) "Show changelog"
+  },
+  (types.Shortcut) {
+    KeyText: (string) (len=1) "P",
+    Text: (string) (len=4) "Play"
+  },
+  (types.Shortcut) {
+    KeyText: (string) (len=3) "U/D",
+    Text: (string) (len=12) "Jump up/down"
+  }
+}

--- a/internal/pkg/flink/components/.snapshots/TestTableViewTestSuite-TestTableShortcutsShouldDisplayPause
+++ b/internal/pkg/flink/components/.snapshots/TestTableViewTestSuite-TestTableShortcutsShouldDisplayPause
@@ -1,0 +1,18 @@
+([]types.Shortcut) (len=4) {
+  (types.Shortcut) {
+    KeyText: (string) (len=1) "Q",
+    Text: (string) (len=4) "Quit"
+  },
+  (types.Shortcut) {
+    KeyText: (string) (len=1) "M",
+    Text: (string) (len=14) "Show changelog"
+  },
+  (types.Shortcut) {
+    KeyText: (string) (len=1) "P",
+    Text: (string) (len=5) "Pause"
+  },
+  (types.Shortcut) {
+    KeyText: (string) (len=3) "U/D",
+    Text: (string) (len=12) "Jump up/down"
+  }
+}

--- a/internal/pkg/flink/components/.snapshots/TestTableViewTestSuite-TestTableShortcutsShouldDisplayPlay
+++ b/internal/pkg/flink/components/.snapshots/TestTableViewTestSuite-TestTableShortcutsShouldDisplayPlay
@@ -1,0 +1,18 @@
+([]types.Shortcut) (len=4) {
+  (types.Shortcut) {
+    KeyText: (string) (len=1) "Q",
+    Text: (string) (len=4) "Quit"
+  },
+  (types.Shortcut) {
+    KeyText: (string) (len=1) "M",
+    Text: (string) (len=14) "Show changelog"
+  },
+  (types.Shortcut) {
+    KeyText: (string) (len=1) "P",
+    Text: (string) (len=4) "Play"
+  },
+  (types.Shortcut) {
+    KeyText: (string) (len=3) "U/D",
+    Text: (string) (len=12) "Jump up/down"
+  }
+}

--- a/internal/pkg/flink/components/.snapshots/TestTableViewTestSuite-TestTableShortcutsShouldDisplayTableMode
+++ b/internal/pkg/flink/components/.snapshots/TestTableViewTestSuite-TestTableShortcutsShouldDisplayTableMode
@@ -1,0 +1,18 @@
+([]types.Shortcut) (len=4) {
+  (types.Shortcut) {
+    KeyText: (string) (len=1) "Q",
+    Text: (string) (len=4) "Quit"
+  },
+  (types.Shortcut) {
+    KeyText: (string) (len=1) "M",
+    Text: (string) (len=10) "Show table"
+  },
+  (types.Shortcut) {
+    KeyText: (string) (len=1) "P",
+    Text: (string) (len=4) "Play"
+  },
+  (types.Shortcut) {
+    KeyText: (string) (len=3) "U/D",
+    Text: (string) (len=12) "Jump up/down"
+  }
+}

--- a/internal/pkg/flink/internal/controller/interactive_output_controller_test.go
+++ b/internal/pkg/flink/internal/controller/interactive_output_controller_test.go
@@ -241,3 +241,99 @@ func (s *InteractiveOutputControllerTestSuite) TestTableTitleDisplaysPageSizeAnd
 
 	cupaloy.SnapshotT(s.T(), actual)
 }
+
+func (s *InteractiveOutputControllerTestSuite) TestArrowUpOrDownStopsFetchWhenAutoRefreshIsRunning() {
+	// Given
+	testCases := []struct {
+		name  string
+		input *tcell.EventKey
+	}{
+		{name: "Test Arrow Up", input: tcell.NewEventKey(tcell.KeyUp, rune(0), tcell.ModNone)},
+		{name: "Test Arrow Down", input: tcell.NewEventKey(tcell.KeyDown, rune(0), tcell.ModNone)},
+	}
+
+	for _, testCase := range testCases {
+		s.T().Run(testCase.name, func(t *testing.T) {
+			s.initMockCalls(&types.MaterializedStatementResults{})
+			s.interactiveOutputController.init()
+			s.resultFetcher.EXPECT().IsAutoRefreshRunning().Return(true)
+			s.resultFetcher.EXPECT().ToggleAutoRefresh()
+			s.updateTableMockCalls(&types.MaterializedStatementResults{})
+
+			result := s.interactiveOutputController.inputCapture(testCase.input)
+
+			require.Nil(t, result)
+		})
+	}
+}
+
+func (s *InteractiveOutputControllerTestSuite) TestArrowUpOrDownDoesNothingWhenAutoRefreshNotRunning() {
+	// Given
+	testCases := []struct {
+		name  string
+		input *tcell.EventKey
+	}{
+		{name: "Test Arrow Up", input: tcell.NewEventKey(tcell.KeyUp, rune(0), tcell.ModNone)},
+		{name: "Test Arrow Down", input: tcell.NewEventKey(tcell.KeyDown, rune(0), tcell.ModNone)},
+	}
+
+	for _, testCase := range testCases {
+		s.T().Run(testCase.name, func(t *testing.T) {
+			s.initMockCalls(&types.MaterializedStatementResults{})
+			s.interactiveOutputController.init()
+			s.resultFetcher.EXPECT().IsAutoRefreshRunning().Return(false)
+
+			result := s.interactiveOutputController.inputCapture(testCase.input)
+
+			require.Equal(t, testCase.input, result)
+		})
+	}
+}
+
+func (s *InteractiveOutputControllerTestSuite) TestJumpUpOrDownStopsFetchWhenAutoRefreshIsRunning() {
+	// Given
+	testCases := []struct {
+		name  string
+		input *tcell.EventKey
+	}{
+		{name: "Test Jump Up", input: tcell.NewEventKey(tcell.KeyRune, rune(components.JumpUpShortcut[0]), tcell.ModNone)},
+		{name: "Test Jump Down", input: tcell.NewEventKey(tcell.KeyRune, rune(components.JumpDownShortcut[0]), tcell.ModNone)},
+	}
+
+	for _, testCase := range testCases {
+		s.T().Run(testCase.name, func(t *testing.T) {
+			s.initMockCalls(&types.MaterializedStatementResults{})
+			s.interactiveOutputController.init()
+			s.resultFetcher.EXPECT().IsAutoRefreshRunning().Return(true)
+			s.resultFetcher.EXPECT().ToggleAutoRefresh()
+			s.updateTableMockCalls(&types.MaterializedStatementResults{})
+
+			result := s.interactiveOutputController.inputCapture(testCase.input)
+
+			require.Nil(t, result)
+		})
+	}
+}
+
+func (s *InteractiveOutputControllerTestSuite) TestJumpUpOrDownScrollsWhenAutoRefreshNotRunning() {
+	// Given
+	testCases := []struct {
+		name  string
+		input *tcell.EventKey
+	}{
+		{name: "Test Jump Up", input: tcell.NewEventKey(tcell.KeyRune, rune(components.JumpUpShortcut[0]), tcell.ModNone)},
+		{name: "Test Jump Down", input: tcell.NewEventKey(tcell.KeyRune, rune(components.JumpDownShortcut[0]), tcell.ModNone)},
+	}
+
+	for _, testCase := range testCases {
+		s.T().Run(testCase.name, func(t *testing.T) {
+			s.initMockCalls(&types.MaterializedStatementResults{})
+			s.interactiveOutputController.init()
+			s.resultFetcher.EXPECT().IsAutoRefreshRunning().Return(false)
+
+			result := s.interactiveOutputController.inputCapture(testCase.input)
+
+			require.Nil(t, result)
+		})
+	}
+}

--- a/internal/pkg/flink/internal/controller/interactive_output_controller_test.go
+++ b/internal/pkg/flink/internal/controller/interactive_output_controller_test.go
@@ -242,7 +242,7 @@ func (s *InteractiveOutputControllerTestSuite) TestTableTitleDisplaysPageSizeAnd
 	cupaloy.SnapshotT(s.T(), actual)
 }
 
-func (s *InteractiveOutputControllerTestSuite) TestArrowUpOrDownStopsFetchWhenAutoRefreshIsRunning() {
+func (s *InteractiveOutputControllerTestSuite) TestArrowUpOrDownTogglesAutoRefreshWhenAutoRefreshIsRunning() {
 	// Given
 	testCases := []struct {
 		name  string
@@ -290,7 +290,7 @@ func (s *InteractiveOutputControllerTestSuite) TestArrowUpOrDownDoesNothingWhenA
 	}
 }
 
-func (s *InteractiveOutputControllerTestSuite) TestJumpUpOrDownStopsFetchWhenAutoRefreshIsRunning() {
+func (s *InteractiveOutputControllerTestSuite) TestJumpUpOrDownTogglesAutoRefreshWhenAutoRefreshIsRunning() {
 	// Given
 	testCases := []struct {
 		name  string


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->
Automatically pause the auto refresh when a user triggers a scroll event (arrow up/down, jump keys U/D)

**Note: merge after   #2052 **
