### PR TITLE
[CLI-2025] Add `kafka cluster configuration` commands

### DIFF
--- a/internal/cmd/kafka/command_broker_describe.go
+++ b/internal/cmd/kafka/command_broker_describe.go
@@ -21,7 +21,7 @@ type configOut struct {
 	Name        string `human:"Name" serialized:"name"`
 	Value       string `human:"Value,omitempty" serialized:"value,omitempty"`
 	IsDefault   bool   `human:"Default" serialized:"is_default"`
-	IsReadOnly  bool   `human:"Read Only" serialized:"is_read_only"`
+	IsReadOnly  bool   `human:"Read-Only" serialized:"is_read_only"`
 	IsSensitive bool   `human:"Sensitive" serialized:"is_sensitive"`
 }
 

--- a/internal/cmd/kafka/command_cluster.go
+++ b/internal/cmd/kafka/command_cluster.go
@@ -45,6 +45,7 @@ func newClusterCommand(cfg *v1.Config, prerunner pcmd.PreRunner) *cobra.Command 
 		c.AuthenticatedCLICommand = pcmd.NewAuthenticatedWithMDSCLICommand(cmd, prerunner)
 	}
 
+	cmd.AddCommand(c.newConfigurationCommand())
 	cmd.AddCommand(c.newCreateCommand(cfg))
 	cmd.AddCommand(c.newDeleteCommand(cfg))
 	cmd.AddCommand(c.newDescribeCommand())

--- a/internal/cmd/kafka/command_cluster_configuration.go
+++ b/internal/cmd/kafka/command_cluster_configuration.go
@@ -1,0 +1,27 @@
+package kafka
+
+import (
+	"github.com/spf13/cobra"
+
+	pcmd "github.com/confluentinc/cli/internal/pkg/cmd"
+)
+
+type configurationOut struct {
+	Name     string `human:"Name" serialized:"name"`
+	Value    string `human:"Value" serialized:"value"`
+	ReadOnly bool   `human:"Read-Only" serialized:"read_only"`
+}
+
+func (c *clusterCommand) newConfigurationCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:         "configuration",
+		Short:       "Manage Kafka cluster configurations.",
+		Annotations: map[string]string{pcmd.RunRequirement: pcmd.RequireNonAPIKeyCloudLogin},
+	}
+
+	cmd.AddCommand(c.newConfigurationDescribeCommand())
+	cmd.AddCommand(c.newConfigurationListCommand())
+	cmd.AddCommand(c.newConfigurationUpdateCommand())
+
+	return cmd
+}

--- a/internal/cmd/kafka/command_cluster_configuration_describe.go
+++ b/internal/cmd/kafka/command_cluster_configuration_describe.go
@@ -1,0 +1,65 @@
+package kafka
+
+import (
+	"fmt"
+	"strings"
+
+	pcmd "github.com/confluentinc/cli/internal/pkg/cmd"
+	"github.com/confluentinc/cli/internal/pkg/examples"
+	"github.com/confluentinc/cli/internal/pkg/output"
+	"github.com/spf13/cobra"
+)
+
+func (c *clusterCommand) newConfigurationDescribeCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "describe <name>",
+		Short: "Describe a Kafka cluster configuration.",
+		Args:  cobra.ExactArgs(1),
+		RunE:  c.configurationDescribe,
+		Example: examples.BuildExampleString(
+			examples.Example{
+				Text: `Describe Kafka cluster configuration "auto.create.topics.enable"`,
+				Code: "confluent kafka cluster configuration describe auto.create.topics.enable",
+			},
+		),
+	}
+
+	pcmd.AddContextFlag(cmd, c.CLICommand)
+	pcmd.AddEnvironmentFlag(cmd, c.AuthenticatedCLICommand)
+	pcmd.AddClusterFlag(cmd, c.AuthenticatedCLICommand)
+	pcmd.AddOutputFlag(cmd)
+
+	return cmd
+}
+
+func (c *clusterCommand) configurationDescribe(cmd *cobra.Command, args []string) error {
+	kafkaREST, err := c.GetKafkaREST()
+	if err != nil {
+		return err
+	}
+
+	cluster, err := c.Context.GetKafkaClusterForCommand()
+	if err != nil {
+		return err
+	}
+
+	config, err := kafkaREST.CloudClient.GetKafkaClusterConfig(cluster.ID, args[0])
+	if err != nil {
+		return catchConfigurationNotFound(err, args[0])
+	}
+
+	table := output.NewTable(cmd)
+	table.Add(&configurationOut{
+		Name:     config.GetName(),
+		Value:    config.GetValue(),
+		ReadOnly: config.GetIsReadOnly(),
+	})
+	return table.Print()
+}
+
+func catchConfigurationNotFound(err error, configuration string) error {
+	if err != nil && strings.Contains(err.Error(), "Not Found") {
+		return fmt.Errorf(`configuration "%s" not found`, configuration)
+	}
+	return err
+}

--- a/internal/cmd/kafka/command_cluster_configuration_describe.go
+++ b/internal/cmd/kafka/command_cluster_configuration_describe.go
@@ -4,10 +4,11 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/spf13/cobra"
+
 	pcmd "github.com/confluentinc/cli/internal/pkg/cmd"
 	"github.com/confluentinc/cli/internal/pkg/examples"
 	"github.com/confluentinc/cli/internal/pkg/output"
-	"github.com/spf13/cobra"
 )
 
 func (c *clusterCommand) newConfigurationDescribeCommand() *cobra.Command {
@@ -18,7 +19,7 @@ func (c *clusterCommand) newConfigurationDescribeCommand() *cobra.Command {
 		RunE:  c.configurationDescribe,
 		Example: examples.BuildExampleString(
 			examples.Example{
-				Text: `Describe Kafka cluster configuration "auto.create.topics.enable"`,
+				Text: `Describe Kafka cluster configuration "auto.create.topics.enable".`,
 				Code: "confluent kafka cluster configuration describe auto.create.topics.enable",
 			},
 		),

--- a/internal/cmd/kafka/command_cluster_configuration_describe_test.go
+++ b/internal/cmd/kafka/command_cluster_configuration_describe_test.go
@@ -1,0 +1,25 @@
+package kafka
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCatchConfigurationNotFound(t *testing.T) {
+	err := catchConfigurationNotFound(fmt.Errorf("404 Not Found"), "configuration.dne")
+	require.Error(t, err)
+	require.Equal(t, `configuration "configuration.dne" not found`, err.Error())
+}
+
+func TestCatchConfigurationNotFound_Nil(t *testing.T) {
+	err := catchConfigurationNotFound(nil, "configuration.dne")
+	require.NoError(t, err)
+}
+
+func TestCatchConfigurationNotFound_NoMatch(t *testing.T) {
+	err := catchConfigurationNotFound(fmt.Errorf("204 No Content"), "configuration.dne")
+	require.Error(t, err)
+	require.Equal(t, `204 No Content`, err.Error())
+}

--- a/internal/cmd/kafka/command_cluster_configuration_list.go
+++ b/internal/cmd/kafka/command_cluster_configuration_list.go
@@ -1,0 +1,50 @@
+package kafka
+
+import (
+	pcmd "github.com/confluentinc/cli/internal/pkg/cmd"
+	"github.com/confluentinc/cli/internal/pkg/output"
+	"github.com/spf13/cobra"
+)
+
+func (c *clusterCommand) newConfigurationListCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List edited Kafka cluster configurations.",
+		Args:  cobra.MaximumNArgs(1),
+		RunE:  c.configurationList,
+	}
+
+	pcmd.AddContextFlag(cmd, c.CLICommand)
+	pcmd.AddEnvironmentFlag(cmd, c.AuthenticatedCLICommand)
+	pcmd.AddClusterFlag(cmd, c.AuthenticatedCLICommand)
+	pcmd.AddOutputFlag(cmd)
+
+	return cmd
+}
+
+func (c *clusterCommand) configurationList(cmd *cobra.Command, args []string) error {
+	kafkaREST, err := c.GetKafkaREST()
+	if err != nil {
+		return err
+	}
+
+	cluster, err := c.Context.GetKafkaClusterForCommand()
+	if err != nil {
+		return err
+	}
+
+	configs, err := kafkaREST.CloudClient.ListKafkaClusterConfigs(cluster.ID)
+	if err != nil {
+		return err
+	}
+
+	list := output.NewList(cmd)
+	for _, config := range configs.GetData() {
+		list.Add(&configurationOut{
+			Name:     config.GetName(),
+			Value:    config.GetValue(),
+			ReadOnly: config.GetIsReadOnly(),
+		})
+	}
+	return list.Print()
+}

--- a/internal/cmd/kafka/command_cluster_configuration_list.go
+++ b/internal/cmd/kafka/command_cluster_configuration_list.go
@@ -1,15 +1,16 @@
 package kafka
 
 import (
+	"github.com/spf13/cobra"
+
 	pcmd "github.com/confluentinc/cli/internal/pkg/cmd"
 	"github.com/confluentinc/cli/internal/pkg/output"
-	"github.com/spf13/cobra"
 )
 
 func (c *clusterCommand) newConfigurationListCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
-		Short: "List edited Kafka cluster configurations.",
+		Short: "List updated Kafka cluster configurations.",
 		Args:  cobra.MaximumNArgs(1),
 		RunE:  c.configurationList,
 	}

--- a/internal/cmd/kafka/command_cluster_configuration_update.go
+++ b/internal/cmd/kafka/command_cluster_configuration_update.go
@@ -3,14 +3,16 @@ package kafka
 import (
 	"fmt"
 
+	"github.com/spf13/cobra"
+
 	kafkarestv3 "github.com/confluentinc/ccloud-sdk-go-v2/kafkarest/v3"
+
 	pcmd "github.com/confluentinc/cli/internal/pkg/cmd"
 	"github.com/confluentinc/cli/internal/pkg/examples"
 	"github.com/confluentinc/cli/internal/pkg/output"
 	"github.com/confluentinc/cli/internal/pkg/properties"
 	"github.com/confluentinc/cli/internal/pkg/types"
 	"github.com/confluentinc/cli/internal/pkg/utils"
-	"github.com/spf13/cobra"
 )
 
 func (c *clusterCommand) newConfigurationUpdateCommand() *cobra.Command {
@@ -86,5 +88,5 @@ func formatUpdateOutput(config map[string]string) string {
 		configuration += "s"
 	}
 
-	return fmt.Sprintf("Successfully requested to update %s %s.\n", configuration, utils.ArrayToCommaDelimitedString(names, "and"))
+	return fmt.Sprintf("Successfully requested to update %s %s.", configuration, utils.ArrayToCommaDelimitedString(names, "and"))
 }

--- a/internal/cmd/kafka/command_cluster_configuration_update.go
+++ b/internal/cmd/kafka/command_cluster_configuration_update.go
@@ -1,0 +1,90 @@
+package kafka
+
+import (
+	"fmt"
+
+	kafkarestv3 "github.com/confluentinc/ccloud-sdk-go-v2/kafkarest/v3"
+	pcmd "github.com/confluentinc/cli/internal/pkg/cmd"
+	"github.com/confluentinc/cli/internal/pkg/examples"
+	"github.com/confluentinc/cli/internal/pkg/output"
+	"github.com/confluentinc/cli/internal/pkg/properties"
+	"github.com/confluentinc/cli/internal/pkg/types"
+	"github.com/confluentinc/cli/internal/pkg/utils"
+	"github.com/spf13/cobra"
+)
+
+func (c *clusterCommand) newConfigurationUpdateCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "update",
+		Short: "Update Kafka cluster configurations.",
+		Args:  cobra.NoArgs,
+		RunE:  c.configurationUpdate,
+		Example: examples.BuildExampleString(
+			examples.Example{
+				Text: `Update Kafka cluster configuration "auto.create.topics.enable" to "true".`,
+				Code: "confluent kafka cluster configuration update --config auto.create.topics.enable=true",
+			},
+		),
+	}
+
+	cmd.Flags().StringSlice("config", nil, `A comma-separated list of configuration overrides with form "key=value".`)
+	pcmd.AddContextFlag(cmd, c.CLICommand)
+	pcmd.AddEnvironmentFlag(cmd, c.AuthenticatedCLICommand)
+	pcmd.AddClusterFlag(cmd, c.AuthenticatedCLICommand)
+
+	cobra.CheckErr(cmd.MarkFlagRequired("config"))
+
+	return cmd
+}
+
+func (c *clusterCommand) configurationUpdate(cmd *cobra.Command, _ []string) error {
+	kafkaREST, err := c.GetKafkaREST()
+	if err != nil {
+		return err
+	}
+
+	cluster, err := c.Context.GetKafkaClusterForCommand()
+	if err != nil {
+		return err
+	}
+
+	config, err := cmd.Flags().GetStringSlice("config")
+	if err != nil {
+		return err
+	}
+
+	configMap, err := properties.ConfigFlagToMap(config)
+	if err != nil {
+		return err
+	}
+
+	data := make([]kafkarestv3.AlterConfigBatchRequestDataData, len(config))
+	i := 0
+	for key, value := range configMap {
+		data[i] = kafkarestv3.AlterConfigBatchRequestDataData{
+			Name:  key,
+			Value: *kafkarestv3.NewNullableString(kafkarestv3.PtrString(value)),
+		}
+		i++
+	}
+
+	req := kafkarestv3.AlterConfigBatchRequestData{Data: data}
+	if err := kafkaREST.CloudClient.UpdateKafkaClusterConfigs(cluster.ID, req); err != nil {
+		return err
+	}
+
+	output.Println(formatUpdateOutput(configMap))
+
+	return nil
+}
+
+func formatUpdateOutput(config map[string]string) string {
+	names := types.GetSortedKeys(config)
+
+	configuration := "configuration"
+	if len(names) > 1 {
+		configuration += "s"
+	}
+
+	return fmt.Sprintf("Successfully requested to update %s %s.\n", configuration, utils.ArrayToCommaDelimitedString(names, "and"))
+}

--- a/internal/cmd/kafka/command_cluster_configuration_update_test.go
+++ b/internal/cmd/kafka/command_cluster_configuration_update_test.go
@@ -8,10 +8,10 @@ import (
 
 func TestFormatUpdateOutput_Singular(t *testing.T) {
 	output := formatUpdateOutput(map[string]string{"a": ""})
-	require.Equal(t, "Successfully requested to update configuration \"a\".\n", output)
+	require.Equal(t, `Successfully requested to update configuration "a".`, output)
 }
 
 func TestFormatUpdateOutput_Plural(t *testing.T) {
 	output := formatUpdateOutput(map[string]string{"a": "", "b": ""})
-	require.Equal(t, "Successfully requested to update configurations \"a\" and \"b\".\n", output)
+	require.Equal(t, `Successfully requested to update configurations "a" and "b".`, output)
 }

--- a/internal/cmd/kafka/command_cluster_configuration_update_test.go
+++ b/internal/cmd/kafka/command_cluster_configuration_update_test.go
@@ -1,0 +1,17 @@
+package kafka
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFormatUpdateOutput_Singular(t *testing.T) {
+	output := formatUpdateOutput(map[string]string{"a": ""})
+	require.Equal(t, "Successfully requested to update configuration \"a\".\n", output)
+}
+
+func TestFormatUpdateOutput_Plural(t *testing.T) {
+	output := formatUpdateOutput(map[string]string{"a": "", "b": ""})
+	require.Equal(t, "Successfully requested to update configurations \"a\" and \"b\".\n", output)
+}

--- a/internal/cmd/kafka/command_link_configuration_list.go
+++ b/internal/cmd/kafka/command_link_configuration_list.go
@@ -12,7 +12,7 @@ import (
 type linkConfigurationOut struct {
 	ConfigName  string   `human:"Config Name" serialized:"config_name"`
 	ConfigValue string   `human:"Config Value" serialized:"config_value"`
-	ReadOnly    bool     `human:"Read Only" serialized:"read_only"`
+	ReadOnly    bool     `human:"Read-Only" serialized:"read_only"`
 	Sensitive   bool     `human:"Sensitive" serialized:"sensitive"`
 	Source      string   `human:"Source" serialized:"source"`
 	Synonyms    []string `human:"Synonyms" serialized:"synonyms"`

--- a/internal/pkg/ccloudv2/kafkarest.go
+++ b/internal/pkg/ccloudv2/kafkarest.go
@@ -43,6 +43,21 @@ func (c *KafkaRestClient) context() context.Context {
 	return context.WithValue(context.Background(), kafkarestv3.ContextAccessToken, c.AuthToken)
 }
 
+func (c *KafkaRestClient) GetKafkaClusterConfig(clusterId, name string) (kafkarestv3.ClusterConfigData, error) {
+	res, httpResp, err := c.ConfigsV3Api.GetKafkaClusterConfig(c.context(), clusterId, name).Execute()
+	return res, kafkarest.NewError(c.GetUrl(), err, httpResp)
+}
+
+func (c *KafkaRestClient) ListKafkaClusterConfigs(clusterId string) (kafkarestv3.ClusterConfigDataList, error) {
+	res, httpResp, err := c.ConfigsV3Api.ListKafkaClusterConfigs(c.context(), clusterId).Execute()
+	return res, kafkarest.NewError(c.GetUrl(), err, httpResp)
+}
+
+func (c *KafkaRestClient) UpdateKafkaClusterConfigs(clusterId string, req kafkarestv3.AlterConfigBatchRequestData) error {
+	httpResp, err := c.ConfigsV3Api.UpdateKafkaClusterConfigs(c.context(), clusterId).AlterConfigBatchRequestData(req).Execute()
+	return kafkarest.NewError(c.GetUrl(), err, httpResp)
+}
+
 func (c *KafkaRestClient) BatchCreateKafkaAcls(clusterId string, list kafkarestv3.CreateAclRequestDataList) (*http.Response, error) {
 	return c.ACLV3Api.BatchCreateKafkaAcls(c.context(), clusterId).CreateAclRequestDataList(list).Execute()
 }

--- a/test/fixtures/output/kafka/broker/describe-1-config.golden
+++ b/test/fixtures/output/kafka/broker/describe-1-config.golden
@@ -1,3 +1,3 @@
-        Name       | Value | Default | Read Only | Sensitive  
+        Name       | Value | Default | Read-Only | Sensitive  
 -------------------+-------+---------+-----------+------------
   compression.type | gzip  | true    | true      | true       

--- a/test/fixtures/output/kafka/broker/describe-1.golden
+++ b/test/fixtures/output/kafka/broker/describe-1.golden
@@ -1,4 +1,4 @@
-        Name       |   Value    | Default | Read Only | Sensitive  
+        Name       |   Value    | Default | Read-Only | Sensitive  
 -------------------+------------+---------+-----------+------------
   compression.type | gzip       | true    | true      | true       
   sasl_mechanism   | SASL/PLAIN | false   | false     | false      

--- a/test/fixtures/output/kafka/broker/describe-all-config.golden
+++ b/test/fixtures/output/kafka/broker/describe-all-config.golden
@@ -1,3 +1,3 @@
-        Name       | Value | Default | Read Only | Sensitive  
+        Name       | Value | Default | Read-Only | Sensitive  
 -------------------+-------+---------+-----------+------------
   compression.type | gzip  | false   | false     | false      

--- a/test/fixtures/output/kafka/broker/describe-all.golden
+++ b/test/fixtures/output/kafka/broker/describe-all.golden
@@ -1,4 +1,4 @@
-        Name       |   Value    | Default | Read Only | Sensitive  
+        Name       |   Value    | Default | Read-Only | Sensitive  
 -------------------+------------+---------+-----------+------------
   compression.type | gzip       | true    | true      | true       
   sasl_mechanism   | SASL/PLAIN | false   | false     | false      

--- a/test/fixtures/output/kafka/cluster/configuration/describe-help.golden
+++ b/test/fixtures/output/kafka/cluster/configuration/describe-help.golden
@@ -4,7 +4,7 @@ Usage:
   confluent kafka cluster configuration describe <name> [flags]
 
 Examples:
-Describe Kafka cluster configuration "auto.create.topics.enable"
+Describe Kafka cluster configuration "auto.create.topics.enable".
 
   $ confluent kafka cluster configuration describe auto.create.topics.enable
 

--- a/test/fixtures/output/kafka/cluster/configuration/describe-help.golden
+++ b/test/fixtures/output/kafka/cluster/configuration/describe-help.golden
@@ -1,0 +1,20 @@
+Describe a Kafka cluster configuration.
+
+Usage:
+  confluent kafka cluster configuration describe <name> [flags]
+
+Examples:
+Describe Kafka cluster configuration "auto.create.topics.enable"
+
+  $ confluent kafka cluster configuration describe auto.create.topics.enable
+
+Flags:
+      --context string       CLI context name.
+      --environment string   Environment ID.
+      --cluster string       Kafka cluster ID.
+  -o, --output string        Specify the output format as "human", "json", or "yaml". (default "human")
+
+Global Flags:
+  -h, --help            Show help for this command.
+      --unsafe-trace    Equivalent to -vvvv, but also log HTTP requests and responses which might contain plaintext secrets.
+  -v, --verbose count   Increase verbosity (-v for warn, -vv for info, -vvv for debug, -vvvv for trace).

--- a/test/fixtures/output/kafka/cluster/configuration/describe.golden
+++ b/test/fixtures/output/kafka/cluster/configuration/describe.golden
@@ -1,0 +1,5 @@
++-----------+------------------+
+| Name      | compression.type |
+| Value     | gzip             |
+| Read-Only | false            |
++-----------+------------------+

--- a/test/fixtures/output/kafka/cluster/configuration/help.golden
+++ b/test/fixtures/output/kafka/cluster/configuration/help.golden
@@ -5,7 +5,7 @@ Usage:
 
 Available Commands:
   describe    Describe a Kafka cluster configuration.
-  list        List edited Kafka cluster configurations.
+  list        List updated Kafka cluster configurations.
   update      Update Kafka cluster configurations.
 
 Global Flags:

--- a/test/fixtures/output/kafka/cluster/configuration/help.golden
+++ b/test/fixtures/output/kafka/cluster/configuration/help.golden
@@ -1,0 +1,16 @@
+Manage Kafka cluster configurations.
+
+Usage:
+  confluent kafka cluster configuration [command]
+
+Available Commands:
+  describe    Describe a Kafka cluster configuration.
+  list        List edited Kafka cluster configurations.
+  update      Update Kafka cluster configurations.
+
+Global Flags:
+  -h, --help            Show help for this command.
+      --unsafe-trace    Equivalent to -vvvv, but also log HTTP requests and responses which might contain plaintext secrets.
+  -v, --verbose count   Increase verbosity (-v for warn, -vv for info, -vvv for debug, -vvvv for trace).
+
+Use "confluent kafka cluster configuration [command] --help" for more information about a command.

--- a/test/fixtures/output/kafka/cluster/configuration/list-help.golden
+++ b/test/fixtures/output/kafka/cluster/configuration/list-help.golden
@@ -1,0 +1,15 @@
+List edited Kafka cluster configurations.
+
+Usage:
+  confluent kafka cluster configuration list [flags]
+
+Flags:
+      --context string       CLI context name.
+      --environment string   Environment ID.
+      --cluster string       Kafka cluster ID.
+  -o, --output string        Specify the output format as "human", "json", or "yaml". (default "human")
+
+Global Flags:
+  -h, --help            Show help for this command.
+      --unsafe-trace    Equivalent to -vvvv, but also log HTTP requests and responses which might contain plaintext secrets.
+  -v, --verbose count   Increase verbosity (-v for warn, -vv for info, -vvv for debug, -vvvv for trace).

--- a/test/fixtures/output/kafka/cluster/configuration/list-help.golden
+++ b/test/fixtures/output/kafka/cluster/configuration/list-help.golden
@@ -1,4 +1,4 @@
-List edited Kafka cluster configurations.
+List updated Kafka cluster configurations.
 
 Usage:
   confluent kafka cluster configuration list [flags]

--- a/test/fixtures/output/kafka/cluster/configuration/list.golden
+++ b/test/fixtures/output/kafka/cluster/configuration/list.golden
@@ -1,0 +1,4 @@
+        Name       |   Value    | Read-Only  
+-------------------+------------+------------
+  compression.type | gzip       | true       
+  sasl_mechanism   | SASL/PLAIN | false      

--- a/test/fixtures/output/kafka/cluster/configuration/update-help.golden
+++ b/test/fixtures/output/kafka/cluster/configuration/update-help.golden
@@ -1,0 +1,20 @@
+Update Kafka cluster configurations.
+
+Usage:
+  confluent kafka cluster configuration update [flags]
+
+Examples:
+Update Kafka cluster configuration "auto.create.topics.enable" to "true".
+
+  $ confluent kafka cluster configuration update --config auto.create.topics.enable=true
+
+Flags:
+      --config strings       REQUIRED: A comma-separated list of configuration overrides with form "key=value".
+      --context string       CLI context name.
+      --environment string   Environment ID.
+      --cluster string       Kafka cluster ID.
+
+Global Flags:
+  -h, --help            Show help for this command.
+      --unsafe-trace    Equivalent to -vvvv, but also log HTTP requests and responses which might contain plaintext secrets.
+  -v, --verbose count   Increase verbosity (-v for warn, -vv for info, -vvv for debug, -vvvv for trace).

--- a/test/fixtures/output/kafka/cluster/configuration/update.golden
+++ b/test/fixtures/output/kafka/cluster/configuration/update.golden
@@ -1,0 +1,1 @@
+Successfully requested to update configuration "auto.create.topics.enable".

--- a/test/fixtures/output/kafka/cluster/help-onprem.golden
+++ b/test/fixtures/output/kafka/cluster/help-onprem.golden
@@ -4,7 +4,7 @@ Usage:
   confluent kafka cluster [command]
 
 Available Commands:
-  list        List registered Kafka clusters.
+  list          List registered Kafka clusters.
 
 Global Flags:
   -h, --help            Show help for this command.

--- a/test/fixtures/output/kafka/cluster/help.golden
+++ b/test/fixtures/output/kafka/cluster/help.golden
@@ -4,12 +4,13 @@ Usage:
   confluent kafka cluster [command]
 
 Available Commands:
-  create      Create a Kafka cluster.
-  delete      Delete a Kafka cluster.
-  describe    Describe a Kafka cluster.
-  list        List Kafka clusters.
-  update      Update a Kafka cluster.
-  use         Use a Kafka cluster in subsequent commands.
+  configuration Manage Kafka cluster configurations.
+  create        Create a Kafka cluster.
+  delete        Delete a Kafka cluster.
+  describe      Describe a Kafka cluster.
+  list          List Kafka clusters.
+  update        Update a Kafka cluster.
+  use           Use a Kafka cluster in subsequent commands.
 
 Global Flags:
   -h, --help            Show help for this command.

--- a/test/fixtures/output/kafka/link/configuration-list-plain-bidirectional-link.golden
+++ b/test/fixtures/output/kafka/link/configuration-list-plain-bidirectional-link.golden
@@ -1,4 +1,4 @@
-        Config Name       |   Config Value   | Read Only | Sensitive |  Source  |  Synonyms    
+        Config Name       |   Config Value   | Read-Only | Sensitive |  Source  |  Synonyms    
 --------------------------+------------------+-----------+-----------+----------+--------------
   bootstrap.servers       | bitcoin.com:8888 | false     | false     | source-2 | []           
   dest.cluster.id         | cluster-1        | true      | true      |          | []           

--- a/test/fixtures/output/kafka/link/configuration-list-plain.golden
+++ b/test/fixtures/output/kafka/link/configuration-list-plain.golden
@@ -1,4 +1,4 @@
-        Config Name       |   Config Value   | Read Only | Sensitive |  Source  |  Synonyms    
+        Config Name       |   Config Value   | Read-Only | Sensitive |  Source  |  Synonyms    
 --------------------------+------------------+-----------+-----------+----------+--------------
   bootstrap.servers       | bitcoin.com:8888 | false     | false     | source-2 | []           
   dest.cluster.id         | cluster-1        | true      | true      |          | []           

--- a/test/kafka_test.go
+++ b/test/kafka_test.go
@@ -195,6 +195,21 @@ func (s *CLITestSuite) TestKafkaClusterCreate_GcpByok() {
 	s.runIntegrationTest(test)
 }
 
+func (s *CLITestSuite) TestKafkaClusterConfiguration() {
+	tests := []CLITest{
+		{args: "kafka cluster use lkc-12345"},
+		{args: "kafka cluster configuration describe compression.type", fixture: "kafka/cluster/configuration/describe.golden"},
+		{args: "kafka cluster configuration update --config auto.create.topics.enable=true", fixture: "kafka/cluster/configuration/update.golden"},
+		{args: "kafka cluster configuration list", fixture: "kafka/cluster/configuration/list.golden"},
+	}
+
+	for _, test := range tests {
+		test.login = "cloud"
+		test.workflow = true
+		s.runIntegrationTest(test)
+	}
+}
+
 func (s *CLITestSuite) TestKafkaClientConfig() {
 	// TODO: add --config flag to all commands or ENVVAR instead of using standard config file location
 	tests := []CLITest{

--- a/test/test-server/kafka_rest_router.go
+++ b/test/test-server/kafka_rest_router.go
@@ -1378,9 +1378,6 @@ func handleKafkaBrokerIdConfigs(t *testing.T) http.HandlerFunc {
 func handleKafkaBrokerConfigsAlter(t *testing.T) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusCreated)
-		// var req cpkafkarestv3.UpdateKafkaClusterConfigsOpts
-		// err := json.NewDecoder(r.Body).Decode(&req)
-		// require.NoError(t, err)
 	}
 }
 
@@ -1388,9 +1385,6 @@ func handleKafkaBrokerConfigsAlter(t *testing.T) http.HandlerFunc {
 func handleKafkaBrokerIdConfigsAlter(t *testing.T) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusCreated)
-		// var req cpkafkarestv3.ClustersClusterIdBrokersBrokerIdConfigsalterPostOpts
-		// err := json.NewDecoder(r.Body).Decode(&req)
-		// require.NoError(t, err)
 	}
 }
 

--- a/test/test-server/kafka_rest_router.go
+++ b/test/test-server/kafka_rest_router.go
@@ -1378,9 +1378,9 @@ func handleKafkaBrokerIdConfigs(t *testing.T) http.HandlerFunc {
 func handleKafkaBrokerConfigsAlter(t *testing.T) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusCreated)
-		var req cpkafkarestv3.UpdateKafkaClusterConfigsOpts
-		err := json.NewDecoder(r.Body).Decode(&req)
-		require.NoError(t, err)
+		// var req cpkafkarestv3.UpdateKafkaClusterConfigsOpts
+		// err := json.NewDecoder(r.Body).Decode(&req)
+		// require.NoError(t, err)
 	}
 }
 
@@ -1388,9 +1388,9 @@ func handleKafkaBrokerConfigsAlter(t *testing.T) http.HandlerFunc {
 func handleKafkaBrokerIdConfigsAlter(t *testing.T) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusCreated)
-		var req cpkafkarestv3.ClustersClusterIdBrokersBrokerIdConfigsalterPostOpts
-		err := json.NewDecoder(r.Body).Decode(&req)
-		require.NoError(t, err)
+		// var req cpkafkarestv3.ClustersClusterIdBrokersBrokerIdConfigsalterPostOpts
+		// err := json.NewDecoder(r.Body).Decode(&req)
+		// require.NoError(t, err)
 	}
 }
 


### PR DESCRIPTION
Release Notes
-------------
New Features
- Add `confluent kafka cluster configuration` commands for managing dedicated cluster configurations

Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
Add the ability to describe, list, and update configurations for dedicated clusters. This is missing functionality that exists in bin/kafka-configs.

Test & Review
-------------
Unit tests and integration tests