### PR TITLE
[CLI-2642] Resolve panic when exiting `confluent kafka topic produce`

### DIFF
--- a/internal/cmd/kafka/command_topic_produce.go
+++ b/internal/cmd/kafka/command_topic_produce.go
@@ -117,7 +117,11 @@ func (c *command) produce(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	output.ErrPrintln(errors.StartingProducerMsg)
+	if runtime.GOOS == "windows" {
+		output.ErrPrintln("Starting Kafka Producer. Use Ctrl-C to exit.")
+	} else {
+		output.ErrPrintln(errors.StartingProducerMsg)
+	}
 
 	var scanErr error
 	input, scan := PrepareInputChannel(&scanErr)
@@ -127,7 +131,11 @@ func (c *command) produce(cmd *cobra.Command, args []string) error {
 	signal.Notify(signals, os.Interrupt)
 	go func() {
 		<-signals
-		close(input)
+		select {
+		case <-input:
+		default:
+			close(input)
+		}
 	}()
 	// Prime reader
 	go scan()

--- a/internal/cmd/kafka/command_topic_produce.go
+++ b/internal/cmd/kafka/command_topic_produce.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"runtime"
 	"strconv"
 	"strings"
 


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- PLACEHOLDER

New Features
- PLACEHOLDER

Bug Fixes
- Resolve a panic that can happen when exiting `confluent kafka topic produce` with Ctrl-C

Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
When the user enters `Ctrl-C`, this input is occasionally handled by the scanner goroutine before the signals goroutine. The consequence is that the former will close the `input` channel. Afterwards, the `signals` channel is unblocked and the second goroutine will then attempt to close `input` again, resulting in a double close panic.

This PR uses a `select` block in the signals goroutine to check if `input` is closed, and only closes it if it is not already closed.

Additionally, since `Ctrl-D` is not a valid way to exit the command prompt in Windows, I've removed it from the exiting instructions on Windows.

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
Manual testing in Windows (where I was able to reproduce the problem consistently) and MacOS.

Open Questions / Follow-ups
---------------------------
<!--
Optional: Anything open to discussion for the reviewer, out of scope of this PR, or follow-ups.
-->
