### PR TITLE
[CLI-2674] Panic: confluent api-key store v3.25.1 

### DIFF
--- a/internal/cmd/api-key/command_store.go
+++ b/internal/cmd/api-key/command_store.go
@@ -111,7 +111,7 @@ func (c *command) store(cmd *cobra.Command, args []string) error {
 		return errors.CatchApiKeyForbiddenAccessError(err, getOperation, httpResp)
 	}
 
-	apiKeyIsValidForTargetCluster := cluster.ID == apiKey.Spec.Resource.GetId()
+	apiKeyIsValidForTargetCluster := cluster.ID == apiKey.GetSpec().Resource.GetId()
 
 	if !apiKeyIsValidForTargetCluster {
 		return errors.NewErrorWithSuggestions(errors.APIKeyNotValidForClusterErrorMsg, errors.APIKeyNotValidForClusterSuggestions)


### PR DESCRIPTION
Release Notes
-------------
Bug Fixes
- fixing panic with `api-key store --resource`

Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok
   * no: DO NOT MERGE until the required features are live in prod  

What
----
Previous change to this line was not using panic-safe `GetSpec()` method.

References
----------
https://confluentinc.atlassian.net/browse/CLI-2674