### PR TITLE
make flink statement name two characters shorter

### DIFF
--- a/internal/pkg/ccloudv2/flink_gateway.go
+++ b/internal/pkg/ccloudv2/flink_gateway.go
@@ -80,7 +80,7 @@ func (c *FlinkGatewayClient) ListAllStatements(environmentId, orgId string) ([]f
 }
 
 func (c *FlinkGatewayClient) CreateStatement(statement, computePoolId, identityPoolId string, properties map[string]string, environmentId, orgId string) (flinkgatewayv1alpha1.SqlV1alpha1Statement, error) {
-	statementName := uuid.New().String()[:20]
+	statementName := uuid.New().String()[:18]
 
 	statementObj := flinkgatewayv1alpha1.SqlV1alpha1Statement{
 		Spec: &flinkgatewayv1alpha1.SqlV1alpha1StatementSpec{


### PR DESCRIPTION
Release Notes
-------------
Make client-generated Flink statement name (that is based on uuid) 2 characters shorter, as the current last two characters are:
 '-'  + one alphanumeric character, which makes the name pattern looking somewhat clumsy. 


Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok
 

What
----
The naming pattern before this PR was picked just to make the whole name shorter without looking much how it looks in the end.  Example: the following statement name `97590109-f7c8-4c5e-b` would become `97590109-f7c8-4c5e` instead.

