### PR TITLE
Fix/KFS-1006-proper error messages for flags

### DIFF
--- a/internal/cmd/flink/command_shell.go
+++ b/internal/cmd/flink/command_shell.go
@@ -80,7 +80,17 @@ func (c *command) startFlinkSqlClient(prerunner pcmd.PreRunner, cmd *cobra.Comma
 
 	resourceId := c.Context.GetOrganization().GetResourceId()
 
-	// Compute pool can be set as a flag or as default in the context
+	environmentId, err := cmd.Flags().GetString("environment")
+	if err != nil {
+		return err
+	}
+	if environmentId == "" {
+		if c.Context.GetCurrentEnvironment() == "" {
+			return errors.NewErrorWithSuggestions("no environment provided", "Provide an environment with `confluent environment use env-123456` or `--environment`.")
+		}
+		environmentId = c.Context.GetCurrentEnvironment()
+	}
+
 	computePool, err := cmd.Flags().GetString("compute-pool")
 	if err != nil {
 		return err
@@ -111,11 +121,6 @@ func (c *command) startFlinkSqlClient(prerunner pcmd.PreRunner, cmd *cobra.Comma
 		if c.Context.KafkaClusterContext.GetActiveKafkaClusterId() != "" {
 			cluster = c.Context.KafkaClusterContext.GetActiveKafkaClusterId()
 		}
-	}
-
-	environmentId, err := c.Context.EnvironmentId()
-	if err != nil {
-		return err
 	}
 
 	unsafeTrace, err := c.Command.Flags().GetBool("unsafe-trace")

--- a/internal/cmd/flink/command_shell.go
+++ b/internal/cmd/flink/command_shell.go
@@ -91,6 +91,11 @@ func (c *command) startFlinkSqlClient(prerunner pcmd.PreRunner, cmd *cobra.Comma
 		environmentId = c.Context.GetCurrentEnvironment()
 	}
 
+	environment, err := c.V2Client.GetOrgEnvironment(environmentId)
+	if err != nil {
+		return errors.NewErrorWithSuggestions(err.Error(), "List available environments with `confluent environment list`.")
+	}
+
 	computePool, err := cmd.Flags().GetString("compute-pool")
 	if err != nil {
 		return err
@@ -137,19 +142,21 @@ func (c *command) startFlinkSqlClient(prerunner pcmd.PreRunner, cmd *cobra.Comma
 
 	verbose, _ := cmd.Flags().GetCount("verbose")
 
+	// use name of environment and not id
 	client.StartApp(
 		flinkGatewayClient,
 		c.authenticated(prerunner.Authenticated(c.AuthenticatedCLICommand), cmd, jwtValidator),
 		types.ApplicationOptions{
-			Context:        c.Context,
-			UnsafeTrace:    unsafeTrace,
-			UserAgent:      c.Version.UserAgent,
-			EnvironmentId:  environmentId,
-			OrgResourceId:  resourceId,
-			KafkaClusterId: cluster,
-			ComputePoolId:  computePool,
-			IdentityPoolId: identityPool,
-			Verbose:        verbose > 0,
+			Context:         c.Context,
+			UnsafeTrace:     unsafeTrace,
+			UserAgent:       c.Version.UserAgent,
+			EnvironmentName: environment.GetDisplayName(),
+			EnvironmentId:   environmentId,
+			OrgResourceId:   resourceId,
+			KafkaClusterId:  cluster,
+			ComputePoolId:   computePool,
+			IdentityPoolId:  identityPool,
+			Verbose:         verbose > 0,
 		})
 	return nil
 }

--- a/internal/cmd/flink/command_shell.go
+++ b/internal/cmd/flink/command_shell.go
@@ -23,8 +23,8 @@ func (c *command) newShellCommand(cfg *v1.Config, prerunner pcmd.PreRunner) *cob
 
 	c.addComputePoolFlag(cmd)
 	cmd.Flags().String("identity-pool", "", "Identity pool ID.")
-	pcmd.AddClusterFlag(cmd, c.AuthenticatedCLICommand)
 	pcmd.AddEnvironmentFlag(cmd, c.AuthenticatedCLICommand)
+	cmd.Flags().String("database", "", "The database which will be used as default database. When using Kafka, this is the cluster display name.")
 	pcmd.AddContextFlag(cmd, c.CLICommand)
 	pcmd.AddOutputFlag(cmd)
 	if cfg.IsTest {
@@ -118,13 +118,13 @@ func (c *command) startFlinkSqlClient(prerunner pcmd.PreRunner, cmd *cobra.Comma
 		identityPool = c.Context.GetCurrentIdentityPool()
 	}
 
-	cluster, err := cmd.Flags().GetString("cluster")
+	database, err := cmd.Flags().GetString("database")
 	if err != nil {
 		return err
 	}
-	if cluster == "" {
-		if c.Context.KafkaClusterContext.GetActiveKafkaClusterId() != "" {
-			cluster = c.Context.KafkaClusterContext.GetActiveKafkaClusterId()
+	if database == "" {
+		if c.Context.KafkaClusterContext.GetActiveKafkaClusterConfig().GetName() != "" {
+			database = c.Context.KafkaClusterContext.GetActiveKafkaClusterConfig().GetName()
 		}
 	}
 
@@ -152,7 +152,7 @@ func (c *command) startFlinkSqlClient(prerunner pcmd.PreRunner, cmd *cobra.Comma
 			EnvironmentName: environment.GetDisplayName(),
 			EnvironmentId:   environmentId,
 			OrgResourceId:   resourceId,
-			KafkaClusterId:  cluster,
+			Database:        database,
 			ComputePoolId:   computePool,
 			IdentityPoolId:  identityPool,
 			Verbose:         verbose > 0,

--- a/internal/cmd/flink/command_shell.go
+++ b/internal/cmd/flink/command_shell.go
@@ -142,7 +142,6 @@ func (c *command) startFlinkSqlClient(prerunner pcmd.PreRunner, cmd *cobra.Comma
 
 	verbose, _ := cmd.Flags().GetCount("verbose")
 
-	// use name of environment and not id
 	client.StartApp(
 		flinkGatewayClient,
 		c.authenticated(prerunner.Authenticated(c.AuthenticatedCLICommand), cmd, jwtValidator),

--- a/internal/pkg/ccloudv2/flink.go
+++ b/internal/pkg/ccloudv2/flink.go
@@ -6,6 +6,7 @@ import (
 	flinkv2 "github.com/confluentinc/ccloud-sdk-go-v2/flink/v2"
 
 	"github.com/confluentinc/cli/internal/pkg/errors"
+	"github.com/confluentinc/cli/internal/pkg/resource"
 )
 
 func newFlinkClient(url, userAgent string, unsafeTrace bool) *flinkv2.APIClient {
@@ -29,12 +30,12 @@ func (c *Client) CreateFlinkComputePool(computePool flinkv2.FcpmV2ComputePool) (
 
 func (c *Client) DeleteFlinkComputePool(id, environment string) error {
 	httpResp, err := c.FlinkClient.ComputePoolsFcpmV2Api.DeleteFcpmV2ComputePool(c.flinkApiContext(), id).Environment(environment).Execute()
-	return errors.CatchCCloudV2ResourceNotFoundError(err, environment, httpResp)
+	return errors.CatchCCloudV2ResourceNotFoundError(err, resource.FlinkComputePool, httpResp)
 }
 
 func (c *Client) DescribeFlinkComputePool(id, environment string) (flinkv2.FcpmV2ComputePool, error) {
 	res, httpResp, err := c.FlinkClient.ComputePoolsFcpmV2Api.GetFcpmV2ComputePool(c.flinkApiContext(), id).Environment(environment).Execute()
-	return res, errors.CatchCCloudV2ResourceNotFoundError(err, environment, httpResp)
+	return res, errors.CatchCCloudV2ResourceNotFoundError(err, resource.FlinkComputePool, httpResp)
 }
 
 func (c *Client) ListFlinkComputePools(environment, specRegion string) ([]flinkv2.FcpmV2ComputePool, error) {
@@ -43,7 +44,7 @@ func (c *Client) ListFlinkComputePools(environment, specRegion string) ([]flinkv
 		req = req.SpecRegion(specRegion)
 	}
 	res, httpResp, err := req.Execute()
-	return res.GetData(), errors.CatchCCloudV2ResourceNotFoundError(err, environment, httpResp)
+	return res.GetData(), errors.CatchCCloudV2ResourceNotFoundError(err, resource.FlinkComputePool, httpResp)
 }
 
 func (c *Client) ListFlinkRegions(cloud string) ([]flinkv2.FcpmV2Region, error) {

--- a/internal/pkg/ccloudv2/flink.go
+++ b/internal/pkg/ccloudv2/flink.go
@@ -30,12 +30,12 @@ func (c *Client) CreateFlinkComputePool(computePool flinkv2.FcpmV2ComputePool) (
 
 func (c *Client) DeleteFlinkComputePool(id, environment string) error {
 	httpResp, err := c.FlinkClient.ComputePoolsFcpmV2Api.DeleteFcpmV2ComputePool(c.flinkApiContext(), id).Environment(environment).Execute()
-	return errors.CatchCCloudV2ResourceNotFoundError(err, resource.FlinkComputePool, httpResp)
+	return errors.CatchComputePoolNotFoundError(err, id, httpResp)
 }
 
 func (c *Client) DescribeFlinkComputePool(id, environment string) (flinkv2.FcpmV2ComputePool, error) {
 	res, httpResp, err := c.FlinkClient.ComputePoolsFcpmV2Api.GetFcpmV2ComputePool(c.flinkApiContext(), id).Environment(environment).Execute()
-	return res, errors.CatchCCloudV2ResourceNotFoundError(err, resource.FlinkComputePool, httpResp)
+	return res, errors.CatchComputePoolNotFoundError(err, id, httpResp)
 }
 
 func (c *Client) ListFlinkComputePools(environment, specRegion string) ([]flinkv2.FcpmV2ComputePool, error) {
@@ -44,7 +44,7 @@ func (c *Client) ListFlinkComputePools(environment, specRegion string) ([]flinkv
 		req = req.SpecRegion(specRegion)
 	}
 	res, httpResp, err := req.Execute()
-	return res.GetData(), errors.CatchCCloudV2ResourceNotFoundError(err, resource.FlinkComputePool, httpResp)
+	return res.GetData(), errors.CatchCCloudV2ResourceNotFoundError(err, resource.Environment, httpResp)
 }
 
 func (c *Client) ListFlinkRegions(cloud string) ([]flinkv2.FcpmV2Region, error) {

--- a/internal/pkg/errors/catcher.go
+++ b/internal/pkg/errors/catcher.go
@@ -207,6 +207,18 @@ func CatchCCloudV2ResourceNotFoundError(err error, resourceType string, r *http.
 	return CatchCCloudV2Error(err, r)
 }
 
+func CatchComputePoolNotFoundError(err error, computePoolId string, r *http.Response) error {
+	if err == nil {
+		return nil
+	}
+
+	if r != nil && r.StatusCode == http.StatusForbidden {
+		return NewWrapErrorWithSuggestions(CatchCCloudV2Error(err, r), fmt.Sprintf(ComputePoolNotFoundErrorMsg, computePoolId), ComputePoolNotFoundSuggestions)
+	}
+
+	return CatchCCloudV2Error(err, r)
+}
+
 func CatchKafkaNotFoundError(err error, clusterId string, r *http.Response) error {
 	if err == nil {
 		return nil

--- a/internal/pkg/errors/error_message.go
+++ b/internal/pkg/errors/error_message.go
@@ -218,6 +218,8 @@ const (
 	MacVersionErrorMsg               = "macOS version >= %s is required (detected: %s)"
 	JavaExecNotFondErrorMsg          = "could not find java executable, please install java or set JAVA_HOME"
 	NothingToDestroyErrorMsg         = "nothing to destroy"
+	ComputePoolNotFoundErrorMsg      = `Flink compute pool with id "%s" not found or access forbiden.`
+	ComputePoolNotFoundSuggestions   = "List available Flink compute pools with `confluent flink compute-pool list`"
 	ConfluentLocalStartedErrorMsg    = "Confluent Local container has already been created"
 	ConfluentLocalStartedSuggestions = "Continue your experience with Confluent Local running `confluent local kafka produce` and `confluent local kafka consume`.\n" +
 		"To stop Confluent Local container, run `confluent local kafka stop` or `docker container rm confluent-local -f`."

--- a/internal/pkg/errors/error_message.go
+++ b/internal/pkg/errors/error_message.go
@@ -218,7 +218,7 @@ const (
 	MacVersionErrorMsg               = "macOS version >= %s is required (detected: %s)"
 	JavaExecNotFondErrorMsg          = "could not find java executable, please install java or set JAVA_HOME"
 	NothingToDestroyErrorMsg         = "nothing to destroy"
-	ComputePoolNotFoundErrorMsg      = `Flink compute pool with id "%s" not found or access forbidden.`
+	ComputePoolNotFoundErrorMsg      = `Flink compute pool "%s" not found or access forbidden.`
 	ComputePoolNotFoundSuggestions   = "List available Flink compute pools with `confluent flink compute-pool list`"
 	ConfluentLocalStartedErrorMsg    = "Confluent Local container has already been created"
 	ConfluentLocalStartedSuggestions = "Continue your experience with Confluent Local running `confluent local kafka produce` and `confluent local kafka consume`.\n" +

--- a/internal/pkg/errors/error_message.go
+++ b/internal/pkg/errors/error_message.go
@@ -218,7 +218,7 @@ const (
 	MacVersionErrorMsg               = "macOS version >= %s is required (detected: %s)"
 	JavaExecNotFondErrorMsg          = "could not find java executable, please install java or set JAVA_HOME"
 	NothingToDestroyErrorMsg         = "nothing to destroy"
-	ComputePoolNotFoundErrorMsg      = `Flink compute pool with id "%s" not found or access forbiden.`
+	ComputePoolNotFoundErrorMsg      = `Flink compute pool with id "%s" not found or access forbidden.`
 	ComputePoolNotFoundSuggestions   = "List available Flink compute pools with `confluent flink compute-pool list`"
 	ConfluentLocalStartedErrorMsg    = "Confluent Local container has already been created"
 	ConfluentLocalStartedSuggestions = "Continue your experience with Confluent Local running `confluent local kafka produce` and `confluent local kafka consume`.\n" +

--- a/internal/pkg/flink/internal/store/store.go
+++ b/internal/pkg/flink/internal/store/store.go
@@ -273,7 +273,7 @@ func NewStore(client ccloudv2.GatewayClientInterface, exitApplication func(), ap
 // We probably want to refactor the keys names and where they are stored. Maybe also the default values.
 func (s *Store) propsDefault(propsWithoutDefault map[string]string) map[string]string {
 	properties := map[string]string{
-		config.ConfigKeyCatalog:       s.appOptions.GetEnvironmentId(),
+		config.ConfigKeyCatalog:       s.appOptions.GetEnvironmentName(),
 		config.ConfigKeyDatabase:      s.appOptions.GetKafkaClusterId(),
 		config.ConfigKeyLocalTimeZone: getLocalTimezone(),
 	}

--- a/internal/pkg/flink/internal/store/store.go
+++ b/internal/pkg/flink/internal/store/store.go
@@ -274,7 +274,7 @@ func NewStore(client ccloudv2.GatewayClientInterface, exitApplication func(), ap
 func (s *Store) propsDefault(propsWithoutDefault map[string]string) map[string]string {
 	properties := map[string]string{
 		config.ConfigKeyCatalog:       s.appOptions.GetEnvironmentName(),
-		config.ConfigKeyDatabase:      s.appOptions.GetKafkaClusterId(),
+		config.ConfigKeyDatabase:      s.appOptions.GetDatabase(),
 		config.ConfigKeyLocalTimeZone: getLocalTimezone(),
 	}
 

--- a/internal/pkg/flink/types/application_options.go
+++ b/internal/pkg/flink/types/application_options.go
@@ -9,6 +9,7 @@ type ApplicationOptions struct {
 	UnsafeTrace       bool
 	UserAgent         string
 	EnvironmentId     string
+	EnvironmentName   string
 	OrgResourceId     string
 	KafkaClusterId    string
 	ComputePoolId     string
@@ -41,6 +42,13 @@ func (a *ApplicationOptions) GetUserAgent() string {
 func (a *ApplicationOptions) GetEnvironmentId() string {
 	if a != nil {
 		return a.EnvironmentId
+	}
+	return ""
+}
+
+func (a *ApplicationOptions) GetEnvironmentName() string {
+	if a != nil {
+		return a.EnvironmentName
 	}
 	return ""
 }

--- a/internal/pkg/flink/types/application_options.go
+++ b/internal/pkg/flink/types/application_options.go
@@ -11,7 +11,7 @@ type ApplicationOptions struct {
 	EnvironmentId     string
 	EnvironmentName   string
 	OrgResourceId     string
-	KafkaClusterId    string
+	Database          string
 	ComputePoolId     string
 	IdentityPoolId    string
 	Verbose           bool
@@ -60,9 +60,9 @@ func (a *ApplicationOptions) GetOrgResourceId() string {
 	return ""
 }
 
-func (a *ApplicationOptions) GetKafkaClusterId() string {
+func (a *ApplicationOptions) GetDatabase() string {
 	if a != nil {
-		return a.KafkaClusterId
+		return a.Database
 	}
 	return ""
 }

--- a/internal/pkg/resource/resource.go
+++ b/internal/pkg/resource/resource.go
@@ -15,7 +15,7 @@ const (
 	ConsumerShare         = "consumer share"
 	Context               = "context"
 	Environment           = "environment"
-	FlinkComputePool      = "flink compute-pool"
+	FlinkComputePool      = "Flink compute pool"
 	FlinkIamBinding       = "Flink IAM binding"
 	FlinkStatement        = "Flink SQL statement"
 	IdentityPool          = "identity pool"

--- a/internal/pkg/resource/resource.go
+++ b/internal/pkg/resource/resource.go
@@ -15,7 +15,7 @@ const (
 	ConsumerShare         = "consumer share"
 	Context               = "context"
 	Environment           = "environment"
-	FlinkComputePool      = "Flink compute pool"
+	FlinkComputePool      = "flink compute-pool"
 	FlinkIamBinding       = "Flink IAM binding"
 	FlinkStatement        = "Flink SQL statement"
 	IdentityPool          = "identity pool"

--- a/test/fixtures/output/flink/shell-help.golden
+++ b/test/fixtures/output/flink/shell-help.golden
@@ -6,8 +6,8 @@ Usage:
 Flags:
       --compute-pool string    Flink compute pool ID.
       --identity-pool string   Identity pool ID.
-      --cluster string         Kafka cluster ID.
       --environment string     Environment ID.
+      --database string        The database which will be used as default database. When using Kafka, this is the cluster display name.
       --context string         CLI context name.
   -o, --output string          Specify the output format as "human", "json", or "yaml". (default "human")
       --fake-gateway           Test the SQL client with fake gateway data.


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->

- environment flag wasn’t being used in confluent flink shell
- we were using the wrong value for default catalog: id instead of the env displayName
- wrong compute pool was showing improper error (environment not found)
- unused `--cluster` flag is now `--database` which is what it was initially designed to be and will be properly passed to the flink client.
- identity pool not found will be shown when sending the first statement - checking for it first would require the user to provide one more flag “provider” for the identity pool. And I don’t think we want users to have to pass one more flag. And this should be alright:

![image](https://github.com/confluentinc/cli/assets/11739405/e68fe187-964d-4276-b199-789b9efe9b05)

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
<!--
Has it been tested? How?
Copy and paste any instructions or steps that can save the reviewer time.
-->

Open Questions / Follow-ups
---------------------------
<!--
Optional: Anything open to discussion for the reviewer, out of scope of this PR, or follow-ups.
-->
