### PR TITLE
feat: cleanup statement on ungraceful table view shutdown

### DIFF
--- a/internal/pkg/flink/app/application.go
+++ b/internal/pkg/flink/app/application.go
@@ -36,7 +36,7 @@ func synchronizedTokenRefresh(tokenRefreshFunc func() error) func() error {
 	}
 }
 
-func StartApp(client ccloudv2.GatewayClientInterface, tokenRefreshFunc func() error, appOptions types.ApplicationOptions) {
+func StartApp(client ccloudv2.GatewayClientInterface, tokenRefreshFunc func() error, appOptions types.ApplicationOptions, reportUsageFunc func()) {
 	// Load history of previous commands from cache file
 	historyStore := history.LoadHistory()
 
@@ -58,7 +58,7 @@ func StartApp(client ccloudv2.GatewayClientInterface, tokenRefreshFunc func() er
 	// Instantiate Component Controllers
 	inputController := controller.NewInputController(historyStore)
 	statementController := controller.NewStatementController(appController, dataStore, consoleParser)
-	interactiveOutputController := controller.NewInteractiveOutputController(components.NewTableView(), resultFetcher, appOptions.GetVerbose())
+	interactiveOutputController := controller.NewInteractiveOutputController(components.NewTableView(), resultFetcher, reportUsageFunc, appOptions.GetVerbose())
 	basicOutputController := controller.NewBasicOutputController(resultFetcher, inputController.GetWindowWidth)
 
 	app := Application{

--- a/internal/pkg/flink/internal/controller/.snapshots/TestInteractiveOutputControllerTestSuite-TestPanicRecovery
+++ b/internal/pkg/flink/internal/controller/.snapshots/TestInteractiveOutputControllerTestSuite-TestPanicRecovery
@@ -1,0 +1,2 @@
+Error: internal error occurred while in table view
+


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->
This change ensures we cleanup statements in case of panics inside the table view, or when the table view is stopped with CtrlC. When a panic occurs the user will see the message "Error: internal error occurred while in table view" and can proceed to submit statement instead of being kicked out of the client. We also still send the usage report to `cc-cli-usage-service`.