### PR TITLE
chore: remove execution.runtime-mode as it's not needed anymore

### DIFF
--- a/internal/cmd/flink/command_shell.go
+++ b/internal/cmd/flink/command_shell.go
@@ -74,8 +74,7 @@ func (c *command) startFlinkSqlClient(prerunner pcmd.PreRunner, cmd *cobra.Comma
 			mock.NewFakeFlinkGatewayClient(),
 			func() error { return nil },
 			types.ApplicationOptions{
-				DefaultProperties: map[string]string{"execution.runtime-mode": "streaming"},
-				UserAgent:         c.Version.UserAgent,
+				UserAgent: c.Version.UserAgent,
 			})
 		return nil
 	}
@@ -149,16 +148,15 @@ func (c *command) startFlinkSqlClient(prerunner pcmd.PreRunner, cmd *cobra.Comma
 		flinkGatewayClient,
 		c.authenticated(prerunner.Authenticated(c.AuthenticatedCLICommand), cmd, jwtValidator),
 		types.ApplicationOptions{
-			DefaultProperties: map[string]string{"execution.runtime-mode": "streaming"},
-			FlinkGatewayUrl:   parsedUrl.String(),
-			UnsafeTrace:       unsafeTrace,
-			UserAgent:         c.Version.UserAgent,
-			EnvironmentId:     environmentId,
-			OrgResourceId:     resourceId,
-			KafkaClusterId:    cluster,
-			ComputePoolId:     computePool,
-			IdentityPoolId:    identityPool,
-			Verbose:           verbose > 0,
+			FlinkGatewayUrl: parsedUrl.String(),
+			UnsafeTrace:     unsafeTrace,
+			UserAgent:       c.Version.UserAgent,
+			EnvironmentId:   environmentId,
+			OrgResourceId:   resourceId,
+			KafkaClusterId:  cluster,
+			ComputePoolId:   computePool,
+			IdentityPoolId:  identityPool,
+			Verbose:         verbose > 0,
 		})
 	return nil
 }

--- a/internal/pkg/flink/config/local_statements.go
+++ b/internal/pkg/flink/config/local_statements.go
@@ -10,11 +10,10 @@ const (
 	ConfigStatementTerminator = ";"
 
 	// keys
-	ConfigKeyCatalog          = "catalog"
-	ConfigKeyDatabase         = "default_database"
-	ConfigKeyOrgResourceId    = "org-resource-id"
-	ConfigKeyExecutionRuntime = "execution.runtime-mode"
-	ConfigKeyLocalTimeZone    = "table.local-time-zone"
-	ConfigKeyResultsTimeout   = "table.results-timeout"
-	ConfigKeyStatementOwner   = "statement-owner"
+	ConfigKeyCatalog        = "catalog"
+	ConfigKeyDatabase       = "default_database"
+	ConfigKeyOrgResourceId  = "org-resource-id"
+	ConfigKeyLocalTimeZone  = "table.local-time-zone"
+	ConfigKeyResultsTimeout = "table.results-timeout"
+	ConfigKeyStatementOwner = "statement-owner"
 )

--- a/internal/pkg/flink/internal/store/store.go
+++ b/internal/pkg/flink/internal/store/store.go
@@ -286,9 +286,6 @@ func (s *Store) propsDefault(propsWithoutDefault map[string]string) map[string]s
 	if _, ok := properties[config.ConfigKeyOrgResourceId]; !ok {
 		properties[config.ConfigKeyOrgResourceId] = s.appOptions.GetOrgResourceId()
 	}
-	if _, ok := properties[config.ConfigKeyExecutionRuntime]; !ok {
-		properties[config.ConfigKeyExecutionRuntime] = "streaming"
-	}
 	if _, ok := properties[config.ConfigKeyLocalTimeZone]; !ok {
 		properties[config.ConfigKeyLocalTimeZone] = getLocalTimezone()
 	}

--- a/internal/pkg/flink/types/application_options.go
+++ b/internal/pkg/flink/types/application_options.go
@@ -14,7 +14,7 @@ type ApplicationOptions struct {
 }
 
 func (a *ApplicationOptions) GetDefaultProperties() map[string]string {
-	if a != nil {
+	if a != nil && a.DefaultProperties != nil {
 		return a.DefaultProperties
 	}
 	return map[string]string{}


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->
Removes execution.runtime-mode from the default properties, as this is not needed anymore and could lead to requests being rejected when server-side validation is introduced

**Note: this does what #2072 did, but without panicing. I added an additional check to the `GetProperties()` method that returns an empty map if the default properties are nil** 
