### PR TITLE
[CLI-2673] Fix cross-compilation for linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ endif
 
 .PHONY: cli-builder
 cli-builder:
-	go install github.com/goreleaser/goreleaser@$(GORELEASER_VERSION) && \
+	GOOS="" GOARCH="" go install github.com/goreleaser/goreleaser@$(GORELEASER_VERSION) && \
 	TAGS=$(TAGS) CGO_ENABLED=$(CGO_ENABLED) CC=$(CC) CXX=$(CXX) CGO_LDFLAGS=$(CGO_LDFLAGS) GOEXPERIMENT=boringcrypto goreleaser build --config .goreleaser-build.yml --clean --single-target --snapshot
 
 include ./mk-files/semver.mk

--- a/debian/patches/standard_build_layout.patch
+++ b/debian/patches/standard_build_layout.patch
@@ -1,5 +1,5 @@
---- cli/Makefile	2023-06-12 10:41:30.495232513 -0700
-+++ debian/Makefile	2023-05-12 09:01:07.702951301 -0700
+--- cli/Makefile	2023-08-03 13:10:31.860027437 -0700
++++ debian/Makefile	2023-07-07 11:26:58.304825004 -0700
 @@ -1,120 +1,130 @@
 -SHELL := /bin/bash
 -GORELEASER_VERSION := v1.17.2
@@ -63,7 +63,7 @@
 -
 -.PHONY: cli-builder
 -cli-builder:
--	go install github.com/goreleaser/goreleaser@$(GORELEASER_VERSION) && \
+-	GOOS="" GOARCH="" go install github.com/goreleaser/goreleaser@$(GORELEASER_VERSION) && \
 -	TAGS=$(TAGS) CGO_ENABLED=$(CGO_ENABLED) CC=$(CC) CXX=$(CXX) CGO_LDFLAGS=$(CGO_LDFLAGS) GOEXPERIMENT=boringcrypto goreleaser build --config .goreleaser-build.yml --clean --single-target --snapshot
 -
 -include ./mk-files/semver.mk


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
`go install` should always use the GOOS and GOARCH of the current system, so default to `""` for both.