### PR TITLE
Remove extraneous GET requests in `confluent api-key list`

### DIFF
--- a/internal/cmd/api-key/command_describe.go
+++ b/internal/cmd/api-key/command_describe.go
@@ -65,7 +65,8 @@ func (c *command) describe(cmd *cobra.Command, args []string) error {
 		serviceAccountsMap := getServiceAccountsMap(serviceAccounts)
 
 		ownerId = apiKey.Spec.Owner.GetId()
-		email = c.getEmail(ownerId, resourceIdToUserIdMap, usersMap, serviceAccountsMap)
+		auditLog := c.getAuditLog()
+		email = c.getEmail(ownerId, auditLog, resourceIdToUserIdMap, usersMap, serviceAccountsMap)
 	}
 
 	resources := []apikeysv2.ObjectReference{apiKey.Spec.GetResource()}

--- a/internal/cmd/api-key/command_describe.go
+++ b/internal/cmd/api-key/command_describe.go
@@ -65,8 +65,8 @@ func (c *command) describe(cmd *cobra.Command, args []string) error {
 		serviceAccountsMap := getServiceAccountsMap(serviceAccounts)
 
 		ownerId = apiKey.Spec.Owner.GetId()
-		auditLog := c.getAuditLog()
-		email = c.getEmail(ownerId, auditLog, resourceIdToUserIdMap, usersMap, serviceAccountsMap)
+		auditLogServiceAccountId := c.getAuditLogServiceAccountId()
+		email = c.getEmail(ownerId, auditLogServiceAccountId, resourceIdToUserIdMap, usersMap, serviceAccountsMap)
 	}
 
 	resources := []apikeysv2.ObjectReference{apiKey.Spec.GetResource()}

--- a/internal/cmd/api-key/command_list.go
+++ b/internal/cmd/api-key/command_list.go
@@ -105,6 +105,8 @@ func (c *command) list(cmd *cobra.Command, _ []string) error {
 	serviceAccountsMap := getServiceAccountsMap(serviceAccounts)
 	usersMap := getUsersMap(allUsers)
 
+	auditLog := c.getAuditLog()
+
 	list := output.NewList(cmd)
 	for _, apiKey := range apiKeys {
 		// ignore keys owned by Confluent-internal user (healthcheck, etc)
@@ -113,8 +115,7 @@ func (c *command) list(cmd *cobra.Command, _ []string) error {
 		}
 
 		ownerId := apiKey.Spec.Owner.GetId()
-		email := c.getEmail(ownerId, resourceIdToUserIdMap, usersMap, serviceAccountsMap)
-
+		email := c.getEmail(ownerId, auditLog, resourceIdToUserIdMap, usersMap, serviceAccountsMap)
 		resources := []apikeysv2.ObjectReference{apiKey.Spec.GetResource()}
 
 		// Check if multicluster keys are enabled, and if so check the resources field
@@ -164,17 +165,15 @@ func mapResourceIdToUserId(users []*ccloudv1.User) map[string]int32 {
 	return idMap
 }
 
-func (c *command) getEmail(resourceId string, resourceIdToUserIdMap map[string]int32, usersMap map[int32]*ccloudv1.User, serviceAccountsMap map[string]bool) string {
+func (c *command) getEmail(resourceId string, auditLog *ccloudv1.AuditLog, resourceIdToUserIdMap map[string]int32, usersMap map[int32]*ccloudv1.User, serviceAccountsMap map[string]bool) string {
 	if _, ok := serviceAccountsMap[resourceId]; ok {
 		return "<service account>"
 	}
 
 	userId := resourceIdToUserIdMap[resourceId]
 
-	if user, err := c.Client.Auth.User(); err == nil {
-		if auditLog := user.GetOrganization().GetAuditLog(); auditLog != nil && auditLog.GetServiceAccountId() == userId {
-			return "<auditlog service account>"
-		}
+	if auditLog != nil && auditLog.GetServiceAccountId() == userId {
+		return "<auditlog service account>"
 	}
 
 	if user, ok := usersMap[userId]; ok {
@@ -189,4 +188,12 @@ func getApiKeyResourceId(id string) string {
 		return ""
 	}
 	return id
+}
+
+func (c *command) getAuditLog() *ccloudv1.AuditLog {
+	var auditLog *ccloudv1.AuditLog
+	if user, err := c.Client.Auth.User(); err == nil {
+		auditLog = user.GetOrganization().GetAuditLog()
+	}
+	return auditLog
 }


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- PLACEHOLDER

New Features
- PLACEHOLDER

Bug Fixes
- PLACEHOLDER

Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
When listing api keys with `confluent api-key list`, we call `c.getEmail` for every single key.

This function first checks if the user ID belongs to a service account. If it doesn't, then this function will next check if it belongs to an auditlog service account, and it does this by making a request to `/api/me`. It then finally checks if the ID belongs to a user account.

The problem here is that this will make a redundant http request for every key attached to a user, which can be quite a lot. A simple fix is to just move the user account check ahead of the auditlog check, but that still leaves open the possibility of calling this endpoint multiple times.

So this PR moves the request into its own `c.getAuditLog` method, calls it before the loop, and passes the audit log into `c.getEmail`.

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
Verified manually with `--unsafe-trace`that the loop no longer produces a bunch of GET requests to `/api/me`.

Open Questions / Follow-ups
---------------------------
<!--
Optional: Anything open to discussion for the reviewer, out of scope of this PR, or follow-ups.
-->
