### PR TITLE
feat/KFS-1058-exit attached mode upon pressing ControlC, ControlD, ControlQ..

### DIFF
--- a/internal/pkg/flink/internal/controller/statement_controller.go
+++ b/internal/pkg/flink/internal/controller/statement_controller.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	fColor "github.com/fatih/color"
+	"github.com/samber/lo"
 
 	"github.com/confluentinc/go-prompt"
 
@@ -129,17 +130,9 @@ func (c *StatementController) userInputIsOneOf(keyEvents ...func(key prompt.Key)
 }
 
 func isCancelEvent(key prompt.Key) bool {
-	switch key {
-	case prompt.ControlC, prompt.ControlD, prompt.ControlQ, prompt.Escape:
-		return true
-	}
-	return false
+	return lo.Contains([]prompt.Key{prompt.ControlC, prompt.ControlD, prompt.ControlQ, prompt.Escape}, key)
 }
 
 func isDetachEvent(key prompt.Key) bool {
-	switch key {
-	case prompt.ControlM, prompt.Enter:
-		return true
-	}
-	return false
+	return lo.Contains([]prompt.Key{prompt.ControlM, prompt.Enter}, key)
 }

--- a/internal/pkg/flink/internal/controller/statement_controller_test.go
+++ b/internal/pkg/flink/internal/controller/statement_controller_test.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/confluentinc/go-prompt"
 
-	"github.com/confluentinc/cli/internal/pkg/flink/test"
+	testUtils "github.com/confluentinc/cli/internal/pkg/flink/test"
 	"github.com/confluentinc/cli/internal/pkg/flink/test/mock"
 	"github.com/confluentinc/cli/internal/pkg/flink/types"
 )
@@ -148,7 +148,7 @@ func (s *StatementControllerTestSuite) TestExecuteStatementPrintsUserInfo() {
 	s.store.EXPECT().WaitPendingStatement(gomock.Any(), processedStatement).Return(&completedStatement, nil)
 	s.store.EXPECT().FetchStatementResults(completedStatement).Return(&completedStatement, nil)
 
-	stdout := test.RunAndCaptureSTDOUT(s.T(), func() {
+	stdout := testUtils.RunAndCaptureSTDOUT(s.T(), func() {
 		_, _ = s.statementController.ExecuteStatement(statementToExecute)
 	})
 
@@ -166,7 +166,7 @@ func (s *StatementControllerTestSuite) TestExecuteStatementWaitsForCompletedStat
 	s.store.EXPECT().FetchStatementResults(runningStatement).Return(&runningStatement, nil)
 	s.store.EXPECT().WaitForTerminalStatementState(gomock.Any(), runningStatement).Return(&completedStatement, nil)
 
-	stdout := test.RunAndCaptureSTDOUT(s.T(), func() {
+	stdout := testUtils.RunAndCaptureSTDOUT(s.T(), func() {
 		returnedStatement, err := s.statementController.ExecuteStatement(statementToExecute)
 		require.Nil(s.T(), err)
 		require.Equal(s.T(), &completedStatement, returnedStatement)
@@ -186,7 +186,7 @@ func (s *StatementControllerTestSuite) TestExecuteStatementWaitsForFailedState()
 	s.store.EXPECT().FetchStatementResults(runningStatement).Return(&runningStatement, nil)
 	s.store.EXPECT().WaitForTerminalStatementState(gomock.Any(), runningStatement).Return(&failedStatement, nil)
 
-	stdout := test.RunAndCaptureSTDOUT(s.T(), func() {
+	stdout := testUtils.RunAndCaptureSTDOUT(s.T(), func() {
 		returnedStatement, err := s.statementController.ExecuteStatement(statementToExecute)
 		require.Nil(s.T(), err)
 		require.Equal(s.T(), &failedStatement, returnedStatement)
@@ -206,7 +206,7 @@ func (s *StatementControllerTestSuite) TestExecuteStatementWaitsForNonEmptyPageT
 	s.store.EXPECT().FetchStatementResults(runningStatement).Return(&runningStatement, nil)
 	s.store.EXPECT().WaitForTerminalStatementState(gomock.Any(), runningStatement).Return(&runningStatementWithNextPage, nil)
 
-	stdout := test.RunAndCaptureSTDOUT(s.T(), func() {
+	stdout := testUtils.RunAndCaptureSTDOUT(s.T(), func() {
 		returnedStatement, err := s.statementController.ExecuteStatement(statementToExecute)
 		require.Nil(s.T(), err)
 		require.Equal(s.T(), &runningStatementWithNextPage, returnedStatement)
@@ -231,7 +231,7 @@ func (s *StatementControllerTestSuite) TestExecuteStatementReturnsWhenUserDetach
 			return &runningStatement, nil
 		})
 
-	stdout := test.RunAndCaptureSTDOUT(s.T(), func() {
+	stdout := testUtils.RunAndCaptureSTDOUT(s.T(), func() {
 		returnedStatement, err := s.statementController.ExecuteStatement(statementToExecute)
 		require.Nil(s.T(), err)
 		require.Error(s.T(), waitForTerminalStateCtx.Err())
@@ -258,9 +258,9 @@ func (s *StatementControllerTestSuite) TestRenderMsgAndStatusLocalStatements() {
 			want:      "Statement successfully submitted.\n",
 		},
 	}
-	for _, tt := range tests {
-		s.T().Run(tt.name, func(t *testing.T) {
-			actual := test.RunAndCaptureSTDOUT(s.T(), tt.statement.PrintStatusMessage)
+	for _, test := range tests {
+		s.T().Run(test.name, func(t *testing.T) {
+			actual := testUtils.RunAndCaptureSTDOUT(s.T(), test.statement.PrintStatusMessage)
 			cupaloy.SnapshotT(t, actual)
 		})
 	}
@@ -283,9 +283,9 @@ func (s *StatementControllerTestSuite) TestRenderMsgAndStatusNonLocalFailedState
 			want:      "Error: statement submission failed\n",
 		},
 	}
-	for _, tt := range tests {
-		s.T().Run(tt.name, func(t *testing.T) {
-			actual := test.RunAndCaptureSTDOUT(s.T(), tt.statement.PrintStatusMessage)
+	for _, test := range tests {
+		s.T().Run(test.name, func(t *testing.T) {
+			actual := testUtils.RunAndCaptureSTDOUT(s.T(), test.statement.PrintStatusMessage)
 			cupaloy.SnapshotT(t, actual)
 		})
 	}
@@ -308,9 +308,9 @@ func (s *StatementControllerTestSuite) TestRenderMsgAndStatusNonLocalNonFailedSt
 			want:      "Statement successfully submitted.\nFetching results...\n",
 		},
 	}
-	for _, tt := range tests {
-		s.T().Run(tt.name, func(t *testing.T) {
-			actual := test.RunAndCaptureSTDOUT(s.T(), tt.statement.PrintStatusMessage)
+	for _, test := range tests {
+		s.T().Run(test.name, func(t *testing.T) {
+			actual := testUtils.RunAndCaptureSTDOUT(s.T(), test.statement.PrintStatusMessage)
 			cupaloy.SnapshotT(t, actual)
 		})
 	}
@@ -349,10 +349,10 @@ func TestIsCancelEvent(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := isCancelEvent(tt.key)
-			require.Equal(t, tt.want, got)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := isCancelEvent(test.key)
+			require.Equal(t, test.want, got)
 		})
 	}
 }
@@ -380,10 +380,10 @@ func TestIsDetachEvent(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := isDetachEvent(tt.key)
-			require.Equal(t, tt.want, got)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := isDetachEvent(test.key)
+			require.Equal(t, test.want, got)
 		})
 	}
 }

--- a/internal/pkg/flink/internal/controller/statement_controller_test.go
+++ b/internal/pkg/flink/internal/controller/statement_controller_test.go
@@ -315,3 +315,75 @@ func (s *StatementControllerTestSuite) TestRenderMsgAndStatusNonLocalNonFailedSt
 		})
 	}
 }
+
+func TestIsCancelEvent(t *testing.T) {
+	tests := []struct {
+		name string
+		key  prompt.Key
+		want bool
+	}{
+		{
+			name: "ControlC",
+			key:  prompt.ControlC,
+			want: true,
+		},
+		{
+			name: "ControlD",
+			key:  prompt.ControlD,
+			want: true,
+		},
+		{
+			name: "ControlQ",
+			key:  prompt.ControlQ,
+			want: true,
+		},
+		{
+			name: "Escape",
+			key:  prompt.Escape,
+			want: true,
+		},
+		{
+			name: "Other",
+			key:  prompt.ShiftDown, // Just an example of a key that is not in the switch cases
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isCancelEvent(tt.key)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestIsDetachEvent(t *testing.T) {
+	tests := []struct {
+		name string
+		key  prompt.Key
+		want bool
+	}{
+		{
+			name: "ControlM",
+			key:  prompt.ControlM,
+			want: true,
+		},
+		{
+			name: "Enter",
+			key:  prompt.Enter,
+			want: true,
+		},
+		{
+			name: "Other",
+			key:  prompt.ShiftUp, // Just an example of a key that is not in the switch cases
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isDetachEvent(tt.key)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->
When submitting persistent queries like INSERT INTO that run in the background we attach to the job and listen for errors and the user can exit this mode now pressing also ctrlC, ctrlD and so on, which are the regular cancelEvents for the other statements. 
 
References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
<!--
Has it been tested? How?
Copy and paste any instructions or steps that can save the reviewer time.
-->
unit tests
Open Questions / Follow-ups
---------------------------
<!--
Optional: Anything open to discussion for the reviewer, out of scope of this PR, or follow-ups.
-->
