### PR TITLE
Add base to goreleaser brews

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -292,6 +292,10 @@ brews:
       branch: "cli-{{ .Version }}"
       pull_request:
         enabled: true
+        base:
+          owner: confluentinc
+          name: homebrew-tap
+          branch: master
     url_template: "https://s3-us-west-2.amazonaws.com/confluent.cloud/confluent-cli/archives/{{ .Version }}/{{ .ArtifactName }}"
     homepage: https://docs.confluent.io/confluent-cli/current/overview.html
     description: CLI for Confluent Cloud and Confluent Platform


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- PLACEHOLDER

New Features
- PLACEHOLDER

Bug Fixes
- PLACEHOLDER

Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
Recently the `gorelease` make target has been failing with
```
error checking for default branch            projectID= statusCode=404 error=GET https://api.github.com/repos//: 404 Not Found []
```
Looking at the goreleaser docs, it looks like 1.19 introduced a `base` section under `pull_requests`. I've added that section to our goreleaser file with the base branch being `master`.

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
Will try it out on next release...

Open Questions / Follow-ups
---------------------------
<!--
Optional: Anything open to discussion for the reviewer, out of scope of this PR, or follow-ups.
-->
