### PR TITLE
check index in range when getting minor version number in update

### DIFF
--- a/internal/pkg/update/client.go
+++ b/internal/pkg/update/client.go
@@ -68,7 +68,7 @@ func NewClient(params *ClientParams) *client {
 
 // CheckForUpdates checks for new versions in the repo
 func (c *client) CheckForUpdates(cliName, currentVersion string, forceCheck bool) (string, string, error) {
-	if c.DisableCheck {
+	if c.DisableCheck || currentVersion == "v0.0.0" {
 		return "", "", nil
 	}
 

--- a/internal/pkg/update/client.go
+++ b/internal/pkg/update/client.go
@@ -37,6 +37,7 @@ type client struct {
 }
 
 var _ Client = (*client)(nil)
+var defaultVersion = "v0.0.0"
 
 // ClientParams are used to configure the update.Client
 type ClientParams struct {
@@ -68,7 +69,7 @@ func NewClient(params *ClientParams) *client {
 
 // CheckForUpdates checks for new versions in the repo
 func (c *client) CheckForUpdates(cliName, currentVersion string, forceCheck bool) (string, string, error) {
-	if c.DisableCheck || currentVersion == "v0.0.0" {
+	if c.DisableCheck || currentVersion == defaultVersion {
 		return "", "", nil
 	}
 

--- a/internal/pkg/update/client.go
+++ b/internal/pkg/update/client.go
@@ -37,7 +37,8 @@ type client struct {
 }
 
 var _ Client = (*client)(nil)
-var defaultVersion = "v0.0.0"
+
+const defaultVersion = "v0.0.0"
 
 // ClientParams are used to configure the update.Client
 type ClientParams struct {

--- a/internal/pkg/update/client_test.go
+++ b/internal/pkg/update/client_test.go
@@ -333,7 +333,7 @@ func TestCheckForUpdates(t *testing.T) {
 					},
 				},
 			}),
-			args:      args{currentVersion: "v0.0.0"},
+			args:      args{currentVersion: "v0.0.1"},
 			wantMajor: "v1.0.0",
 			wantMinor: "v0.1.0",
 		},

--- a/internal/pkg/update/s3/public.go
+++ b/internal/pkg/update/s3/public.go
@@ -87,6 +87,9 @@ func (r *PublicRepo) GetLatestMajorAndMinorVersion(name string, current *version
 		return versions[idx].GreaterThanOrEqual(nextMajorVer)
 	}) - 1
 
+	if minorIdx < 0 {
+		return nil, nil, errors.New(errors.GetBinaryVersionsErrorMsg)
+	}
 	minor := versions[minorIdx]
 
 	return major, minor, nil

--- a/internal/pkg/update/s3/public.go
+++ b/internal/pkg/update/s3/public.go
@@ -72,7 +72,9 @@ func (r *PublicRepo) GetLatestMajorAndMinorVersion(name string, current *version
 
 	// The index of the largest available version. This may be a major version update.
 	majorIdx := len(versions) - 1
-
+	if majorIdx < 0 {
+		return nil, nil, errors.New(errors.GetBinaryVersionsErrorMsg)
+	}
 	major := versions[majorIdx]
 	if current.Segments()[0] == major.Segments()[0] {
 		major = nil


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- PLACEHOLDER

New Features
- PLACEHOLDER

Bug Fixes
- PLACEHOLDER

Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok
   * no: DO NOT MERGE until the required features are live in prod  

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->
got a panic report that index was out of range (-1) on line 93. that could only happen if `nextMajorVersion` was declared to be `v0` which makes no sense. Return a `failed to obtain correct version info` error if that happens.

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->
https://confluent.slack.com/archives/C010Y0EP5MZ/p1689092199750689

Test & Review
-------------
<!--
Has it been tested? How?
Copy and paste any instructions or steps that can save the reviewer time.
-->

Open Questions / Follow-ups
---------------------------
<!--
Optional: Anything open to discussion for the reviewer, out of scope of this PR, or follow-ups.
-->
