### PR TITLE
DGS-6578 AsyncAPI: Add correct Kafka bindings section

### DIFF
--- a/internal/cmd/asyncapi/command_export.go
+++ b/internal/cmd/asyncapi/command_export.go
@@ -35,13 +35,13 @@ type command struct {
 }
 
 type confluentBinding struct {
-	BindingVersion     string             `json:"bindingVersion,omitempty"`
-	Partitions         int32              `json:"partitions,omitempty"`
-	TopicConfiguration topicConfiguration `json:"topicConfiguration,omitempty"`
-	XConfigs           map[string]string  `json:"x-configs,omitempty"`
+	BindingVersion     string                   `json:"bindingVersion,omitempty"`
+	Partitions         int32                    `json:"partitions,omitempty"`
+	TopicConfiguration topicConfigurationExport `json:"topicConfiguration,omitempty"`
+	XConfigs           map[string]string        `json:"x-configs,omitempty"`
 }
 
-type topicConfiguration struct {
+type topicConfigurationExport struct {
 	CleanupPolicy       []string `json:"cleanup.policy,omitempty"`
 	RetentionTime       int64    `json:"retention.ms,omitempty"`
 	RetentionSize       int64    `json:"retention.bytes,omitempty"`
@@ -352,7 +352,7 @@ func (c *command) getBindings(clusterId, topicName string) (*bindings, error) {
 	}
 
 	// Turn topicConfigMap into correct format
-	topicConfigs := topicConfiguration{}
+	topicConfigs := topicConfigurationExport{}
 	jsonString, err := json.Marshal(topicConfigMap)
 	if err != nil {
 		return nil, err

--- a/internal/cmd/asyncapi/command_export.go
+++ b/internal/cmd/asyncapi/command_export.go
@@ -2,8 +2,10 @@ package asyncapi
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -25,6 +27,7 @@ import (
 	"github.com/confluentinc/cli/internal/pkg/log"
 	"github.com/confluentinc/cli/internal/pkg/output"
 	"github.com/confluentinc/cli/internal/pkg/serdes"
+	"github.com/confluentinc/cli/internal/pkg/types"
 )
 
 type command struct {
@@ -32,8 +35,18 @@ type command struct {
 }
 
 type confluentBinding struct {
-	XPartitions int32             `json:"x-partitions,omitempty"`
-	XConfigs    map[string]string `json:"x-configs,omitempty"`
+	BindingVersion string            `json:"bindingVersion,omitempty"`
+	Partitions     int32             `json:"partitions,omitempty"`
+	TopicConfigs   topicConfig       `json:"topicConfiguration,omitempty"`
+	XConfigs       map[string]string `json:"x-configs,omitempty"`
+}
+
+type topicConfig struct {
+	CleanupPolicy       []string `json:"cleanup.policy,omitempty"`
+	RetentionTime       int64    `json:"retention.ms,omitempty"`
+	RetentionSize       int64    `json:"retention.bytes,omitempty"`
+	DeleteRetentionTime int64    `json:"delete.retention.ms,omitempty"`
+	MaxMessageSize      int32    `json:"max.message.bytes,omitempty"`
 }
 
 type bindings struct {
@@ -306,13 +319,53 @@ func (c *command) getBindings(clusterId, topicName string) (*bindings, error) {
 	if partitionsResp.Data != nil {
 		numPartitions = int32(len(partitionsResp.Data))
 	}
-	configsMap := make(map[string]string)
+	customConfigMap := make(map[string]string)
+	topicConfigMap := make(map[string]interface{})
+
+	// Determine whether the given config value can be put into the AsyncAPI Kakfa bindings or put into our custom struct for extra configs
+	topicConfigOptions := types.NewSet(
+		"cleanup.policy",
+		"delete.retention.ms",
+		"max.message.bytes",
+		"retention.bytes",
+		"retention.ms",
+	)
 	for _, config := range configs.Data {
-		configsMap[config.GetName()] = config.GetValue()
+		if topicConfigOptions.Contains(config.GetName()) {
+			if config.GetName() == "cleanup.policy" {
+				topicConfigMap[config.GetName()] = strings.Split(config.GetValue(), ",")
+			} else if config.GetName() == "max.message.bytes" {
+				topicConfigMap[config.GetName()], err = strconv.ParseInt(config.GetValue(), 10, 32)
+				if err != nil {
+					return nil, err
+				}
+			} else {
+				topicConfigMap[config.GetName()], err = strconv.ParseInt(config.GetValue(), 10, 64)
+				if err != nil {
+					return nil, err
+				}
+			}
+		} else {
+			customConfigMap[config.GetName()] = config.GetValue()
+		}
 	}
+
+	// Turn topicConfigMap into correct format
+	topicConfigs := topicConfig{}
+	jsonString, err := json.Marshal(topicConfigMap)
+	if err != nil {
+		return nil, err
+	}
+	err = json.Unmarshal(jsonString, &topicConfigs)
+	if err != nil {
+		return nil, err
+	}
+
 	var channelBindings any = confluentBinding{
-		XPartitions: numPartitions,
-		XConfigs:    configsMap,
+		BindingVersion: "0.4.0",
+		Partitions:     numPartitions,
+		TopicConfigs:   topicConfigs,
+		XConfigs:       customConfigMap,
 	}
 	messageBindings := spec.MessageBindingsObject{Kafka: &spec.KafkaMessage{Key: &spec.KafkaMessageKey{Schema: map[string]any{"type": "string"}}}}
 	operationBindings := spec.OperationBindingsObject{Kafka: &spec.KafkaOperation{

--- a/internal/cmd/asyncapi/command_export.go
+++ b/internal/cmd/asyncapi/command_export.go
@@ -27,7 +27,6 @@ import (
 	"github.com/confluentinc/cli/internal/pkg/log"
 	"github.com/confluentinc/cli/internal/pkg/output"
 	"github.com/confluentinc/cli/internal/pkg/serdes"
-	"github.com/confluentinc/cli/internal/pkg/types"
 )
 
 type command struct {
@@ -322,31 +321,22 @@ func (c *command) getBindings(clusterId, topicName string) (*bindings, error) {
 	customConfigMap := make(map[string]string)
 	topicConfigMap := make(map[string]any)
 
-	// Determine whether the given config value can be put into the AsyncAPI Kakfa bindings or put into our custom struct for extra configs
-	topicConfigOptions := types.NewSet(
-		"cleanup.policy",
-		"delete.retention.ms",
-		"max.message.bytes",
-		"retention.bytes",
-		"retention.ms",
-	)
+	// Determine whether the given config value can be put into the AsyncAPI Kafka bindings or put into our custom struct for extra configs
 	for _, config := range configs.Data {
-		if topicConfigOptions.Contains(config.GetName()) {
-			switch config.GetName() {
-			case "cleanup.policy":
-				topicConfigMap[config.GetName()] = strings.Split(config.GetValue(), ",")
-			case "max.message.bytes":
-				topicConfigMap[config.GetName()], err = strconv.ParseInt(config.GetValue(), 10, 32)
-				if err != nil {
-					return nil, err
-				}
-			default:
-				topicConfigMap[config.GetName()], err = strconv.ParseInt(config.GetValue(), 10, 64)
-				if err != nil {
-					return nil, err
-				}
+		switch config.GetName() {
+		case "cleanup.policy":
+			topicConfigMap[config.GetName()] = strings.Split(config.GetValue(), ",")
+		case "max.message.bytes":
+			topicConfigMap[config.GetName()], err = strconv.ParseInt(config.GetValue(), 10, 32)
+			if err != nil {
+				return nil, err
 			}
-		} else {
+		case "delete.retention.ms", "retention.bytes", "retention.ms":
+			topicConfigMap[config.GetName()], err = strconv.ParseInt(config.GetValue(), 10, 64)
+			if err != nil {
+				return nil, err
+			}
+		default:
 			customConfigMap[config.GetName()] = config.GetValue()
 		}
 	}

--- a/internal/cmd/asyncapi/command_import.go
+++ b/internal/cmd/asyncapi/command_import.go
@@ -41,13 +41,13 @@ type flagsImport struct {
 }
 
 type kafkaBinding struct {
-	BindingVersion     string                `yaml:"bindingVersion"`
-	Partitions         int32                 `yaml:"partitions"`
-	TopicConfiguration topicConfigurationPtr `yaml:"topicConfiguration"`
-	XConfigs           map[string]string     `yaml:"x-configs"`
+	BindingVersion     string                   `yaml:"bindingVersion"`
+	Partitions         int32                    `yaml:"partitions"`
+	TopicConfiguration topicConfigurationImport `yaml:"topicConfiguration"`
+	XConfigs           map[string]string        `yaml:"x-configs"`
 }
 
-type topicConfigurationPtr struct {
+type topicConfigurationImport struct {
 	CleanupPolicy       *[]string `yaml:"cleanup.policy"`
 	RetentionTime       *int64    `yaml:"retention.ms"`
 	RetentionSize       *int64    `yaml:"retention.bytes"`
@@ -353,13 +353,13 @@ func combineTopicConfigs(kafkaBinding kafkaBinding) map[string]string {
 		configs["cleanup.policy"] = strings.Join(*topicConfig.CleanupPolicy, ",")
 	}
 	if topicConfig.RetentionTime != nil {
-		configs["retention.ms"] = strconv.FormatInt(*topicConfig.RetentionTime, 10)
+		configs["retention.ms"] = fmt.Sprint(*topicConfig.RetentionTime)
 	}
 	if topicConfig.RetentionSize != nil {
-		configs["retention.bytes"] = strconv.FormatInt(*topicConfig.RetentionSize, 10)
+		configs["retention.bytes"] = fmt.Sprint(*topicConfig.RetentionSize)
 	}
 	if topicConfig.DeleteRetentionTime != nil {
-		configs["delete.retention.ms"] = strconv.FormatInt(*topicConfig.DeleteRetentionTime, 10)
+		configs["delete.retention.ms"] = fmt.Sprint(*topicConfig.DeleteRetentionTime)
 	}
 	if topicConfig.MaxMessageSize != nil {
 		configs["max.message.bytes"] = strconv.Itoa(int(*topicConfig.MaxMessageSize))

--- a/internal/cmd/asyncapi/command_import.go
+++ b/internal/cmd/asyncapi/command_import.go
@@ -364,7 +364,6 @@ func combineTopicConfigs(kafkaBinding kafkaBinding) map[string]string {
 	if topicConfig.MaxMessageSize != nil {
 		configs["max.message.bytes"] = strconv.Itoa(int(*topicConfig.MaxMessageSize))
 	}
-
 	return configs
 }
 

--- a/test/fixtures/input/asyncapi/asyncapi-spec.yaml
+++ b/test/fixtures/input/asyncapi/asyncapi-spec.yaml
@@ -24,9 +24,15 @@ channels:
         $ref: '#/components/messages/Topic1Message'
     bindings:
       kafka:
+        bindingVersion: 0.4.0
+        partitions: 2
+        topicConfiguration:
+          cleanup.policy:
+          - delete
+          delete.retention.ms: 86400000
         x-configs:
-          cleanup.policy: delete
-          delete.retention.ms: "86400000"
+          compression.type: producer
+          file.delete.delay.ms: "60000"
     x-messageCompatibility: FORWARD
 components:
   messages:

--- a/test/fixtures/output/asyncapi/asyncapi-spec.yaml
+++ b/test/fixtures/output/asyncapi/asyncapi-spec.yaml
@@ -19,10 +19,12 @@ channels:
         $ref: '#/components/messages/Topic1Message'
     bindings:
       kafka:
-        x-partitions: 3
-        x-configs:
-          cleanup.policy: delete
-          delete.retention.ms: "86400000"
+        bindingVersion: 0.4.0
+        partitions: 3
+        topicConfiguration:
+          cleanup.policy:
+          - delete
+          delete.retention.ms: 8.64e+07
     x-messageCompatibility: FORWARD
 components:
   messages:

--- a/test/fixtures/output/asyncapi/asyncapi-topic-specified.yaml
+++ b/test/fixtures/output/asyncapi/asyncapi-topic-specified.yaml
@@ -19,10 +19,12 @@ channels:
         $ref: '#/components/messages/Topic1Message'
     bindings:
       kafka:
-        x-partitions: 3
-        x-configs:
-          cleanup.policy: delete
-          delete.retention.ms: "86400000"
+        bindingVersion: 0.4.0
+        partitions: 3
+        topicConfiguration:
+          cleanup.policy:
+          - delete
+          delete.retention.ms: 8.64e+07
     x-messageCompatibility: FORWARD
 components:
   messages:


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Bug Fixes
- Fix `confluent asyncapi import` and `confluent asyncapi export` to follow AsyncAPI documentation for Kafka channel bindings, with explicit fields for `bindingVersion`, `partitions`, and `topicConfiguration`.

Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->

We are not outputting Kafka bindings in the correct format. Previously, our Kafka bindings struct looked like this (x- in front of a field means that it is custom, not specified in the asyncapi documentation)

```
type confluentBinding struct {
	XPartitions int32             `json:"x-partitions,omitempty"`
	XConfigs    map[string]string `json:"x-configs,omitempty"`
}
```

However, not all of these fields should have been custom. The asyncapi spec does include a Kafka bindings section (under references), its just not exposed by the library we are using to help us convert from Kafka<->Asyncapi.

This PR fixes the following problem by using a new struct that includes all of the fields specified in the latest version of the  asyncapi documentation (keeping x-configs to include fields not listed in asyncapi documentation)

```
type confluentBinding struct {
	BindingVersion string            `json:"bindingVersion,omitempty"`
	Partitions     int32             `json:"partitions,omitempty"`
	TopicConfigs   topicConfig       `json:"topicConfiguration,omitempty"`
	XConfigs       map[string]string `json:"x-configs,omitempty"`
}
```
FF for another example - https://confluentinc.atlassian.net/browse/FF-10843

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->
Asyncapi Kafka bindings
https://github.com/asyncapi/bindings/blob/master/kafka/README.md

Test & Review
-------------
<!--
Has it been tested? How?
Copy and paste any instructions or steps that can save the reviewer time.
-->

Updated integration tests to follow new format

Tested by creating topics/schemas on confluent cloud, exporting them and importing on another cluster (checking that the topic configs are correct).

Open Questions / Follow-ups
---------------------------
<!--
Optional: Anything open to discussion for the reviewer, out of scope of this PR, or follow-ups.
-->
Can link https://github.com/asyncapi/bindings/blob/master/kafka/README.md in release notes if seems helpful

Tried but export code maybe could be cleaner