### PR TITLE
feat: make results stabler

### DIFF
--- a/internal/pkg/flink/internal/controller/.snapshots/TestInteractiveOutputControllerTestSuite-TestTableTitleDisplaysPageSizeAndCacheSizeWithUnsafeTrace
+++ b/internal/pkg/flink/internal/controller/.snapshots/TestInteractiveOutputControllerTestSuite-TestTableTitleDisplaysPageSizeAndCacheSizeWithUnsafeTrace
@@ -1,1 +1,1 @@
- Table mode (auto refresh 1.0s) | last page size: 10 | current cache size: 10/10 | table size: 10 
+ Table mode (auto refresh 1.0s) | last page size: 10 | current cache size: 10/10 | table size: 10 | pending retraction: 0 

--- a/internal/pkg/flink/internal/controller/interactive_output_controller.go
+++ b/internal/pkg/flink/internal/controller/interactive_output_controller.go
@@ -194,13 +194,14 @@ func (t *InteractiveOutputController) getTableTitle() string {
 
 	if t.debug {
 		return fmt.Sprintf(
-			" %s (%s) | last page size: %d | current cache size: %d/%d | table size: %d ",
+			" %s (%s) | last page size: %d | current cache size: %d/%d | table size: %d | pending retraction: %d ",
 			mode,
 			state,
 			t.resultFetcher.GetStatement().GetPageSize(),
 			t.resultFetcher.GetMaterializedStatementResults().GetChangelogSize(),
 			t.resultFetcher.GetMaterializedStatementResults().GetMaxResults(),
 			t.resultFetcher.GetMaterializedStatementResults().GetTableSize(),
+			t.resultFetcher.GetMaterializedStatementResults().GetPendingRemovalCount(),
 		)
 	}
 

--- a/internal/pkg/flink/internal/controller/interactive_output_controller_test.go
+++ b/internal/pkg/flink/internal/controller/interactive_output_controller_test.go
@@ -236,7 +236,7 @@ func (s *InteractiveOutputControllerTestSuite) TestTableTitleDisplaysPageSizeAnd
 	s.resultFetcher.EXPECT().IsTableMode().Return(true)
 	s.resultFetcher.EXPECT().GetFetchState().Return(types.Running)
 	s.resultFetcher.EXPECT().GetStatement().Return(executedStatementWithResults)
-	s.resultFetcher.EXPECT().GetMaterializedStatementResults().Return(&mat).Times(3)
+	s.resultFetcher.EXPECT().GetMaterializedStatementResults().Return(&mat).Times(4)
 	s.interactiveOutputController.debug = true
 
 	actual := s.interactiveOutputController.getTableTitle()

--- a/internal/pkg/flink/types/statements.go
+++ b/internal/pkg/flink/types/statements.go
@@ -60,10 +60,6 @@ const (
 
 type StatementResultOperation float64
 
-func (s StatementResultOperation) IsInsertOperation() bool {
-	return s == INSERT || s == UPDATE_AFTER
-}
-
 func (s StatementResultOperation) String() string {
 	switch s {
 	case INSERT:


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok
   * no: DO NOT MERGE until the required features are live in prod  

What
----
In best case we expect the retraction for a row to be immediately followed by the update. To limit the number of shuffles we get as a result of new updates coming in, we maintain a queue of elements that are retracted and fill these first with incoming updates.


References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
<!--
Has it been tested? How?
Copy and paste any instructions or steps that can save the reviewer time.
-->

Open Questions / Follow-ups
---------------------------
<!--
Optional: Anything open to discussion for the reviewer, out of scope of this PR, or follow-ups.
-->
