### PR TITLE
KGLOBAL-3306: Fix TopicsNames to TopicName

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/confluentinc/go-netrc v0.0.0-20220321173724-4d50f36ff450
 	github.com/confluentinc/go-prompt v0.2.19
 	github.com/confluentinc/go-ps1 v1.0.2
-	github.com/confluentinc/kafka-rest-sdk-go/kafkarestv3 v0.3.14
+	github.com/confluentinc/kafka-rest-sdk-go/kafkarestv3 v0.3.16
 	github.com/confluentinc/mds-sdk-go-public/mdsv1 v0.0.0-20230117192233-7e6d894d74a9
 	github.com/confluentinc/mds-sdk-go-public/mdsv2alpha1 v0.0.0-20230117192233-7e6d894d74a9
 	github.com/confluentinc/properties v0.0.0-20190814194548-42c10394a787

--- a/go.sum
+++ b/go.sum
@@ -155,6 +155,8 @@ github.com/confluentinc/go-ps1 v1.0.2 h1:+4cKOzWs3AWmxL2s96oHu0QutZESDRXECnhFzm2
 github.com/confluentinc/go-ps1 v1.0.2/go.mod h1:qmgG9xQgFd4u7/CS6eA9nNP8eQqOtXuRHmZ4+w7Vprs=
 github.com/confluentinc/kafka-rest-sdk-go/kafkarestv3 v0.3.14 h1:/ifiYRgvbtzTrMxsntzAc2NFXsZxfCpjHZG03X9BDxw=
 github.com/confluentinc/kafka-rest-sdk-go/kafkarestv3 v0.3.14/go.mod h1:qJAUraWU9BERQWyalrPsxt+ECELWPV+qsyOaP00VidY=
+github.com/confluentinc/kafka-rest-sdk-go/kafkarestv3 v0.3.16 h1:LRnj8GhoK0HotSX2GJ/zP/2jSOHwtWOwgkItx3MXmNI=
+github.com/confluentinc/kafka-rest-sdk-go/kafkarestv3 v0.3.16/go.mod h1:qJAUraWU9BERQWyalrPsxt+ECELWPV+qsyOaP00VidY=
 github.com/confluentinc/mds-sdk-go-public/mdsv1 v0.0.0-20230117192233-7e6d894d74a9 h1:z8+7/YVstZwsyPFt+s+fCWk8wa+JIgj6pEhEUMVmUcI=
 github.com/confluentinc/mds-sdk-go-public/mdsv1 v0.0.0-20230117192233-7e6d894d74a9/go.mod h1:2Ug8TKPkJXnazoTwlf72RawtttFZYNB3WB/8w3Hgfro=
 github.com/confluentinc/mds-sdk-go-public/mdsv2alpha1 v0.0.0-20230117192233-7e6d894d74a9 h1:O3xty/V/9T3uMH3RAWsBSeh+Qo1lUKh4v1BgfHRjLvo=

--- a/internal/cmd/kafka/command_link_list.go
+++ b/internal/cmd/kafka/command_link_list.go
@@ -86,10 +86,8 @@ func (c *linkCommand) list(cmd *cobra.Command, _ []string) error {
 	list := output.NewList(cmd)
 	for _, data := range listLinksRespDataList.Data {
 		if includeTopics {
-			if len(data.GetTopicNames()) > 0 {
-				for _, topic := range data.GetTopicNames() {
-					list.Add(newLink(data, topic))
-				}
+			for _, topic := range data.GetTopicNames() {
+				list.Add(newLink(data, topic))
 			}
 		} else {
 			list.Add(newLink(data, ""))

--- a/internal/cmd/kafka/command_link_list.go
+++ b/internal/cmd/kafka/command_link_list.go
@@ -86,15 +86,10 @@ func (c *linkCommand) list(cmd *cobra.Command, _ []string) error {
 	list := output.NewList(cmd)
 	for _, data := range listLinksRespDataList.Data {
 		if includeTopics {
-			// data.GetTopicsNames() is empty even when the http response contains a non-empty list of topic names,
-			// this function call is a temporary work-around for this issue
-			mirrorTopicNames, err := getMirrorTopicNames(kafkaREST, cluster.ID, data.GetLinkName())
-			if err != nil {
-				return err
-			}
-
-			for _, topicName := range mirrorTopicNames {
-				list.Add(newLink(data, topicName))
+			if len(data.GetTopicNames()) > 0 {
+				for _, topic := range data.GetTopicNames() {
+					list.Add(newLink(data, topic))
+				}
 			}
 		} else {
 			list.Add(newLink(data, ""))
@@ -112,18 +107,4 @@ func getListFields(includeTopics bool) []string {
 	}
 
 	return append(x, "SourceClusterId", "DestinationClusterId", "RemoteClusterId", "State", "Error", "ErrorMessage")
-}
-
-func getMirrorTopicNames(kafkaREST *pcmd.KafkaREST, clusterId, linkName string) ([]string, error) {
-	listMirrorTopicsResponseDataList, httpResp, err := kafkaREST.CloudClient.ListKafkaMirrorTopicsUnderLink(clusterId, linkName)
-	if err != nil {
-		return nil, kafkarest.NewError(kafkaREST.CloudClient.GetUrl(), err, httpResp)
-	}
-
-	mirrorTopicNames := make([]string, len(listMirrorTopicsResponseDataList.GetData()))
-	for i, data := range listMirrorTopicsResponseDataList.GetData() {
-		mirrorTopicNames[i] = data.GetMirrorTopicName()
-	}
-
-	return mirrorTopicNames, nil
 }

--- a/internal/cmd/kafka/command_link_list_onprem.go
+++ b/internal/cmd/kafka/command_link_list_onprem.go
@@ -67,10 +67,8 @@ func (c *linkCommand) listOnPrem(cmd *cobra.Command, _ []string) error {
 	list := output.NewList(cmd)
 	for _, data := range listLinksRespDataList.Data {
 		if includeTopics {
-			if len(data.TopicNames) > 0 {
-				for _, topic := range data.TopicNames {
-					list.Add(newLinkOnPrem(data, topic))
-				}
+			for _, topic := range data.TopicNames {
+				list.Add(newLinkOnPrem(data, topic))
 			}
 		} else {
 			list.Add(newLinkOnPrem(data, ""))

--- a/internal/cmd/kafka/command_link_list_onprem.go
+++ b/internal/cmd/kafka/command_link_list_onprem.go
@@ -66,9 +66,11 @@ func (c *linkCommand) listOnPrem(cmd *cobra.Command, _ []string) error {
 
 	list := output.NewList(cmd)
 	for _, data := range listLinksRespDataList.Data {
-		if includeTopics && len(data.TopicsNames) > 0 {
-			for _, topic := range data.TopicsNames {
-				list.Add(newLinkOnPrem(data, topic))
+		if includeTopics {
+			if len(data.TopicNames) > 0 {
+				for _, topic := range data.TopicNames {
+					list.Add(newLinkOnPrem(data, topic))
+				}
 			}
 		} else {
 			list.Add(newLinkOnPrem(data, ""))

--- a/internal/pkg/ccloudv2/kafkarest.go
+++ b/internal/pkg/ccloudv2/kafkarest.go
@@ -119,10 +119,6 @@ func (c *KafkaRestClient) ListKafkaLinks(clusterId string) (kafkarestv3.ListLink
 	return c.ClusterLinkingV3Api.ListKafkaLinks(c.context(), clusterId).Execute()
 }
 
-func (c *KafkaRestClient) ListKafkaMirrorTopicsUnderLink(clusterId, linkName string) (kafkarestv3.ListMirrorTopicsResponseDataList, *http.Response, error) {
-	return c.ClusterLinkingV3Api.ListKafkaMirrorTopicsUnderLink(c.context(), clusterId, linkName).Execute()
-}
-
 func (c *KafkaRestClient) UpdateKafkaLinkConfigBatch(clusterId, linkName string, data kafkarestv3.AlterConfigBatchRequestData) (*http.Response, error) {
 	return c.ClusterLinkingV3Api.UpdateKafkaLinkConfigBatch(c.context(), clusterId, linkName).AlterConfigBatchRequestData(data).Execute()
 }

--- a/test/test-server/kafka_rest_router.go
+++ b/test/test-server/kafka_rest_router.go
@@ -235,6 +235,8 @@ func handleKafkaRPTopics(t *testing.T) http.HandlerFunc {
 	}
 }
 
+func PtrString(v string) *string { return &v }
+
 // Handler for: "/kafka/v3/clusters/{cluster}/topics/{topic}/configs"
 func handleKafkaRPTopicConfigs(t *testing.T) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
@@ -248,16 +250,16 @@ func handleKafkaRPTopicConfigs(t *testing.T) http.HandlerFunc {
 					Data: []cpkafkarestv3.TopicConfigData{
 						{
 							Name:  "cleanup.policy",
-							Value: cpkafkarestv3.PtrString("delete"),
+							Value: PtrString("delete"),
 						},
 						{
 							Name:       "compression.type",
-							Value:      cpkafkarestv3.PtrString("producer"),
+							Value:      PtrString("producer"),
 							IsReadOnly: true,
 						},
 						{
 							Name:  "retention.ms",
-							Value: cpkafkarestv3.PtrString("604800000"),
+							Value: PtrString("604800000"),
 						},
 					},
 				}
@@ -270,12 +272,12 @@ func handleKafkaRPTopicConfigs(t *testing.T) http.HandlerFunc {
 					Data: []cpkafkarestv3.TopicConfigData{
 						{
 							Name:       "compression.type",
-							Value:      cpkafkarestv3.PtrString("producer"),
+							Value:      PtrString("producer"),
 							IsReadOnly: true,
 						},
 						{
 							Name:  "retention.ms",
-							Value: cpkafkarestv3.PtrString("1"),
+							Value: PtrString("1"),
 						},
 					},
 				}
@@ -650,10 +652,10 @@ func handleKafkaRPLink(t *testing.T) http.HandlerFunc {
 					err := json.NewEncoder(w).Encode(cpkafkarestv3.ListLinksResponseData{
 						Kind:                 "",
 						Metadata:             cpkafkarestv3.ResourceMetadata{},
-						DestinationClusterId: cpkafkarestv3.PtrString("cluster-2"),
+						DestinationClusterId: PtrString("cluster-2"),
 						LinkName:             link,
 						ClusterLinkId:        "LINKID1",
-						TopicsNames:          []string{"link-1-topic-1", "link-1-topic-2"},
+						TopicNames:           []string{"link-1-topic-1", "link-1-topic-2"},
 					})
 					require.NoError(t, err)
 				case "lkc-describe-topic":


### PR DESCRIPTION
Release Notes
-------------
Bug Fixes
- Correctly display Confluent Platform mirror topics in `confluent kafka link list --include-topics`

Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod? yes

What
----
For CCloud, revert the workaround introduced in https://github.com/confluentinc/cli/pull/1912 since it is no longer needed.
For CP, fix the issue by changing TopicsNames to TopicName.

References
----------
KGLOBAL-3306

Test & Review
-------------
- Manual tested on CCloud with 3 mirror topics
- make test