### PR TITLE
Fix api secret decryption issue on Windows

### DIFF
--- a/internal/pkg/config/v1/api_key_pair.go
+++ b/internal/pkg/config/v1/api_key_pair.go
@@ -16,7 +16,7 @@ type APIKeyPair struct {
 }
 
 func (c *APIKeyPair) DecryptSecret() error {
-	if strings.HasPrefix(c.Secret, secret.AesGcm) && (c.Salt != nil || runtime.GOOS == "windows") {
+	if (strings.HasPrefix(c.Secret, secret.AesGcm) && c.Salt != nil) || runtime.GOOS == "windows" {
 		decryptedSecret, err := secret.Decrypt(c.Key, c.Secret, c.Salt, c.Nonce)
 		if err != nil {
 			return err


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- PLACEHOLDER

New Features
- PLACEHOLDER

Bug Fixes
- Fix authentication issue in `confluent kafka topic [produce | consume]` on Windows

Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
Encrypted api secrets don't have an `AesGcm` prefix, so we shouldn't check for that before decrypting secrets on Windows.

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
Manual testing on Windows, Linux, and MacOS.

Open Questions / Follow-ups
---------------------------
Next: fix an issue on Windows with `confluent kafka topic produce` where `Ctrl-C` causes a panic and `Ctrl-D` does nothing. In other words, the only way to exit out of `consume` on Windows is to panic.

This doesn't appear to be harmful, but we definitely want to exit gracefully.
