### PR TITLE
CLI automatically uses LD test env when not logged into prod

### DIFF
--- a/internal/cmd/command.go
+++ b/internal/cmd/command.go
@@ -83,7 +83,7 @@ func NewConfluentCommand(cfg *v1.Config) *cobra.Command {
 	loginCredentialsManager := pauth.NewLoginCredentialsManager(netrcHandler, form.NewPrompt(), ccloudClient)
 	loginOrganizationManager := pauth.NewLoginOrganizationManagerImpl()
 	mdsClientManager := &pauth.MDSClientManagerImpl{}
-	featureflags.Init(cfg.Version, cfg.IsTest, cfg.DisableFeatureFlags)
+	featureflags.Init(cfg)
 
 	cmd.SetHelpFunc(func(cmd *cobra.Command, args []string) {
 		pcmd.LabelRequiredFlags(cmd)

--- a/internal/pkg/cmd/prerunner_test.go
+++ b/internal/pkg/cmd/prerunner_test.go
@@ -123,7 +123,8 @@ func getPreRunBase() *pcmd.PreRun {
 }
 
 func TestPreRun_Anonymous_SetLoggingLevel(t *testing.T) {
-	featureflags.Init(nil, true, false)
+	cfg := &v1.Config{Version: nil, IsTest: true, DisableFeatureFlags: false}
+	featureflags.Init(cfg)
 
 	tests := map[string]log.Level{
 		"":      log.ERROR,

--- a/internal/pkg/cmd/prerunner_test.go
+++ b/internal/pkg/cmd/prerunner_test.go
@@ -123,7 +123,7 @@ func getPreRunBase() *pcmd.PreRun {
 }
 
 func TestPreRun_Anonymous_SetLoggingLevel(t *testing.T) {
-	cfg := &v1.Config{Version: nil, IsTest: true, DisableFeatureFlags: false}
+	cfg := &v1.Config{IsTest: true, Contexts: map[string]*v1.Context{}}
 	featureflags.Init(cfg)
 
 	tests := map[string]log.Level{

--- a/internal/pkg/cmd/test_helpers.go
+++ b/internal/pkg/cmd/test_helpers.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	v1 "github.com/confluentinc/cli/internal/pkg/config/v1"
 	"github.com/confluentinc/cli/internal/pkg/featureflags"
 )
 
@@ -23,7 +24,8 @@ func ExecuteCommandC(root *cobra.Command, args ...string) (*cobra.Command, strin
 	root.SetOut(buf)
 	root.SetArgs(args)
 
-	featureflags.Init(nil, true, false)
+	cfg := &v1.Config{Version: nil, IsTest: true, DisableFeatureFlags: false}
+	featureflags.Init(cfg)
 
 	c, err := root.ExecuteC()
 	return c, buf.String(), err

--- a/internal/pkg/cmd/test_helpers.go
+++ b/internal/pkg/cmd/test_helpers.go
@@ -24,7 +24,7 @@ func ExecuteCommandC(root *cobra.Command, args ...string) (*cobra.Command, strin
 	root.SetOut(buf)
 	root.SetArgs(args)
 
-	cfg := &v1.Config{Version: nil, IsTest: true, DisableFeatureFlags: false}
+	cfg := &v1.Config{IsTest: true, Contexts: map[string]*v1.Context{}}
 	featureflags.Init(cfg)
 
 	c, err := root.ExecuteC()

--- a/internal/pkg/config/v1/platform.go
+++ b/internal/pkg/config/v1/platform.go
@@ -6,3 +6,10 @@ type Platform struct {
 	Server     string `json:"server"`
 	CaCertPath string `json:"ca_cert_path,omitempty"`
 }
+
+func (p *Platform) GetName() string {
+	if p != nil {
+		return p.Name
+	}
+	return ""
+}

--- a/internal/pkg/featureflags/feature_flags.go
+++ b/internal/pkg/featureflags/feature_flags.go
@@ -31,9 +31,10 @@ const (
 	userPath = "users/%s"
 )
 
+const cliProdEnv = "confluent.cloud"
+
 const (
 	cliProdEnvClientId     = "61af57740127630ce47de5be"
-	cliProdEnv             = "confluent.cloud"
 	cliTestEnvClientId     = "61af57740127630ce47de5bd"
 	ccloudProdEnvClientId  = "5c636508aa445d32c86f26b1"
 	ccloudStagEnvClientId  = "5c63651f1df21432a45fc773"
@@ -58,15 +59,7 @@ type launchDarklyManager struct {
 }
 
 func Init(cfg *v1.Config) {
-	var platformName string
-	if !cfg.IsTest {
-		currentContext, err := cfg.FindContext(cfg.CurrentContext)
-		if err != nil {
-			log.CliLogger.Warnf("Current context %s not found", cfg.CurrentContext)
-		} else {
-			platformName = currentContext.PlatformName
-		}
-	}
+	platformName := cfg.Context().GetPlatform().GetName()
 	cliBasePath := fmt.Sprintf(baseURL, auth.CCloudURL, cliProdEnvClientId)
 	if cfg.IsTest {
 		cliBasePath = fmt.Sprintf(baseURL, testserver.TestCloudUrl.String(), "1234")


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok
   * no: DO NOT MERGE until the required features are live in prod  

What
----
Now the CLI automatically uses the LaunchDarkly Test environment to fetch feature flags when the user is not logged into the prod environment. Setting the `XX_LAUNCH_DARKLY_TEST_ENV` variable is now no longer needed.

References
----------
https://confluentinc.atlassian.net/browse/CLI-2624

Test & Review
-------------

