### PR TITLE
Fix autocompletion for `kafka cluster create`, formatting improvements

### DIFF
--- a/internal/cmd/asyncapi/account_details.go
+++ b/internal/cmd/asyncapi/account_details.go
@@ -86,8 +86,10 @@ func (d *accountDetails) getSchemaDetails() error {
 		return fmt.Errorf("protobuf is not supported")
 	}
 
-	// JSON or Avro Format
-	d.channelDetails.contentType = fmt.Sprintf("application/%s", strings.ToLower(schema.SchemaType))
+	if schema.SchemaType == "AVRO" || schema.SchemaType == "JSON" {
+		d.channelDetails.contentType = fmt.Sprintf("application/%s", strings.ToLower(schema.SchemaType))
+	}
+
 	if err := json.Unmarshal([]byte(schema.Schema), &d.channelDetails.unmarshalledSchema); err != nil {
 		d.channelDetails.unmarshalledSchema, err = handlePrimitiveSchemas(schema.Schema, err)
 		log.CliLogger.Warn(err)

--- a/internal/cmd/asyncapi/account_details.go
+++ b/internal/cmd/asyncapi/account_details.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/swaggest/go-asyncapi/spec-2.4.0"
 
@@ -81,19 +82,17 @@ func (d *accountDetails) getSchemaDetails() error {
 		schema.SchemaType = "AVRO"
 	}
 
-	switch schema.SchemaType {
-	case "JSON":
-		d.channelDetails.contentType = "application/json"
-	case "AVRO":
-		d.channelDetails.contentType = "application/avro"
-	case "PROTOBUF":
+	if schema.SchemaType == "PROTOBUF" {
 		return fmt.Errorf("protobuf is not supported")
 	}
+
 	// JSON or Avro Format
+	d.channelDetails.contentType = fmt.Sprintf("application/%s", strings.ToLower(schema.SchemaType))
 	if err := json.Unmarshal([]byte(schema.Schema), &d.channelDetails.unmarshalledSchema); err != nil {
 		d.channelDetails.unmarshalledSchema, err = handlePrimitiveSchemas(schema.Schema, err)
 		log.CliLogger.Warn(err)
 	}
+
 	return nil
 }
 
@@ -101,7 +100,7 @@ func handlePrimitiveSchemas(schema string, err error) (map[string]any, error) {
 	unmarshalledSchema := make(map[string]any)
 	primitiveTypes := []string{"string", "null", "boolean", "int", "long", "float", "double", "bytes"}
 	for _, primitiveType := range primitiveTypes {
-		if schema == fmt.Sprintf("\"%s\"", primitiveType) {
+		if schema == fmt.Sprintf(`"%s"`, primitiveType) {
 			unmarshalledSchema["type"] = primitiveType
 			return unmarshalledSchema, nil
 		}

--- a/internal/cmd/kafka/command_link_configuration_list.go
+++ b/internal/cmd/kafka/command_link_configuration_list.go
@@ -46,12 +46,12 @@ func (c *linkCommand) configurationList(cmd *cobra.Command, args []string) error
 		return errors.New(errors.RestProxyNotAvailableMsg)
 	}
 
-	clusterId, err := getKafkaClusterLkcId(c.AuthenticatedCLICommand)
+	cluster, err := c.Context.GetKafkaClusterForCommand()
 	if err != nil {
 		return err
 	}
 
-	listLinkConfigsRespData, httpResp, err := kafkaREST.CloudClient.ListKafkaLinkConfigs(clusterId, linkName)
+	listLinkConfigsRespData, httpResp, err := kafkaREST.CloudClient.ListKafkaLinkConfigs(cluster.ID, linkName)
 	if err != nil {
 		return kafkarest.NewError(kafkaREST.CloudClient.GetUrl(), err, httpResp)
 	}

--- a/internal/cmd/kafka/command_link_configuration_update.go
+++ b/internal/cmd/kafka/command_link_configuration_update.go
@@ -65,14 +65,14 @@ func (c *linkCommand) configurationUpdate(cmd *cobra.Command, args []string) err
 		return errors.New(errors.RestProxyNotAvailableMsg)
 	}
 
-	clusterId, err := getKafkaClusterLkcId(c.AuthenticatedCLICommand)
+	cluster, err := c.Context.GetKafkaClusterForCommand()
 	if err != nil {
 		return err
 	}
 
 	data := toAlterConfigBatchRequestData(configMap)
 
-	if httpResp, err := kafkaREST.CloudClient.UpdateKafkaLinkConfigBatch(clusterId, linkName, data); err != nil {
+	if httpResp, err := kafkaREST.CloudClient.UpdateKafkaLinkConfigBatch(cluster.ID, linkName, data); err != nil {
 		return kafkarest.NewError(kafkaREST.CloudClient.GetUrl(), err, httpResp)
 	}
 

--- a/internal/cmd/kafka/command_link_create.go
+++ b/internal/cmd/kafka/command_link_create.go
@@ -177,12 +177,12 @@ func (c *linkCommand) create(cmd *cobra.Command, args []string) error {
 		return errors.New(errors.RestProxyNotAvailableMsg)
 	}
 
-	clusterId, err := getKafkaClusterLkcId(c.AuthenticatedCLICommand)
+	cluster, err := c.Context.GetKafkaClusterForCommand()
 	if err != nil {
 		return err
 	}
 
-	if httpResp, err := kafkaREST.CloudClient.CreateKafkaLink(clusterId, linkName, !noValidate, dryRun, data); err != nil {
+	if httpResp, err := kafkaREST.CloudClient.CreateKafkaLink(cluster.ID, linkName, !noValidate, dryRun, data); err != nil {
 		return kafkarest.NewError(kafkaREST.CloudClient.GetUrl(), err, httpResp)
 	}
 

--- a/internal/cmd/kafka/command_link_delete.go
+++ b/internal/cmd/kafka/command_link_delete.go
@@ -41,7 +41,7 @@ func (c *linkCommand) delete(cmd *cobra.Command, args []string) error {
 		return errors.New(errors.RestProxyNotAvailableMsg)
 	}
 
-	clusterId, err := getKafkaClusterLkcId(c.AuthenticatedCLICommand)
+	cluster, err := c.Context.GetKafkaClusterForCommand()
 	if err != nil {
 		return err
 	}
@@ -51,7 +51,7 @@ func (c *linkCommand) delete(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if httpResp, err := kafkaREST.CloudClient.DeleteKafkaLink(clusterId, linkName); err != nil {
+	if httpResp, err := kafkaREST.CloudClient.DeleteKafkaLink(cluster.ID, linkName); err != nil {
 		return kafkarest.NewError(kafkaREST.CloudClient.GetUrl(), err, httpResp)
 	}
 

--- a/internal/cmd/kafka/command_link_describe.go
+++ b/internal/cmd/kafka/command_link_describe.go
@@ -50,12 +50,12 @@ func (c *linkCommand) describe(cmd *cobra.Command, args []string) error {
 		return errors.New(errors.RestProxyNotAvailableMsg)
 	}
 
-	clusterId, err := getKafkaClusterLkcId(c.AuthenticatedCLICommand)
+	cluster, err := c.Context.GetKafkaClusterForCommand()
 	if err != nil {
 		return err
 	}
 
-	data, httpResp, err := kafkaREST.CloudClient.GetKafkaLink(clusterId, linkName)
+	data, httpResp, err := kafkaREST.CloudClient.GetKafkaLink(cluster.ID, linkName)
 	if err != nil {
 		return kafkarest.NewError(kafkaREST.CloudClient.GetUrl(), err, httpResp)
 	}

--- a/internal/cmd/kafka/command_link_list.go
+++ b/internal/cmd/kafka/command_link_list.go
@@ -73,12 +73,12 @@ func (c *linkCommand) list(cmd *cobra.Command, _ []string) error {
 		return errors.New(errors.RestProxyNotAvailableMsg)
 	}
 
-	clusterId, err := getKafkaClusterLkcId(c.AuthenticatedCLICommand)
+	cluster, err := c.Context.GetKafkaClusterForCommand()
 	if err != nil {
 		return err
 	}
 
-	listLinksRespDataList, httpResp, err := kafkaREST.CloudClient.ListKafkaLinks(clusterId)
+	listLinksRespDataList, httpResp, err := kafkaREST.CloudClient.ListKafkaLinks(cluster.ID)
 	if err != nil {
 		return kafkarest.NewError(kafkaREST.CloudClient.GetUrl(), err, httpResp)
 	}
@@ -88,7 +88,7 @@ func (c *linkCommand) list(cmd *cobra.Command, _ []string) error {
 		if includeTopics {
 			// data.GetTopicsNames() is empty even when the http response contains a non-empty list of topic names,
 			// this function call is a temporary work-around for this issue
-			mirrorTopicNames, err := getMirrorTopicNames(kafkaREST, clusterId, data.GetLinkName())
+			mirrorTopicNames, err := getMirrorTopicNames(kafkaREST, cluster.ID, data.GetLinkName())
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/kafka/command_mirror.go
+++ b/internal/cmd/kafka/command_mirror.go
@@ -82,13 +82,13 @@ func (c *mirrorCommand) autocompleteMirrorTopics(cmd *cobra.Command) []string {
 		return nil
 	}
 
-	lkc, err := getKafkaClusterLkcId(c.AuthenticatedCLICommand)
+	cluster, err := c.Context.GetKafkaClusterForCommand()
 	if err != nil {
 		return nil
 	}
 
 	opts := &kafkarestv3.ListKafkaMirrorTopicsUnderLinkOpts{MirrorStatus: optional.EmptyInterface()}
-	listMirrorTopicsResponseDataList, _, err := kafkaREST.Client.ClusterLinkingV3Api.ListKafkaMirrorTopicsUnderLink(kafkaREST.Context, lkc, linkName, opts)
+	listMirrorTopicsResponseDataList, _, err := kafkaREST.Client.ClusterLinkingV3Api.ListKafkaMirrorTopicsUnderLink(kafkaREST.Context, cluster.ID, linkName, opts)
 	if err != nil {
 		return nil
 	}

--- a/internal/cmd/kafka/command_mirror_create.go
+++ b/internal/cmd/kafka/command_mirror_create.go
@@ -92,7 +92,7 @@ func (c *mirrorCommand) create(cmd *cobra.Command, args []string) error {
 		return errors.New(errors.RestProxyNotAvailableMsg)
 	}
 
-	lkc, err := getKafkaClusterLkcId(c.AuthenticatedCLICommand)
+	cluster, err := c.Context.GetKafkaClusterForCommand()
 	if err != nil {
 		return err
 	}
@@ -109,7 +109,7 @@ func (c *mirrorCommand) create(cmd *cobra.Command, args []string) error {
 		createMirrorTopicRequestData.MirrorTopicName = &mirrorTopicName
 	}
 
-	if httpResp, err := kafkaREST.CloudClient.CreateKafkaMirrorTopic(lkc, linkName, createMirrorTopicRequestData); err != nil {
+	if httpResp, err := kafkaREST.CloudClient.CreateKafkaMirrorTopic(cluster.ID, linkName, createMirrorTopicRequestData); err != nil {
 		return kafkarest.NewError(kafkaREST.CloudClient.GetUrl(), err, httpResp)
 	}
 

--- a/internal/cmd/kafka/command_mirror_describe.go
+++ b/internal/cmd/kafka/command_mirror_describe.go
@@ -52,12 +52,12 @@ func (c *mirrorCommand) describe(cmd *cobra.Command, args []string) error {
 		return errors.New(errors.RestProxyNotAvailableMsg)
 	}
 
-	lkc, err := getKafkaClusterLkcId(c.AuthenticatedCLICommand)
+	cluster, err := c.Context.GetKafkaClusterForCommand()
 	if err != nil {
 		return err
 	}
 
-	mirror, httpResp, err := kafkaREST.Client.ClusterLinkingV3Api.ReadKafkaMirrorTopic(kafkaREST.Context, lkc, linkName, mirrorTopicName)
+	mirror, httpResp, err := kafkaREST.Client.ClusterLinkingV3Api.ReadKafkaMirrorTopic(kafkaREST.Context, cluster.ID, linkName, mirrorTopicName)
 	if err != nil {
 		return kafkarest.NewError(kafkaREST.CloudClient.GetUrl(), err, httpResp)
 	}

--- a/internal/cmd/kafka/command_mirror_failover.go
+++ b/internal/cmd/kafka/command_mirror_failover.go
@@ -58,7 +58,7 @@ func (c *mirrorCommand) failover(cmd *cobra.Command, args []string) error {
 		return errors.New(errors.RestProxyNotAvailableMsg)
 	}
 
-	lkc, err := getKafkaClusterLkcId(c.AuthenticatedCLICommand)
+	cluster, err := c.Context.GetKafkaClusterForCommand()
 	if err != nil {
 		return err
 	}
@@ -68,7 +68,7 @@ func (c *mirrorCommand) failover(cmd *cobra.Command, args []string) error {
 		ValidateOnly:            optional.NewBool(dryRun),
 	}
 
-	results, httpResp, err := kafkaREST.Client.ClusterLinkingV3Api.UpdateKafkaMirrorTopicsFailover(kafkaREST.Context, lkc, linkName, failoverMirrorOpt)
+	results, httpResp, err := kafkaREST.Client.ClusterLinkingV3Api.UpdateKafkaMirrorTopicsFailover(kafkaREST.Context, cluster.ID, linkName, failoverMirrorOpt)
 	if err != nil {
 		return kafkarest.NewError(kafkaREST.CloudClient.GetUrl(), err, httpResp)
 	}

--- a/internal/cmd/kafka/command_mirror_list.go
+++ b/internal/cmd/kafka/command_mirror_list.go
@@ -62,7 +62,7 @@ func (c *mirrorCommand) list(cmd *cobra.Command, _ []string) error {
 		return errors.New(errors.RestProxyNotAvailableMsg)
 	}
 
-	lkc, err := getKafkaClusterLkcId(c.AuthenticatedCLICommand)
+	cluster, err := c.Context.GetKafkaClusterForCommand()
 	if err != nil {
 		return err
 	}
@@ -77,10 +77,10 @@ func (c *mirrorCommand) list(cmd *cobra.Command, _ []string) error {
 
 	if linkName == "" {
 		opts := &kafkarestv3.ListKafkaMirrorTopicsOpts{MirrorStatus: mirrorStatusOpt}
-		listMirrorTopicsResponseDataList, httpResp, err = kafkaREST.Client.ClusterLinkingV3Api.ListKafkaMirrorTopics(kafkaREST.Context, lkc, opts)
+		listMirrorTopicsResponseDataList, httpResp, err = kafkaREST.Client.ClusterLinkingV3Api.ListKafkaMirrorTopics(kafkaREST.Context, cluster.ID, opts)
 	} else {
 		opts := &kafkarestv3.ListKafkaMirrorTopicsUnderLinkOpts{MirrorStatus: mirrorStatusOpt}
-		listMirrorTopicsResponseDataList, httpResp, err = kafkaREST.Client.ClusterLinkingV3Api.ListKafkaMirrorTopicsUnderLink(kafkaREST.Context, lkc, linkName, opts)
+		listMirrorTopicsResponseDataList, httpResp, err = kafkaREST.Client.ClusterLinkingV3Api.ListKafkaMirrorTopicsUnderLink(kafkaREST.Context, cluster.ID, linkName, opts)
 	}
 	if err != nil {
 		return kafkarest.NewError(kafkaREST.CloudClient.GetUrl(), err, httpResp)

--- a/internal/cmd/kafka/command_mirror_pause.go
+++ b/internal/cmd/kafka/command_mirror_pause.go
@@ -58,7 +58,7 @@ func (c *mirrorCommand) pause(cmd *cobra.Command, args []string) error {
 		return errors.New(errors.RestProxyNotAvailableMsg)
 	}
 
-	lkc, err := getKafkaClusterLkcId(c.AuthenticatedCLICommand)
+	cluster, err := c.Context.GetKafkaClusterForCommand()
 	if err != nil {
 		return err
 	}
@@ -68,7 +68,7 @@ func (c *mirrorCommand) pause(cmd *cobra.Command, args []string) error {
 		ValidateOnly:            optional.NewBool(dryRun),
 	}
 
-	results, httpResp, err := kafkaREST.Client.ClusterLinkingV3Api.UpdateKafkaMirrorTopicsPause(kafkaREST.Context, lkc, linkName, pauseMirrorOpt)
+	results, httpResp, err := kafkaREST.Client.ClusterLinkingV3Api.UpdateKafkaMirrorTopicsPause(kafkaREST.Context, cluster.ID, linkName, pauseMirrorOpt)
 	if err != nil {
 		return kafkarest.NewError(kafkaREST.CloudClient.GetUrl(), err, httpResp)
 	}

--- a/internal/cmd/kafka/command_mirror_promote.go
+++ b/internal/cmd/kafka/command_mirror_promote.go
@@ -58,7 +58,7 @@ func (c *mirrorCommand) promote(cmd *cobra.Command, args []string) error {
 		return errors.New(errors.RestProxyNotAvailableMsg)
 	}
 
-	lkc, err := getKafkaClusterLkcId(c.AuthenticatedCLICommand)
+	cluster, err := c.Context.GetKafkaClusterForCommand()
 	if err != nil {
 		return err
 	}
@@ -68,7 +68,7 @@ func (c *mirrorCommand) promote(cmd *cobra.Command, args []string) error {
 		ValidateOnly:            optional.NewBool(dryRun),
 	}
 
-	results, httpResp, err := kafkaREST.Client.ClusterLinkingV3Api.UpdateKafkaMirrorTopicsPromote(kafkaREST.Context, lkc, linkName, promoteMirrorOpt)
+	results, httpResp, err := kafkaREST.Client.ClusterLinkingV3Api.UpdateKafkaMirrorTopicsPromote(kafkaREST.Context, cluster.ID, linkName, promoteMirrorOpt)
 	if err != nil {
 		return kafkarest.NewError(kafkaREST.CloudClient.GetUrl(), err, httpResp)
 	}

--- a/internal/cmd/kafka/command_mirror_resume.go
+++ b/internal/cmd/kafka/command_mirror_resume.go
@@ -61,7 +61,7 @@ func (c *mirrorCommand) resume(cmd *cobra.Command, args []string) error {
 		return errors.New(errors.RestProxyNotAvailableMsg)
 	}
 
-	lkc, err := getKafkaClusterLkcId(c.AuthenticatedCLICommand)
+	cluster, err := c.Context.GetKafkaClusterForCommand()
 	if err != nil {
 		return err
 	}
@@ -71,7 +71,7 @@ func (c *mirrorCommand) resume(cmd *cobra.Command, args []string) error {
 		ValidateOnly:            optional.NewBool(dryRun),
 	}
 
-	results, httpResp, err := kafkaREST.Client.ClusterLinkingV3Api.UpdateKafkaMirrorTopicsResume(kafkaREST.Context, lkc, linkName, resumeMirrorOpt)
+	results, httpResp, err := kafkaREST.Client.ClusterLinkingV3Api.UpdateKafkaMirrorTopicsResume(kafkaREST.Context, cluster.ID, linkName, resumeMirrorOpt)
 	if err != nil {
 		return kafkarest.NewError(kafkaREST.CloudClient.GetUrl(), err, httpResp)
 	}

--- a/internal/cmd/kafka/utils.go
+++ b/internal/cmd/kafka/utils.go
@@ -70,14 +70,6 @@ func toAlterConfigBatchRequestDataOnPrem(configsMap map[string]string) cpkafkare
 	return cpkafkarestv3.AlterConfigBatchRequestData{Data: kafkaRestConfigs}
 }
 
-func getKafkaClusterLkcId(c *pcmd.AuthenticatedCLICommand) (string, error) {
-	kafkaClusterConfig, err := c.Context.GetKafkaClusterForCommand()
-	if err != nil {
-		return "", err
-	}
-	return kafkaClusterConfig.ID, nil
-}
-
 func handleOpenApiError(httpResp *_nethttp.Response, err error, client *cpkafkarestv3.APIClient) error {
 	if err == nil {
 		return nil

--- a/internal/pkg/cmd/flags.go
+++ b/internal/pkg/cmd/flags.go
@@ -50,7 +50,7 @@ func AutocompleteApiKeys(client *ccloudv2.Client) []string {
 
 func AddAvailabilityFlag(cmd *cobra.Command) {
 	cmd.Flags().String("availability", kafka.Availabilities[0], fmt.Sprintf("Specify the availability of the cluster as %s.", utils.ArrayToCommaDelimitedString(kafka.Availabilities, "or")))
-	RegisterFlagCompletionFunc(cmd, output.FlagName, func(_ *cobra.Command, _ []string) []string { return kafka.Availabilities })
+	RegisterFlagCompletionFunc(cmd, "availability", func(_ *cobra.Command, _ []string) []string { return kafka.Availabilities })
 }
 
 func AddByokKeyFlag(cmd *cobra.Command, command *AuthenticatedCLICommand) {
@@ -393,7 +393,7 @@ func AutocompleteUsers(client *ccloudv2.Client) []string {
 
 func AddTypeFlag(cmd *cobra.Command) {
 	cmd.Flags().String("type", kafka.Types[0], fmt.Sprintf("Specify the type of the Kafka cluster as %s.", utils.ArrayToCommaDelimitedString(kafka.Types, "or")))
-	RegisterFlagCompletionFunc(cmd, output.FlagName, func(_ *cobra.Command, _ []string) []string { return kafka.Types })
+	RegisterFlagCompletionFunc(cmd, "type", func(_ *cobra.Command, _ []string) []string { return kafka.Types })
 }
 
 func AddValueFormatFlag(cmd *cobra.Command) {

--- a/internal/pkg/config/v1/environment_context.go
+++ b/internal/pkg/config/v1/environment_context.go
@@ -1,10 +1,10 @@
 package v1
 
 type EnvironmentContext struct {
-	CurrentFlinkComputePool string `json:"current_flink_compute_pool,omitempty"`
-	CurrentIdentityPool     string `json:"current_identity_pool,omitempty"`
 	CurrentFlinkCatalog     string `json:"current_flink_catalog,omitempty"`
+	CurrentFlinkComputePool string `json:"current_flink_compute_pool,omitempty"`
 	CurrentFlinkDatabase    string `json:"current_flink_database,omitempty"`
+	CurrentIdentityPool     string `json:"current_identity_pool,omitempty"`
 }
 
 func NewEnvironmentContext() *EnvironmentContext {

--- a/test/byok_test.go
+++ b/test/byok_test.go
@@ -41,7 +41,7 @@ func (s *CLITestSuite) TestByokDescribe() {
 	}
 }
 
-func (s *CLITestSuite) TestByokAutocomplete() {
+func (s *CLITestSuite) TestByok_Autocomplete() {
 	test := CLITest{args: `__complete byok describe ""`, login: "cloud", fixture: "byok/describe-autocomplete.golden"}
 	s.runIntegrationTest(test)
 }

--- a/test/environment_test.go
+++ b/test/environment_test.go
@@ -49,7 +49,7 @@ func (s *CLITestSuite) TestEnvironmentUse() {
 	}
 }
 
-func (s *CLITestSuite) TestEnvironmentAutocomplete() {
+func (s *CLITestSuite) TestEnvironment_Autocomplete() {
 	test := CLITest{args: `__complete environment describe ""`, login: "cloud", fixture: "environment/describe-autocomplete.golden"}
 	s.runIntegrationTest(test)
 }

--- a/test/fixtures/output/kafka/create-availability-autocomplete.golden
+++ b/test/fixtures/output/kafka/create-availability-autocomplete.golden
@@ -1,0 +1,4 @@
+single-zone
+multi-zone
+:4
+Completion ended with directive: ShellCompDirectiveNoFileComp

--- a/test/fixtures/output/kafka/create-type-autocomplete.golden
+++ b/test/fixtures/output/kafka/create-type-autocomplete.golden
@@ -1,0 +1,5 @@
+basic
+standard
+dedicated
+:4
+Completion ended with directive: ShellCompDirectiveNoFileComp

--- a/test/iam_test.go
+++ b/test/iam_test.go
@@ -362,7 +362,7 @@ func (s *CLITestSuite) TestIamPoolList() {
 	}
 }
 
-func (s *CLITestSuite) TestIamAutocomplete() {
+func (s *CLITestSuite) TestIam_Autocomplete() {
 	tests := []CLITest{
 		{args: `__complete iam pool describe --provider op-12345 ""`, fixture: "iam/identity-pool/describe-autocomplete.golden"},
 		{args: `__complete iam provider describe ""`, fixture: "iam/identity-provider/describe-autocomplete.golden"},

--- a/test/kafka_test.go
+++ b/test/kafka_test.go
@@ -468,8 +468,10 @@ func (s *CLITestSuite) TestKafkaQuota() {
 	}
 }
 
-func (s *CLITestSuite) TestKafkaAutocomplete() {
+func (s *CLITestSuite) TestKafka_Autocomplete() {
 	tests := []CLITest{
+		{args: `__complete kafka cluster create my-cluster --availability ""`, fixture: "kafka/create-availability-autocomplete.golden"},
+		{args: `__complete kafka cluster create my-cluster --type ""`, fixture: "kafka/create-type-autocomplete.golden"},
 		{args: `__complete kafka cluster describe ""`, fixture: "kafka/describe-autocomplete.golden"},
 		{args: `__complete kafka link delete ""`, fixture: "kafka/link/list-link-delete-autocomplete.golden", useKafka: "lkc-describe-topic"}, // use delete since link has no describe subcommand
 		{args: `__complete kafka mirror describe --link link-1 ""`, fixture: "kafka/mirror/describe-autocomplete.golden", useKafka: "lkc-describe-topic"},


### PR DESCRIPTION
Release Notes
-------------
Bug Fixes
- Fix autocompletion of `--availability` and `--type` flags in `confluent kafka cluster create`

Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
Fix autocompletion, consolidate Kafka REST helper function, improve overall formatting