### PR TITLE
Refactor/KFS-984 and KFS-982 update out msg and timeout accounts for gateway response time

### DIFF
--- a/internal/pkg/flink/internal/controller/.snapshots/TestStatementControllerTestSuite-TestExecuteStatementPrintsUserInfo
+++ b/internal/pkg/flink/internal/controller/.snapshots/TestStatementControllerTestSuite-TestExecuteStatementPrintsUserInfo
@@ -1,5 +1,5 @@
 Statement name: test-statement
 Statement successfully submitted.
-Fetching results...
+Waiting for statement to be ready. Statement phase is .
 status detail message.
 

--- a/internal/pkg/flink/internal/controller/.snapshots/TestStatementControllerTestSuite-TestExecuteStatementPrintsUserInfo
+++ b/internal/pkg/flink/internal/controller/.snapshots/TestStatementControllerTestSuite-TestExecuteStatementPrintsUserInfo
@@ -1,6 +1,6 @@
 Statement name: test-statement
 Statement successfully submitted.
-Waiting for statement to be ready. Statement phase is COMPLETED.
-Statement phase is COMPLETED.
+Waiting for statement to be ready. Statement phase is PENDING.
+Statement phase is PENDING.
 status detail message.
 

--- a/internal/pkg/flink/internal/controller/.snapshots/TestStatementControllerTestSuite-TestExecuteStatementPrintsUserInfo
+++ b/internal/pkg/flink/internal/controller/.snapshots/TestStatementControllerTestSuite-TestExecuteStatementPrintsUserInfo
@@ -1,5 +1,6 @@
 Statement name: test-statement
 Statement successfully submitted.
-Waiting for statement to be ready. Statement phase is .
+Waiting for statement to be ready. Statement phase is COMPLETED.
+Statement phase is COMPLETED.
 status detail message.
 

--- a/internal/pkg/flink/internal/controller/.snapshots/TestStatementControllerTestSuite-TestRenderMsgAndStatusNonLocalNonFailedStatements-statement_with_name
+++ b/internal/pkg/flink/internal/controller/.snapshots/TestStatementControllerTestSuite-TestRenderMsgAndStatusNonLocalNonFailedStatements-statement_with_name
@@ -1,4 +1,4 @@
 Statement name: test-statement
 Statement successfully submitted.
-Fetching results...
+Waiting for statement to be ready. Statement phase is RUNNING.
 

--- a/internal/pkg/flink/internal/controller/.snapshots/TestStatementControllerTestSuite-TestRenderMsgAndStatusNonLocalNonFailedStatements-statement_without_name
+++ b/internal/pkg/flink/internal/controller/.snapshots/TestStatementControllerTestSuite-TestRenderMsgAndStatusNonLocalNonFailedStatements-statement_without_name
@@ -1,3 +1,3 @@
 Statement successfully submitted.
-Fetching results...
+Waiting for statement to be ready. Statement phase is RUNNING.
 

--- a/internal/pkg/flink/internal/controller/statement_controller.go
+++ b/internal/pkg/flink/internal/controller/statement_controller.go
@@ -38,7 +38,7 @@ func (c *StatementController) ExecuteStatement(statementToExecute string) (*type
 		c.handleStatementError(*err)
 		return nil, err
 	}
-	processedStatement.PrintStatusDetail()
+	processedStatement.PrintStatementDoneStatus()
 
 	return processedStatement, nil
 }

--- a/internal/pkg/flink/internal/controller/statement_controller_test.go
+++ b/internal/pkg/flink/internal/controller/statement_controller_test.go
@@ -110,6 +110,7 @@ func (s *StatementControllerTestSuite) TestExecuteStatementPrintsUserInfo() {
 	processedStatement := types.ProcessedStatement{
 		StatementName: "test-statement",
 		StatusDetail:  "status detail message",
+		Status:        types.COMPLETED,
 	}
 	s.store.EXPECT().ProcessStatement(statementToExecute).Return(&processedStatement, nil)
 	s.consoleParser.EXPECT().Read().Return(nil, nil).AnyTimes()

--- a/internal/pkg/flink/internal/controller/statement_controller_test.go
+++ b/internal/pkg/flink/internal/controller/statement_controller_test.go
@@ -110,7 +110,7 @@ func (s *StatementControllerTestSuite) TestExecuteStatementPrintsUserInfo() {
 	processedStatement := types.ProcessedStatement{
 		StatementName: "test-statement",
 		StatusDetail:  "status detail message",
-		Status:        types.COMPLETED,
+		Status:        types.PENDING,
 	}
 	s.store.EXPECT().ProcessStatement(statementToExecute).Return(&processedStatement, nil)
 	s.consoleParser.EXPECT().Read().Return(nil, nil).AnyTimes()

--- a/internal/pkg/flink/internal/store/store.go
+++ b/internal/pkg/flink/internal/store/store.go
@@ -190,7 +190,7 @@ func (s *Store) waitForPendingStatement(ctx context.Context, statementName strin
 		} else {
 			lastProgressUpdateTime += waitTime
 			elapsedWaitTime += waitTime
-			waitTime = waitTime - getRequestDuration
+			waitTime -= getRequestDuration
 			time.Sleep(waitTime)
 		}
 

--- a/internal/pkg/flink/internal/store/store_test.go
+++ b/internal/pkg/flink/internal/store/store_test.go
@@ -154,7 +154,7 @@ func TestWaitForPendingHitsErrorRetryLimit(t *testing.T) {
 		},
 	}
 	expectedError := &types.StatementError{
-		Message:        fmt.Sprintf("the server can't process this statement right now, exiting after 6 retries"),
+		Message:        "the server can't process this statement right now, exiting after 6 retries",
 		FailureMessage: fmt.Sprintf("captured retryable errors: %s", strings.Repeat(statusDetailMessage+"; ", 5)+statusDetailMessage),
 	}
 	client.EXPECT().GetStatement("envId", statementName, "orgId").Return(statementObj, nil).AnyTimes()

--- a/internal/pkg/flink/internal/store/store_test.go
+++ b/internal/pkg/flink/internal/store/store_test.go
@@ -133,7 +133,7 @@ func TestWaitForPendingTimesout(t *testing.T) {
 
 func TestWaitForPendingHitsErrorRetryLimit(t *testing.T) {
 	statementName := "statementName"
-	timeout := time.Duration(10) * time.Second
+	timeout := 10 * time.Second
 
 	client := mock.NewMockGatewayClientInterface(gomock.NewController(t))
 	appOptions := types.ApplicationOptions{

--- a/internal/pkg/flink/types/statements.go
+++ b/internal/pkg/flink/types/statements.go
@@ -165,7 +165,6 @@ func (s ProcessedStatement) printStatusMessageOfLocalStatement() {
 }
 
 func (s ProcessedStatement) printStatusMessageOfNonLocalStatement() {
-
 	if s.StatementName != "" {
 		utils.OutputInfof("Statement name: %s\n", s.StatementName)
 	}

--- a/internal/pkg/flink/types/statements.go
+++ b/internal/pkg/flink/types/statements.go
@@ -165,6 +165,7 @@ func (s ProcessedStatement) printStatusMessageOfLocalStatement() {
 }
 
 func (s ProcessedStatement) printStatusMessageOfNonLocalStatement() {
+
 	if s.StatementName != "" {
 		utils.OutputInfof("Statement name: %s\n", s.StatementName)
 	}
@@ -172,7 +173,7 @@ func (s ProcessedStatement) printStatusMessageOfNonLocalStatement() {
 		utils.OutputErr(fmt.Sprintf("Error: %s", "statement submission failed"))
 	} else {
 		utils.OutputInfo("Statement successfully submitted.")
-		utils.OutputInfo("Fetching results...")
+		utils.OutputInfo(fmt.Sprintf("Waiting for statement to be ready. Statement phase is %s.", s.Status))
 	}
 }
 
@@ -180,8 +181,10 @@ func (s ProcessedStatement) GetPageSize() int {
 	return len(s.StatementResults.GetRows())
 }
 
-func (s ProcessedStatement) PrintStatusDetail() {
-	// print status detail message if available
+func (s ProcessedStatement) PrintStatementDoneStatus() {
+	if s.Status != "" {
+		output.Printf("Statement phase is %s.\n", s.Status)
+	}
 	if s.StatusDetail != "" {
 		output.Printf("%s.\n", s.StatusDetail)
 	}


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->
- Adjusted the message sent while waiting for results to be ready
- Also print status
- Print complete/running status after statement is ready
- properly account for gateway response time when calculating timeout

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
<!--
Has it been tested? How?
Copy and paste any instructions or steps that can save the reviewer time.
-->
Tests updated

Open Questions / Follow-ups
---------------------------
<!--
Optional: Anything open to discussion for the reviewer, out of scope of this PR, or follow-ups.
-->
