### PR TITLE
feat: adjust logic when to show basic vs. interactive table

### DIFF
--- a/internal/pkg/flink/app/application.go
+++ b/internal/pkg/flink/app/application.go
@@ -13,6 +13,8 @@ import (
 	"github.com/confluentinc/cli/internal/pkg/flink/types"
 )
 
+const minNumColumnsToUseInteractiveTable = 4
+
 type Application struct {
 	history                     *history.History
 	store                       types.StoreInterface
@@ -118,10 +120,10 @@ func (a *Application) getOutputController(processedStatementWithResults types.Pr
 	if processedStatementWithResults.IsLocalStatement {
 		return a.basicOutputController
 	}
-	if processedStatementWithResults.PageToken != "" {
+	if processedStatementWithResults.PageToken != "" || processedStatementWithResults.IsSelectStatement {
 		return a.interactiveOutputController
 	}
-	if len(processedStatementWithResults.StatementResults.GetHeaders()) > 1 && len(processedStatementWithResults.StatementResults.GetRows()) > 1 {
+	if len(processedStatementWithResults.StatementResults.GetHeaders()) >= minNumColumnsToUseInteractiveTable {
 		return a.interactiveOutputController
 	}
 

--- a/internal/pkg/flink/types/statements.go
+++ b/internal/pkg/flink/types/statements.go
@@ -125,23 +125,26 @@ const (
 
 // Custom Internal type that shall be used internally by the client
 type ProcessedStatement struct {
-	StatementName    string `json:"statement_name"`
-	Kind             string `json:"statement"`
-	ComputePool      string `json:"compute_pool"`
-	Status           PHASE  `json:"status"`
-	StatusDetail     string `json:"status_detail,omitempty"` // Shown at the top before the table
-	IsLocalStatement bool
-	PageToken        string
-	ResultSchema     flinkgatewayv1alpha1.SqlV1alpha1ResultSchema
-	StatementResults *StatementResults
+	StatementName     string `json:"statement_name"`
+	Kind              string `json:"statement"`
+	ComputePool       string `json:"compute_pool"`
+	Status            PHASE  `json:"status"`
+	StatusDetail      string `json:"status_detail,omitempty"` // Shown at the top before the table
+	IsLocalStatement  bool
+	IsSelectStatement bool
+	PageToken         string
+	ResultSchema      flinkgatewayv1alpha1.SqlV1alpha1ResultSchema
+	StatementResults  *StatementResults
 }
 
 func NewProcessedStatement(statementObj flinkgatewayv1alpha1.SqlV1alpha1Statement) *ProcessedStatement {
+	statement := strings.ToLower(strings.TrimSpace(statementObj.Spec.GetStatement()))
 	return &ProcessedStatement{
-		StatementName: statementObj.Spec.GetStatementName(),
-		StatusDetail:  statementObj.Status.GetDetail(),
-		Status:        PHASE(statementObj.Status.GetPhase()),
-		ResultSchema:  statementObj.Status.GetResultSchema(),
+		StatementName:     statementObj.Spec.GetStatementName(),
+		StatusDetail:      statementObj.Status.GetDetail(),
+		Status:            PHASE(statementObj.Status.GetPhase()),
+		ResultSchema:      statementObj.Status.GetResultSchema(),
+		IsSelectStatement: strings.HasPrefix(statement, "select"),
 	}
 }
 


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->
We now use the interactive table when either of these cases is true for a non-local statement:
- the results include a next page token
- the statement is a SELECT statement 
- the results have more than 3 columns

In all other cases the basic table is used.

**Note: we need the additional isSelectStatement check before deciding based on the number of columns, because of statements like this one:  `SELECT NOW(), COUNT(*) FROM (VALUES (1), (2), (3));`. This is a statement with retractions, but it only has two columns. You definitely want to use the interactive mode here though, so you can check out the results in both the changelog and the table mode. Because you never now what you'll get with a SELECT statement, it is safer to just always use the interactive table.**
