### PR TITLE
Add plaintext support for `kafka topic consume` with unauthenticated Schema Registry

### DIFF
--- a/internal/cmd/asyncapi/command_export.go
+++ b/internal/cmd/asyncapi/command_export.go
@@ -106,7 +106,7 @@ func (c *command) export(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return err
 	}
-	accountDetails, err := c.getAccountDetails(flags)
+	accountDetails, err := c.getAccountDetails(cmd, flags)
 	if err != nil {
 		return err
 	}
@@ -208,13 +208,13 @@ func (c *command) getChannelDetails(details *accountDetails, flags *flags) error
 	return nil
 }
 
-func (c *command) getAccountDetails(flags *flags) (*accountDetails, error) {
+func (c *command) getAccountDetails(cmd *cobra.Command, flags *flags) (*accountDetails, error) {
 	details := new(accountDetails)
 	if err := c.getClusterDetails(details, flags); err != nil {
 		return nil, err
 	}
 
-	srClient, err := c.GetSchemaRegistryClient()
+	srClient, err := c.GetSchemaRegistryClient(cmd)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/cmd/asyncapi/command_import.go
+++ b/internal/cmd/asyncapi/command_import.go
@@ -179,7 +179,7 @@ func (c *command) asyncapiImport(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	details, err := c.getAccountDetails(&flags{kafkaApiKey: flagsImp.kafkaApiKey})
+	details, err := c.getAccountDetails(cmd, &flags{kafkaApiKey: flagsImp.kafkaApiKey})
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/kafka/command_topic_consume.go
+++ b/internal/cmd/kafka/command_topic_consume.go
@@ -164,7 +164,7 @@ func (c *command) consume(cmd *cobra.Command, args []string) error {
 	var srClient *schemaregistry.Client
 	if valueFormat != "string" {
 		// Only initialize client and context when schema is specified.
-		srClient, err = c.GetSchemaRegistryClient()
+		srClient, err = c.GetSchemaRegistryClient(cmd)
 		if err != nil {
 			if err.Error() == errors.NotLoggedInErrorMsg {
 				return new(errors.SRNotAuthenticatedError)

--- a/internal/cmd/kafka/command_topic_consume_onprem.go
+++ b/internal/cmd/kafka/command_topic_consume_onprem.go
@@ -55,7 +55,6 @@ func (c *command) newConsumeCommandOnPrem() *cobra.Command {
 
 	cobra.CheckErr(cmd.MarkFlagFilename("config-file", "avsc", "json"))
 	cobra.CheckErr(cmd.MarkFlagRequired("bootstrap"))
-	cobra.CheckErr(cmd.MarkFlagRequired("ca-location"))
 
 	cmd.MarkFlagsMutuallyExclusive("config", "config-file")
 	cmd.MarkFlagsMutuallyExclusive("from-beginning", "offset")
@@ -147,11 +146,7 @@ func (c *command) consumeOnPrem(cmd *cobra.Command, args []string) error {
 
 	var srClient *schemaregistry.Client
 	if valueFormat != "string" {
-		// Only initialize client and context when schema is specified.
-		if c.Context.State == nil { // require log-in to use oauthbearer token
-			return errors.NewErrorWithSuggestions(errors.NotLoggedInErrorMsg, errors.AuthTokenSuggestions)
-		}
-		srClient, err = c.GetSchemaRegistryClient()
+		srClient, err = c.GetSchemaRegistryClient(cmd)
 		if err != nil {
 			return err
 		}

--- a/internal/cmd/kafka/command_topic_produce.go
+++ b/internal/cmd/kafka/command_topic_produce.go
@@ -170,7 +170,7 @@ func (c *command) registerSchema(cmd *cobra.Command, schemaCfg *sr.RegisterSchem
 	referencePathMap := map[string]string{}
 
 	if len(schemaCfg.SchemaPath) > 0 {
-		srClient, err := c.GetSchemaRegistryClient()
+		srClient, err := c.GetSchemaRegistryClient(cmd)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -306,7 +306,7 @@ func (c *command) initSchemaAndGetInfo(cmd *cobra.Command, topic, mode string) (
 	metaInfo := []byte{}
 
 	if schemaId.IsSet() {
-		srClient, err := c.GetSchemaRegistryClient()
+		srClient, err := c.GetSchemaRegistryClient(cmd)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/internal/cmd/kafka/command_topic_produce_onprem.go
+++ b/internal/cmd/kafka/command_topic_produce_onprem.go
@@ -230,7 +230,7 @@ func (c *command) registerSchemaOnPrem(cmd *cobra.Command, schemaCfg *sr.Registe
 			return nil, nil, errors.NewErrorWithSuggestions(errors.NotLoggedInErrorMsg, errors.AuthTokenSuggestions)
 		}
 
-		srClient, err := c.GetSchemaRegistryClient()
+		srClient, err := c.GetSchemaRegistryClient(cmd)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/internal/cmd/kafka/confluent_kafka_configs.go
+++ b/internal/cmd/kafka/confluent_kafka_configs.go
@@ -82,13 +82,11 @@ func getConsumerConfigMap(group string, kafka *configv1.KafkaClusterConfig, clie
 	return configMap, nil
 }
 
-func getOnPremCommonConfig(clientID, bootstrap, caLocation string) *ckafka.ConfigMap {
+func getOnPremCommonConfig(clientID, bootstrap string) *ckafka.ConfigMap {
 	return &ckafka.ConfigMap{
 		"ssl.endpoint.identification.algorithm": "https",
 		"client.id":                             clientID,
 		"bootstrap.servers":                     bootstrap,
-		"enable.ssl.certificate.verification":   true,
-		"ssl.ca.location":                       caLocation,
 	}
 }
 
@@ -97,16 +95,31 @@ func getOnPremProducerConfigMap(cmd *cobra.Command, clientID string) (*ckafka.Co
 	if err != nil {
 		return nil, err
 	}
-	caLocation, err := cmd.Flags().GetString("ca-location")
+
+	configMap := getOnPremCommonConfig(clientID, bootstrap)
+
+	protocol, err := cmd.Flags().GetString("protocol")
 	if err != nil {
 		return nil, err
 	}
-	configMap := getOnPremCommonConfig(clientID, bootstrap, caLocation)
+	if protocol == "SSL" || protocol == "SASL_SSL" {
+		caLocation, err := cmd.Flags().GetString("ca-location")
+		if err != nil {
+			return nil, err
+		}
 
-	if err := configMap.SetKey("retry.backoff.ms", "250"); err != nil {
+		if err := configMap.SetKey("enable.ssl.certificate.verification", true); err != nil {
+			return nil, err
+		}
+		if err := configMap.SetKey("ssl.ca.location", caLocation); err != nil {
+			return nil, err
+		}
+	}
+
+	if err := configMap.SetKey("retry.backoff.ms", 250); err != nil {
 		return nil, err
 	}
-	if err := configMap.SetKey("request.timeout.ms", "10000"); err != nil {
+	if err := configMap.SetKey("request.timeout.ms", 10000); err != nil {
 		return nil, err
 	}
 
@@ -122,11 +135,26 @@ func getOnPremConsumerConfigMap(cmd *cobra.Command, clientID string) (*ckafka.Co
 	if err != nil {
 		return nil, err
 	}
-	caLocation, err := cmd.Flags().GetString("ca-location")
+
+	configMap := getOnPremCommonConfig(clientID, bootstrap)
+
+	protocol, err := cmd.Flags().GetString("protocol")
 	if err != nil {
 		return nil, err
 	}
-	configMap := getOnPremCommonConfig(clientID, bootstrap, caLocation)
+	if protocol == "SSL" || protocol == "SASL_SSL" {
+		caLocation, err := cmd.Flags().GetString("ca-location")
+		if err != nil {
+			return nil, err
+		}
+
+		if err := configMap.SetKey("enable.ssl.certificate.verification", true); err != nil {
+			return nil, err
+		}
+		if err := configMap.SetKey("ssl.ca.location", caLocation); err != nil {
+			return nil, err
+		}
+	}
 
 	group, err := cmd.Flags().GetString("group")
 	if err != nil {
@@ -158,6 +186,11 @@ func setProtocolConfig(cmd *cobra.Command, configMap *ckafka.ConfigMap) (*ckafka
 		return nil, err
 	}
 	switch protocol {
+	case "PLAINTEXT":
+		configMap, err = setPlaintextConfig(configMap)
+		if err != nil {
+			return nil, err
+		}
 	case "SSL":
 		configMap, err = setSSLConfig(cmd, configMap)
 		if err != nil {
@@ -170,6 +203,13 @@ func setProtocolConfig(cmd *cobra.Command, configMap *ckafka.ConfigMap) (*ckafka
 		}
 	default:
 		return nil, errors.NewErrorWithSuggestions(fmt.Errorf(errors.InvalidSecurityProtocolErrorMsg, protocol).Error(), errors.OnPremConfigGuideSuggestions)
+	}
+	return configMap, nil
+}
+
+func setPlaintextConfig(configMap *ckafka.ConfigMap) (*ckafka.ConfigMap, error) {
+	if err := configMap.SetKey("security.protocol", "PLAINTEXT"); err != nil {
+		return nil, err
 	}
 	return configMap, nil
 }

--- a/internal/cmd/schema-registry/command_cluster_describe.go
+++ b/internal/cmd/schema-registry/command_cluster_describe.go
@@ -85,7 +85,7 @@ func (c *command) clusterDescribe(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	client, err := c.GetSchemaRegistryClient()
+	client, err := c.GetSchemaRegistryClient(cmd)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/schema-registry/command_cluster_update.go
+++ b/internal/cmd/schema-registry/command_cluster_update.go
@@ -71,14 +71,14 @@ func (c *command) clusterUpdate(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 	if mode != "" {
-		return c.updateTopLevelMode(mode)
+		return c.updateTopLevelMode(cmd, mode)
 	}
 
 	return errors.New(errors.CompatibilityOrModeErrorMsg)
 }
 
 func (c *command) updateTopLevelCompatibility(cmd *cobra.Command) error {
-	client, err := c.GetSchemaRegistryClient()
+	client, err := c.GetSchemaRegistryClient(cmd)
 	if err != nil {
 		return err
 	}
@@ -160,8 +160,8 @@ func (c *command) getConfigUpdateRequest(cmd *cobra.Command) (srsdk.ConfigUpdate
 	return req, nil
 }
 
-func (c *command) updateTopLevelMode(mode string) error {
-	client, err := c.GetSchemaRegistryClient()
+func (c *command) updateTopLevelMode(cmd *cobra.Command, mode string) error {
+	client, err := c.GetSchemaRegistryClient(cmd)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/schema-registry/command_compatibility_validate.go
+++ b/internal/cmd/schema-registry/command_compatibility_validate.go
@@ -98,7 +98,7 @@ func (c *command) compatibilityValidate(cmd *cobra.Command, args []string) error
 		return err
 	}
 
-	client, err := c.GetSchemaRegistryClient()
+	client, err := c.GetSchemaRegistryClient(cmd)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/schema-registry/command_config_describe.go
+++ b/internal/cmd/schema-registry/command_config_describe.go
@@ -72,7 +72,7 @@ func (c *command) newConfigDescribeCommand(cfg *v1.Config) *cobra.Command {
 }
 
 func (c *command) configDescribe(cmd *cobra.Command, args []string) error {
-	client, err := c.GetSchemaRegistryClient()
+	client, err := c.GetSchemaRegistryClient(cmd)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/schema-registry/command_exporter_create.go
+++ b/internal/cmd/schema-registry/command_exporter_create.go
@@ -64,7 +64,7 @@ func (c *command) newExporterCreateCommand(cfg *v1.Config) *cobra.Command {
 }
 
 func (c *command) exporterCreate(cmd *cobra.Command, args []string) error {
-	client, err := c.GetSchemaRegistryClient()
+	client, err := c.GetSchemaRegistryClient(cmd)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/schema-registry/command_exporter_delete.go
+++ b/internal/cmd/schema-registry/command_exporter_delete.go
@@ -45,7 +45,7 @@ func (c *command) newExporterDeleteCommand(cfg *v1.Config) *cobra.Command {
 }
 
 func (c *command) exporterDelete(cmd *cobra.Command, args []string) error {
-	client, err := c.GetSchemaRegistryClient()
+	client, err := c.GetSchemaRegistryClient(cmd)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/schema-registry/command_exporter_describe.go
+++ b/internal/cmd/schema-registry/command_exporter_describe.go
@@ -52,7 +52,7 @@ func (c *command) newExporterDescribeCommand(cfg *v1.Config) *cobra.Command {
 }
 
 func (c *command) exporterDescribe(cmd *cobra.Command, args []string) error {
-	client, err := c.GetSchemaRegistryClient()
+	client, err := c.GetSchemaRegistryClient(cmd)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/schema-registry/command_exporter_getconfig.go
+++ b/internal/cmd/schema-registry/command_exporter_getconfig.go
@@ -39,7 +39,7 @@ func (c *command) newExporterGetConfigCommand(cfg *v1.Config) *cobra.Command {
 }
 
 func (c *command) exporterGetConfig(cmd *cobra.Command, args []string) error {
-	client, err := c.GetSchemaRegistryClient()
+	client, err := c.GetSchemaRegistryClient(cmd)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/schema-registry/command_exporter_getstatus.go
+++ b/internal/cmd/schema-registry/command_exporter_getstatus.go
@@ -49,7 +49,7 @@ func (c *command) newExporterGetStatusCommand(cfg *v1.Config) *cobra.Command {
 }
 
 func (c *command) exporterGetStatus(cmd *cobra.Command, args []string) error {
-	client, err := c.GetSchemaRegistryClient()
+	client, err := c.GetSchemaRegistryClient(cmd)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/schema-registry/command_exporter_list.go
+++ b/internal/cmd/schema-registry/command_exporter_list.go
@@ -43,7 +43,7 @@ func (c *command) newExporterListCommand(cfg *v1.Config) *cobra.Command {
 }
 
 func (c *command) exporterList(cmd *cobra.Command, _ []string) error {
-	client, err := c.GetSchemaRegistryClient()
+	client, err := c.GetSchemaRegistryClient(cmd)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/schema-registry/command_exporter_pause.go
+++ b/internal/cmd/schema-registry/command_exporter_pause.go
@@ -40,7 +40,7 @@ func (c *command) newExporterPauseCommand(cfg *v1.Config) *cobra.Command {
 }
 
 func (c *command) exporterPause(cmd *cobra.Command, args []string) error {
-	client, err := c.GetSchemaRegistryClient()
+	client, err := c.GetSchemaRegistryClient(cmd)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/schema-registry/command_exporter_reset.go
+++ b/internal/cmd/schema-registry/command_exporter_reset.go
@@ -40,7 +40,7 @@ func (c *command) newExporterResetCommand(cfg *v1.Config) *cobra.Command {
 }
 
 func (c *command) exporterReset(cmd *cobra.Command, args []string) error {
-	client, err := c.GetSchemaRegistryClient()
+	client, err := c.GetSchemaRegistryClient(cmd)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/schema-registry/command_exporter_resume.go
+++ b/internal/cmd/schema-registry/command_exporter_resume.go
@@ -40,7 +40,7 @@ func (c *command) newExporterResumeCommand(cfg *v1.Config) *cobra.Command {
 }
 
 func (c *command) exporterResume(cmd *cobra.Command, args []string) error {
-	client, err := c.GetSchemaRegistryClient()
+	client, err := c.GetSchemaRegistryClient(cmd)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/schema-registry/command_exporter_update.go
+++ b/internal/cmd/schema-registry/command_exporter_update.go
@@ -66,7 +66,7 @@ func (c *command) newExporterUpdateCommand(cfg *v1.Config) *cobra.Command {
 }
 
 func (c *command) exporterUpdate(cmd *cobra.Command, args []string) error {
-	client, err := c.GetSchemaRegistryClient()
+	client, err := c.GetSchemaRegistryClient(cmd)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/schema-registry/command_schema_create.go
+++ b/internal/cmd/schema-registry/command_schema_create.go
@@ -153,7 +153,7 @@ func (c *command) schemaCreate(cmd *cobra.Command, _ []string) error {
 		}
 	}
 
-	client, err := c.GetSchemaRegistryClient()
+	client, err := c.GetSchemaRegistryClient(cmd)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/schema-registry/command_schema_delete.go
+++ b/internal/cmd/schema-registry/command_schema_delete.go
@@ -63,7 +63,7 @@ func (c *command) newSchemaDeleteCommand(cfg *v1.Config) *cobra.Command {
 }
 
 func (c *command) schemaDelete(cmd *cobra.Command, _ []string) error {
-	client, err := c.GetSchemaRegistryClient()
+	client, err := c.GetSchemaRegistryClient(cmd)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/schema-registry/command_schema_describe.go
+++ b/internal/cmd/schema-registry/command_schema_describe.go
@@ -88,7 +88,7 @@ func (c *command) schemaDescribe(cmd *cobra.Command, args []string) error {
 		return errors.New(errors.SchemaOrSubjectErrorMsg)
 	}
 
-	client, err := c.GetSchemaRegistryClient()
+	client, err := c.GetSchemaRegistryClient(cmd)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/schema-registry/command_schema_list.go
+++ b/internal/cmd/schema-registry/command_schema_list.go
@@ -70,7 +70,7 @@ func (c *command) newSchemaListCommand(cfg *v1.Config) *cobra.Command {
 }
 
 func (c *command) schemaList(cmd *cobra.Command, _ []string) error {
-	client, err := c.GetSchemaRegistryClient()
+	client, err := c.GetSchemaRegistryClient(cmd)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/schema-registry/command_subject_describe.go
+++ b/internal/cmd/schema-registry/command_subject_describe.go
@@ -57,7 +57,7 @@ func (c *command) newSubjectDescribeCommand(cfg *v1.Config) *cobra.Command {
 }
 
 func (c *command) subjectDescribe(cmd *cobra.Command, args []string) error {
-	client, err := c.GetSchemaRegistryClient()
+	client, err := c.GetSchemaRegistryClient(cmd)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/schema-registry/command_subject_list.go
+++ b/internal/cmd/schema-registry/command_subject_list.go
@@ -48,7 +48,7 @@ func (c *command) newSubjectListCommand(cfg *v1.Config) *cobra.Command {
 }
 
 func (c *command) subjectList(cmd *cobra.Command, _ []string) error {
-	client, err := c.GetSchemaRegistryClient()
+	client, err := c.GetSchemaRegistryClient(cmd)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/schema-registry/command_subject_update.go
+++ b/internal/cmd/schema-registry/command_subject_update.go
@@ -74,7 +74,7 @@ func (c *command) newSubjectUpdateCommand(cfg *v1.Config) *cobra.Command {
 func (c *command) subjectUpdate(cmd *cobra.Command, args []string) error {
 	subject := args[0]
 
-	client, err := c.GetSchemaRegistryClient()
+	client, err := c.GetSchemaRegistryClient(cmd)
 	if err != nil {
 		return err
 	}

--- a/internal/pkg/cmd/flags.go
+++ b/internal/pkg/cmd/flags.go
@@ -270,8 +270,9 @@ func AddPrincipalFlag(cmd *cobra.Command, command *AuthenticatedCLICommand) {
 }
 
 func AddProtocolFlag(cmd *cobra.Command) {
-	cmd.Flags().String("protocol", "SSL", fmt.Sprintf("Specify the broker communication protocol as %s.", utils.ArrayToCommaDelimitedString(kafka.Protocols, "or")))
-	RegisterFlagCompletionFunc(cmd, "protocol", func(_ *cobra.Command, _ []string) []string { return kafka.Protocols })
+	protocols := []string{"PLAINTEXT", "SASL_SSL", "SSL"}
+	cmd.Flags().String("protocol", "SSL", fmt.Sprintf("Specify the broker communication protocol as %s.", utils.ArrayToCommaDelimitedString(protocols, "or")))
+	RegisterFlagCompletionFunc(cmd, "protocol", func(_ *cobra.Command, _ []string) []string { return protocols })
 }
 
 func AddProviderFlag(cmd *cobra.Command, command *AuthenticatedCLICommand) {

--- a/internal/pkg/cmd/flags.go
+++ b/internal/pkg/cmd/flags.go
@@ -231,12 +231,10 @@ func AddMechanismFlag(cmd *cobra.Command, command *AuthenticatedCLICommand) {
 
 func autocompleteMechanisms(protocol string) []string {
 	switch protocol {
-	default:
-		return nil
-	case "SSL":
-		return nil
 	case "SASL_SSL":
 		return []string{"PLAIN", "OAUTHBEARER"}
+	default:
+		return nil
 	}
 }
 
@@ -272,7 +270,7 @@ func AddPrincipalFlag(cmd *cobra.Command, command *AuthenticatedCLICommand) {
 }
 
 func AddProtocolFlag(cmd *cobra.Command) {
-	cmd.Flags().String("protocol", "SSL", "Security protocol used to communicate with brokers.")
+	cmd.Flags().String("protocol", "SSL", fmt.Sprintf("Specify the broker communication protocol as %s.", utils.ArrayToCommaDelimitedString(kafka.Protocols, "or")))
 	RegisterFlagCompletionFunc(cmd, "protocol", func(_ *cobra.Command, _ []string) []string { return kafka.Protocols })
 }
 

--- a/internal/pkg/kafka/protocol.go
+++ b/internal/pkg/kafka/protocol.go
@@ -1,3 +1,0 @@
-package kafka
-
-var Protocols = []string{"SSL", "SASL_SSL"}

--- a/internal/pkg/schema-registry/client.go
+++ b/internal/pkg/schema-registry/client.go
@@ -11,7 +11,14 @@ type Client struct {
 	context context.Context
 }
 
-func NewClient(configuration *srsdk.Configuration, authToken string) *Client {
+func NewClient(configuration *srsdk.Configuration) *Client {
+	return &Client{
+		APIClient: srsdk.NewAPIClient(configuration),
+		context:   context.Background(),
+	}
+}
+
+func NewClientWithToken(configuration *srsdk.Configuration, authToken string) *Client {
 	return &Client{
 		APIClient: srsdk.NewAPIClient(configuration),
 		context:   context.WithValue(context.Background(), srsdk.ContextAccessToken, authToken),

--- a/test/fixtures/output/kafka/topic/consume-help-onprem.golden
+++ b/test/fixtures/output/kafka/topic/consume-help-onprem.golden
@@ -22,7 +22,7 @@ Flags:
       --cert-location string              Path to client's public key (PEM) used for SSL authentication.
       --key-location string               Path to client's private key (PEM) used for SSL authentication.
       --key-password string               Private key passphrase for SSL authentication.
-      --protocol string                   Specify the broker communication protocol as "SSL" or "SASL_SSL". (default "SSL")
+      --protocol string                   Specify the broker communication protocol as "PLAINTEXT", "SASL_SSL", or "SSL". (default "SSL")
       --sasl-mechanism string             SASL_SSL mechanism used for authentication. (default "PLAIN")
       --group string                      Consumer group ID.
   -b, --from-beginning                    Consume from beginning of the topic.

--- a/test/fixtures/output/kafka/topic/consume-help-onprem.golden
+++ b/test/fixtures/output/kafka/topic/consume-help-onprem.golden
@@ -16,13 +16,13 @@ Consume message from topic "my_topic" with SASL_SSL/OAUTHBEARER protocol enabled
 
 Flags:
       --bootstrap string                  REQUIRED: Comma-separated list of broker hosts, each formatted as "host" or "host:port".
-      --ca-location string                REQUIRED: File or directory path to one or more CA certificates for verifying the broker's key with SSL.
+      --ca-location string                File or directory path to one or more CA certificates for verifying the broker's key with SSL.
       --username string                   SASL_SSL username for use with PLAIN mechanism.
       --password string                   SASL_SSL password for use with PLAIN mechanism.
       --cert-location string              Path to client's public key (PEM) used for SSL authentication.
       --key-location string               Path to client's private key (PEM) used for SSL authentication.
       --key-password string               Private key passphrase for SSL authentication.
-      --protocol string                   Security protocol used to communicate with brokers. (default "SSL")
+      --protocol string                   Specify the broker communication protocol as "SSL" or "SASL_SSL". (default "SSL")
       --sasl-mechanism string             SASL_SSL mechanism used for authentication. (default "PLAIN")
       --group string                      Consumer group ID.
   -b, --from-beginning                    Consume from beginning of the topic.

--- a/test/fixtures/output/kafka/topic/produce-help-onprem.golden
+++ b/test/fixtures/output/kafka/topic/produce-help-onprem.golden
@@ -22,7 +22,7 @@ Flags:
       --cert-location string              Path to client's public key (PEM) used for SSL authentication.
       --key-location string               Path to client's private key (PEM) used for SSL authentication.
       --key-password string               Private key passphrase for SSL authentication.
-      --protocol string                   Security protocol used to communicate with brokers. (default "SSL")
+      --protocol string                   Specify the broker communication protocol as "SSL" or "SASL_SSL". (default "SSL")
       --sasl-mechanism string             SASL_SSL mechanism used for authentication. (default "PLAIN")
       --key-schema string                 The filepath of the message key schema.
       --schema string                     The filepath of the message value schema.

--- a/test/fixtures/output/kafka/topic/produce-help-onprem.golden
+++ b/test/fixtures/output/kafka/topic/produce-help-onprem.golden
@@ -22,7 +22,7 @@ Flags:
       --cert-location string              Path to client's public key (PEM) used for SSL authentication.
       --key-location string               Path to client's private key (PEM) used for SSL authentication.
       --key-password string               Private key passphrase for SSL authentication.
-      --protocol string                   Specify the broker communication protocol as "SSL" or "SASL_SSL". (default "SSL")
+      --protocol string                   Specify the broker communication protocol as "PLAINTEXT", "SASL_SSL", or "SSL". (default "SSL")
       --sasl-mechanism string             SASL_SSL mechanism used for authentication. (default "PLAIN")
       --key-schema string                 The filepath of the message key schema.
       --schema string                     The filepath of the message value schema.


### PR DESCRIPTION
Release Notes
-------------
New Features
- Support `--protocol PLAINTEXT` in `confluent kafka topic consume`
- Enable Schema Registry to be used without authentication on-premises, for the purpose of demos 

Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
Both of these tasks are needed before we can use `confluent` in https://developer.confluent.io/tutorials/create-stateful-aggregation-count/flinksql.html, instead of `kafka-avro-console-consumer` and `kafka-configs`.

Test & Review
-------------
Manually tested in demo.