### PR TITLE
CLI-2589 fix panic when running `api-key store` with resource flag

### DIFF
--- a/internal/cmd/api-key/command_store.go
+++ b/internal/cmd/api-key/command_store.go
@@ -112,7 +112,7 @@ func (c *command) store(cmd *cobra.Command, args []string) error {
 		return errors.CatchApiKeyForbiddenAccessError(err, getOperation, httpResp)
 	}
 
-	apiKeyIsValidForTargetCluster := apiKey.Spec.Resource != nil && cluster.ID == apiKey.Spec.Resource.Id
+	apiKeyIsValidForTargetCluster := cluster.ID == apiKey.Spec.Resource.GetId()
 
 	if !apiKeyIsValidForTargetCluster {
 		return errors.NewErrorWithSuggestions(errors.APIKeyNotValidForClusterErrorMsg, errors.APIKeyNotValidForClusterSuggestions)

--- a/internal/cmd/api-key/command_store.go
+++ b/internal/cmd/api-key/command_store.go
@@ -112,7 +112,7 @@ func (c *command) store(cmd *cobra.Command, args []string) error {
 		return errors.CatchApiKeyForbiddenAccessError(err, getOperation, httpResp)
 	}
 
-	apiKeyIsValidForTargetCluster := (cluster.ID == apiKey.Spec.Resource.Id)
+	apiKeyIsValidForTargetCluster := apiKey.Spec.Resource != nil && cluster.ID == apiKey.Spec.Resource.Id
 
 	if !apiKeyIsValidForTargetCluster {
 		return errors.NewErrorWithSuggestions(errors.APIKeyNotValidForClusterErrorMsg, errors.APIKeyNotValidForClusterSuggestions)


### PR DESCRIPTION
Release Notes
-------------
Bug Fixes
- Prevents a panic when passing a non-existent Kafka cluster to `confluent api-key store --resource`

Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok
   * no: DO NOT MERGE until the required features are live in prod  

What
----
A panic can occur when the user tries to store an api-key secret for a resource that doesn’t exist anymore for that api-key.

References
----------
https://confluentinc.atlassian.net/browse/CLI-2589 
