### PR TITLE
Fix `billing cost list` typo

### DIFF
--- a/internal/cmd/billing/command_cost_list.go
+++ b/internal/cmd/billing/command_cost_list.go
@@ -39,7 +39,7 @@ func (c *command) newCostListCommand() *cobra.Command {
 		Example: examples.BuildExampleString(
 			examples.Example{
 				Text: `List billing costs from 2023-01-01 to 2023-01-10:`,
-				Code: "confluent billing list --start-date 2023-01-01 --end-date 2023-01-10",
+				Code: "confluent billing cost list --start-date 2023-01-01 --end-date 2023-01-10",
 			},
 		),
 	}

--- a/test/fixtures/output/billing/cost/list-help.golden
+++ b/test/fixtures/output/billing/cost/list-help.golden
@@ -6,7 +6,7 @@ Usage:
 Examples:
 List billing costs from 2023-01-01 to 2023-01-10:
 
-  $ confluent billing list --start-date 2023-01-01 --end-date 2023-01-10
+  $ confluent billing cost list --start-date 2023-01-01 --end-date 2023-01-10
 
 Flags:
       --start-date string   REQUIRED: Start date.

--- a/test/fixtures/output/billing/cost/list-missing-flag.golden
+++ b/test/fixtures/output/billing/cost/list-missing-flag.golden
@@ -5,7 +5,7 @@ Usage:
 Examples:
 List billing costs from 2023-01-01 to 2023-01-10:
 
-  $ confluent billing list --start-date 2023-01-01 --end-date 2023-01-10
+  $ confluent billing cost list --start-date 2023-01-01 --end-date 2023-01-10
 
 Flags:
       --start-date string   REQUIRED: Start date.


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
Example was missing "cost".