### PR TITLE
fixing panic in kafka client-config create

### DIFF
--- a/internal/pkg/dynamic-config/dynamic_context.go
+++ b/internal/pkg/dynamic-config/dynamic_context.go
@@ -183,7 +183,7 @@ func (d *DynamicContext) SchemaRegistryCluster(cmd *cobra.Command) (*v1.SchemaRe
 			if len(srClusters) != 0 {
 				cluster = makeSRCluster(&srClusters[0])
 			} else {
-				cluster = nil
+				return nil, errors.NewSRNotEnabledError()
 			}
 			clusterChanged = true
 		}

--- a/internal/pkg/dynamic-config/dynamic_context.go
+++ b/internal/pkg/dynamic-config/dynamic_context.go
@@ -146,7 +146,7 @@ func (d *DynamicContext) UseAPIKey(apiKey string, clusterId string) error {
 }
 
 // SchemaRegistryCluster returns the SchemaRegistryCluster of the Context,
-// or an empty SchemaRegistryCluster if there is none set,
+// or a SRNotEnabledError if there is none set,
 // or an ErrNotLoggedIn if the user is not logged in.
 func (d *DynamicContext) SchemaRegistryCluster(cmd *cobra.Command) (*v1.SchemaRegistryCluster, error) {
 	resource, _ := cmd.Flags().GetString("resource")
@@ -159,6 +159,7 @@ func (d *DynamicContext) SchemaRegistryCluster(cmd *cobra.Command) (*v1.SchemaRe
 
 	var cluster *v1.SchemaRegistryCluster
 	var clusterChanged bool
+	var srNotEnabledErr error
 	if resourceType == presource.SchemaRegistryCluster {
 		for _, srCluster := range d.SchemaRegistryClusters {
 			if srCluster.GetId() == resource {
@@ -183,7 +184,8 @@ func (d *DynamicContext) SchemaRegistryCluster(cmd *cobra.Command) (*v1.SchemaRe
 			if len(srClusters) != 0 {
 				cluster = makeSRCluster(&srClusters[0])
 			} else {
-				return nil, errors.NewSRNotEnabledError()
+				cluster = nil
+				srNotEnabledErr = errors.NewSRNotEnabledError()
 			}
 			clusterChanged = true
 		}
@@ -194,7 +196,7 @@ func (d *DynamicContext) SchemaRegistryCluster(cmd *cobra.Command) (*v1.SchemaRe
 			return nil, err
 		}
 	}
-	return cluster, nil
+	return cluster, srNotEnabledErr
 }
 
 func (d *DynamicContext) HasLogin() bool {


### PR DESCRIPTION
Release Notes
-------------
Bug Fixes

- Prevents panic when trying to run `kafka client-config create` commands

Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
Fixes a nil dereference panic that can occur when `kafka client-config create` is run if Schema Registry is not enabled for the current environment

References
----------
https://confluentinc.atlassian.net/browse/CLI-2574 
