### PR TITLE
Use built-in flag combination primitives from Cobra

### DIFF
--- a/internal/cmd/api-key/command_list.go
+++ b/internal/cmd/api-key/command_list.go
@@ -46,6 +46,8 @@ func (c *command) newListCommand() *cobra.Command {
 	pcmd.AddServiceAccountFlag(cmd, c.AuthenticatedCLICommand)
 	pcmd.AddOutputFlag(cmd)
 
+	cmd.MarkFlagsMutuallyExclusive("current-user", "service-account")
+
 	return cmd
 }
 
@@ -89,9 +91,6 @@ func (c *command) list(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 	if currentUser {
-		if serviceAccount != "" {
-			return errors.Errorf(errors.ProhibitedFlagCombinationErrorMsg, "service-account", "current-user")
-		}
 		serviceAccount, err = c.getCurrentUserId()
 		if err != nil {
 			return err

--- a/internal/cmd/kafka/command_acl.go
+++ b/internal/cmd/kafka/command_acl.go
@@ -42,7 +42,7 @@ func newAclCommand(cfg *v1.Config, prerunner pcmd.PreRunner) *cobra.Command {
 // validateAddAndDelete ensures the minimum requirements for acl add and delete are met
 func validateAddAndDelete(binding *ACLConfiguration) {
 	if binding.Entry.Principal == "" {
-		err := fmt.Errorf(errors.ExactlyOneSetErrorMsg, "service-account, principal")
+		err := fmt.Errorf(errors.ExactlyOneSetErrorMsg, "`--service-account`, `--principal`")
 		binding.errors = multierror.Append(binding.errors, err)
 	}
 

--- a/internal/cmd/kafka/command_acl_create.go
+++ b/internal/cmd/kafka/command_acl_create.go
@@ -46,6 +46,8 @@ func (c *aclCommand) newCreateCommand() *cobra.Command {
 
 	cobra.CheckErr(cmd.MarkFlagRequired("operations"))
 
+	cmd.MarkFlagsMutuallyExclusive("service-account", "principal")
+
 	return cmd
 }
 

--- a/internal/cmd/kafka/command_acl_delete.go
+++ b/internal/cmd/kafka/command_acl_delete.go
@@ -40,6 +40,8 @@ func (c *aclCommand) newDeleteCommand() *cobra.Command {
 
 	cobra.CheckErr(cmd.MarkFlagRequired("operations"))
 
+	cmd.MarkFlagsMutuallyExclusive("service-account", "principal")
+
 	return cmd
 }
 

--- a/internal/cmd/kafka/command_acl_list.go
+++ b/internal/cmd/kafka/command_acl_list.go
@@ -28,6 +28,8 @@ func (c *aclCommand) newListCommand() *cobra.Command {
 	cmd.Flags().String("principal", "", `Principal for this operation, prefixed with "User:".`)
 	pcmd.AddOutputFlag(cmd)
 
+	cmd.MarkFlagsMutuallyExclusive("service-account", "principal")
+
 	return cmd
 }
 

--- a/internal/cmd/kafka/command_quota_create.go
+++ b/internal/cmd/kafka/command_quota_create.go
@@ -1,14 +1,11 @@
 package kafka
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 
 	kafkaquotasv1 "github.com/confluentinc/ccloud-sdk-go-v2/kafka-quotas/v1"
 
 	pcmd "github.com/confluentinc/cli/internal/pkg/cmd"
-	"github.com/confluentinc/cli/internal/pkg/errors"
 	"github.com/confluentinc/cli/internal/pkg/examples"
 	"github.com/confluentinc/cli/internal/pkg/output"
 )
@@ -41,6 +38,7 @@ func (c *quotaCommand) newCreateCommand() *cobra.Command {
 	pcmd.AddOutputFlag(cmd)
 
 	cobra.CheckErr(cmd.MarkFlagRequired("name"))
+	cmd.MarkFlagsRequiredTogether("ingress", "egress")
 
 	return cmd
 }
@@ -120,11 +118,10 @@ func getQuotaThroughput(cmd *cobra.Command) (*kafkaquotasv1.KafkaQuotasV1Through
 		return nil, err
 	}
 
-	if ingress == "" || egress == "" {
-		return nil, fmt.Errorf(errors.MustSpecifyBothFlagsErrorMsg, "ingress", "egress")
-	}
-	return &kafkaquotasv1.KafkaQuotasV1Throughput{
+	throughput := &kafkaquotasv1.KafkaQuotasV1Throughput{
 		IngressByteRate: ingress,
 		EgressByteRate:  egress,
-	}, nil
+	}
+
+	return throughput, nil
 }

--- a/internal/cmd/kafka/command_topic_consume.go
+++ b/internal/cmd/kafka/command_topic_consume.go
@@ -64,6 +64,9 @@ func newConsumeCommand(prerunner pcmd.PreRunner, clientId string) *cobra.Command
 
 	cobra.CheckErr(cmd.MarkFlagFilename("config-file", "avsc", "json"))
 
+	cmd.MarkFlagsMutuallyExclusive("config", "config-file")
+	cmd.MarkFlagsMutuallyExclusive("from-beginning", "offset")
+
 	return cmd
 }
 
@@ -108,10 +111,6 @@ func (c *hasAPIKeyTopicCommand) consume(cmd *cobra.Command, args []string) error
 		return err
 	}
 
-	if cmd.Flags().Changed("config-file") && cmd.Flags().Changed("config") {
-		return errors.Errorf(errors.ProhibitedFlagCombinationErrorMsg, "config-file", "config")
-	}
-
 	configFile, err := cmd.Flags().GetString("config-file")
 	if err != nil {
 		return err
@@ -135,10 +134,6 @@ func (c *hasAPIKeyTopicCommand) consume(cmd *cobra.Command, args []string) error
 
 	if err := c.validateTopic(adminClient, topic, cluster); err != nil {
 		return err
-	}
-
-	if cmd.Flags().Changed("from-beginning") && cmd.Flags().Changed("offset") {
-		return errors.Errorf(errors.ProhibitedFlagCombinationErrorMsg, "from-beginning", "offset")
 	}
 
 	offset, err := GetOffsetWithFallback(cmd)

--- a/internal/cmd/kafka/command_topic_consume_onprem.go
+++ b/internal/cmd/kafka/command_topic_consume_onprem.go
@@ -54,9 +54,11 @@ func (c *authenticatedTopicCommand) newConsumeCommandOnPrem() *cobra.Command {
 	cmd.Flags().String("schema-registry-endpoint", "", "The URL of the Schema Registry cluster.")
 
 	cobra.CheckErr(cmd.MarkFlagFilename("config-file", "avsc", "json"))
-
 	cobra.CheckErr(cmd.MarkFlagRequired("bootstrap"))
 	cobra.CheckErr(cmd.MarkFlagRequired("ca-location"))
+
+	cmd.MarkFlagsMutuallyExclusive("config", "config-file")
+	cmd.MarkFlagsMutuallyExclusive("from-beginning", "offset")
 
 	return cmd
 }
@@ -87,10 +89,6 @@ func (c *authenticatedTopicCommand) consumeOnPrem(cmd *cobra.Command, args []str
 		return err
 	}
 
-	if cmd.Flags().Changed("config-file") && cmd.Flags().Changed("config") {
-		return errors.Errorf(errors.ProhibitedFlagCombinationErrorMsg, "config-file", "config")
-	}
-
 	configFile, err := cmd.Flags().GetString("config-file")
 	if err != nil {
 		return err
@@ -119,10 +117,6 @@ func (c *authenticatedTopicCommand) consumeOnPrem(cmd *cobra.Command, args []str
 	topicName := args[0]
 	if err := ValidateTopic(adminClient, topicName); err != nil {
 		return err
-	}
-
-	if cmd.Flags().Changed("from-beginning") && cmd.Flags().Changed("offset") {
-		return errors.Errorf(errors.ProhibitedFlagCombinationErrorMsg, "from-beginning", "offset")
 	}
 
 	offset, err := GetOffsetWithFallback(cmd)

--- a/internal/cmd/kafka/command_topic_produce.go
+++ b/internal/cmd/kafka/command_topic_produce.go
@@ -53,7 +53,10 @@ func newProduceCommand(prerunner pcmd.PreRunner, clientId string) *cobra.Command
 	cmd.Flags().String("cluster", "", "Kafka cluster ID.")
 	pcmd.AddContextFlag(cmd, c.CLICommand)
 	cmd.Flags().String("environment", "", "Environment ID.")
+
+	// Deprecated
 	pcmd.AddOutputFlag(cmd)
+	cmd.Flags().MarkHidden("output")
 
 	cobra.CheckErr(cmd.MarkFlagFilename("schema", "avsc", "json", "proto"))
 	cobra.CheckErr(cmd.MarkFlagFilename("references", "json"))

--- a/internal/cmd/kafka/command_topic_produce.go
+++ b/internal/cmd/kafka/command_topic_produce.go
@@ -59,6 +59,9 @@ func newProduceCommand(prerunner pcmd.PreRunner, clientId string) *cobra.Command
 	cobra.CheckErr(cmd.MarkFlagFilename("references", "json"))
 	cobra.CheckErr(cmd.MarkFlagFilename("config-file", "avsc", "json"))
 
+	cmd.MarkFlagsMutuallyExclusive("schema", "schema-id")
+	cmd.MarkFlagsMutuallyExclusive("config", "config-file")
+
 	return cmd
 }
 
@@ -69,17 +72,9 @@ func (c *hasAPIKeyTopicCommand) produce(cmd *cobra.Command, args []string) error
 		return err
 	}
 
-	if cmd.Flags().Changed("schema") && cmd.Flags().Changed("schema-id") {
-		return errors.Errorf(errors.ProhibitedFlagCombinationErrorMsg, "schema", "schema-id")
-	}
-
 	serializationProvider, metaInfo, err := c.initSchemaAndGetInfo(cmd, topic)
 	if err != nil {
 		return err
-	}
-
-	if cmd.Flags().Changed("config-file") && cmd.Flags().Changed("config") {
-		return errors.Errorf(errors.ProhibitedFlagCombinationErrorMsg, "config-file", "config")
 	}
 
 	configFile, err := cmd.Flags().GetString("config-file")

--- a/internal/cmd/kafka/command_topic_produce.go
+++ b/internal/cmd/kafka/command_topic_produce.go
@@ -56,7 +56,7 @@ func newProduceCommand(prerunner pcmd.PreRunner, clientId string) *cobra.Command
 
 	// Deprecated
 	pcmd.AddOutputFlag(cmd)
-	cmd.Flags().MarkHidden("output")
+	cobra.CheckErr(cmd.Flags().MarkHidden("output"))
 
 	cobra.CheckErr(cmd.MarkFlagFilename("schema", "avsc", "json", "proto"))
 	cobra.CheckErr(cmd.MarkFlagFilename("references", "json"))

--- a/internal/cmd/kafka/command_topic_produce_onprem.go
+++ b/internal/cmd/kafka/command_topic_produce_onprem.go
@@ -57,14 +57,12 @@ func (c *authenticatedTopicCommand) newProduceCommandOnPrem() *cobra.Command {
 	cobra.CheckErr(cmd.MarkFlagRequired("bootstrap"))
 	cobra.CheckErr(cmd.MarkFlagRequired("ca-location"))
 
+	cmd.MarkFlagsMutuallyExclusive("config-file", "config")
+
 	return cmd
 }
 
 func (c *authenticatedTopicCommand) produceOnPrem(cmd *cobra.Command, args []string) error {
-	if cmd.Flags().Changed("config-file") && cmd.Flags().Changed("config") {
-		return errors.Errorf(errors.ProhibitedFlagCombinationErrorMsg, "config-file", "config")
-	}
-
 	configFile, err := cmd.Flags().GetString("config-file")
 	if err != nil {
 		return err

--- a/internal/cmd/kafka/kafka_api.go
+++ b/internal/cmd/kafka/kafka_api.go
@@ -95,7 +95,7 @@ func fromArgs(conf *ACLConfiguration) func(*pflag.Flag) {
 
 func setConfigPrincipal(conf *ACLConfiguration, isServiceAccount bool, v string) {
 	if conf.Entry.Principal != "" {
-		conf.errors = multierror.Append(conf.errors, fmt.Errorf(errors.ExactlyOneSetErrorMsg, "service-account, principal"))
+		conf.errors = multierror.Append(conf.errors, fmt.Errorf(errors.ExactlyOneSetErrorMsg, "`--service-account`, `--principal`"))
 		return
 	}
 

--- a/internal/cmd/local/command_kafka_topic_consume.go
+++ b/internal/cmd/local/command_kafka_topic_consume.go
@@ -44,6 +44,9 @@ func (c *Command) newKafkaTopicConsumeCommand() *cobra.Command {
 
 	cobra.CheckErr(cmd.MarkFlagFilename("config-file", "avsc", "json"))
 
+	cmd.MarkFlagsMutuallyExclusive("from-beginning", "offset")
+	cmd.MarkFlagsMutuallyExclusive("config", "config-file")
+
 	return cmd
 }
 
@@ -82,10 +85,6 @@ func (c *Command) kafkaTopicConsume(cmd *cobra.Command, args []string) error {
 	err = kafka.ValidateTopic(adminClient, topicName)
 	if err != nil {
 		return err
-	}
-
-	if cmd.Flags().Changed("from-beginning") && cmd.Flags().Changed("offset") {
-		return errors.Errorf(errors.ProhibitedFlagCombinationErrorMsg, "from-beginning", "offset")
 	}
 
 	offset, err := kafka.GetOffsetWithFallback(cmd)
@@ -139,10 +138,6 @@ func newOnPremConsumer(cmd *cobra.Command, bootstrap string) (*ckafka.Consumer, 
 		"bootstrap.servers":                     bootstrap,
 		"partition.assignment.strategy":         "cooperative-sticky",
 		"security.protocol":                     "PLAINTEXT",
-	}
-
-	if cmd.Flags().Changed("config-file") && cmd.Flags().Changed("config") {
-		return nil, errors.Errorf(errors.ProhibitedFlagCombinationErrorMsg, "config-file", "config")
 	}
 
 	configFile, err := cmd.Flags().GetString("config-file")

--- a/internal/cmd/local/command_kafka_topic_produce.go
+++ b/internal/cmd/local/command_kafka_topic_produce.go
@@ -40,6 +40,8 @@ func (c *Command) newKafkaTopicProduceCommand() *cobra.Command {
 
 	cobra.CheckErr(cmd.MarkFlagFilename("config-file", "avsc", "json"))
 
+	cmd.MarkFlagsMutuallyExclusive("config", "config-file")
+
 	return cmd
 }
 
@@ -126,10 +128,6 @@ func newOnPremProducer(cmd *cobra.Command, bootstrap string) (*ckafka.Producer, 
 		"retry.backoff.ms":                      "250",
 		"request.timeout.ms":                    "10000",
 		"security.protocol":                     "PLAINTEXT",
-	}
-
-	if cmd.Flags().Changed("config-file") && cmd.Flags().Changed("config") {
-		return nil, errors.Errorf(errors.ProhibitedFlagCombinationErrorMsg, "config-file", "config")
 	}
 
 	configFile, err := cmd.Flags().GetString("config-file")

--- a/internal/cmd/login/command.go
+++ b/internal/cmd/login/command.go
@@ -84,6 +84,7 @@ func New(cfg *v1.Config, prerunner pcmd.PreRunner, ccloudClientFactory pauth.CCl
 	cmd.Flags().Bool("save", false, "Save username and encrypted password (non-SSO credentials) to the configuration file in your $HOME directory, and to macOS keychain if applicable. You will be logged back in when your token expires, after one hour for Confluent Cloud, or after six hours for Confluent Platform.")
 
 	cobra.CheckErr(cmd.Flags().MarkHidden("us-gov"))
+
 	cmd.MarkFlagsMutuallyExclusive("url", "us-gov")
 
 	return cmd

--- a/internal/pkg/errors/error_message.go
+++ b/internal/pkg/errors/error_message.go
@@ -399,9 +399,6 @@ const (
 	AWSCredsExpiredErrorMsg         = "AWS credentials in profile %s are expired"
 	FindAWSCredsErrorMsg            = "failed to find AWS credentials in profiles: %s"
 
-	// Flag Errors
-	ProhibitedFlagCombinationErrorMsg = "cannot use `--%s` and `--%s` flags at the same time"
-
 	// catcher
 	CCloudBackendErrorPrefix           = "Confluent Cloud backend error"
 	UnexpectedBackendOutputPrefix      = "unexpected CCloud backend output"
@@ -495,5 +492,4 @@ const (
 	DeleteResourceErrorMsg        = `failed to delete %s "%s": %v`
 	DeleteResourceConfirmErrorMsg = `input does not match "%s"`
 	UpdateResourceErrorMsg        = `failed to update %s "%s": %v`
-	MustSpecifyBothFlagsErrorMsg  = "must specify both `--%s` and `--%s`"
 )

--- a/test/fixtures/output/kafka/quota/create-no-ingress.golden
+++ b/test/fixtures/output/kafka/quota/create-no-ingress.golden
@@ -1,1 +1,28 @@
-Error: must specify both `--ingress` and `--egress`
+Error: if any flags in the group [ingress egress] are set they must all be set; missing [ingress]
+Usage:
+  confluent kafka quota create [flags]
+
+Examples:
+Create client quotas for service accounts "sa-1234" and "sa-5678" on cluster "lkc-1234".
+
+  $ confluent kafka quota create --name clientQuota --ingress 500 --egress 100 --principals sa-1234,sa-5678 --cluster lkc-1234
+
+Create a default client quota for all principals without an explicit quota assignment.
+
+  $ confluent kafka quota create --name defaultQuota --ingress 500 --egress 500 --principals "<default>" --cluster lkc-1234
+
+Flags:
+      --name string          REQUIRED: Display name for quota.
+      --description string   Description of quota.
+      --ingress string       Ingress throughput limit for client (bytes/second).
+      --egress string        Egress throughput limit for client (bytes/second).
+      --principals strings   A comma-separated list of service accounts to apply the quota to. Use "<default>" to apply the quota to all service accounts.
+      --cluster string       Kafka cluster ID.
+      --environment string   Environment ID.
+  -o, --output string        Specify the output format as "human", "json", or "yaml". (default "human")
+
+Global Flags:
+  -h, --help            Show help for this command.
+      --unsafe-trace    Equivalent to -vvvv, but also log HTTP requests and responses which might contain plaintext secrets.
+  -v, --verbose count   Increase verbosity (-v for warn, -vv for info, -vvv for debug, -vvvv for trace).
+

--- a/test/fixtures/output/kafka/topic/produce-help.golden
+++ b/test/fixtures/output/kafka/topic/produce-help.golden
@@ -22,7 +22,6 @@ Flags:
       --cluster string                      Kafka cluster ID.
       --context string                      CLI context name.
       --environment string                  Environment ID.
-  -o, --output string                       Specify the output format as "human", "json", or "yaml". (default "human")
 
 Global Flags:
   -h, --help            Show help for this command.


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
A recent version of Cobra added two functions to mark flags as (1) required together and (2) mutually exclusive. Use the built-in functions instead of an inconsistent hardcoded solution.

Also mark `--output` as deprecated in `confluent kafka topic produce`, since it doesn't get used and can be deleted in the next major version.