### PR TITLE
fix: make basic output the default regardless of number of columns

### DIFF
--- a/internal/pkg/flink/app/application.go
+++ b/internal/pkg/flink/app/application.go
@@ -13,8 +13,6 @@ import (
 	"github.com/confluentinc/cli/internal/pkg/flink/types"
 )
 
-const minNumColumnsToUseInteractiveTable = 4
-
 type Application struct {
 	history                     *history.History
 	store                       types.StoreInterface
@@ -111,14 +109,10 @@ func (a *Application) isAuthenticated() bool {
 }
 
 func (a *Application) getOutputController(processedStatementWithResults types.ProcessedStatement) types.OutputControllerInterface {
-	// only use view for non-local statements, that have more than one row and more than one column
 	if processedStatementWithResults.IsLocalStatement {
 		return a.basicOutputController
 	}
 	if processedStatementWithResults.PageToken != "" || processedStatementWithResults.IsSelectStatement {
-		return a.interactiveOutputController
-	}
-	if len(processedStatementWithResults.StatementResults.GetHeaders()) >= minNumColumnsToUseInteractiveTable {
 		return a.interactiveOutputController
 	}
 

--- a/internal/pkg/flink/app/application_test.go
+++ b/internal/pkg/flink/app/application_test.go
@@ -223,12 +223,12 @@ func (s *ApplicationTestSuite) TestShouldUseTView() {
 			isBasicOutput: true,
 		},
 		{
-			name: "statement with 4 columns should use TView",
+			name: "statement with 4 columns should not use TView",
 			statement: types.ProcessedStatement{StatementResults: &types.StatementResults{
 				Headers: []string{"Column 1", "Column 2", "Column 3", "Column 4"},
 				Rows:    []types.StatementResultRow{},
 			}},
-			isBasicOutput: false,
+			isBasicOutput: true,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->
This makes it so that we only use the interactive output when we have a next page token or the statement is a select statement. We do not factor in the number of columns in this decision anymore. 

The main reason for this is the DESCRIBE statement. With the results of the DESCRIBE statement being displayed in the interactive table, the user needs to run the DESCRIBE, then memorize the field names and schema, and then write their query in one go. It is much easier for the user, if we just print the fields and the schema, so that the subsequent queries can be written without going back and forth between the terminal and the interactive table.