### PR TITLE
Fix/duplicated entries

### DIFF
--- a/internal/pkg/flink/internal/results/result_fetcher.go
+++ b/internal/pkg/flink/internal/results/result_fetcher.go
@@ -16,6 +16,7 @@ type ResultFetcher struct {
 	materializedStatementResults types.MaterializedStatementResults
 	fetchState                   int32
 	autoRefreshCallback          func()
+	fetchLock                    sync.Mutex
 }
 
 const (
@@ -77,6 +78,10 @@ func (t *ResultFetcher) isAutoRefreshStartAllowed() bool {
 }
 
 func (t *ResultFetcher) fetchNextPageAndUpdateState() {
+	// lock here to make sure we don't fetch the same page twice
+	t.fetchLock.Lock()
+	defer t.fetchLock.Unlock()
+
 	newResults, err := t.store.FetchStatementResults(t.GetStatement())
 	t.updateState(newResults, err)
 }

--- a/internal/pkg/flink/types/statements.go
+++ b/internal/pkg/flink/types/statements.go
@@ -37,8 +37,11 @@ type StatementResultRow struct {
 
 func (r *StatementResultRow) GetRowKey() string {
 	rowKey := strings.Builder{}
-	for _, field := range r.GetFields() {
+	for idx, field := range r.GetFields() {
 		rowKey.WriteString(field.ToString())
+		if idx != len(r.GetFields())-1 {
+			rowKey.WriteString("-")
+		}
 	}
 	return rowKey.String()
 }


### PR DESCRIPTION
What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->
Sometimes, when in the interactive table you will see duplicated events come in, which should never happen. It seems to only happen when you play/pause the fetch a lot, so I've investigated this a bit and there should be only two cases that could lead to duplicated table entries:
- fetching the same page twice (this seems to happen due to a race condition in some cases)
- key collisions when inserting events (this is a bug because we don't use separators between columns when computing the row keys)

The first one can be avoided by synchronizing access to the fetchNextPage function. To avoid the second one we need a separator between columns when computing the key, otherwise this row {"12", "3"} would have the same key as this row {"1", "23"} -> "123". With a separator they will have different keys: "12-3", "1-23"


