### PR TITLE
notify context is cloud when run on-prem cmds after cloud login

### DIFF
--- a/internal/pkg/cmd/run_requirements_test.go
+++ b/internal/pkg/cmd/run_requirements_test.go
@@ -97,7 +97,7 @@ func TestErrIfMissingRunRequirement_Error(t *testing.T) {
 		{RequireNonAPIKeyCloudLogin, apiKeyCloudCfg, v1.RequireNonAPIKeyCloudLoginErr},
 		{RequireNonAPIKeyCloudLoginOrOnPremLogin, apiKeyCloudCfg, v1.RequireNonAPIKeyCloudLoginOrOnPremLoginErr},
 		{RequireNonAPIKeyCloudLoginOrOnPremLogin, apiKeyCloudCfg, v1.RequireNonAPIKeyCloudLoginOrOnPremLoginErr},
-		{RequireOnPremLogin, cloudCfg(regularOrgContextState), v1.RequireOnPremLoginErr},
+		{RequireOnPremLogin, cloudCfg(regularOrgContextState), v1.CloudLoginRequireOnPremLoginErr},
 	} {
 		cmd := &cobra.Command{Annotations: map[string]string{RunRequirement: test.req}}
 		err := ErrIfMissingRunRequirement(cmd, test.cfg)

--- a/internal/pkg/cmd/run_requirements_test.go
+++ b/internal/pkg/cmd/run_requirements_test.go
@@ -97,7 +97,7 @@ func TestErrIfMissingRunRequirement_Error(t *testing.T) {
 		{RequireNonAPIKeyCloudLogin, apiKeyCloudCfg, v1.RequireNonAPIKeyCloudLoginErr},
 		{RequireNonAPIKeyCloudLoginOrOnPremLogin, apiKeyCloudCfg, v1.RequireNonAPIKeyCloudLoginOrOnPremLoginErr},
 		{RequireNonAPIKeyCloudLoginOrOnPremLogin, apiKeyCloudCfg, v1.RequireNonAPIKeyCloudLoginOrOnPremLoginErr},
-		{RequireOnPremLogin, cloudCfg(regularOrgContextState), v1.CloudLoginRequireOnPremLoginErr},
+		{RequireOnPremLogin, cloudCfg(regularOrgContextState), v1.RunningOnPremCommandInCloudErr},
 	} {
 		cmd := &cobra.Command{Annotations: map[string]string{RunRequirement: test.req}}
 		err := ErrIfMissingRunRequirement(cmd, test.cfg)

--- a/internal/pkg/config/v1/config.go
+++ b/internal/pkg/config/v1/config.go
@@ -64,7 +64,7 @@ var (
 		"you must log in to Confluent Platform to use this command",
 		"Log in to Confluent Platform with `confluent login --url <mds-url>`.",
 	)
-	CloudLoginRequireOnPremLoginErr = errors.NewErrorWithSuggestions(
+	RunningOnPremCommandInCloudErr = errors.NewErrorWithSuggestions(
 		"this is not a Confluent Cloud command. You must log in to Confluent Platform to use this command",
 		"Log in to Confluent Platform with `confluent login --url <mds-url>`.\n"+`Run command with "--help" to see available commands.`,
 	)
@@ -655,7 +655,7 @@ func (c *Config) CheckIsOnPremLogin() error {
 		if !c.isCloud() {
 			return nil
 		} else {
-			return CloudLoginRequireOnPremLoginErr
+			return RunningOnPremCommandInCloudErr
 		}
 	}
 	return RequireOnPremLoginErr

--- a/internal/pkg/config/v1/config.go
+++ b/internal/pkg/config/v1/config.go
@@ -66,7 +66,7 @@ var (
 	)
 	RunningOnPremCommandInCloudErr = errors.NewErrorWithSuggestions(
 		"this is not a Confluent Cloud command. You must log in to Confluent Platform to use this command",
-		"Log in to Confluent Platform with `confluent login --url <mds-url>`.\n"+`Run command with "--help" to see available commands.`,
+		"Log in to Confluent Platform with `confluent login --url <mds-url>`.\n"+`Use the "--help" flag to see available commands.`,
 	)
 )
 

--- a/internal/pkg/config/v1/config.go
+++ b/internal/pkg/config/v1/config.go
@@ -62,7 +62,11 @@ var (
 	)
 	RequireOnPremLoginErr = errors.NewErrorWithSuggestions(
 		"you must log in to Confluent Platform to use this command",
-		"Log in with `confluent login --url <mds-url>`.",
+		"Log in to Confluent Platform with `confluent login --url <mds-url>`.",
+	)
+	CloudLoginRequireOnPremLoginErr = errors.NewErrorWithSuggestions(
+		"this is not a Confluent Cloud command. You must log in to Confluent Platform to use this command",
+		"Log in to Confluent Platform with `confluent login --url <mds-url>`.\n"+`Run command with "--help" to see available commands.`,
 	)
 )
 
@@ -647,8 +651,12 @@ func (c *Config) GetFilename() string {
 
 func (c *Config) CheckIsOnPremLogin() error {
 	ctx := c.Context()
-	if ctx != nil && ctx.PlatformName != "" && !c.isCloud() {
-		return nil
+	if ctx != nil && ctx.PlatformName != "" {
+		if !c.isCloud() {
+			return nil
+		} else {
+			return CloudLoginRequireOnPremLoginErr
+		}
 	}
 	return RequireOnPremLoginErr
 }


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- PLACEHOLDER

New Features
- Clear error message when user runs on premise commands when logged into Confluent Cloud

Bug Fixes
- PLACEHOLDER

Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->
if logged in to cloud but runs a cp cmd, will notify:
```
mhe@C02DV0KVMD6T cli % confluent cluster list
Error: this is not a Confluent Cloud command. You must log in to Confluent Platform to use this command

Suggestions:
    Log in with `confluent login --url <mds-url>`.
    Run command with "--help" to see available commands.
```

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
<!--
Has it been tested? How?
Copy and paste any instructions or steps that can save the reviewer time.
-->

Open Questions / Follow-ups
---------------------------
<!--
Optional: Anything open to discussion for the reviewer, out of scope of this PR, or follow-ups.
-->
