### PR TITLE
[FLINKCC-146] Revert "chore: remove execution.runtime-mode as it's not needed anymo…

### DIFF
--- a/internal/cmd/flink/command_shell.go
+++ b/internal/cmd/flink/command_shell.go
@@ -74,7 +74,8 @@ func (c *command) startFlinkSqlClient(prerunner pcmd.PreRunner, cmd *cobra.Comma
 			mock.NewFakeFlinkGatewayClient(),
 			func() error { return nil },
 			types.ApplicationOptions{
-				UserAgent: c.Version.UserAgent,
+				DefaultProperties: map[string]string{"execution.runtime-mode": "streaming"},
+				UserAgent:         c.Version.UserAgent,
 			})
 		return nil
 	}
@@ -148,15 +149,16 @@ func (c *command) startFlinkSqlClient(prerunner pcmd.PreRunner, cmd *cobra.Comma
 		flinkGatewayClient,
 		c.authenticated(prerunner.Authenticated(c.AuthenticatedCLICommand), cmd, jwtValidator),
 		types.ApplicationOptions{
-			FlinkGatewayUrl: parsedUrl.String(),
-			UnsafeTrace:     unsafeTrace,
-			UserAgent:       c.Version.UserAgent,
-			EnvironmentId:   environmentId,
-			OrgResourceId:   resourceId,
-			KafkaClusterId:  cluster,
-			ComputePoolId:   computePool,
-			IdentityPoolId:  identityPool,
-			Verbose:         verbose > 0,
+			DefaultProperties: map[string]string{"execution.runtime-mode": "streaming"},
+			FlinkGatewayUrl:   parsedUrl.String(),
+			UnsafeTrace:       unsafeTrace,
+			UserAgent:         c.Version.UserAgent,
+			EnvironmentId:     environmentId,
+			OrgResourceId:     resourceId,
+			KafkaClusterId:    cluster,
+			ComputePoolId:     computePool,
+			IdentityPoolId:    identityPool,
+			Verbose:           verbose > 0,
 		})
 	return nil
 }

--- a/internal/pkg/flink/config/local_statements.go
+++ b/internal/pkg/flink/config/local_statements.go
@@ -10,10 +10,11 @@ const (
 	ConfigStatementTerminator = ";"
 
 	// keys
-	ConfigKeyCatalog        = "catalog"
-	ConfigKeyDatabase       = "default_database"
-	ConfigKeyOrgResourceId  = "org-resource-id"
-	ConfigKeyLocalTimeZone  = "table.local-time-zone"
-	ConfigKeyResultsTimeout = "table.results-timeout"
-	ConfigKeyStatementOwner = "statement-owner"
+	ConfigKeyCatalog          = "catalog"
+	ConfigKeyDatabase         = "default_database"
+	ConfigKeyOrgResourceId    = "org-resource-id"
+	ConfigKeyExecutionRuntime = "execution.runtime-mode"
+	ConfigKeyLocalTimeZone    = "table.local-time-zone"
+	ConfigKeyResultsTimeout   = "table.results-timeout"
+	ConfigKeyStatementOwner   = "statement-owner"
 )

--- a/internal/pkg/flink/internal/store/store.go
+++ b/internal/pkg/flink/internal/store/store.go
@@ -286,6 +286,9 @@ func (s *Store) propsDefault(propsWithoutDefault map[string]string) map[string]s
 	if _, ok := properties[config.ConfigKeyOrgResourceId]; !ok {
 		properties[config.ConfigKeyOrgResourceId] = s.appOptions.GetOrgResourceId()
 	}
+	if _, ok := properties[config.ConfigKeyExecutionRuntime]; !ok {
+		properties[config.ConfigKeyExecutionRuntime] = "streaming"
+	}
 	if _, ok := properties[config.ConfigKeyLocalTimeZone]; !ok {
 		properties[config.ConfigKeyLocalTimeZone] = getLocalTimezone()
 	}


### PR DESCRIPTION
…re (#2072)"

This reverts commit a7e372c8934399f81e8b2cf61b6f1288206d6cac.

It crashes CLI https://confluentinc.atlassian.net/browse/FLINKCC-146

Release Notes
-------------
Rollback of a very recent PR 
