### PR TITLE
[CLI-2592] Correctly default to Avro when a schema type is not returned

### DIFF
--- a/internal/cmd/asyncapi/account_details.go
+++ b/internal/cmd/asyncapi/account_details.go
@@ -75,9 +75,12 @@ func (d *accountDetails) getSchemaDetails() error {
 		return err
 	}
 	d.channelDetails.schema = &schema
+
+	// The backend considers "AVRO" to be the default schema type.
 	if schema.SchemaType == "" {
 		schema.SchemaType = "AVRO"
 	}
+
 	switch schema.SchemaType {
 	case "JSON":
 		d.channelDetails.contentType = "application/json"

--- a/internal/cmd/schema-registry/command_schema_describe.go
+++ b/internal/cmd/schema-registry/command_schema_describe.go
@@ -267,6 +267,10 @@ func convertRootSchema(root *srsdk.SchemaString, id int32) *srsdk.Schema {
 		return nil
 	}
 
+	if root.SchemaType == "" {
+		root.SchemaType = "AVRO"
+	}
+
 	return &srsdk.Schema{
 		Id:         id,
 		SchemaType: root.SchemaType,

--- a/internal/cmd/schema-registry/command_schema_describe.go
+++ b/internal/cmd/schema-registry/command_schema_describe.go
@@ -267,6 +267,7 @@ func convertRootSchema(root *srsdk.SchemaString, id int32) *srsdk.Schema {
 		return nil
 	}
 
+	// The backend considers "AVRO" to be the default schema type.
 	if root.SchemaType == "" {
 		root.SchemaType = "AVRO"
 	}

--- a/internal/cmd/schema-registry/command_schema_describe.go
+++ b/internal/cmd/schema-registry/command_schema_describe.go
@@ -217,7 +217,7 @@ func traverseDAG(srClient *srsdk.APIClient, ctx context.Context, visited map[str
 func printSchema(schemaID int64, schema, schemaType string, refs []srsdk.SchemaReference, metadata *srsdk.Metadata, ruleset *srsdk.RuleSet) error {
 	output.Printf("Schema ID: %d\n", schemaID)
 
-	if schemaType != "" {
+	if schemaType == "" {
 		schemaType = "AVRO"
 	}
 	output.Println("Type: " + schemaType)

--- a/internal/cmd/schema-registry/command_schema_describe.go
+++ b/internal/cmd/schema-registry/command_schema_describe.go
@@ -217,6 +217,7 @@ func traverseDAG(srClient *srsdk.APIClient, ctx context.Context, visited map[str
 func printSchema(schemaID int64, schema, schemaType string, refs []srsdk.SchemaReference, metadata *srsdk.Metadata, ruleset *srsdk.RuleSet) error {
 	output.Printf("Schema ID: %d\n", schemaID)
 
+	// The backend considers "AVRO" to be the default schema type.
 	if schemaType == "" {
 		schemaType = "AVRO"
 	}

--- a/test/test-server/schema_registry_handlers.go
+++ b/test/test-server/schema_registry_handlers.go
@@ -215,7 +215,7 @@ func handleSRById(t *testing.T) http.HandlerFunc {
 		id64, err := strconv.ParseInt(idStr, 10, 32)
 		require.NoError(t, err)
 
-		schema := srsdk.Schema{Subject: "my-subject", Version: 1, SchemaType: "AVRO", Id: int32(id64)}
+		schema := srsdk.Schema{Subject: "my-subject", Version: 1, Id: int32(id64)}
 		switch id64 {
 		case 1001:
 			schema.Schema = "schema0"


### PR DESCRIPTION
Release Notes
-------------
Bug Fixes
- Fix "type" output in `confluent schema-registry schema describe` and properly format Avro schemas

Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
Fixing a typo from an earlier PR, this time with updated tests 🤦‍♂️

Test & Review
-------------
Modify tests to match backend response.