### PR TITLE
Deprecate `kafka topic produce --schema-id`

### DIFF
--- a/cmd/lint/main.go
+++ b/cmd/lint/main.go
@@ -224,6 +224,7 @@ var vocabWords = []string{
 	"env",
 	"eu",
 	"failover",
+	"filepath",
 	"flink",
 	"formatter",
 	"gcp",

--- a/internal/cmd/kafka/command_topic_produce.go
+++ b/internal/cmd/kafka/command_topic_produce.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"strconv"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -37,8 +38,7 @@ func newProduceCommand(prerunner pcmd.PreRunner, clientId string) *cobra.Command
 	}
 	cmd.RunE = c.produce
 
-	cmd.Flags().String("schema", "", "The path to the schema file.")
-	cmd.Flags().Int32("schema-id", 0, "The ID of the schema.")
+	cmd.Flags().String("schema", "", "The ID or filepath of the message value schema.")
 	pcmd.AddValueFormatFlag(cmd)
 	cmd.Flags().String("references", "", "The path to the references file.")
 	cmd.Flags().Bool("parse-key", false, "Parse key from the message.")
@@ -55,7 +55,10 @@ func newProduceCommand(prerunner pcmd.PreRunner, clientId string) *cobra.Command
 	cmd.Flags().String("environment", "", "Environment ID.")
 	pcmd.AddOutputFlag(cmd)
 
-	cobra.CheckErr(cmd.MarkFlagFilename("schema", "avsc", "json", "proto"))
+	// Deprecated
+	cmd.Flags().Int32("schema-id", 0, "The ID of the schema.")
+	cobra.CheckErr(cmd.Flags().MarkHidden("schema-id"))
+
 	cobra.CheckErr(cmd.MarkFlagFilename("references", "json"))
 	cobra.CheckErr(cmd.MarkFlagFilename("config-file", "avsc", "json"))
 
@@ -274,6 +277,7 @@ func (c *hasAPIKeyTopicCommand) initSchemaAndGetInfo(cmd *cobra.Command, topic s
 
 	subject := topicNameStrategy(topic)
 
+	// Deprecated
 	schemaId, err := cmd.Flags().GetInt32("schema-id")
 	if err != nil {
 		return nil, nil, err
@@ -284,12 +288,17 @@ func (c *hasAPIKeyTopicCommand) initSchemaAndGetInfo(cmd *cobra.Command, topic s
 		return nil, nil, err
 	}
 
+	isSchemaId := cmd.Flags().Changed("schema-id")
+	if id, err := strconv.ParseInt(schemaPath, 10, 32); err == nil {
+		schemaId = int32(id)
+		isSchemaId = true
+	}
+
 	var valueFormat string
 	referencePathMap := map[string]string{}
 	metaInfo := []byte{}
 
-	if cmd.Flags().Changed("schema-id") {
-		// request schema information from schemaID
+	if isSchemaId {
 		srClient, ctx, err := c.getSchemaRegistryClient(cmd)
 		if err != nil {
 			return nil, nil, err
@@ -323,7 +332,7 @@ func (c *hasAPIKeyTopicCommand) initSchemaAndGetInfo(cmd *cobra.Command, topic s
 		return nil, nil, err
 	}
 
-	if schemaPath != "" && !cmd.Flags().Changed("schema-id") {
+	if schemaPath != "" && !isSchemaId {
 		// read schema info from local file and register schema
 		schemaCfg := &sr.RegisterSchemaConfigs{
 			SchemaDir:   dir,
@@ -344,7 +353,7 @@ func (c *hasAPIKeyTopicCommand) initSchemaAndGetInfo(cmd *cobra.Command, topic s
 	}
 
 	if err := serializationProvider.LoadSchema(schemaPath, referencePathMap); err != nil {
-		return nil, nil, errors.NewWrapErrorWithSuggestions(err, "failed to load schema", errors.FailedToLoadSchemaSuggestions)
+		return nil, nil, errors.NewWrapErrorWithSuggestions(err, "failed to load schema", "Specify a schema by passing a schema ID or the path to a schema file to the `--schema` flag.")
 	}
 
 	return serializationProvider, metaInfo, nil

--- a/internal/pkg/cmd/flags.go
+++ b/internal/pkg/cmd/flags.go
@@ -400,7 +400,7 @@ func AddValueFormatFlag(cmd *cobra.Command) {
 	arr := []string{"string", "avro", "jsonschema", "protobuf"}
 	str := utils.ArrayToCommaDelimitedString(arr, "or")
 
-	cmd.Flags().String("value-format", "string", fmt.Sprintf("Format of message value as %s. Note that schema references are not supported for avro.", str))
+	cmd.Flags().String("value-format", arr[0], fmt.Sprintf("Format message value as %s. Note that schema references are not supported for Avro.", str))
 
 	RegisterFlagCompletionFunc(cmd, "value-format", func(_ *cobra.Command, _ []string) []string {
 		return arr

--- a/internal/pkg/errors/error_message.go
+++ b/internal/pkg/errors/error_message.go
@@ -188,7 +188,6 @@ const (
 	ProducingToCompactedTopicErrorMsg    = "producer has detected an INVALID_RECORD error for topic %s"
 	ProducingToCompactedTopicSuggestions = "If the topic has schema validation enabled, ensure you are producing with a schema-enabled producer.\n" +
 		"If your topic is compacted, ensure you are producing a record with a key."
-	FailedToLoadSchemaSuggestions   = "Specify a schema by passing the path to a schema file to the `--schema` flag, or by passing a registered schema ID to the `--schema-id` flag."
 	ExceedPartitionLimitSuggestions = "The total partition limit for a dedicated cluster may be increased by expanding its CKU count using `confluent kafka cluster update <id> --cku <count>`."
 
 	// Cluster Link commands

--- a/test/fixtures/output/asyncapi/export-help.golden
+++ b/test/fixtures/output/asyncapi/export-help.golden
@@ -18,7 +18,7 @@ Flags:
       --schema-registry-api-secret string   API secret for Schema Registry.
       --schema-context string               Use a specific schema context. (default "default")
       --topics strings                      A comma-separated list of topics to export. Supports prefixes ending with a wildcard (*).
-      --value-format string                 Format of message value as "string", "avro", "jsonschema", or "protobuf". Note that schema references are not supported for avro. (default "string")
+      --value-format string                 Format message value as "string", "avro", "jsonschema", or "protobuf". Note that schema references are not supported for Avro. (default "string")
       --cluster string                      Kafka cluster ID.
       --environment string                  Environment ID.
 

--- a/test/fixtures/output/kafka/topic/consume-help-onprem.golden
+++ b/test/fixtures/output/kafka/topic/consume-help-onprem.golden
@@ -28,7 +28,7 @@ Flags:
   -b, --from-beginning                    Consume from beginning of the topic.
       --offset int                        The offset from the beginning to consume from.
       --partition int32                   The partition to consume from. (default -1)
-      --value-format string               Format of message value as "string", "avro", "jsonschema", or "protobuf". Note that schema references are not supported for avro. (default "string")
+      --value-format string               Format message value as "string", "avro", "jsonschema", or "protobuf". Note that schema references are not supported for Avro. (default "string")
       --print-key                         Print key of the message.
       --full-header                       Print complete content of message headers.
       --timestamp                         Print message timestamp in milliseconds.

--- a/test/fixtures/output/kafka/topic/consume-help.golden
+++ b/test/fixtures/output/kafka/topic/consume-help.golden
@@ -15,7 +15,7 @@ Flags:
   -b, --from-beginning                      Consume from beginning of the topic.
       --offset int                          The offset from the beginning to consume from.
       --partition int32                     The partition to consume from. (default -1)
-      --value-format string                 Format of message value as "string", "avro", "jsonschema", or "protobuf". Note that schema references are not supported for avro. (default "string")
+      --value-format string                 Format message value as "string", "avro", "jsonschema", or "protobuf". Note that schema references are not supported for Avro. (default "string")
       --print-key                           Print key of the message.
       --full-header                         Print complete content of message headers.
       --delimiter string                    The delimiter separating each key and value. (default "\t")

--- a/test/fixtures/output/kafka/topic/produce-help-onprem.golden
+++ b/test/fixtures/output/kafka/topic/produce-help-onprem.golden
@@ -25,7 +25,7 @@ Flags:
       --protocol string                   Security protocol used to communicate with brokers. (default "SSL")
       --sasl-mechanism string             SASL_SSL mechanism used for authentication. (default "PLAIN")
       --schema string                     The path to the local schema file.
-      --value-format string               Format of message value as "string", "avro", "jsonschema", or "protobuf". Note that schema references are not supported for avro. (default "string")
+      --value-format string               Format message value as "string", "avro", "jsonschema", or "protobuf". Note that schema references are not supported for Avro. (default "string")
       --references string                 The path to the references file.
       --parse-key                         Parse key from the message.
       --delimiter string                  The delimiter separating each key and value. (default ":")

--- a/test/fixtures/output/kafka/topic/produce-help.golden
+++ b/test/fixtures/output/kafka/topic/produce-help.golden
@@ -6,9 +6,8 @@ Usage:
   confluent kafka topic produce <topic> [flags]
 
 Flags:
-      --schema string                       The path to the schema file.
-      --schema-id int32                     The ID of the schema.
-      --value-format string                 Format of message value as "string", "avro", "jsonschema", or "protobuf". Note that schema references are not supported for avro. (default "string")
+      --schema string                       A filepath or ID of the message value schema.
+      --value-format string                 Format message value as "string", "avro", "jsonschema", or "protobuf". Note that schema references are not supported for Avro. (default "string")
       --references string                   The path to the references file.
       --parse-key                           Parse key from the message.
       --delimiter string                    The delimiter separating each key and value. (default ":")

--- a/test/fixtures/output/kafka/topic/produce-help.golden
+++ b/test/fixtures/output/kafka/topic/produce-help.golden
@@ -6,7 +6,7 @@ Usage:
   confluent kafka topic produce <topic> [flags]
 
 Flags:
-      --schema string                       A filepath or ID of the message value schema.
+      --schema string                       The ID or filepath of the message value schema.
       --value-format string                 Format message value as "string", "avro", "jsonschema", or "protobuf". Note that schema references are not supported for Avro. (default "string")
       --references string                   The path to the references file.
       --parse-key                           Parse key from the message.

--- a/test/fixtures/output/kafka/topic/produce-no-schema.golden
+++ b/test/fixtures/output/kafka/topic/produce-no-schema.golden
@@ -1,4 +1,4 @@
 Error: failed to load schema: open : no such file or directory
 
 Suggestions:
-    Specify a schema by passing the path to a schema file to the `--schema` flag, or by passing a registered schema ID to the `--schema-id` flag.
+    Specify a schema by passing a schema ID or the path to a schema file to the `--schema` flag.


### PR DESCRIPTION
Release Notes
-------------
New Features
- Support passing schema IDs to the `--schema` flag in `confluent kafka topic produce`

Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
In https://confluentinc.atlassian.net/browse/CLI-2182, we want to support schemas for message keys. Currently, this would require adding `--key-schema` and `--key-schema-id` to mirror `--schema` and `--schema-id`. This PR allows passing IDs to `--schema` so we can deprecate `--schema-id`. (... so in a following PR we only need to add `--key-schema`).

Test & Review
-------------
Updated relevant tests