### PR TITLE
suggest `confluent kafka cluster` when run `confluent cluster` while logged in to cloud

### DIFF
--- a/internal/pkg/cmd/prerunner.go
+++ b/internal/pkg/cmd/prerunner.go
@@ -448,6 +448,9 @@ func (r *PreRun) AuthenticatedWithMDS(command *AuthenticatedCLICommand) func(*co
 
 		// Even if there was an error while setting the context, notify the user about any unmet run requirements first.
 		if err := ErrIfMissingRunRequirement(cmd, r.Config); err != nil {
+			if err == v1.RunningOnPremCommandInCloudErr && strings.Contains(cmd.CommandPath(), "confluent cluster") {
+				return v1.RunningClusterCommandInCloudErr
+			}
 			return err
 		}
 

--- a/internal/pkg/cmd/prerunner.go
+++ b/internal/pkg/cmd/prerunner.go
@@ -36,7 +36,8 @@ type wrongLoginCommandError struct {
 
 var wrongLoginCommandErrorWithSuggestion = wrongLoginCommandError{
 	"`%s` is not a Confluent Cloud command. Did you mean `%s`?",
-	"Log in to Confluent Platform with `confluent login --url <mds-url>` to use `%s`."}
+	"If you are a Confluent Cloud user, run `%s` instead.\n" +
+		"If you are attempting to connect to Confluent Platform, login with `confluent login --url <mds-url>` to use `%s`."}
 
 var wrongLoginCommandsMap = map[string]string{
 	"confluent cluster": "confluent kafka cluster",
@@ -466,7 +467,7 @@ func (r *PreRun) AuthenticatedWithMDS(command *AuthenticatedCLICommand) func(*co
 					if strings.HasPrefix(cmd.CommandPath(), topLevelCmd) {
 						suggestCmdPath := strings.Replace(cmd.CommandPath(), topLevelCmd, suggestCmd, 1)
 						return errors.NewErrorWithSuggestions(fmt.Sprintf(wrongLoginCommandErrorWithSuggestion.errorString, cmd.CommandPath(), suggestCmdPath),
-							fmt.Sprintf(wrongLoginCommandErrorWithSuggestion.suggestionString, cmd.CommandPath()))
+							fmt.Sprintf(wrongLoginCommandErrorWithSuggestion.suggestionString, suggestCmdPath, cmd.CommandPath()))
 					}
 				}
 			}

--- a/internal/pkg/cmd/prerunner.go
+++ b/internal/pkg/cmd/prerunner.go
@@ -29,6 +29,16 @@ import (
 	"github.com/confluentinc/cli/internal/pkg/version"
 )
 
+type wrongLoginCommandError struct {
+	errorString      string
+	suggestionString string
+}
+
+var wrongLoginCommandErrors = map[string]wrongLoginCommandError{
+	"confluent cluster": {"`%s` is not a Confluent Cloud command. Did you mean `confluent kafka cluster %s`?",
+		"Log in to Confluent Platform with `confluent login --url <mds-url>` to use `%s`."},
+}
+
 // PreRun is a helper class for automatically setting up Cobra PersistentPreRun commands
 type PreRunner interface {
 	Anonymous(command *CLICommand, willAuthenticate bool) func(*cobra.Command, []string) error
@@ -448,8 +458,14 @@ func (r *PreRun) AuthenticatedWithMDS(command *AuthenticatedCLICommand) func(*co
 
 		// Even if there was an error while setting the context, notify the user about any unmet run requirements first.
 		if err := ErrIfMissingRunRequirement(cmd, r.Config); err != nil {
-			if err == v1.RunningOnPremCommandInCloudErr && strings.Contains(cmd.CommandPath(), "confluent cluster") {
-				return v1.RunningClusterCommandInCloudErr
+			if err == v1.RunningOnPremCommandInCloudErr {
+				for topLevelCmd, errorStruct := range wrongLoginCommandErrors {
+					if strings.HasPrefix(cmd.CommandPath(), topLevelCmd) {
+						trimmed := strings.TrimPrefix(cmd.CommandPath(), topLevelCmd+" ")
+						return errors.NewErrorWithSuggestions(fmt.Sprintf(errorStruct.errorString, cmd.CommandPath(), trimmed),
+							fmt.Sprintf(errorStruct.suggestionString, cmd.CommandPath()))
+					}
+				}
 			}
 			return err
 		}

--- a/internal/pkg/config/v1/config.go
+++ b/internal/pkg/config/v1/config.go
@@ -68,10 +68,6 @@ var (
 		"this is not a Confluent Cloud command. You must log in to Confluent Platform to use this command",
 		"Log in to Confluent Platform with `confluent login --url <mds-url>`.\n"+`Use the "--help" flag to see available commands.`,
 	)
-	RunningClusterCommandInCloudErr = errors.NewErrorWithSuggestions(
-		"`confluent cluster` is not a Confluent Cloud command. Did you mean `confluent kafka cluster`?",
-		"Log in to Confluent Platform with `confluent login --url <mds-url>` to use `confluent cluster`.",
-	)
 )
 
 // Config represents the CLI configuration.

--- a/internal/pkg/config/v1/config.go
+++ b/internal/pkg/config/v1/config.go
@@ -68,6 +68,10 @@ var (
 		"this is not a Confluent Cloud command. You must log in to Confluent Platform to use this command",
 		"Log in to Confluent Platform with `confluent login --url <mds-url>`.\n"+`Use the "--help" flag to see available commands.`,
 	)
+	RunningClusterCommandInCloudErr = errors.NewErrorWithSuggestions(
+		"`confluent cluster` is not a Confluent Cloud command. Did you mean `confluent kafka cluster`?",
+		"Log in to Confluent Platform with `confluent login --url <mds-url>` to use `confluent cluster`.",
+	)
 )
 
 // Config represents the CLI configuration.


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- PLACEHOLDER

New Features
- Add a suggestion to use `confluent kafka cluster` when users run the on-premises `confluent cluster` command while logged in to Confluent Cloud

Bug Fixes
- PLACEHOLDER

Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->
```
mhe@C02DV0KVMD6T cli % confluent cluster list --context login-mhe@confluent.io-https://confluent.cloud
Error: `confluent cluster list` is not a Confluent Cloud command. Did you mean `confluent kafka cluster list`?

Suggestions:
    If you are a Confluent Cloud user, run `confluent kafka cluster list` instead.
    If you are attempting to connect to Confluent Platform, login with `confluent login --url <mds-url>` to use `confluent cluster list`.
```
```
mhe@C02DV0KVMD6T cli % confluent audit-log config
Error: this is not a Confluent Cloud command. You must log in to Confluent Platform to use this command

Suggestions:
    Log in to Confluent Platform with `confluent login --url <mds-url>`.
    Use the "--help" flag to see available commands.
```


References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
<!--
Has it been tested? How?
Copy and paste any instructions or steps that can save the reviewer time.
-->

Open Questions / Follow-ups
---------------------------
<!--
Optional: Anything open to discussion for the reviewer, out of scope of this PR, or follow-ups.
-->
