### PR TITLE
[CLI-2576] Detect Homebrew installation on `confluent update`

### DIFF
--- a/.goreleaser-build.yml
+++ b/.goreleaser-build.yml
@@ -5,3 +5,5 @@ builds:
     main: cmd/confluent/main.go
     flags:
       - -tags={{.Env.TAGS}}
+    ldflags:
+      - -X main.disableUpdates=true

--- a/.goreleaser-build.yml
+++ b/.goreleaser-build.yml
@@ -5,5 +5,3 @@ builds:
     main: cmd/confluent/main.go
     flags:
       - -tags={{.Env.TAGS}}
-    ldflags:
-      - -X main.disableUpdates=true

--- a/internal/cmd/command.go
+++ b/internal/cmd/command.go
@@ -131,6 +131,7 @@ func NewConfluentCommand(cfg *v1.Config) *cobra.Command {
 	cmd.AddCommand(secret.New(prerunner, flagResolver, secrets.NewPasswordProtectionPlugin()))
 	cmd.AddCommand(shell.New(cmd, func() *cobra.Command { return NewConfluentCommand(cfg) }))
 	cmd.AddCommand(streamshare.New(prerunner))
+	cmd.AddCommand(update.New(cfg, prerunner, updateClient))
 	cmd.AddCommand(version.New(prerunner, cfg.Version))
 
 	dc := dynamicconfig.New(cfg, nil)
@@ -138,9 +139,6 @@ func NewConfluentCommand(cfg *v1.Config) *cobra.Command {
 
 	if cfg.IsTest || featureflags.Manager.BoolVariation("cli.flink", dc.Context(), v1.CliLaunchDarklyClient, true, false) {
 		cmd.AddCommand(flink.New(cfg, prerunner))
-	}
-	if !cfg.DisableUpdates {
-		cmd.AddCommand(update.New(cfg, prerunner, updateClient))
 	}
 
 	changeDefaults(cmd, cfg)

--- a/internal/cmd/update/command.go
+++ b/internal/cmd/update/command.go
@@ -91,7 +91,7 @@ func (c *command) update(cmd *cobra.Command, _ []string) error {
 
 		return errors.NewErrorWithSuggestions(
 			message,
-			"If installed with Confluent Platform, you may install an independent, updated version of the CLI, as long as it maintains compatibility: https://docs.confluent.io/platform/current/installation/versions-interoperability.html#confluent-cli",
+			"Use a package manager to update the binary, if applicable. Otherwise, consider deleting this binary and re-installing a newer version.",
 		)
 	}
 

--- a/internal/cmd/update/command.go
+++ b/internal/cmd/update/command.go
@@ -3,6 +3,7 @@ package update
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -12,8 +13,10 @@ import (
 	pcmd "github.com/confluentinc/cli/internal/pkg/cmd"
 	v1 "github.com/confluentinc/cli/internal/pkg/config/v1"
 	"github.com/confluentinc/cli/internal/pkg/errors"
+	"github.com/confluentinc/cli/internal/pkg/exec"
 	"github.com/confluentinc/cli/internal/pkg/log"
 	"github.com/confluentinc/cli/internal/pkg/output"
+	"github.com/confluentinc/cli/internal/pkg/types"
 	"github.com/confluentinc/cli/internal/pkg/update"
 	"github.com/confluentinc/cli/internal/pkg/update/s3"
 	pversion "github.com/confluentinc/cli/internal/pkg/version"
@@ -28,6 +31,8 @@ const (
 	CheckInterval           = 24 * time.Hour
 )
 
+const homebrewFormula = "confluentinc/tap/cli"
+
 type command struct {
 	*pcmd.CLICommand
 	version *pversion.Version
@@ -36,9 +41,10 @@ type command struct {
 
 func New(cfg *v1.Config, prerunner pcmd.PreRunner, client update.Client) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "update",
-		Short: fmt.Sprintf("Update the %s.", pversion.FullCLIName),
-		Args:  cobra.NoArgs,
+		Use:    "update",
+		Short:  fmt.Sprintf("Update the %s.", pversion.FullCLIName),
+		Args:   cobra.NoArgs,
+		Hidden: cfg.DisableUpdates,
 	}
 
 	cmd.Flags().BoolP("yes", "y", false, "Update without prompting.")
@@ -74,6 +80,21 @@ func NewClient(cliName string, disableUpdateCheck bool) update.Client {
 }
 
 func (c *command) update(cmd *cobra.Command, _ []string) error {
+	if c.Config.DisableUpdates {
+		message := "updates are disabled for this binary"
+		if isHomebrew() {
+			return errors.NewErrorWithSuggestions(
+				message,
+				fmt.Sprintf("If installed with Homebrew, run `brew upgrade %s`.", homebrewFormula),
+			)
+		}
+
+		return errors.NewErrorWithSuggestions(
+			message,
+			"If installed with Confluent Platform, you may install an independent, updated version of the CLI, as long as it maintains compatibility: https://docs.confluent.io/platform/current/installation/versions-interoperability.html#confluent-cli",
+		)
+	}
+
 	yes, err := cmd.Flags().GetBool("yes")
 	if err != nil {
 		return errors.Wrap(err, errors.ReadingYesFlagErrorMsg)
@@ -138,6 +159,30 @@ func (c *command) update(cmd *cobra.Command, _ []string) error {
 	}
 
 	return nil
+}
+
+func isHomebrew() bool {
+	out, err := exec.NewCommand("brew", "ls", homebrewFormula).Output()
+	if err != nil {
+		return false
+	}
+
+	homebrewPaths := strings.Split(strings.TrimSpace(string(out)), "\n")
+	log.CliLogger.Tracef("Detected Homebrew installation: %v", homebrewPaths)
+
+	path, err := os.Executable()
+	if err != nil {
+		return false
+	}
+
+	path, err = filepath.EvalSymlinks(path)
+	if err != nil {
+		return false
+	}
+
+	log.CliLogger.Tracef("Executable path: %s", path)
+
+	return types.Contains(homebrewPaths, path)
 }
 
 func (c *command) getReleaseNotes(cliName, latestBinaryVersion string) string {


### PR DESCRIPTION
Release Notes
-------------
New Features
- Suggest updating with `brew upgrade` if installed with Homebrew

Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
If updates are disabled (CP or Homebrew), mark `confluent update` as hidden and return a helpful suggestion on execution.
* For Homebrew, suggest `brew upgrade`
* For CP, suggest independently installing a binary according to https://docs.confluent.io/platform/current/installation/versions-interoperability.html#confluent-cli

Test & Review
-------------
Manually tested all of the negative paths, added tracing to debug the positive path, if needed.