### PR TITLE
[CLI-2680] Adding global no-op update error checking + message

### DIFF
--- a/internal/cmd/context/command_update.go
+++ b/internal/cmd/context/command_update.go
@@ -25,6 +25,10 @@ func (c *command) newUpdateCommand() *cobra.Command {
 }
 
 func (c *command) update(cmd *cobra.Command, args []string) error {
+	if err := errors.CheckNoUpdate(cmd.Flags(), "kafka-cluster", "name"); err != nil {
+		return err
+	}
+
 	ctx, err := c.context(args)
 	if err != nil {
 		return err
@@ -37,10 +41,6 @@ func (c *command) update(cmd *cobra.Command, args []string) error {
 
 	kafkaCluster, err := cmd.Flags().GetString("kafka-cluster")
 	if err != nil {
-		return err
-	}
-
-	if err := errors.CheckNoOpUpdate(cmd.Flags(), "name", "kafka-cluster"); err != nil {
 		return err
 	}
 

--- a/internal/cmd/context/command_update.go
+++ b/internal/cmd/context/command_update.go
@@ -40,8 +40,8 @@ func (c *command) update(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if name == "" && kafkaCluster == "" {
-		return fmt.Errorf("must use at least one of the following flags: `--name`, `--kafka-cluster`")
+	if err := errors.CheckNoOpUpdate(cmd.Flags(), "name", "kafka-cluster"); err != nil {
+		return err
 	}
 
 	if name != "" && name != ctx.Name {

--- a/internal/cmd/iam/command_groupmapping_update.go
+++ b/internal/cmd/iam/command_groupmapping_update.go
@@ -50,8 +50,8 @@ func (c *groupMappingCommand) update(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if description == "" && name == "" && filter == "" {
-		return errors.New("one of `--description`, `--name`, or `--filter` must be set")
+	if err := errors.CheckNoOpUpdate(cmd.Flags(), "description", "name", "filter"); err != nil {
+		return err
 	}
 
 	update := ssov2.IamV2SsoGroupMapping{Id: ssov2.PtrString(args[0])}

--- a/internal/cmd/iam/command_groupmapping_update.go
+++ b/internal/cmd/iam/command_groupmapping_update.go
@@ -35,6 +35,10 @@ func (c *groupMappingCommand) newUpdateCommand() *cobra.Command {
 }
 
 func (c *groupMappingCommand) update(cmd *cobra.Command, args []string) error {
+	if err := errors.CheckNoUpdate(cmd.Flags(), "description", "name", "filter"); err != nil {
+		return err
+	}
+
 	name, err := cmd.Flags().GetString("name")
 	if err != nil {
 		return err
@@ -47,10 +51,6 @@ func (c *groupMappingCommand) update(cmd *cobra.Command, args []string) error {
 
 	filter, err := cmd.Flags().GetString("filter")
 	if err != nil {
-		return err
-	}
-
-	if err := errors.CheckNoOpUpdate(cmd.Flags(), "description", "name", "filter"); err != nil {
 		return err
 	}
 

--- a/internal/cmd/iam/command_pool_update.go
+++ b/internal/cmd/iam/command_pool_update.go
@@ -39,6 +39,16 @@ func (c *identityPoolCommand) newUpdateCommand() *cobra.Command {
 }
 
 func (c *identityPoolCommand) update(cmd *cobra.Command, args []string) error {
+	flagsToCheck := []string{
+		"description",
+		"filter",
+		"identity-claim",
+		"name",
+	}
+	if err := errors.CheckNoUpdate(cmd.Flags(), flagsToCheck...); err != nil {
+		return err
+	}
+
 	description, err := cmd.Flags().GetString("description")
 	if err != nil {
 		return err
@@ -61,10 +71,6 @@ func (c *identityPoolCommand) update(cmd *cobra.Command, args []string) error {
 
 	identityClaim, err := cmd.Flags().GetString("identity-claim")
 	if err != nil {
-		return err
-	}
-
-	if err := errors.CheckNoOpUpdate(cmd.Flags(), "description", "name", "filter", "identity-claim"); err != nil {
 		return err
 	}
 

--- a/internal/cmd/iam/command_pool_update.go
+++ b/internal/cmd/iam/command_pool_update.go
@@ -64,8 +64,8 @@ func (c *identityPoolCommand) update(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if description == "" && filter == "" && identityClaim == "" && name == "" {
-		return errors.New("one of `--description`, `--filter`, `--identity-claim`, or `--name` must be set")
+	if err := errors.CheckNoOpUpdate(cmd.Flags(), "description", "name", "filter", "identity-claim"); err != nil {
+		return err
 	}
 
 	identityPoolId := args[0]

--- a/internal/cmd/iam/command_pool_update.go
+++ b/internal/cmd/iam/command_pool_update.go
@@ -39,13 +39,13 @@ func (c *identityPoolCommand) newUpdateCommand() *cobra.Command {
 }
 
 func (c *identityPoolCommand) update(cmd *cobra.Command, args []string) error {
-	flagsToCheck := []string{
+	flags := []string{
 		"description",
 		"filter",
 		"identity-claim",
 		"name",
 	}
-	if err := errors.CheckNoUpdate(cmd.Flags(), flagsToCheck...); err != nil {
+	if err := errors.CheckNoUpdate(cmd.Flags(), flags...); err != nil {
 		return err
 	}
 

--- a/internal/cmd/iam/command_provider_update.go
+++ b/internal/cmd/iam/command_provider_update.go
@@ -44,8 +44,8 @@ func (c *identityProviderCommand) update(cmd *cobra.Command, args []string) erro
 		return err
 	}
 
-	if description == "" && name == "" {
-		return errors.New("one of `--description` or `--name` must be set")
+	if err := errors.CheckNoOpUpdate(cmd.Flags(), "name", "description"); err != nil {
+		return err
 	}
 
 	update := identityproviderv2.IamV2IdentityProviderUpdate{Id: identityproviderv2.PtrString(args[0])}

--- a/internal/cmd/iam/command_provider_update.go
+++ b/internal/cmd/iam/command_provider_update.go
@@ -34,6 +34,10 @@ func (c *identityProviderCommand) newUpdateCommand() *cobra.Command {
 }
 
 func (c *identityProviderCommand) update(cmd *cobra.Command, args []string) error {
+	if err := errors.CheckNoUpdate(cmd.Flags(), "description", "name"); err != nil {
+		return err
+	}
+
 	name, err := cmd.Flags().GetString("name")
 	if err != nil {
 		return err
@@ -41,10 +45,6 @@ func (c *identityProviderCommand) update(cmd *cobra.Command, args []string) erro
 
 	description, err := cmd.Flags().GetString("description")
 	if err != nil {
-		return err
-	}
-
-	if err := errors.CheckNoOpUpdate(cmd.Flags(), "name", "description"); err != nil {
 		return err
 	}
 

--- a/internal/cmd/kafka/command_cluster_update.go
+++ b/internal/cmd/kafka/command_cluster_update.go
@@ -43,8 +43,8 @@ func (c *clusterCommand) newUpdateCommand(cfg *config.Config) *cobra.Command {
 }
 
 func (c *clusterCommand) update(cmd *cobra.Command, args []string) error {
-	if err := errors.CheckNoOpUpdate(cmd.Flags(), "cku", "name"); err != nil {
-		return errors.New(errors.NameOrCKUFlagErrorMsg)
+	if err := errors.CheckNoUpdate(cmd.Flags(), "cku", "name"); err != nil {
+		return err
 	}
 
 	environmentId, err := c.Context.EnvironmentId()

--- a/internal/cmd/kafka/command_cluster_update.go
+++ b/internal/cmd/kafka/command_cluster_update.go
@@ -43,7 +43,7 @@ func (c *clusterCommand) newUpdateCommand(cfg *config.Config) *cobra.Command {
 }
 
 func (c *clusterCommand) update(cmd *cobra.Command, args []string) error {
-	if !cmd.Flags().Changed("name") && !cmd.Flags().Changed("cku") {
+	if err := errors.CheckNoOpUpdate(cmd.Flags(), "cku", "name"); err != nil {
 		return errors.New(errors.NameOrCKUFlagErrorMsg)
 	}
 

--- a/internal/cmd/kafka/command_quota_update.go
+++ b/internal/cmd/kafka/command_quota_update.go
@@ -38,7 +38,15 @@ func (c *quotaCommand) newUpdateCommand() *cobra.Command {
 }
 
 func (c *quotaCommand) update(cmd *cobra.Command, args []string) error {
-	if err := errors.CheckNoOpUpdate(cmd.Flags(), "ingress", "egress", "add-principals", "remove-principals", "description", "name"); err != nil {
+	flags := []string{
+		"add-principals",
+		"description",
+		"egress",
+		"ingress",
+		"name",
+		"remove-principals",
+	}
+	if err := errors.CheckNoUpdate(cmd.Flags(), flags...); err != nil {
 		return err
 	}
 	quotaId := args[0]

--- a/internal/cmd/kafka/command_quota_update.go
+++ b/internal/cmd/kafka/command_quota_update.go
@@ -6,6 +6,7 @@ import (
 	kafkaquotas "github.com/confluentinc/ccloud-sdk-go-v2/kafka-quotas/v1"
 
 	pcmd "github.com/confluentinc/cli/internal/pkg/cmd"
+	"github.com/confluentinc/cli/internal/pkg/errors"
 	"github.com/confluentinc/cli/internal/pkg/examples"
 	"github.com/confluentinc/cli/internal/pkg/output"
 	"github.com/confluentinc/cli/internal/pkg/types"
@@ -37,6 +38,9 @@ func (c *quotaCommand) newUpdateCommand() *cobra.Command {
 }
 
 func (c *quotaCommand) update(cmd *cobra.Command, args []string) error {
+	if err := errors.CheckNoOpUpdate(cmd.Flags(), "ingress", "egress", "add-principals", "remove-principals", "description", "name"); err != nil {
+		return err
+	}
 	quotaId := args[0]
 
 	quota, err := c.V2Client.DescribeKafkaQuota(quotaId)

--- a/internal/cmd/pipeline/command_update.go
+++ b/internal/cmd/pipeline/command_update.go
@@ -66,8 +66,8 @@ func (c *command) update(cmd *cobra.Command, args []string) error {
 	flags := []string{
 		"activation-privilege",
 		"description",
-		"name",
 		"ksql-cluster",
+		"name",
 		"secret",
 		"sql-file",
 		"update-schema-registry",

--- a/internal/cmd/pipeline/command_update.go
+++ b/internal/cmd/pipeline/command_update.go
@@ -63,6 +63,19 @@ func (c *command) newUpdateCommand() *cobra.Command {
 }
 
 func (c *command) update(cmd *cobra.Command, args []string) error {
+	flags := []string{
+		"activation-privilege",
+		"description",
+		"name",
+		"ksql-cluster",
+		"secret",
+		"sql-file",
+		"update-schema-registry",
+	}
+	if err := errors.CheckNoUpdate(cmd.Flags(), flags...); err != nil {
+		return err
+	}
+
 	name, err := cmd.Flags().GetString("name")
 	if err != nil {
 		return err
@@ -90,11 +103,6 @@ func (c *command) update(cmd *cobra.Command, args []string) error {
 
 	cluster, err := c.Context.GetKafkaClusterForCommand()
 	if err != nil {
-		return err
-	}
-
-	if err := errors.CheckNoOpUpdate(cmd.Flags(), "name", "description",
-		"ksql-cluster", "sql-file", "secret", "activation-privilege", "update-schema-registry"); err != nil {
 		return err
 	}
 

--- a/internal/cmd/pipeline/command_update.go
+++ b/internal/cmd/pipeline/command_update.go
@@ -1,7 +1,6 @@
 package pipeline
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -9,6 +8,7 @@ import (
 	streamdesignerv1 "github.com/confluentinc/ccloud-sdk-go-v2/stream-designer/v1"
 
 	pcmd "github.com/confluentinc/cli/internal/pkg/cmd"
+	"github.com/confluentinc/cli/internal/pkg/errors"
 	"github.com/confluentinc/cli/internal/pkg/examples"
 )
 
@@ -93,16 +93,9 @@ func (c *command) update(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if name == "" && description == "" && sqlFile == "" && len(secrets) == 0 && ksqlCluster == "" &&
-		!cmd.Flags().Changed("activation-privilege") && !cmd.Flags().Changed("update-schema-registry") {
-		return fmt.Errorf("one of the update options must be provided:" +
-			" `--name`," +
-			" `--description`," +
-			" `--ksql-cluster`," +
-			" `--sql-file`," +
-			" `--secret`," +
-			" `--activation-privilege`," +
-			" `--update-schema-registry`")
+	if err := errors.CheckNoOpUpdate(cmd.Flags(), "name", "description",
+		"ksql-cluster", "sql-file", "secret", "activation-privilege", "update-schema-registry"); err != nil {
+		return err
 	}
 
 	updatePipeline := streamdesignerv1.SdV1Pipeline{Spec: &streamdesignerv1.SdV1PipelineSpec{}}

--- a/internal/pkg/errors/error_message.go
+++ b/internal/pkg/errors/error_message.go
@@ -139,7 +139,6 @@ const (
 	InvalidAvailableFlagErrorMsg                     = "invalid value \"%s\" for `--availability` flag"
 	InvalidAvailableFlagSuggestions                  = "Allowed values for `--availability` flag are: %s, %s."
 	InvalidTypeFlagErrorMsg                          = "invalid value \"%s\" for `--type` flag"
-	NameOrCKUFlagErrorMsg                            = "must either specify --name with non-empty value or --cku (for dedicated clusters) with positive integer"
 	NonEmptyNameErrorMsg                             = "`--name` flag value must not be empty"
 	KafkaClusterNotFoundErrorMsg                     = `Kafka cluster "%s" not found`
 	KafkaClusterStillProvisioningErrorMsg            = "your cluster is still provisioning, so it can't be updated yet; please retry in a few minutes"

--- a/internal/pkg/errors/no_op_error.go
+++ b/internal/pkg/errors/no_op_error.go
@@ -7,7 +7,7 @@ import (
 	"github.com/spf13/pflag"
 )
 
-func CheckNoOpUpdate(flags *pflag.FlagSet, flagsToCheck ...string) error {
+func CheckNoUpdate(flags *pflag.FlagSet, flagsToCheck ...string) error {
 	var unsetFlags []string
 	for _, flag := range flagsToCheck {
 		if !flags.Changed(flag) {
@@ -15,7 +15,7 @@ func CheckNoOpUpdate(flags *pflag.FlagSet, flagsToCheck ...string) error {
 		}
 	}
 	if len(unsetFlags) == len(flagsToCheck) {
-		return fmt.Errorf("one of the following flags must be set: %s", strings.Join(unsetFlags, ", "))
+		return fmt.Errorf("at least one of the following flags must be set: %s", strings.Join(unsetFlags, ", "))
 	}
 	return nil
 }

--- a/internal/pkg/errors/no_op_error.go
+++ b/internal/pkg/errors/no_op_error.go
@@ -1,0 +1,22 @@
+package errors
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/pflag"
+)
+
+func CheckNoOpUpdate(flags *pflag.FlagSet, flagsToCheck ...string) error {
+	var unsetFlags []string
+	for _, flag := range flagsToCheck {
+		if !flags.Changed(flag) {
+			unsetFlags = append(unsetFlags, fmt.Sprintf("`--%s`", flag))
+		}
+	}
+	if len(unsetFlags) == len(flagsToCheck) {
+		return errors.New(fmt.Sprintf("one of the following flags must be set: %s", strings.Join(unsetFlags, ", ")))
+	}
+	return nil
+}

--- a/internal/pkg/errors/no_op_error.go
+++ b/internal/pkg/errors/no_op_error.go
@@ -1,7 +1,6 @@
 package errors
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 
@@ -16,7 +15,7 @@ func CheckNoOpUpdate(flags *pflag.FlagSet, flagsToCheck ...string) error {
 		}
 	}
 	if len(unsetFlags) == len(flagsToCheck) {
-		return errors.New(fmt.Sprintf("one of the following flags must be set: %s", strings.Join(unsetFlags, ", ")))
+		return fmt.Errorf("one of the following flags must be set: %s", strings.Join(unsetFlags, ", "))
 	}
 	return nil
 }

--- a/test/fixtures/output/context/update/1.golden
+++ b/test/fixtures/output/context/update/1.golden
@@ -1,1 +1,1 @@
-Error: one of the following flags must be set: `--name`, `--kafka-cluster`
+Error: at least one of the following flags must be set: `--kafka-cluster`, `--name`

--- a/test/fixtures/output/context/update/1.golden
+++ b/test/fixtures/output/context/update/1.golden
@@ -1,1 +1,1 @@
-Error: must use at least one of the following flags: `--name`, `--kafka-cluster`
+Error: one of the following flags must be set: `--name`, `--kafka-cluster`

--- a/test/fixtures/output/iam/identity-pool/no-op-update.golden
+++ b/test/fixtures/output/iam/identity-pool/no-op-update.golden
@@ -1,0 +1,1 @@
+Error: one of the following flags must be set: `--description`, `--name`, `--filter`, `--identity-claim`

--- a/test/fixtures/output/iam/identity-pool/no-op-update.golden
+++ b/test/fixtures/output/iam/identity-pool/no-op-update.golden
@@ -1,1 +1,1 @@
-Error: one of the following flags must be set: `--description`, `--name`, `--filter`, `--identity-claim`
+Error: at least one of the following flags must be set: `--description`, `--filter`, `--identity-claim`, `--name`

--- a/test/fixtures/output/kafka/cluster/create-flag-error.golden
+++ b/test/fixtures/output/kafka/cluster/create-flag-error.golden
@@ -1,1 +1,1 @@
-Error: must either specify --name with non-empty value or --cku (for dedicated clusters) with positive integer
+Error: at least one of the following flags must be set: `--cku`, `--name`

--- a/test/fixtures/output/kafka/quota/no-op-update.golden
+++ b/test/fixtures/output/kafka/quota/no-op-update.golden
@@ -1,1 +1,1 @@
-Error: one of the following flags must be set: `--ingress`, `--egress`, `--add-principals`, `--remove-principals`, `--description`, `--name`
+Error: at least one of the following flags must be set: `--add-principals`, `--description`, `--egress`, `--ingress`, `--name`, `--remove-principals`

--- a/test/fixtures/output/kafka/quota/no-op-update.golden
+++ b/test/fixtures/output/kafka/quota/no-op-update.golden
@@ -1,0 +1,1 @@
+Error: one of the following flags must be set: `--ingress`, `--egress`, `--add-principals`, `--remove-principals`, `--description`, `--name`

--- a/test/iam_test.go
+++ b/test/iam_test.go
@@ -271,6 +271,7 @@ func (s *CLITestSuite) TestIamPool() {
 		{args: "iam pool delete pool-1 --provider op-12345 --force", fixture: "iam/identity-pool/delete-dne.golden", exitCode: 1},
 		{args: "iam pool describe pool-12345 --provider op-12345", fixture: "iam/identity-pool/describe.golden"},
 		{args: `iam pool update pool-12345 --provider op-12345 --name "updated-name" --description "updated description" --identity-claim new-sub --filter "claims.iss=https://new-company.new-provider.com"`, fixture: "iam/identity-pool/update.golden"},
+		{args: "iam pool update pool-12345 --provider op-12345", fixture: "iam/identity-pool/no-op-update.golden", exitCode: 1},
 		{args: "iam pool list --provider op-12345", fixture: "iam/identity-pool/list.golden"},
 	}
 

--- a/test/kafka_test.go
+++ b/test/kafka_test.go
@@ -480,6 +480,7 @@ func (s *CLITestSuite) TestKafkaQuota() {
 		{args: "kafka quota delete cq-1234 --force", fixture: "kafka/quota/delete.golden"},
 		{args: "kafka quota delete cq-1234", input: "cq-1234\n", fixture: "kafka/quota/delete-prompt.golden"},
 		{args: "kafka quota update cq-1234 --ingress 100 --egress 100 --add-principals sa-4321 --remove-principals sa-1234 --name newName", fixture: "kafka/quota/update.golden"},
+		{args: "kafka quota update cq-1234", fixture: "kafka/quota/no-op-update.golden", exitCode: 1},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Release Notes
-------------
Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
Several resources' `update` commands check for a no-op update request and return an error instead of sending an extraneous API request. This PR standardizes the error checking and error string format.

This includes `iam group-mapping, pool, provider`, `pipeline`, `kafka cluster, quota` and `context`.

References
----------
https://confluentinc.atlassian.net/browse/CLI-2680

Test & Review
-------------
Added no-op `update` subcommand integration tests.
