### PR TITLE
added new FlinkError to propagate status code

### DIFF
--- a/internal/pkg/ccloudv2/flink_gateway.go
+++ b/internal/pkg/ccloudv2/flink_gateway.go
@@ -2,8 +2,8 @@ package ccloudv2
 
 import (
 	"context"
-
 	"github.com/google/uuid"
+	"net/http"
 
 	flinkgatewayv1alpha1 "github.com/confluentinc/ccloud-sdk-go-v2/flink-gateway/v1alpha1"
 
@@ -43,12 +43,12 @@ func (c *FlinkGatewayClient) flinkGatewayApiContext() context.Context {
 
 func (c *FlinkGatewayClient) DeleteStatement(environmentId, statementName, orgId string) error {
 	httpResp, err := c.StatementsSqlV1alpha1Api.DeleteSqlV1alpha1Statement(c.flinkGatewayApiContext(), environmentId, statementName).OrgId(orgId).Execute()
-	return errors.CatchCCloudV2Error(err, httpResp)
+	return newFlinkError(err, httpResp)
 }
 
 func (c *FlinkGatewayClient) GetStatement(environmentId, statementName, orgId string) (flinkgatewayv1alpha1.SqlV1alpha1Statement, error) {
 	resp, httpResp, err := c.StatementsSqlV1alpha1Api.GetSqlV1alpha1Statement(c.flinkGatewayApiContext(), environmentId, statementName).OrgId(orgId).Execute()
-	return resp, errors.CatchCCloudV2Error(err, httpResp)
+	return resp, newFlinkError(err, httpResp)
 }
 
 func (c *FlinkGatewayClient) ListStatements(environmentId, orgId, pageToken, computePoolId string) (flinkgatewayv1alpha1.SqlV1alpha1StatementList, error) {
@@ -62,7 +62,7 @@ func (c *FlinkGatewayClient) ListStatements(environmentId, orgId, pageToken, com
 		req = req.PageToken(pageToken)
 	}
 	resp, httpResp, err := req.Execute()
-	return resp, errors.CatchCCloudV2Error(err, httpResp)
+	return resp, newFlinkError(err, httpResp)
 }
 
 func (c *FlinkGatewayClient) ListAllStatements(environmentId, orgId, computePoolId string) ([]flinkgatewayv1alpha1.SqlV1alpha1Statement, error) {
@@ -97,7 +97,7 @@ func (c *FlinkGatewayClient) CreateStatement(statement, computePoolId, identityP
 		},
 	}
 	resp, httpResp, err := c.StatementsSqlV1alpha1Api.CreateSqlV1alpha1Statement(c.flinkGatewayApiContext(), environmentId).SqlV1alpha1Statement(statementObj).OrgId(orgId).Execute()
-	return resp, errors.CatchCCloudV2Error(err, httpResp)
+	return resp, newFlinkError(err, httpResp)
 }
 
 func (c *FlinkGatewayClient) GetStatementResults(environmentId, statementId, orgId, pageToken string) (flinkgatewayv1alpha1.SqlV1alpha1StatementResult, error) {
@@ -106,10 +106,50 @@ func (c *FlinkGatewayClient) GetStatementResults(environmentId, statementId, org
 		req = req.PageToken(pageToken)
 	}
 	resp, httpResp, err := req.Execute()
-	return resp, errors.CatchCCloudV2Error(err, httpResp)
+	return resp, newFlinkError(err, httpResp)
 }
 
 func (c *FlinkGatewayClient) GetExceptions(environmentId, statementId, orgId string) (flinkgatewayv1alpha1.SqlV1alpha1StatementExceptionList, error) {
 	resp, httpResp, err := c.StatementExceptionsSqlV1alpha1Api.GetSqlV1alpha1StatementExceptions(c.flinkGatewayApiContext(), environmentId, statementId).OrgId(orgId).Execute()
-	return resp, errors.CatchCCloudV2Error(err, httpResp)
+	return resp, newFlinkError(err, httpResp)
+}
+
+// FlinkError extends the ErrorWithSuggestion with a status code.
+type FlinkError struct {
+	error          string
+	suggestionsMsg string
+	statusCode     int
+}
+
+func (f FlinkError) StatusCode() int {
+	return f.statusCode
+}
+
+func (f FlinkError) GetSuggestionsMsg() string {
+	return f.suggestionsMsg
+}
+
+func (f FlinkError) Error() string {
+	return f.error
+}
+
+type Coder interface {
+	StatusCode() int
+}
+
+var _ Coder = (*FlinkError)(nil)
+var _ errors.ErrorWithSuggestions = (*FlinkError)(nil)
+
+// Extends error with status code, including suggestion if err type is ErrorWithSuggestion
+func newFlinkError(err error, r *http.Response) error {
+	err = errors.CatchCCloudV2Error(err, r)
+	suggestion := ""
+	if suggester, ok := err.(errors.ErrorWithSuggestions); ok {
+		suggestion = suggester.GetSuggestionsMsg()
+	}
+	return FlinkError{
+		statusCode:     r.StatusCode,
+		error:          err.Error(),
+		suggestionsMsg: suggestion,
+	}
 }

--- a/internal/pkg/ccloudv2/flink_gateway.go
+++ b/internal/pkg/ccloudv2/flink_gateway.go
@@ -2,8 +2,9 @@ package ccloudv2
 
 import (
 	"context"
-	"github.com/google/uuid"
 	"net/http"
+
+	"github.com/google/uuid"
 
 	flinkgatewayv1alpha1 "github.com/confluentinc/ccloud-sdk-go-v2/flink-gateway/v1alpha1"
 
@@ -43,12 +44,12 @@ func (c *FlinkGatewayClient) flinkGatewayApiContext() context.Context {
 
 func (c *FlinkGatewayClient) DeleteStatement(environmentId, statementName, orgId string) error {
 	httpResp, err := c.StatementsSqlV1alpha1Api.DeleteSqlV1alpha1Statement(c.flinkGatewayApiContext(), environmentId, statementName).OrgId(orgId).Execute()
-	return newFlinkError(err, httpResp)
+	return makeFlinkError(err, httpResp)
 }
 
 func (c *FlinkGatewayClient) GetStatement(environmentId, statementName, orgId string) (flinkgatewayv1alpha1.SqlV1alpha1Statement, error) {
 	resp, httpResp, err := c.StatementsSqlV1alpha1Api.GetSqlV1alpha1Statement(c.flinkGatewayApiContext(), environmentId, statementName).OrgId(orgId).Execute()
-	return resp, newFlinkError(err, httpResp)
+	return resp, makeFlinkError(err, httpResp)
 }
 
 func (c *FlinkGatewayClient) ListStatements(environmentId, orgId, pageToken, computePoolId string) (flinkgatewayv1alpha1.SqlV1alpha1StatementList, error) {
@@ -62,7 +63,7 @@ func (c *FlinkGatewayClient) ListStatements(environmentId, orgId, pageToken, com
 		req = req.PageToken(pageToken)
 	}
 	resp, httpResp, err := req.Execute()
-	return resp, newFlinkError(err, httpResp)
+	return resp, makeFlinkError(err, httpResp)
 }
 
 func (c *FlinkGatewayClient) ListAllStatements(environmentId, orgId, computePoolId string) ([]flinkgatewayv1alpha1.SqlV1alpha1Statement, error) {
@@ -97,7 +98,7 @@ func (c *FlinkGatewayClient) CreateStatement(statement, computePoolId, identityP
 		},
 	}
 	resp, httpResp, err := c.StatementsSqlV1alpha1Api.CreateSqlV1alpha1Statement(c.flinkGatewayApiContext(), environmentId).SqlV1alpha1Statement(statementObj).OrgId(orgId).Execute()
-	return resp, newFlinkError(err, httpResp)
+	return resp, makeFlinkError(err, httpResp)
 }
 
 func (c *FlinkGatewayClient) GetStatementResults(environmentId, statementId, orgId, pageToken string) (flinkgatewayv1alpha1.SqlV1alpha1StatementResult, error) {
@@ -106,19 +107,27 @@ func (c *FlinkGatewayClient) GetStatementResults(environmentId, statementId, org
 		req = req.PageToken(pageToken)
 	}
 	resp, httpResp, err := req.Execute()
-	return resp, newFlinkError(err, httpResp)
+	return resp, makeFlinkError(err, httpResp)
 }
 
 func (c *FlinkGatewayClient) GetExceptions(environmentId, statementId, orgId string) (flinkgatewayv1alpha1.SqlV1alpha1StatementExceptionList, error) {
 	resp, httpResp, err := c.StatementExceptionsSqlV1alpha1Api.GetSqlV1alpha1StatementExceptions(c.flinkGatewayApiContext(), environmentId, statementId).OrgId(orgId).Execute()
-	return resp, newFlinkError(err, httpResp)
+	return resp, makeFlinkError(err, httpResp)
 }
 
 // FlinkError extends the ErrorWithSuggestion with a status code.
 type FlinkError struct {
-	error          string
+	errorMsg       string
 	suggestionsMsg string
 	statusCode     int
+}
+
+func NewFlinkError(errorMsg string, suggestionsMsg string, statusCode int) FlinkError {
+	return FlinkError{
+		errorMsg:       errorMsg,
+		suggestionsMsg: suggestionsMsg,
+		statusCode:     statusCode,
+	}
 }
 
 func (f FlinkError) StatusCode() int {
@@ -130,7 +139,7 @@ func (f FlinkError) GetSuggestionsMsg() string {
 }
 
 func (f FlinkError) Error() string {
-	return f.error
+	return f.errorMsg
 }
 
 type Coder interface {
@@ -141,7 +150,7 @@ var _ Coder = (*FlinkError)(nil)
 var _ errors.ErrorWithSuggestions = (*FlinkError)(nil)
 
 // Extends error with status code, including suggestion if err type is ErrorWithSuggestion
-func newFlinkError(err error, r *http.Response) error {
+func makeFlinkError(err error, r *http.Response) error {
 	err = errors.CatchCCloudV2Error(err, r)
 	suggestion := ""
 	if suggester, ok := err.(errors.ErrorWithSuggestions); ok {
@@ -149,7 +158,7 @@ func newFlinkError(err error, r *http.Response) error {
 	}
 	return FlinkError{
 		statusCode:     r.StatusCode,
-		error:          err.Error(),
+		errorMsg:       err.Error(),
 		suggestionsMsg: suggestion,
 	}
 }

--- a/internal/pkg/ccloudv2/flink_gateway.go
+++ b/internal/pkg/ccloudv2/flink_gateway.go
@@ -2,7 +2,6 @@ package ccloudv2
 
 import (
 	"context"
-	"net/http"
 
 	"github.com/google/uuid"
 
@@ -44,12 +43,12 @@ func (c *FlinkGatewayClient) flinkGatewayApiContext() context.Context {
 
 func (c *FlinkGatewayClient) DeleteStatement(environmentId, statementName, orgId string) error {
 	httpResp, err := c.StatementsSqlV1alpha1Api.DeleteSqlV1alpha1Statement(c.flinkGatewayApiContext(), environmentId, statementName).OrgId(orgId).Execute()
-	return catchFlinkError(err, httpResp)
+	return errors.CatchFlinkError(err, httpResp)
 }
 
 func (c *FlinkGatewayClient) GetStatement(environmentId, statementName, orgId string) (flinkgatewayv1alpha1.SqlV1alpha1Statement, error) {
 	resp, httpResp, err := c.StatementsSqlV1alpha1Api.GetSqlV1alpha1Statement(c.flinkGatewayApiContext(), environmentId, statementName).OrgId(orgId).Execute()
-	return resp, catchFlinkError(err, httpResp)
+	return resp, errors.CatchFlinkError(err, httpResp)
 }
 
 func (c *FlinkGatewayClient) ListStatements(environmentId, orgId, pageToken, computePoolId string) (flinkgatewayv1alpha1.SqlV1alpha1StatementList, error) {
@@ -63,7 +62,7 @@ func (c *FlinkGatewayClient) ListStatements(environmentId, orgId, pageToken, com
 		req = req.PageToken(pageToken)
 	}
 	resp, httpResp, err := req.Execute()
-	return resp, catchFlinkError(err, httpResp)
+	return resp, errors.CatchFlinkError(err, httpResp)
 }
 
 func (c *FlinkGatewayClient) ListAllStatements(environmentId, orgId, computePoolId string) ([]flinkgatewayv1alpha1.SqlV1alpha1Statement, error) {
@@ -98,7 +97,7 @@ func (c *FlinkGatewayClient) CreateStatement(statement, computePoolId, identityP
 		},
 	}
 	resp, httpResp, err := c.StatementsSqlV1alpha1Api.CreateSqlV1alpha1Statement(c.flinkGatewayApiContext(), environmentId).SqlV1alpha1Statement(statementObj).OrgId(orgId).Execute()
-	return resp, catchFlinkError(err, httpResp)
+	return resp, errors.CatchFlinkError(err, httpResp)
 }
 
 func (c *FlinkGatewayClient) GetStatementResults(environmentId, statementId, orgId, pageToken string) (flinkgatewayv1alpha1.SqlV1alpha1StatementResult, error) {
@@ -107,65 +106,10 @@ func (c *FlinkGatewayClient) GetStatementResults(environmentId, statementId, org
 		req = req.PageToken(pageToken)
 	}
 	resp, httpResp, err := req.Execute()
-	return resp, catchFlinkError(err, httpResp)
+	return resp, errors.CatchFlinkError(err, httpResp)
 }
 
 func (c *FlinkGatewayClient) GetExceptions(environmentId, statementId, orgId string) (flinkgatewayv1alpha1.SqlV1alpha1StatementExceptionList, error) {
 	resp, httpResp, err := c.StatementExceptionsSqlV1alpha1Api.GetSqlV1alpha1StatementExceptions(c.flinkGatewayApiContext(), environmentId, statementId).OrgId(orgId).Execute()
-	return resp, catchFlinkError(err, httpResp)
-}
-
-// FlinkError extends the ErrorWithSuggestion with a status code.
-type FlinkError struct {
-	errorMsg       string
-	suggestionsMsg string
-	statusCode     int
-}
-
-func NewFlinkError(errorMsg string, suggestionsMsg string, statusCode int) FlinkError {
-	return FlinkError{
-		errorMsg:       errorMsg,
-		suggestionsMsg: suggestionsMsg,
-		statusCode:     statusCode,
-	}
-}
-
-func (f FlinkError) StatusCode() int {
-	return f.statusCode
-}
-
-func (f FlinkError) GetSuggestionsMsg() string {
-	return f.suggestionsMsg
-}
-
-func (f FlinkError) Error() string {
-	return f.errorMsg
-}
-
-type Coder interface {
-	StatusCode() int
-}
-
-var _ Coder = (*FlinkError)(nil)
-var _ errors.ErrorWithSuggestions = (*FlinkError)(nil)
-
-// Extends error with status code, including suggestion if err type is ErrorWithSuggestion
-func catchFlinkError(err error, r *http.Response) error {
-	if err == nil {
-		return nil
-	}
-	err = errors.CatchCCloudV2Error(err, r)
-	suggestion := ""
-	if suggester, ok := err.(errors.ErrorWithSuggestions); ok {
-		suggestion = suggester.GetSuggestionsMsg()
-	}
-	var statusCode int
-	if r != nil {
-		statusCode = r.StatusCode
-	}
-	return FlinkError{
-		statusCode:     statusCode,
-		errorMsg:       err.Error(),
-		suggestionsMsg: suggestion,
-	}
+	return resp, errors.CatchFlinkError(err, httpResp)
 }

--- a/internal/pkg/ccloudv2/flink_gateway.go
+++ b/internal/pkg/ccloudv2/flink_gateway.go
@@ -43,12 +43,12 @@ func (c *FlinkGatewayClient) flinkGatewayApiContext() context.Context {
 
 func (c *FlinkGatewayClient) DeleteStatement(environmentId, statementName, orgId string) error {
 	httpResp, err := c.StatementsSqlV1alpha1Api.DeleteSqlV1alpha1Statement(c.flinkGatewayApiContext(), environmentId, statementName).OrgId(orgId).Execute()
-	return flink.CatchFlinkError(err, httpResp)
+	return flink.CatchError(err, httpResp)
 }
 
 func (c *FlinkGatewayClient) GetStatement(environmentId, statementName, orgId string) (flinkgatewayv1alpha1.SqlV1alpha1Statement, error) {
 	resp, httpResp, err := c.StatementsSqlV1alpha1Api.GetSqlV1alpha1Statement(c.flinkGatewayApiContext(), environmentId, statementName).OrgId(orgId).Execute()
-	return resp, flink.CatchFlinkError(err, httpResp)
+	return resp, flink.CatchError(err, httpResp)
 }
 
 func (c *FlinkGatewayClient) ListStatements(environmentId, orgId, pageToken, computePoolId string) (flinkgatewayv1alpha1.SqlV1alpha1StatementList, error) {
@@ -62,7 +62,7 @@ func (c *FlinkGatewayClient) ListStatements(environmentId, orgId, pageToken, com
 		req = req.PageToken(pageToken)
 	}
 	resp, httpResp, err := req.Execute()
-	return resp, flink.CatchFlinkError(err, httpResp)
+	return resp, flink.CatchError(err, httpResp)
 }
 
 func (c *FlinkGatewayClient) ListAllStatements(environmentId, orgId, computePoolId string) ([]flinkgatewayv1alpha1.SqlV1alpha1Statement, error) {
@@ -97,7 +97,7 @@ func (c *FlinkGatewayClient) CreateStatement(statement, computePoolId, identityP
 		},
 	}
 	resp, httpResp, err := c.StatementsSqlV1alpha1Api.CreateSqlV1alpha1Statement(c.flinkGatewayApiContext(), environmentId).SqlV1alpha1Statement(statementObj).OrgId(orgId).Execute()
-	return resp, flink.CatchFlinkError(err, httpResp)
+	return resp, flink.CatchError(err, httpResp)
 }
 
 func (c *FlinkGatewayClient) GetStatementResults(environmentId, statementId, orgId, pageToken string) (flinkgatewayv1alpha1.SqlV1alpha1StatementResult, error) {
@@ -106,10 +106,10 @@ func (c *FlinkGatewayClient) GetStatementResults(environmentId, statementId, org
 		req = req.PageToken(pageToken)
 	}
 	resp, httpResp, err := req.Execute()
-	return resp, flink.CatchFlinkError(err, httpResp)
+	return resp, flink.CatchError(err, httpResp)
 }
 
 func (c *FlinkGatewayClient) GetExceptions(environmentId, statementId, orgId string) (flinkgatewayv1alpha1.SqlV1alpha1StatementExceptionList, error) {
 	resp, httpResp, err := c.StatementExceptionsSqlV1alpha1Api.GetSqlV1alpha1StatementExceptions(c.flinkGatewayApiContext(), environmentId, statementId).OrgId(orgId).Execute()
-	return resp, flink.CatchFlinkError(err, httpResp)
+	return resp, flink.CatchError(err, httpResp)
 }

--- a/internal/pkg/ccloudv2/flink_gateway.go
+++ b/internal/pkg/ccloudv2/flink_gateway.go
@@ -112,7 +112,7 @@ func (c *FlinkGatewayClient) GetStatementResults(environmentId, statementId, org
 
 func (c *FlinkGatewayClient) GetExceptions(environmentId, statementId, orgId string) (flinkgatewayv1alpha1.SqlV1alpha1StatementExceptionList, error) {
 	resp, httpResp, err := c.StatementExceptionsSqlV1alpha1Api.GetSqlV1alpha1StatementExceptions(c.flinkGatewayApiContext(), environmentId, statementId).OrgId(orgId).Execute()
-	return resp, makeFlinkError(err, httpResp)
+	return resp, catchFlinkError(err, httpResp)
 }
 
 // FlinkError extends the ErrorWithSuggestion with a status code.

--- a/internal/pkg/ccloudv2/flink_gateway.go
+++ b/internal/pkg/ccloudv2/flink_gateway.go
@@ -44,12 +44,12 @@ func (c *FlinkGatewayClient) flinkGatewayApiContext() context.Context {
 
 func (c *FlinkGatewayClient) DeleteStatement(environmentId, statementName, orgId string) error {
 	httpResp, err := c.StatementsSqlV1alpha1Api.DeleteSqlV1alpha1Statement(c.flinkGatewayApiContext(), environmentId, statementName).OrgId(orgId).Execute()
-	return makeFlinkError(err, httpResp)
+	return catchFlinkError(err, httpResp)
 }
 
 func (c *FlinkGatewayClient) GetStatement(environmentId, statementName, orgId string) (flinkgatewayv1alpha1.SqlV1alpha1Statement, error) {
 	resp, httpResp, err := c.StatementsSqlV1alpha1Api.GetSqlV1alpha1Statement(c.flinkGatewayApiContext(), environmentId, statementName).OrgId(orgId).Execute()
-	return resp, makeFlinkError(err, httpResp)
+	return resp, catchFlinkError(err, httpResp)
 }
 
 func (c *FlinkGatewayClient) ListStatements(environmentId, orgId, pageToken, computePoolId string) (flinkgatewayv1alpha1.SqlV1alpha1StatementList, error) {
@@ -63,7 +63,7 @@ func (c *FlinkGatewayClient) ListStatements(environmentId, orgId, pageToken, com
 		req = req.PageToken(pageToken)
 	}
 	resp, httpResp, err := req.Execute()
-	return resp, makeFlinkError(err, httpResp)
+	return resp, catchFlinkError(err, httpResp)
 }
 
 func (c *FlinkGatewayClient) ListAllStatements(environmentId, orgId, computePoolId string) ([]flinkgatewayv1alpha1.SqlV1alpha1Statement, error) {
@@ -98,7 +98,7 @@ func (c *FlinkGatewayClient) CreateStatement(statement, computePoolId, identityP
 		},
 	}
 	resp, httpResp, err := c.StatementsSqlV1alpha1Api.CreateSqlV1alpha1Statement(c.flinkGatewayApiContext(), environmentId).SqlV1alpha1Statement(statementObj).OrgId(orgId).Execute()
-	return resp, makeFlinkError(err, httpResp)
+	return resp, catchFlinkError(err, httpResp)
 }
 
 func (c *FlinkGatewayClient) GetStatementResults(environmentId, statementId, orgId, pageToken string) (flinkgatewayv1alpha1.SqlV1alpha1StatementResult, error) {
@@ -107,7 +107,7 @@ func (c *FlinkGatewayClient) GetStatementResults(environmentId, statementId, org
 		req = req.PageToken(pageToken)
 	}
 	resp, httpResp, err := req.Execute()
-	return resp, makeFlinkError(err, httpResp)
+	return resp, catchFlinkError(err, httpResp)
 }
 
 func (c *FlinkGatewayClient) GetExceptions(environmentId, statementId, orgId string) (flinkgatewayv1alpha1.SqlV1alpha1StatementExceptionList, error) {
@@ -150,7 +150,7 @@ var _ Coder = (*FlinkError)(nil)
 var _ errors.ErrorWithSuggestions = (*FlinkError)(nil)
 
 // Extends error with status code, including suggestion if err type is ErrorWithSuggestion
-func makeFlinkError(err error, r *http.Response) error {
+func catchFlinkError(err error, r *http.Response) error {
 	if err == nil {
 		return nil
 	}

--- a/internal/pkg/ccloudv2/flink_gateway.go
+++ b/internal/pkg/ccloudv2/flink_gateway.go
@@ -151,13 +151,20 @@ var _ errors.ErrorWithSuggestions = (*FlinkError)(nil)
 
 // Extends error with status code, including suggestion if err type is ErrorWithSuggestion
 func makeFlinkError(err error, r *http.Response) error {
+	if err == nil {
+		return nil
+	}
 	err = errors.CatchCCloudV2Error(err, r)
 	suggestion := ""
 	if suggester, ok := err.(errors.ErrorWithSuggestions); ok {
 		suggestion = suggester.GetSuggestionsMsg()
 	}
+	var statusCode int
+	if r != nil {
+		statusCode = r.StatusCode
+	}
 	return FlinkError{
-		statusCode:     r.StatusCode,
+		statusCode:     statusCode,
 		errorMsg:       err.Error(),
 		suggestionsMsg: suggestion,
 	}

--- a/internal/pkg/ccloudv2/flink_gateway.go
+++ b/internal/pkg/ccloudv2/flink_gateway.go
@@ -7,7 +7,7 @@ import (
 
 	flinkgatewayv1alpha1 "github.com/confluentinc/ccloud-sdk-go-v2/flink-gateway/v1alpha1"
 
-	"github.com/confluentinc/cli/internal/pkg/errors"
+	"github.com/confluentinc/cli/internal/pkg/errors/flink"
 )
 
 type GatewayClientInterface interface {
@@ -43,12 +43,12 @@ func (c *FlinkGatewayClient) flinkGatewayApiContext() context.Context {
 
 func (c *FlinkGatewayClient) DeleteStatement(environmentId, statementName, orgId string) error {
 	httpResp, err := c.StatementsSqlV1alpha1Api.DeleteSqlV1alpha1Statement(c.flinkGatewayApiContext(), environmentId, statementName).OrgId(orgId).Execute()
-	return errors.CatchFlinkError(err, httpResp)
+	return flink.CatchFlinkError(err, httpResp)
 }
 
 func (c *FlinkGatewayClient) GetStatement(environmentId, statementName, orgId string) (flinkgatewayv1alpha1.SqlV1alpha1Statement, error) {
 	resp, httpResp, err := c.StatementsSqlV1alpha1Api.GetSqlV1alpha1Statement(c.flinkGatewayApiContext(), environmentId, statementName).OrgId(orgId).Execute()
-	return resp, errors.CatchFlinkError(err, httpResp)
+	return resp, flink.CatchFlinkError(err, httpResp)
 }
 
 func (c *FlinkGatewayClient) ListStatements(environmentId, orgId, pageToken, computePoolId string) (flinkgatewayv1alpha1.SqlV1alpha1StatementList, error) {
@@ -62,7 +62,7 @@ func (c *FlinkGatewayClient) ListStatements(environmentId, orgId, pageToken, com
 		req = req.PageToken(pageToken)
 	}
 	resp, httpResp, err := req.Execute()
-	return resp, errors.CatchFlinkError(err, httpResp)
+	return resp, flink.CatchFlinkError(err, httpResp)
 }
 
 func (c *FlinkGatewayClient) ListAllStatements(environmentId, orgId, computePoolId string) ([]flinkgatewayv1alpha1.SqlV1alpha1Statement, error) {
@@ -97,7 +97,7 @@ func (c *FlinkGatewayClient) CreateStatement(statement, computePoolId, identityP
 		},
 	}
 	resp, httpResp, err := c.StatementsSqlV1alpha1Api.CreateSqlV1alpha1Statement(c.flinkGatewayApiContext(), environmentId).SqlV1alpha1Statement(statementObj).OrgId(orgId).Execute()
-	return resp, errors.CatchFlinkError(err, httpResp)
+	return resp, flink.CatchFlinkError(err, httpResp)
 }
 
 func (c *FlinkGatewayClient) GetStatementResults(environmentId, statementId, orgId, pageToken string) (flinkgatewayv1alpha1.SqlV1alpha1StatementResult, error) {
@@ -106,10 +106,10 @@ func (c *FlinkGatewayClient) GetStatementResults(environmentId, statementId, org
 		req = req.PageToken(pageToken)
 	}
 	resp, httpResp, err := req.Execute()
-	return resp, errors.CatchFlinkError(err, httpResp)
+	return resp, flink.CatchFlinkError(err, httpResp)
 }
 
 func (c *FlinkGatewayClient) GetExceptions(environmentId, statementId, orgId string) (flinkgatewayv1alpha1.SqlV1alpha1StatementExceptionList, error) {
 	resp, httpResp, err := c.StatementExceptionsSqlV1alpha1Api.GetSqlV1alpha1StatementExceptions(c.flinkGatewayApiContext(), environmentId, statementId).OrgId(orgId).Execute()
-	return resp, errors.CatchFlinkError(err, httpResp)
+	return resp, flink.CatchFlinkError(err, httpResp)
 }

--- a/internal/pkg/ccloudv2/flink_gateway_test.go
+++ b/internal/pkg/ccloudv2/flink_gateway_test.go
@@ -14,7 +14,7 @@ import (
 func TestFlinkErrorCodeWhenErrors(t *testing.T) {
 	res := &http.Response{Body: io.NopCloser(strings.NewReader(`{"errors":[{"detail":"There is an error"}]}`)), StatusCode: http.StatusMethodNotAllowed}
 
-	err := makeFlinkError(errors.New("Some Error"), res)
+	err := catchFlinkError(errors.New("Some Error"), res)
 	require.Error(t, err)
 
 	flinkError, ok := err.(FlinkError)
@@ -26,12 +26,12 @@ func TestFlinkErrorCodeWhenErrors(t *testing.T) {
 func TestFlinkErrorNil(t *testing.T) {
 	res := &http.Response{Body: io.NopCloser(strings.NewReader(`{"errors":[{"detail":"There is an error"}]}`)), StatusCode: http.StatusMethodNotAllowed}
 
-	err := makeFlinkError(nil, res)
+	err := catchFlinkError(nil, res)
 	require.Nil(t, err)
 }
 
 func TestFlinkErrorNilHttpRes(t *testing.T) {
-	err := makeFlinkError(errors.New("Some Error"), nil)
+	err := catchFlinkError(errors.New("Some Error"), nil)
 	require.Error(t, err)
 
 	flinkError, ok := err.(FlinkError)
@@ -43,7 +43,7 @@ func TestFlinkErrorNilHttpRes(t *testing.T) {
 func TestFlinkErrorCodeWhenErrorMessage(t *testing.T) {
 	res := &http.Response{Body: io.NopCloser(strings.NewReader(`{"message":"unauthorized"}`)), StatusCode: http.StatusUnauthorized}
 
-	err := makeFlinkError(errors.New("Some Error"), res)
+	err := catchFlinkError(errors.New("Some Error"), res)
 	require.Error(t, err)
 
 	flinkError, ok := err.(FlinkError)
@@ -55,7 +55,7 @@ func TestFlinkErrorCodeWhenErrorMessage(t *testing.T) {
 func TestFlinkErrorCodeWhenNestedMessage(t *testing.T) {
 	res := &http.Response{Body: io.NopCloser(strings.NewReader(`{"error":{"message":"gateway error"}}`)), StatusCode: http.StatusMethodNotAllowed}
 
-	err := makeFlinkError(errors.New("Some Error"), res)
+	err := catchFlinkError(errors.New("Some Error"), res)
 	require.Error(t, err)
 
 	flinkError, ok := err.(FlinkError)
@@ -67,7 +67,7 @@ func TestFlinkErrorCodeWhenNestedMessage(t *testing.T) {
 func TestFlinkErrorOnlyStatusCode(t *testing.T) {
 	res := &http.Response{Body: io.NopCloser(strings.NewReader("")), StatusCode: http.StatusMethodNotAllowed}
 
-	err := makeFlinkError(errors.New("Some Error"), res)
+	err := catchFlinkError(errors.New("Some Error"), res)
 	require.Error(t, err)
 
 	flinkError, ok := err.(FlinkError)

--- a/internal/pkg/ccloudv2/flink_gateway_test.go
+++ b/internal/pkg/ccloudv2/flink_gateway_test.go
@@ -14,64 +14,64 @@ import (
 func TestFlinkErrorCodeWhenErrors(t *testing.T) {
 	res := &http.Response{Body: io.NopCloser(strings.NewReader(`{"errors":[{"detail":"There is an error"}]}`)), StatusCode: http.StatusMethodNotAllowed}
 
-	err := catchFlinkError(errors.New("Some Error"), res)
+	err := errors.CatchFlinkError(errors.New("Some Error"), res)
 	require.Error(t, err)
 
-	flinkError, ok := err.(FlinkError)
+	flinkError, ok := err.(errors.FlinkError)
 	require.True(t, ok)
-	require.Equal(t, http.StatusMethodNotAllowed, flinkError.statusCode)
+	require.Equal(t, http.StatusMethodNotAllowed, flinkError.StatusCode())
 	require.Equal(t, err.Error(), flinkError.Error())
 }
 
 func TestFlinkErrorNil(t *testing.T) {
 	res := &http.Response{Body: io.NopCloser(strings.NewReader(`{"errors":[{"detail":"There is an error"}]}`)), StatusCode: http.StatusMethodNotAllowed}
 
-	err := catchFlinkError(nil, res)
+	err := errors.CatchFlinkError(nil, res)
 	require.Nil(t, err)
 }
 
 func TestFlinkErrorNilHttpRes(t *testing.T) {
-	err := catchFlinkError(errors.New("Some Error"), nil)
+	err := errors.CatchFlinkError(errors.New("Some Error"), nil)
 	require.Error(t, err)
 
-	flinkError, ok := err.(FlinkError)
+	flinkError, ok := err.(errors.FlinkError)
 	require.True(t, ok)
-	require.Equal(t, 0, flinkError.statusCode)
+	require.Equal(t, 0, flinkError.StatusCode())
 	require.Equal(t, err.Error(), flinkError.Error())
 }
 
 func TestFlinkErrorCodeWhenErrorMessage(t *testing.T) {
 	res := &http.Response{Body: io.NopCloser(strings.NewReader(`{"message":"unauthorized"}`)), StatusCode: http.StatusUnauthorized}
 
-	err := catchFlinkError(errors.New("Some Error"), res)
+	err := errors.CatchFlinkError(errors.New("Some Error"), res)
 	require.Error(t, err)
 
-	flinkError, ok := err.(FlinkError)
+	flinkError, ok := err.(errors.FlinkError)
 	require.True(t, ok)
-	require.Equal(t, http.StatusUnauthorized, flinkError.statusCode)
+	require.Equal(t, http.StatusUnauthorized, flinkError.StatusCode())
 	require.Equal(t, err.Error(), flinkError.Error())
 }
 
 func TestFlinkErrorCodeWhenNestedMessage(t *testing.T) {
 	res := &http.Response{Body: io.NopCloser(strings.NewReader(`{"error":{"message":"gateway error"}}`)), StatusCode: http.StatusMethodNotAllowed}
 
-	err := catchFlinkError(errors.New("Some Error"), res)
+	err := errors.CatchFlinkError(errors.New("Some Error"), res)
 	require.Error(t, err)
 
-	flinkError, ok := err.(FlinkError)
+	flinkError, ok := err.(errors.FlinkError)
 	require.True(t, ok)
-	require.Equal(t, http.StatusMethodNotAllowed, flinkError.statusCode)
+	require.Equal(t, http.StatusMethodNotAllowed, flinkError.StatusCode())
 	require.Equal(t, err.Error(), flinkError.Error())
 }
 
 func TestFlinkErrorOnlyStatusCode(t *testing.T) {
 	res := &http.Response{Body: io.NopCloser(strings.NewReader("")), StatusCode: http.StatusMethodNotAllowed}
 
-	err := catchFlinkError(errors.New("Some Error"), res)
+	err := errors.CatchFlinkError(errors.New("Some Error"), res)
 	require.Error(t, err)
 
-	flinkError, ok := err.(FlinkError)
+	flinkError, ok := err.(errors.FlinkError)
 	require.True(t, ok)
-	require.Equal(t, http.StatusMethodNotAllowed, flinkError.statusCode)
+	require.Equal(t, http.StatusMethodNotAllowed, flinkError.StatusCode())
 	require.Equal(t, err.Error(), flinkError.Error())
 }

--- a/internal/pkg/ccloudv2/flink_gateway_test.go
+++ b/internal/pkg/ccloudv2/flink_gateway_test.go
@@ -9,15 +9,16 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/confluentinc/cli/internal/pkg/errors"
+	"github.com/confluentinc/cli/internal/pkg/errors/flink"
 )
 
 func TestFlinkErrorCodeWhenErrors(t *testing.T) {
 	res := &http.Response{Body: io.NopCloser(strings.NewReader(`{"errors":[{"detail":"There is an error"}]}`)), StatusCode: http.StatusMethodNotAllowed}
 
-	err := errors.CatchFlinkError(errors.New("Some Error"), res)
+	err := flink.CatchFlinkError(errors.New("Some Error"), res)
 	require.Error(t, err)
 
-	flinkError, ok := err.(errors.FlinkError)
+	flinkError, ok := err.(flink.FlinkError)
 	require.True(t, ok)
 	require.Equal(t, http.StatusMethodNotAllowed, flinkError.StatusCode())
 	require.Equal(t, err.Error(), flinkError.Error())
@@ -26,15 +27,15 @@ func TestFlinkErrorCodeWhenErrors(t *testing.T) {
 func TestFlinkErrorNil(t *testing.T) {
 	res := &http.Response{Body: io.NopCloser(strings.NewReader(`{"errors":[{"detail":"There is an error"}]}`)), StatusCode: http.StatusMethodNotAllowed}
 
-	err := errors.CatchFlinkError(nil, res)
+	err := flink.CatchFlinkError(nil, res)
 	require.Nil(t, err)
 }
 
 func TestFlinkErrorNilHttpRes(t *testing.T) {
-	err := errors.CatchFlinkError(errors.New("Some Error"), nil)
+	err := flink.CatchFlinkError(errors.New("Some Error"), nil)
 	require.Error(t, err)
 
-	flinkError, ok := err.(errors.FlinkError)
+	flinkError, ok := err.(flink.FlinkError)
 	require.True(t, ok)
 	require.Equal(t, 0, flinkError.StatusCode())
 	require.Equal(t, err.Error(), flinkError.Error())
@@ -43,10 +44,10 @@ func TestFlinkErrorNilHttpRes(t *testing.T) {
 func TestFlinkErrorCodeWhenErrorMessage(t *testing.T) {
 	res := &http.Response{Body: io.NopCloser(strings.NewReader(`{"message":"unauthorized"}`)), StatusCode: http.StatusUnauthorized}
 
-	err := errors.CatchFlinkError(errors.New("Some Error"), res)
+	err := flink.CatchFlinkError(errors.New("Some Error"), res)
 	require.Error(t, err)
 
-	flinkError, ok := err.(errors.FlinkError)
+	flinkError, ok := err.(flink.FlinkError)
 	require.True(t, ok)
 	require.Equal(t, http.StatusUnauthorized, flinkError.StatusCode())
 	require.Equal(t, err.Error(), flinkError.Error())
@@ -55,10 +56,10 @@ func TestFlinkErrorCodeWhenErrorMessage(t *testing.T) {
 func TestFlinkErrorCodeWhenNestedMessage(t *testing.T) {
 	res := &http.Response{Body: io.NopCloser(strings.NewReader(`{"error":{"message":"gateway error"}}`)), StatusCode: http.StatusMethodNotAllowed}
 
-	err := errors.CatchFlinkError(errors.New("Some Error"), res)
+	err := flink.CatchFlinkError(errors.New("Some Error"), res)
 	require.Error(t, err)
 
-	flinkError, ok := err.(errors.FlinkError)
+	flinkError, ok := err.(flink.FlinkError)
 	require.True(t, ok)
 	require.Equal(t, http.StatusMethodNotAllowed, flinkError.StatusCode())
 	require.Equal(t, err.Error(), flinkError.Error())
@@ -67,10 +68,10 @@ func TestFlinkErrorCodeWhenNestedMessage(t *testing.T) {
 func TestFlinkErrorOnlyStatusCode(t *testing.T) {
 	res := &http.Response{Body: io.NopCloser(strings.NewReader("")), StatusCode: http.StatusMethodNotAllowed}
 
-	err := errors.CatchFlinkError(errors.New("Some Error"), res)
+	err := flink.CatchFlinkError(errors.New("Some Error"), res)
 	require.Error(t, err)
 
-	flinkError, ok := err.(errors.FlinkError)
+	flinkError, ok := err.(flink.FlinkError)
 	require.True(t, ok)
 	require.Equal(t, http.StatusMethodNotAllowed, flinkError.StatusCode())
 	require.Equal(t, err.Error(), flinkError.Error())

--- a/internal/pkg/ccloudv2/flink_gateway_test.go
+++ b/internal/pkg/ccloudv2/flink_gateway_test.go
@@ -1,18 +1,20 @@
 package ccloudv2
 
 import (
-	"github.com/confluentinc/cli/internal/pkg/errors"
-	"github.com/stretchr/testify/require"
 	"io"
 	"net/http"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/confluentinc/cli/internal/pkg/errors"
 )
 
 func TestFlinkErrorCodeWhenErrors(t *testing.T) {
 	res := &http.Response{Body: io.NopCloser(strings.NewReader(`{"errors":[{"detail":"There is an error"}]}`)), StatusCode: http.StatusMethodNotAllowed}
 
-	err := newFlinkError(errors.New("Some Error"), res)
+	err := makeFlinkError(errors.New("Some Error"), res)
 	require.Error(t, err)
 
 	flinkError, ok := err.(FlinkError)
@@ -24,7 +26,7 @@ func TestFlinkErrorCodeWhenErrors(t *testing.T) {
 func TestFlinkErrorCodeWhenErrorMessage(t *testing.T) {
 	res := &http.Response{Body: io.NopCloser(strings.NewReader(`{"message":"unauthorized"}`)), StatusCode: http.StatusUnauthorized}
 
-	err := newFlinkError(errors.New("Some Error"), res)
+	err := makeFlinkError(errors.New("Some Error"), res)
 	require.Error(t, err)
 
 	flinkError, ok := err.(FlinkError)
@@ -36,7 +38,7 @@ func TestFlinkErrorCodeWhenErrorMessage(t *testing.T) {
 func TestFlinkErrorCodeWhenNestedMessage(t *testing.T) {
 	res := &http.Response{Body: io.NopCloser(strings.NewReader(`{"error":{"message":"gateway error"}}`)), StatusCode: http.StatusMethodNotAllowed}
 
-	err := newFlinkError(errors.New("Some Error"), res)
+	err := makeFlinkError(errors.New("Some Error"), res)
 	require.Error(t, err)
 
 	flinkError, ok := err.(FlinkError)
@@ -48,7 +50,7 @@ func TestFlinkErrorCodeWhenNestedMessage(t *testing.T) {
 func TestFlinkErrorOnlyStatusCode(t *testing.T) {
 	res := &http.Response{Body: io.NopCloser(strings.NewReader("")), StatusCode: http.StatusMethodNotAllowed}
 
-	err := newFlinkError(errors.New("Some Error"), res)
+	err := makeFlinkError(errors.New("Some Error"), res)
 	require.Error(t, err)
 
 	flinkError, ok := err.(FlinkError)

--- a/internal/pkg/ccloudv2/flink_gateway_test.go
+++ b/internal/pkg/ccloudv2/flink_gateway_test.go
@@ -23,6 +23,23 @@ func TestFlinkErrorCodeWhenErrors(t *testing.T) {
 	require.Equal(t, err.Error(), flinkError.Error())
 }
 
+func TestFlinkErrorNil(t *testing.T) {
+	res := &http.Response{Body: io.NopCloser(strings.NewReader(`{"errors":[{"detail":"There is an error"}]}`)), StatusCode: http.StatusMethodNotAllowed}
+
+	err := makeFlinkError(nil, res)
+	require.Nil(t, err)
+}
+
+func TestFlinkErrorNilHttpRes(t *testing.T) {
+	err := makeFlinkError(errors.New("Some Error"), nil)
+	require.Error(t, err)
+
+	flinkError, ok := err.(FlinkError)
+	require.True(t, ok)
+	require.Equal(t, 0, flinkError.statusCode)
+	require.Equal(t, err.Error(), flinkError.Error())
+}
+
 func TestFlinkErrorCodeWhenErrorMessage(t *testing.T) {
 	res := &http.Response{Body: io.NopCloser(strings.NewReader(`{"message":"unauthorized"}`)), StatusCode: http.StatusUnauthorized}
 

--- a/internal/pkg/ccloudv2/flink_gateway_test.go
+++ b/internal/pkg/ccloudv2/flink_gateway_test.go
@@ -15,7 +15,7 @@ import (
 func TestFlinkErrorCodeWhenErrors(t *testing.T) {
 	res := &http.Response{Body: io.NopCloser(strings.NewReader(`{"errors":[{"detail":"There is an error"}]}`)), StatusCode: http.StatusMethodNotAllowed}
 
-	err := flink.CatchFlinkError(errors.New("Some Error"), res)
+	err := flink.CatchError(errors.New("Some Error"), res)
 	require.Error(t, err)
 
 	flinkError, ok := err.(flink.FlinkError)
@@ -27,12 +27,12 @@ func TestFlinkErrorCodeWhenErrors(t *testing.T) {
 func TestFlinkErrorNil(t *testing.T) {
 	res := &http.Response{Body: io.NopCloser(strings.NewReader(`{"errors":[{"detail":"There is an error"}]}`)), StatusCode: http.StatusMethodNotAllowed}
 
-	err := flink.CatchFlinkError(nil, res)
+	err := flink.CatchError(nil, res)
 	require.Nil(t, err)
 }
 
 func TestFlinkErrorNilHttpRes(t *testing.T) {
-	err := flink.CatchFlinkError(errors.New("Some Error"), nil)
+	err := flink.CatchError(errors.New("Some Error"), nil)
 	require.Error(t, err)
 
 	flinkError, ok := err.(flink.FlinkError)
@@ -44,7 +44,7 @@ func TestFlinkErrorNilHttpRes(t *testing.T) {
 func TestFlinkErrorCodeWhenErrorMessage(t *testing.T) {
 	res := &http.Response{Body: io.NopCloser(strings.NewReader(`{"message":"unauthorized"}`)), StatusCode: http.StatusUnauthorized}
 
-	err := flink.CatchFlinkError(errors.New("Some Error"), res)
+	err := flink.CatchError(errors.New("Some Error"), res)
 	require.Error(t, err)
 
 	flinkError, ok := err.(flink.FlinkError)
@@ -56,7 +56,7 @@ func TestFlinkErrorCodeWhenErrorMessage(t *testing.T) {
 func TestFlinkErrorCodeWhenNestedMessage(t *testing.T) {
 	res := &http.Response{Body: io.NopCloser(strings.NewReader(`{"error":{"message":"gateway error"}}`)), StatusCode: http.StatusMethodNotAllowed}
 
-	err := flink.CatchFlinkError(errors.New("Some Error"), res)
+	err := flink.CatchError(errors.New("Some Error"), res)
 	require.Error(t, err)
 
 	flinkError, ok := err.(flink.FlinkError)
@@ -68,7 +68,7 @@ func TestFlinkErrorCodeWhenNestedMessage(t *testing.T) {
 func TestFlinkErrorOnlyStatusCode(t *testing.T) {
 	res := &http.Response{Body: io.NopCloser(strings.NewReader("")), StatusCode: http.StatusMethodNotAllowed}
 
-	err := flink.CatchFlinkError(errors.New("Some Error"), res)
+	err := flink.CatchError(errors.New("Some Error"), res)
 	require.Error(t, err)
 
 	flinkError, ok := err.(flink.FlinkError)

--- a/internal/pkg/ccloudv2/flink_gateway_test.go
+++ b/internal/pkg/ccloudv2/flink_gateway_test.go
@@ -1,0 +1,58 @@
+package ccloudv2
+
+import (
+	"github.com/confluentinc/cli/internal/pkg/errors"
+	"github.com/stretchr/testify/require"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestFlinkErrorCodeWhenErrors(t *testing.T) {
+	res := &http.Response{Body: io.NopCloser(strings.NewReader(`{"errors":[{"detail":"There is an error"}]}`)), StatusCode: http.StatusMethodNotAllowed}
+
+	err := newFlinkError(errors.New("Some Error"), res)
+	require.Error(t, err)
+
+	flinkError, ok := err.(FlinkError)
+	require.True(t, ok)
+	require.Equal(t, http.StatusMethodNotAllowed, flinkError.statusCode)
+	require.Equal(t, err.Error(), flinkError.Error())
+}
+
+func TestFlinkErrorCodeWhenErrorMessage(t *testing.T) {
+	res := &http.Response{Body: io.NopCloser(strings.NewReader(`{"message":"unauthorized"}`)), StatusCode: http.StatusUnauthorized}
+
+	err := newFlinkError(errors.New("Some Error"), res)
+	require.Error(t, err)
+
+	flinkError, ok := err.(FlinkError)
+	require.True(t, ok)
+	require.Equal(t, http.StatusUnauthorized, flinkError.statusCode)
+	require.Equal(t, err.Error(), flinkError.Error())
+}
+
+func TestFlinkErrorCodeWhenNestedMessage(t *testing.T) {
+	res := &http.Response{Body: io.NopCloser(strings.NewReader(`{"error":{"message":"gateway error"}}`)), StatusCode: http.StatusMethodNotAllowed}
+
+	err := newFlinkError(errors.New("Some Error"), res)
+	require.Error(t, err)
+
+	flinkError, ok := err.(FlinkError)
+	require.True(t, ok)
+	require.Equal(t, http.StatusMethodNotAllowed, flinkError.statusCode)
+	require.Equal(t, err.Error(), flinkError.Error())
+}
+
+func TestFlinkErrorOnlyStatusCode(t *testing.T) {
+	res := &http.Response{Body: io.NopCloser(strings.NewReader("")), StatusCode: http.StatusMethodNotAllowed}
+
+	err := newFlinkError(errors.New("Some Error"), res)
+	require.Error(t, err)
+
+	flinkError, ok := err.(FlinkError)
+	require.True(t, ok)
+	require.Equal(t, http.StatusMethodNotAllowed, flinkError.statusCode)
+	require.Equal(t, err.Error(), flinkError.Error())
+}

--- a/internal/pkg/errors/flink/flink_errors.go
+++ b/internal/pkg/errors/flink/flink_errors.go
@@ -41,7 +41,7 @@ var _ Coder = (*FlinkError)(nil)
 var _ errors.ErrorWithSuggestions = (*FlinkError)(nil)
 
 // Extends error with status code, including suggestion if err type is ErrorWithSuggestion
-func CatchFlinkError(err error, r *http.Response) error {
+func CatchError(err error, r *http.Response) error {
 	if err == nil {
 		return nil
 	}

--- a/internal/pkg/errors/flink/flink_errors.go
+++ b/internal/pkg/errors/flink/flink_errors.go
@@ -1,6 +1,10 @@
-package errors
+package flink
 
-import "net/http"
+import (
+	"net/http"
+
+	"github.com/confluentinc/cli/internal/pkg/errors"
+)
 
 // FlinkError extends the ErrorWithSuggestion with a status code.
 type FlinkError struct {
@@ -34,16 +38,16 @@ type Coder interface {
 }
 
 var _ Coder = (*FlinkError)(nil)
-var _ ErrorWithSuggestions = (*FlinkError)(nil)
+var _ errors.ErrorWithSuggestions = (*FlinkError)(nil)
 
 // Extends error with status code, including suggestion if err type is ErrorWithSuggestion
 func CatchFlinkError(err error, r *http.Response) error {
 	if err == nil {
 		return nil
 	}
-	err = CatchCCloudV2Error(err, r)
+	err = errors.CatchCCloudV2Error(err, r)
 	suggestion := ""
-	if suggester, ok := err.(ErrorWithSuggestions); ok {
+	if suggester, ok := err.(errors.ErrorWithSuggestions); ok {
 		suggestion = suggester.GetSuggestionsMsg()
 	}
 	var statusCode int

--- a/internal/pkg/errors/flink_errors.go
+++ b/internal/pkg/errors/flink_errors.go
@@ -1,0 +1,58 @@
+package errors
+
+import "net/http"
+
+// FlinkError extends the ErrorWithSuggestion with a status code.
+type FlinkError struct {
+	errorMsg       string
+	suggestionsMsg string
+	statusCode     int
+}
+
+func NewFlinkError(errorMsg string, suggestionsMsg string, statusCode int) FlinkError {
+	return FlinkError{
+		errorMsg:       errorMsg,
+		suggestionsMsg: suggestionsMsg,
+		statusCode:     statusCode,
+	}
+}
+
+func (f FlinkError) StatusCode() int {
+	return f.statusCode
+}
+
+func (f FlinkError) GetSuggestionsMsg() string {
+	return f.suggestionsMsg
+}
+
+func (f FlinkError) Error() string {
+	return f.errorMsg
+}
+
+type Coder interface {
+	StatusCode() int
+}
+
+var _ Coder = (*FlinkError)(nil)
+var _ ErrorWithSuggestions = (*FlinkError)(nil)
+
+// Extends error with status code, including suggestion if err type is ErrorWithSuggestion
+func CatchFlinkError(err error, r *http.Response) error {
+	if err == nil {
+		return nil
+	}
+	err = CatchCCloudV2Error(err, r)
+	suggestion := ""
+	if suggester, ok := err.(ErrorWithSuggestions); ok {
+		suggestion = suggester.GetSuggestionsMsg()
+	}
+	var statusCode int
+	if r != nil {
+		statusCode = r.StatusCode
+	}
+	return FlinkError{
+		statusCode:     statusCode,
+		errorMsg:       err.Error(),
+		suggestionsMsg: suggestion,
+	}
+}

--- a/internal/pkg/flink/internal/controller/statement_controller.go
+++ b/internal/pkg/flink/internal/controller/statement_controller.go
@@ -55,7 +55,7 @@ func (c *StatementController) ExecuteStatement(statementToExecute string) (*type
 
 func (c *StatementController) handleStatementError(err types.StatementError) {
 	utils.OutputErr(err.Error())
-	if err.HttpResponseCode == http.StatusUnauthorized {
+	if err.StatusCode == http.StatusUnauthorized {
 		c.applicationController.ExitApplication()
 	}
 }

--- a/internal/pkg/flink/internal/controller/statement_controller_test.go
+++ b/internal/pkg/flink/internal/controller/statement_controller_test.go
@@ -105,7 +105,7 @@ func (s *StatementControllerTestSuite) TestExecuteStatement() {
 
 func (s *StatementControllerTestSuite) TestExecuteStatementExitApplicationOnUnauthorizedResponse() {
 	statementToExecute := "select 1;"
-	processedStatementError := types.StatementError{Message: "unauthorized", HttpResponseCode: 401}
+	processedStatementError := types.StatementError{Message: "unauthorized", StatusCode: 401}
 	s.store.EXPECT().ProcessStatement(statementToExecute).Return(nil, &processedStatementError)
 	s.applicationController.EXPECT().ExitApplication()
 

--- a/internal/pkg/flink/internal/controller/statement_controller_test.go
+++ b/internal/pkg/flink/internal/controller/statement_controller_test.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"context"
+	"net/http"
 	"testing"
 	"time"
 
@@ -105,7 +106,7 @@ func (s *StatementControllerTestSuite) TestExecuteStatement() {
 
 func (s *StatementControllerTestSuite) TestExecuteStatementExitApplicationOnUnauthorizedResponse() {
 	statementToExecute := "select 1;"
-	processedStatementError := types.StatementError{Message: "unauthorized", StatusCode: 401}
+	processedStatementError := types.StatementError{Message: "unauthorized", StatusCode: http.StatusUnauthorized}
 	s.store.EXPECT().ProcessStatement(statementToExecute).Return(nil, &processedStatementError)
 	s.applicationController.EXPECT().ExitApplication()
 

--- a/internal/pkg/flink/internal/store/store.go
+++ b/internal/pkg/flink/internal/store/store.go
@@ -173,9 +173,7 @@ func (s *Store) waitForPendingStatement(ctx context.Context, statementName strin
 
 			statusDetail := s.getStatusDetail(statementObj)
 			if err != nil {
-				return nil, &types.StatementError{
-					Message:        err.Error(),
-					FailureMessage: statusDetail}
+				return nil, types.NewStatementErrorFailureMsg(err, statusDetail)
 			}
 
 			phase = types.PHASE(statementObj.Status.GetPhase())

--- a/internal/pkg/flink/internal/store/store_test.go
+++ b/internal/pkg/flink/internal/store/store_test.go
@@ -21,7 +21,7 @@ import (
 	flinkgatewayv1alpha1 "github.com/confluentinc/ccloud-sdk-go-v2/flink-gateway/v1alpha1"
 
 	"github.com/confluentinc/cli/internal/pkg/ccloudv2"
-	cliErrors "github.com/confluentinc/cli/internal/pkg/errors"
+	"github.com/confluentinc/cli/internal/pkg/errors/flink"
 	"github.com/confluentinc/cli/internal/pkg/flink/config"
 	"github.com/confluentinc/cli/internal/pkg/flink/test/mock"
 	"github.com/confluentinc/cli/internal/pkg/flink/types"
@@ -229,7 +229,7 @@ func TestWaitForPendingStatementErrors(t *testing.T) {
 		},
 	}
 
-	returnedError := cliErrors.NewFlinkError("couldn't get statement", "", http.StatusInternalServerError)
+	returnedError := flink.NewFlinkError("couldn't get statement", "", http.StatusInternalServerError)
 	expectedError := &types.StatementError{
 		Message:        returnedError.Error(),
 		FailureMessage: statusDetailMessage,
@@ -265,7 +265,7 @@ func TestCancelPendingStatement(t *testing.T) {
 		},
 	}
 
-	flinkError := cliErrors.NewFlinkError("error", "", http.StatusInternalServerError)
+	flinkError := flink.NewFlinkError("error", "", http.StatusInternalServerError)
 	expectedErr := &types.StatementError{Message: "result retrieval aborted. Statement will be deleted", StatusCode: http.StatusInternalServerError}
 	client.EXPECT().GetStatement("envId", statementName, "orgId").Return(statementObj, nil).AnyTimes()
 	client.EXPECT().GetExceptions("envId", statementName, "orgId").Return(flinkgatewayv1alpha1.SqlV1alpha1StatementExceptionList{}, flinkError).AnyTimes()
@@ -807,7 +807,7 @@ func (s *StoreTestSuite) TestDeleteStatementFailsOnError() {
 
 	statementName := "TEST_STATEMENT"
 
-	flinkError := cliErrors.NewFlinkError("error", "", http.StatusInternalServerError)
+	flinkError := flink.NewFlinkError("error", "", http.StatusInternalServerError)
 	client.EXPECT().DeleteStatement("envId", statementName, "orgId").Return(flinkError)
 	wasStatementDeleted := store.DeleteStatement(statementName)
 	require.False(s.T(), wasStatementDeleted)

--- a/internal/pkg/flink/internal/store/store_test.go
+++ b/internal/pkg/flink/internal/store/store_test.go
@@ -21,6 +21,7 @@ import (
 	flinkgatewayv1alpha1 "github.com/confluentinc/ccloud-sdk-go-v2/flink-gateway/v1alpha1"
 
 	"github.com/confluentinc/cli/internal/pkg/ccloudv2"
+	cliErrors "github.com/confluentinc/cli/internal/pkg/errors"
 	"github.com/confluentinc/cli/internal/pkg/flink/config"
 	"github.com/confluentinc/cli/internal/pkg/flink/test/mock"
 	"github.com/confluentinc/cli/internal/pkg/flink/types"
@@ -228,7 +229,7 @@ func TestWaitForPendingStatementErrors(t *testing.T) {
 		},
 	}
 
-	returnedError := ccloudv2.NewFlinkError("couldn't get statement", "", http.StatusInternalServerError)
+	returnedError := cliErrors.NewFlinkError("couldn't get statement", "", http.StatusInternalServerError)
 	expectedError := &types.StatementError{
 		Message:        returnedError.Error(),
 		FailureMessage: statusDetailMessage,
@@ -264,7 +265,7 @@ func TestCancelPendingStatement(t *testing.T) {
 		},
 	}
 
-	flinkError := ccloudv2.NewFlinkError("error", "", http.StatusInternalServerError)
+	flinkError := cliErrors.NewFlinkError("error", "", http.StatusInternalServerError)
 	expectedErr := &types.StatementError{Message: "result retrieval aborted. Statement will be deleted", StatusCode: http.StatusInternalServerError}
 	client.EXPECT().GetStatement("envId", statementName, "orgId").Return(statementObj, nil).AnyTimes()
 	client.EXPECT().GetExceptions("envId", statementName, "orgId").Return(flinkgatewayv1alpha1.SqlV1alpha1StatementExceptionList{}, flinkError).AnyTimes()
@@ -806,7 +807,7 @@ func (s *StoreTestSuite) TestDeleteStatementFailsOnError() {
 
 	statementName := "TEST_STATEMENT"
 
-	flinkError := ccloudv2.NewFlinkError("error", "", http.StatusInternalServerError)
+	flinkError := cliErrors.NewFlinkError("error", "", http.StatusInternalServerError)
 	client.EXPECT().DeleteStatement("envId", statementName, "orgId").Return(flinkError)
 	wasStatementDeleted := store.DeleteStatement(statementName)
 	require.False(s.T(), wasStatementDeleted)

--- a/internal/pkg/flink/internal/store/store_utils.go
+++ b/internal/pkg/flink/internal/store/store_utils.go
@@ -323,9 +323,9 @@ func processHttpErrors(resp *http.Response, err error) error {
 	if resp != nil && resp.StatusCode >= 400 {
 		if resp.StatusCode == http.StatusUnauthorized {
 			return &types.StatementError{
-				Message:          "unauthorized",
-				Suggestion:       `Please run "confluent login"`,
-				HttpResponseCode: resp.StatusCode,
+				Message:    "unauthorized",
+				Suggestion: `Please run "confluent login"`,
+				StatusCode: resp.StatusCode,
 			}
 		}
 

--- a/internal/pkg/flink/types/statement_error.go
+++ b/internal/pkg/flink/types/statement_error.go
@@ -3,7 +3,7 @@ package types
 import (
 	"fmt"
 
-	"github.com/confluentinc/cli/internal/pkg/ccloudv2"
+	"github.com/confluentinc/cli/internal/pkg/errors"
 	"github.com/confluentinc/cli/internal/pkg/utils"
 )
 
@@ -53,7 +53,7 @@ func (e *StatementError) Error() string {
 
 // StatusCode extract the status code if the error implements Coder interface.
 func StatusCode(err error) int {
-	if coder, ok := err.(ccloudv2.Coder); ok {
+	if coder, ok := err.(errors.Coder); ok {
 		return coder.StatusCode()
 	}
 	return 0

--- a/internal/pkg/flink/types/statement_error.go
+++ b/internal/pkg/flink/types/statement_error.go
@@ -3,7 +3,7 @@ package types
 import (
 	"fmt"
 
-	"github.com/confluentinc/cli/internal/pkg/errors"
+	"github.com/confluentinc/cli/internal/pkg/errors/flink"
 	"github.com/confluentinc/cli/internal/pkg/utils"
 )
 
@@ -53,7 +53,7 @@ func (e *StatementError) Error() string {
 
 // StatusCode extract the status code if the error implements Coder interface.
 func StatusCode(err error) int {
-	if coder, ok := err.(errors.Coder); ok {
+	if coder, ok := err.(flink.Coder); ok {
 		return coder.StatusCode()
 	}
 	return 0

--- a/internal/pkg/flink/types/statement_error.go
+++ b/internal/pkg/flink/types/statement_error.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"fmt"
+
 	"github.com/confluentinc/cli/internal/pkg/ccloudv2"
 	"github.com/confluentinc/cli/internal/pkg/utils"
 )

--- a/internal/pkg/flink/types/statement_error.go
+++ b/internal/pkg/flink/types/statement_error.go
@@ -2,16 +2,31 @@ package types
 
 import (
 	"fmt"
-
+	"github.com/confluentinc/cli/internal/pkg/ccloudv2"
 	"github.com/confluentinc/cli/internal/pkg/utils"
 )
 
 type StatementError struct {
-	Message          string
-	HttpResponseCode int
-	FailureMessage   string
-	Usage            []string
-	Suggestion       string
+	Message        string
+	StatusCode     int
+	FailureMessage string
+	Usage          []string
+	Suggestion     string
+}
+
+func NewStatementError(err error) *StatementError {
+	return &StatementError{
+		Message:    err.Error(),
+		StatusCode: StatusCode(err),
+	}
+}
+
+func NewStatementErrorFailureMsg(err error, failureMsg string) *StatementError {
+	return &StatementError{
+		Message:        err.Error(),
+		StatusCode:     StatusCode(err),
+		FailureMessage: failureMsg,
+	}
 }
 
 func (e *StatementError) Error() string {
@@ -33,4 +48,12 @@ func (e *StatementError) Error() string {
 	}
 
 	return errStr
+}
+
+// StatusCode extract the status code if the error implements Coder interface.
+func StatusCode(err error) int {
+	if coder, ok := err.(ccloudv2.Coder); ok {
+		return coder.StatusCode()
+	}
+	return 0
 }


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
We want to propagate the status code from the gateway client. Added a new error type FlinkError which implements ErrorWithSuggestion and Coder so we just extend existing functionalities with extra error code.
