### PR TITLE
change CatchCCloudV2Error to always return an errorWithSuggestion including the status code

### DIFF
--- a/internal/cmd/flink/command_compute_pool_delete.go
+++ b/internal/cmd/flink/command_compute_pool_delete.go
@@ -36,6 +36,9 @@ func (c *command) computePoolDelete(cmd *cobra.Command, args []string) error {
 
 	computePool, err := c.V2Client.DescribeFlinkComputePool(args[0], environmentId)
 	if err != nil {
+		if coder, ok := err.(errors.Coder); ok {
+			coder.GetStatusCode()
+		}
 		return err
 	}
 

--- a/internal/cmd/flink/command_compute_pool_delete.go
+++ b/internal/cmd/flink/command_compute_pool_delete.go
@@ -36,9 +36,6 @@ func (c *command) computePoolDelete(cmd *cobra.Command, args []string) error {
 
 	computePool, err := c.V2Client.DescribeFlinkComputePool(args[0], environmentId)
 	if err != nil {
-		if coder, ok := err.(errors.Coder); ok {
-			coder.GetStatusCode()
-		}
 		return err
 	}
 

--- a/internal/pkg/errors/catcher.go
+++ b/internal/pkg/errors/catcher.go
@@ -177,7 +177,7 @@ func CatchCCloudV2Error(err error, r *http.Response) error {
 		return NewWrapErrorWithSuggestionsAndCode(err, errorMessage, "", statusCode)
 	}
 
-	return NewWrapErrorWithSuggestionsAndCode(err, err.Error(), "", statusCode)
+	return NewErrorWithSuggestionsAndCode(err.Error(), "", statusCode)
 }
 
 func CatchResourceNotFoundError(err error, resourceId string) error {

--- a/internal/pkg/errors/catcher_test.go
+++ b/internal/pkg/errors/catcher_test.go
@@ -1,6 +1,7 @@
 package errors
 
 import (
+	"errors"
 	"io"
 	"net/http"
 	"strings"
@@ -15,6 +16,42 @@ func TestCatchClustersExceedError(t *testing.T) {
 	err := CatchClusterConfigurationNotValidError(New("402 Payment Required"), res)
 	require.Error(t, err)
 	require.Equal(t, err.Error(), "Your environment is currently limited to 50 kafka clusters: 402 Payment Required")
+}
+
+func TestCatchErrorCodeWhenErrors(t *testing.T) {
+	res := &http.Response{Body: io.NopCloser(strings.NewReader(`{"errors":[{"detail":"There is an error"}]}`)), StatusCode: 405}
+
+	err := CatchCCloudV2Error(errors.New("Some Error"), res)
+	require.Error(t, err)
+	require.Equal(t, 405, StatusCode(err))
+
+}
+
+func TestCatchErrorCodeWhenErrorMessage(t *testing.T) {
+	res := &http.Response{Body: io.NopCloser(strings.NewReader(`{"message":"unauthorized"}`)), StatusCode: 401}
+
+	err := CatchCCloudV2Error(errors.New("Some Error"), res)
+	require.Error(t, err)
+	require.Equal(t, 401, StatusCode(err))
+
+}
+
+func TestCatchErrorCodeWhenNestedMessage(t *testing.T) {
+	res := &http.Response{Body: io.NopCloser(strings.NewReader(`{"error":{"message":"gateway error"}}`)), StatusCode: 405}
+
+	err := CatchCCloudV2Error(errors.New("Some Error"), res)
+	require.Error(t, err)
+	require.Equal(t, 405, StatusCode(err))
+
+}
+
+func TestCatchErrorOnlyStatusCode(t *testing.T) {
+	res := &http.Response{Body: io.NopCloser(strings.NewReader("")), StatusCode: 405}
+
+	err := CatchCCloudV2Error(errors.New("Some Error"), res)
+	require.Error(t, err)
+	require.Equal(t, 405, StatusCode(err))
+
 }
 
 func TestCatchServiceAccountExceedError(t *testing.T) {

--- a/internal/pkg/errors/catcher_test.go
+++ b/internal/pkg/errors/catcher_test.go
@@ -19,39 +19,35 @@ func TestCatchClustersExceedError(t *testing.T) {
 }
 
 func TestCatchErrorCodeWhenErrors(t *testing.T) {
-	res := &http.Response{Body: io.NopCloser(strings.NewReader(`{"errors":[{"detail":"There is an error"}]}`)), StatusCode: 405}
+	res := &http.Response{Body: io.NopCloser(strings.NewReader(`{"errors":[{"detail":"There is an error"}]}`)), StatusCode: http.StatusMethodNotAllowed}
 
 	err := CatchCCloudV2Error(errors.New("Some Error"), res)
 	require.Error(t, err)
-	require.Equal(t, 405, StatusCode(err))
-
+	require.Equal(t, http.StatusMethodNotAllowed, StatusCode(err))
 }
 
 func TestCatchErrorCodeWhenErrorMessage(t *testing.T) {
-	res := &http.Response{Body: io.NopCloser(strings.NewReader(`{"message":"unauthorized"}`)), StatusCode: 401}
+	res := &http.Response{Body: io.NopCloser(strings.NewReader(`{"message":"unauthorized"}`)), StatusCode: http.StatusUnauthorized}
 
 	err := CatchCCloudV2Error(errors.New("Some Error"), res)
 	require.Error(t, err)
-	require.Equal(t, 401, StatusCode(err))
-
+	require.Equal(t, http.StatusUnauthorized, StatusCode(err))
 }
 
 func TestCatchErrorCodeWhenNestedMessage(t *testing.T) {
-	res := &http.Response{Body: io.NopCloser(strings.NewReader(`{"error":{"message":"gateway error"}}`)), StatusCode: 405}
+	res := &http.Response{Body: io.NopCloser(strings.NewReader(`{"error":{"message":"gateway error"}}`)), StatusCode: http.StatusMethodNotAllowed}
 
 	err := CatchCCloudV2Error(errors.New("Some Error"), res)
 	require.Error(t, err)
-	require.Equal(t, 405, StatusCode(err))
-
+	require.Equal(t, http.StatusMethodNotAllowed, StatusCode(err))
 }
 
 func TestCatchErrorOnlyStatusCode(t *testing.T) {
-	res := &http.Response{Body: io.NopCloser(strings.NewReader("")), StatusCode: 405}
+	res := &http.Response{Body: io.NopCloser(strings.NewReader("")), StatusCode: http.StatusMethodNotAllowed}
 
 	err := CatchCCloudV2Error(errors.New("Some Error"), res)
 	require.Error(t, err)
-	require.Equal(t, 405, StatusCode(err))
-
+	require.Equal(t, http.StatusMethodNotAllowed, StatusCode(err))
 }
 
 func TestCatchServiceAccountExceedError(t *testing.T) {

--- a/internal/pkg/errors/error_with_suggestions.go
+++ b/internal/pkg/errors/error_with_suggestions.go
@@ -17,6 +17,7 @@ type ErrorWithSuggestions interface {
 
 type ErrorWithSuggestionsImpl struct {
 	errorMsg       string
+	statusCode     int
 	suggestionsMsg string
 }
 
@@ -27,10 +28,26 @@ func NewErrorWithSuggestions(errorMsg string, suggestionsMsg string) ErrorWithSu
 	}
 }
 
+func NewErrorWithSuggestionsAndCode(errorMsg string, suggestionsMsg string, statusCode int) ErrorWithSuggestions {
+	return &ErrorWithSuggestionsImpl{
+		errorMsg:       errorMsg,
+		suggestionsMsg: suggestionsMsg,
+		statusCode:     statusCode,
+	}
+}
+
 func NewWrapErrorWithSuggestions(err error, errorMsg string, suggestionsMsg string) ErrorWithSuggestions {
 	return &ErrorWithSuggestionsImpl{
 		errorMsg:       Wrap(err, errorMsg).Error(),
 		suggestionsMsg: suggestionsMsg,
+	}
+}
+
+func NewWrapErrorWithSuggestionsAndCode(err error, errorMsg string, suggestionsMsg string, statusCode int) ErrorWithSuggestions {
+	return &ErrorWithSuggestionsImpl{
+		errorMsg:       Wrap(err, errorMsg).Error(),
+		suggestionsMsg: suggestionsMsg,
+		statusCode:     statusCode,
 	}
 }
 
@@ -40,6 +57,10 @@ func (b *ErrorWithSuggestionsImpl) Error() string {
 
 func (b *ErrorWithSuggestionsImpl) GetSuggestionsMsg() string {
 	return b.suggestionsMsg
+}
+
+func (b *ErrorWithSuggestionsImpl) GetStatusCode() int {
+	return b.statusCode
 }
 
 func DisplaySuggestionsMessage(err error) string {
@@ -58,4 +79,16 @@ func ComposeSuggestionsMessage(msg string) string {
 		suggestionsMsg += fmt.Sprintf(suggestionsLineFormat, line)
 	}
 	return suggestionsMsg
+}
+
+type Coder interface {
+	GetStatusCode() int
+}
+
+// StatusCode extract the status code if the error implements Coder interface.
+func StatusCode(err error) int {
+	if coder, ok := err.(Coder); ok {
+		return coder.GetStatusCode()
+	}
+	return 0
 }

--- a/internal/pkg/flink/internal/controller/statement_controller.go
+++ b/internal/pkg/flink/internal/controller/statement_controller.go
@@ -55,7 +55,7 @@ func (c *StatementController) ExecuteStatement(statementToExecute string) (*type
 
 func (c *StatementController) handleStatementError(err types.StatementError) {
 	utils.OutputErr(err.Error())
-	if err.HttpResponseCode == http.StatusUnauthorized {
+	if err.StatusCode == http.StatusUnauthorized {
 		c.applicationController.ExitApplication()
 	}
 }

--- a/internal/pkg/flink/internal/controller/statement_controller_test.go
+++ b/internal/pkg/flink/internal/controller/statement_controller_test.go
@@ -105,7 +105,7 @@ func (s *StatementControllerTestSuite) TestExecuteStatement() {
 
 func (s *StatementControllerTestSuite) TestExecuteStatementExitApplicationOnUnauthorizedResponse() {
 	statementToExecute := "select 1;"
-	processedStatementError := types.StatementError{Message: "unauthorized", HttpResponseCode: 401}
+	processedStatementError := types.StatementError{Message: "unauthorized", StatusCode: 401}
 	s.store.EXPECT().ProcessStatement(statementToExecute).Return(nil, &processedStatementError)
 	s.applicationController.EXPECT().ExitApplication()
 

--- a/internal/pkg/flink/internal/store/.snapshots/TestProcessSetStatement-should_return_all_keys_and_values_from_config_if_configKey_is_empty
+++ b/internal/pkg/flink/internal/store/.snapshots/TestProcessSetStatement-should_return_all_keys_and_values_from_config_if_configKey_is_empty
@@ -39,7 +39,7 @@
         },
         (types.AtomicStatementResultField) {
           Type: (types.StatementResultFieldType) (len=7) "VARCHAR",
-          Value: (string) (len=9) "UTC+01:00"
+          Value: (string) (len=19) "UTC+01:00 (default)"
         }
       }
     }

--- a/internal/pkg/flink/internal/store/.snapshots/TestProcessSetStatement-should_return_all_keys_and_values_from_config_if_configKey_is_empty
+++ b/internal/pkg/flink/internal/store/.snapshots/TestProcessSetStatement-should_return_all_keys_and_values_from_config_if_configKey_is_empty
@@ -39,7 +39,7 @@
         },
         (types.AtomicStatementResultField) {
           Type: (types.StatementResultFieldType) (len=7) "VARCHAR",
-          Value: (string) (len=19) "UTC+01:00 (default)"
+          Value: (string) (len=9) "UTC+02:00"
         }
       }
     }

--- a/internal/pkg/flink/internal/store/.snapshots/TestProcessSetStatement-should_return_all_keys_and_values_from_config_if_configKey_is_empty_after_updates
+++ b/internal/pkg/flink/internal/store/.snapshots/TestProcessSetStatement-should_return_all_keys_and_values_from_config_if_configKey_is_empty_after_updates
@@ -52,7 +52,7 @@
         },
         (types.AtomicStatementResultField) {
           Type: (types.StatementResultFieldType) (len=7) "VARCHAR",
-          Value: (string) (len=19) "UTC+01:00 (default)"
+          Value: (string) (len=9) "UTC+02:00"
         }
       }
     },

--- a/internal/pkg/flink/internal/store/.snapshots/TestProcessSetStatement-should_return_all_keys_and_values_from_config_if_configKey_is_empty_after_updates
+++ b/internal/pkg/flink/internal/store/.snapshots/TestProcessSetStatement-should_return_all_keys_and_values_from_config_if_configKey_is_empty_after_updates
@@ -52,7 +52,7 @@
         },
         (types.AtomicStatementResultField) {
           Type: (types.StatementResultFieldType) (len=7) "VARCHAR",
-          Value: (string) (len=9) "UTC+01:00"
+          Value: (string) (len=19) "UTC+01:00 (default)"
         }
       }
     },

--- a/internal/pkg/flink/internal/store/store.go
+++ b/internal/pkg/flink/internal/store/store.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	_ "embed"
 	"fmt"
-	"github.com/confluentinc/cli/internal/pkg/errors"
 	"net/url"
 	"strings"
 	"time"
@@ -12,6 +11,7 @@ import (
 	flinkgatewayv1alpha1 "github.com/confluentinc/ccloud-sdk-go-v2/flink-gateway/v1alpha1"
 
 	"github.com/confluentinc/cli/internal/pkg/ccloudv2"
+	"github.com/confluentinc/cli/internal/pkg/errors"
 	"github.com/confluentinc/cli/internal/pkg/flink/config"
 	"github.com/confluentinc/cli/internal/pkg/flink/internal/results"
 	"github.com/confluentinc/cli/internal/pkg/flink/types"

--- a/internal/pkg/flink/internal/store/store.go
+++ b/internal/pkg/flink/internal/store/store.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	_ "embed"
 	"fmt"
+	"github.com/confluentinc/cli/internal/pkg/errors"
 	"net/url"
 	"strings"
 	"time"
@@ -85,11 +86,13 @@ func (s *Store) ProcessStatement(statement string) (*types.ProcessedStatement, *
 		s.appOptions.GetEnvironmentId(),
 		s.appOptions.GetOrgResourceId(),
 	)
+
 	if err != nil {
 		statusDetail := s.getStatusDetail(statementObj)
 		return nil, &types.StatementError{
 			Message:        err.Error(),
 			FailureMessage: statusDetail,
+			StatusCode:     errors.StatusCode(err),
 		}
 	}
 	return types.NewProcessedStatement(statementObj), nil
@@ -168,7 +171,7 @@ func (s *Store) waitForPendingStatement(ctx context.Context, statementName strin
 		select {
 		case <-ctx.Done():
 			s.DeleteStatement(statementName)
-			return nil, &types.StatementError{Message: "result retrieval aborted. Statement will be deleted", HttpResponseCode: 499}
+			return nil, &types.StatementError{Message: "result retrieval aborted. Statement will be deleted", StatusCode: 499}
 		default:
 			start := time.Now()
 			statementObj, err := s.authenticatedGatewayClient().GetStatement(s.appOptions.GetEnvironmentId(), statementName, s.appOptions.GetOrgResourceId())

--- a/internal/pkg/flink/internal/store/store_utils.go
+++ b/internal/pkg/flink/internal/store/store_utils.go
@@ -323,9 +323,9 @@ func processHttpErrors(resp *http.Response, err error) error {
 	if resp != nil && resp.StatusCode >= 400 {
 		if resp.StatusCode == http.StatusUnauthorized {
 			return &types.StatementError{
-				Message:          "unauthorized",
-				Suggestion:       `Please run "confluent login"`,
-				HttpResponseCode: resp.StatusCode,
+				Message:    "unauthorized",
+				Suggestion: `Please run "confluent login"`,
+				StatusCode: resp.StatusCode,
 			}
 		}
 

--- a/internal/pkg/flink/internal/store/store_utils_test.go
+++ b/internal/pkg/flink/internal/store/store_utils_test.go
@@ -83,7 +83,7 @@ func TestProcessSetStatement(t *testing.T) {
 	// Create a new store
 	client := ccloudv2.NewFlinkGatewayClient("url", "userAgent", false, "authToken")
 	s := NewStore(client, nil, &types.ApplicationOptions{}, tokenRefreshFunc).(*Store)
-	s.Properties.Set(config.ConfigKeyLocalTimeZone, "UTC+01:00")
+	s.Properties.Set(config.ConfigKeyLocalTimeZone, "UTC+02:00")
 
 	t.Run("should return an error message if statement is invalid", func(t *testing.T) {
 		_, err := s.processSetStatement("se key=value")

--- a/internal/pkg/flink/types/statement_error.go
+++ b/internal/pkg/flink/types/statement_error.go
@@ -7,11 +7,11 @@ import (
 )
 
 type StatementError struct {
-	Message          string
-	HttpResponseCode int
-	FailureMessage   string
-	Usage            []string
-	Suggestion       string
+	Message        string
+	StatusCode     int
+	FailureMessage string
+	Usage          []string
+	Suggestion     string
 }
 
 func (e *StatementError) Error() string {


### PR DESCRIPTION
…luding the status code

Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
Extended the errorWithSuggestion type to include the status code. Updated CatchCCloudV2Error to always return an errortWithSuggestion so there will always be a status code available from SDK errors. 

This is needed to implement custom logic for different status codes (e.g. retry)

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
<!--
Has it been tested? How?
Copy and paste any instructions or steps that can save the reviewer time.
-->

Open Questions / Follow-ups
---------------------------
<!--
Optional: Anything open to discussion for the reviewer, out of scope of this PR, or follow-ups.
-->
