### PR TITLE
[confluent-local] verify machine arch matches cli arch before starting docker

### DIFF
--- a/internal/cmd/local/command_kafka_start.go
+++ b/internal/cmd/local/command_kafka_start.go
@@ -196,7 +196,11 @@ func getContainerEnvironmentWithPorts(ports *v1.LocalPorts) []string {
 }
 
 func checkMachineArch() error {
-	cmd := exec.Command("uname", "-m")
+	if runtime.GOOS == "windows" {
+		return nil
+	}
+
+	cmd := exec.Command("uname", "-m") // outputs system architecture info
 	output, err := cmd.Output()
 	if err != nil {
 		return err
@@ -205,9 +209,8 @@ func checkMachineArch() error {
 	if systemArch == "x86_64" {
 		systemArch = "amd64"
 	}
-	fmt.Println(systemArch, runtime.GOARCH)
 	if systemArch != runtime.GOARCH {
-		return errors.New(fmt.Sprintf("Running %s Confluent CLI on a %s machine. Please download the correct version.", runtime.GOARCH, systemArch))
+		return errors.NewErrorWithSuggestions(fmt.Sprintf(`Binary architecture "%s" does not match system architecture "%s"`, runtime.GOARCH, systemArch), "Download the correct version of CLI to continue.")
 	}
 	return nil
 }

--- a/internal/cmd/local/command_kafka_start.go
+++ b/internal/cmd/local/command_kafka_start.go
@@ -43,8 +43,7 @@ func (c *Command) newKafkaStartCommand() *cobra.Command {
 }
 
 func (c *Command) kafkaStart(cmd *cobra.Command, args []string) error {
-	err := checkMachineArch()
-	if err != nil {
+	if err := checkMachineArch(); err != nil {
 		return err
 	}
 
@@ -210,7 +209,7 @@ func checkMachineArch() error {
 		systemArch = "amd64"
 	}
 	if systemArch != runtime.GOARCH {
-		return errors.NewErrorWithSuggestions(fmt.Sprintf(`Binary architecture "%s" does not match system architecture "%s"`, runtime.GOARCH, systemArch), "Download the correct version of CLI to continue.")
+		return errors.NewErrorWithSuggestions(fmt.Sprintf(`binary architecture "%s" does not match system architecture "%s"`, runtime.GOARCH, systemArch), "Download the CLI with the correct architecture to continue.")
 	}
 	return nil
 }


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- PLACEHOLDER

New Features
- PLACEHOLDER

Bug Fixes
- Print an error message when `confluent local kafka start` is run from an AMD64 binary on an ARM64 machine

Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->
m2 machine supports running amd64 software even though it's arm64 natively, which will cause problem that cli will try to create a amd64 container that can't be run on arm64 m2. Add a arch check in `confluent local kafka start`.

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->


Test & Review
-------------
<!--
Has it been tested? How?
Copy and paste any instructions or steps that can save the reviewer time.
-->

Open Questions / Follow-ups
---------------------------
<!--
Optional: Anything open to discussion for the reviewer, out of scope of this PR, or follow-ups.
-->
