### PR TITLE
Support configuration files and configuration key=value pairs with `--config`

### DIFF
--- a/internal/cmd/kafka/command_broker_update.go
+++ b/internal/cmd/kafka/command_broker_update.go
@@ -32,7 +32,7 @@ func (c *brokerCommand) newUpdateCommand() *cobra.Command {
 		),
 	}
 
-	cmd.Flags().StringSlice("config", nil, `A comma-separated list of configuration overrides ("key=value") for the broker being updated.`)
+	pcmd.AddConfigFlag(cmd)
 	cmd.Flags().Bool("all", false, "Apply configuration update to all brokers in the cluster.")
 	cmd.Flags().AddFlagSet(pcmd.OnPremKafkaRestSet())
 	pcmd.AddOutputFlag(cmd)
@@ -58,11 +58,11 @@ func (c *brokerCommand) update(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	configs, err := cmd.Flags().GetStringSlice("config")
+	config, err := cmd.Flags().GetStringSlice("config")
 	if err != nil {
 		return err
 	}
-	configMap, err := properties.ConfigFlagToMap(configs)
+	configMap, err := properties.GetMap(config)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/kafka/command_cluster_configuration_update.go
+++ b/internal/cmd/kafka/command_cluster_configuration_update.go
@@ -50,6 +50,7 @@ func (c *clusterCommand) configurationUpdate(cmd *cobra.Command, _ []string) err
 		return err
 	}
 
+	// Deprecated
 	configFile, err := cmd.Flags().GetString(configFileFlagName)
 	if err != nil {
 		return err

--- a/internal/cmd/kafka/command_cluster_configuration_update.go
+++ b/internal/cmd/kafka/command_cluster_configuration_update.go
@@ -29,7 +29,7 @@ func (c *clusterCommand) newConfigurationUpdateCommand() *cobra.Command {
 		),
 	}
 
-	cmd.Flags().StringSlice("config", nil, `A comma-separated list of configuration overrides with form "key=value".`)
+	pcmd.AddConfigFlag(cmd)
 	pcmd.AddContextFlag(cmd, c.CLICommand)
 	pcmd.AddEnvironmentFlag(cmd, c.AuthenticatedCLICommand)
 	pcmd.AddClusterFlag(cmd, c.AuthenticatedCLICommand)
@@ -50,7 +50,15 @@ func (c *clusterCommand) configurationUpdate(cmd *cobra.Command, _ []string) err
 		return err
 	}
 
-	configMap, err := properties.ConfigFlagToMap(config)
+	configFile, err := cmd.Flags().GetString(configFileFlagName)
+	if err != nil {
+		return err
+	}
+	if configFile != "" {
+		config = []string{configFile}
+	}
+
+	configMap, err := properties.GetMap(config)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/kafka/command_cluster_configuration_update.go
+++ b/internal/cmd/kafka/command_cluster_configuration_update.go
@@ -49,16 +49,6 @@ func (c *clusterCommand) configurationUpdate(cmd *cobra.Command, _ []string) err
 	if err != nil {
 		return err
 	}
-
-	// Deprecated
-	configFile, err := cmd.Flags().GetString(configFileFlagName)
-	if err != nil {
-		return err
-	}
-	if configFile != "" {
-		config = []string{configFile}
-	}
-
 	configMap, err := properties.GetMap(config)
 	if err != nil {
 		return err

--- a/internal/cmd/kafka/command_link_configuration_update.go
+++ b/internal/cmd/kafka/command_link_configuration_update.go
@@ -47,6 +47,7 @@ func (c *linkCommand) configurationUpdate(cmd *cobra.Command, args []string) err
 		return err
 	}
 
+	// Deprecated
 	configFile, err := cmd.Flags().GetString(configFileFlagName)
 	if err != nil {
 		return err

--- a/internal/cmd/kafka/command_link_configuration_update.go
+++ b/internal/cmd/kafka/command_link_configuration_update.go
@@ -21,17 +21,20 @@ func (c *linkCommand) newConfigurationUpdateCommand() *cobra.Command {
 		Example: examples.BuildExampleString(
 			examples.Example{
 				Text: `Update configuration values for the cluster link "my-link".`,
-				Code: "confluent kafka link configuration update my-link --config-file my-config.txt",
+				Code: "confluent kafka link configuration update my-link --config my-config.txt",
 			},
 		),
 	}
 
-	cmd.Flags().String(configFileFlagName, "", "Name of the file containing link configuration overrides. Each property key-value pair should have the format of key=value. Properties are separated by new-line characters.")
+	pcmd.AddConfigFlag(cmd)
 	pcmd.AddClusterFlag(cmd, c.AuthenticatedCLICommand)
 	pcmd.AddEnvironmentFlag(cmd, c.AuthenticatedCLICommand)
 	pcmd.AddContextFlag(cmd, c.CLICommand)
 
-	cobra.CheckErr(cmd.MarkFlagRequired(configFileFlagName))
+	// Deprecated
+	cmd.Flags().String(configFileFlagName, "", "Name of the file containing link configuration overrides. Each property key-value pair should have the format of key=value. Properties are separated by new-line characters.")
+	cobra.CheckErr(cmd.Flags().MarkHidden(configFileFlagName))
+	cmd.MarkFlagsMutuallyExclusive("config", configFileFlagName)
 
 	return cmd
 }
@@ -39,21 +42,22 @@ func (c *linkCommand) newConfigurationUpdateCommand() *cobra.Command {
 func (c *linkCommand) configurationUpdate(cmd *cobra.Command, args []string) error {
 	linkName := args[0]
 
-	configFile, err := cmd.Flags().GetString(configFileFlagName)
+	config, err := cmd.Flags().GetStringSlice("config")
 	if err != nil {
 		return err
 	}
 
-	configMap := make(map[string]string)
+	configFile, err := cmd.Flags().GetString(configFileFlagName)
+	if err != nil {
+		return err
+	}
 	if configFile != "" {
-		configMap, err = properties.FileToMap(configFile)
-		if err != nil {
-			return err
-		}
+		config = []string{configFile}
 	}
 
-	if len(configMap) == 0 {
-		return errors.New(errors.EmptyConfigErrorMsg)
+	configMap, err := properties.GetMap(config)
+	if err != nil {
+		return err
 	}
 
 	kafkaREST, err := c.GetKafkaREST()

--- a/internal/cmd/kafka/command_link_configuration_update_onprem.go
+++ b/internal/cmd/kafka/command_link_configuration_update_onprem.go
@@ -23,16 +23,19 @@ func (c *linkCommand) newConfigurationUpdateCommandOnPrem() *cobra.Command {
 		Example: examples.BuildExampleString(
 			examples.Example{
 				Text: `Update configuration values for the cluster link "my-link".`,
-				Code: "confluent kafka link configuration update my-link --config-file my-config.txt",
+				Code: "confluent kafka link configuration update my-link --config my-config.txt",
 			},
 		),
 	}
 
-	cmd.Flags().String(configFileFlagName, "", "Name of the file containing link configuration overrides. Each property key-value pair should have the format of key=value. Properties are separated by new-line characters.")
+	pcmd.AddConfigFlag(cmd)
 	cmd.Flags().AddFlagSet(pcmd.OnPremKafkaRestSet())
 	pcmd.AddContextFlag(cmd, c.CLICommand)
 
-	cobra.CheckErr(cmd.MarkFlagRequired(configFileFlagName))
+	// Deprecated
+	cmd.Flags().String(configFileFlagName, "", "Name of the file containing link configuration overrides. Each property key-value pair should have the format of key=value. Properties are separated by new-line characters.")
+	cobra.CheckErr(cmd.Flags().MarkHidden(configFileFlagName))
+	cmd.MarkFlagsMutuallyExclusive("config", configFileFlagName)
 
 	return cmd
 }
@@ -40,21 +43,22 @@ func (c *linkCommand) newConfigurationUpdateCommandOnPrem() *cobra.Command {
 func (c *linkCommand) configurationUpdateOnPrem(cmd *cobra.Command, args []string) error {
 	linkName := args[0]
 
-	configFile, err := cmd.Flags().GetString(configFileFlagName)
+	config, err := cmd.Flags().GetStringSlice("config")
 	if err != nil {
 		return err
 	}
 
-	configMap := make(map[string]string)
+	configFile, err := cmd.Flags().GetString(configFileFlagName)
+	if err != nil {
+		return err
+	}
 	if configFile != "" {
-		configMap, err = properties.FileToMap(configFile)
-		if err != nil {
-			return err
-		}
+		config = []string{configFile}
 	}
 
-	if len(configMap) == 0 {
-		return errors.New(errors.EmptyConfigErrorMsg)
+	configMap, err := properties.GetMap(config)
+	if err != nil {
+		return err
 	}
 
 	client, ctx, err := initKafkaRest(c.AuthenticatedCLICommand, cmd)

--- a/internal/cmd/kafka/command_link_configuration_update_onprem.go
+++ b/internal/cmd/kafka/command_link_configuration_update_onprem.go
@@ -48,6 +48,7 @@ func (c *linkCommand) configurationUpdateOnPrem(cmd *cobra.Command, args []strin
 		return err
 	}
 
+	// Deprecated
 	configFile, err := cmd.Flags().GetString(configFileFlagName)
 	if err != nil {
 		return err

--- a/internal/cmd/kafka/command_link_create.go
+++ b/internal/cmd/kafka/command_link_create.go
@@ -129,6 +129,7 @@ func (c *linkCommand) create(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	// Deprecated
 	configFile, err := cmd.Flags().GetString(configFileFlagName)
 	if err != nil {
 		return err

--- a/internal/cmd/kafka/command_link_create_onprem.go
+++ b/internal/cmd/kafka/command_link_create_onprem.go
@@ -65,6 +65,7 @@ func (c *linkCommand) createOnPrem(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	// Deprecated
 	configFile, err := cmd.Flags().GetString(configFileFlagName)
 	if err != nil {
 		return err

--- a/internal/cmd/kafka/command_mirror_create.go
+++ b/internal/cmd/kafka/command_mirror_create.go
@@ -80,6 +80,7 @@ func (c *mirrorCommand) create(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	// Deprecated
 	configFile, err := cmd.Flags().GetString(configFileFlagName)
 	if err != nil {
 		return err

--- a/internal/cmd/kafka/command_mirror_create.go
+++ b/internal/cmd/kafka/command_mirror_create.go
@@ -27,7 +27,7 @@ func (c *mirrorCommand) newCreateCommand() *cobra.Command {
 			},
 			examples.Example{
 				Text: "Create a mirror topic with a custom replication factor and configuration file:",
-				Code: "confluent kafka mirror create my-topic --link my-link --replication-factor 5 --config-file my-config.txt",
+				Code: "confluent kafka mirror create my-topic --link my-link --replication-factor 5 --config my-config.txt",
 			},
 			examples.Example{
 				Text: `Create a mirror topic "src_my-topic" where "src_" is the prefix configured on the link:`,
@@ -38,11 +38,16 @@ func (c *mirrorCommand) newCreateCommand() *cobra.Command {
 
 	pcmd.AddLinkFlag(cmd, c.AuthenticatedCLICommand)
 	cmd.Flags().Int32(replicationFactorFlagName, 3, "Replication factor.")
-	cmd.Flags().String(configFileFlagName, "", "Name of a file with additional topic configuration. Each property should be on its own line with the format: key=value.")
+	pcmd.AddConfigFlag(cmd)
 	cmd.Flags().String(sourceTopicFlagName, "", "Name of the source topic to be mirrored over the cluster link. Only required when there is a prefix configured on the link.")
 	pcmd.AddClusterFlag(cmd, c.AuthenticatedCLICommand)
 	pcmd.AddContextFlag(cmd, c.CLICommand)
 	pcmd.AddEnvironmentFlag(cmd, c.AuthenticatedCLICommand)
+
+	// Deprecated
+	cmd.Flags().String(configFileFlagName, "", "Name of a file with additional topic configuration. Each property should be on its own line with the format: key=value.")
+	cobra.CheckErr(cmd.Flags().MarkHidden(configFileFlagName))
+	cmd.MarkFlagsMutuallyExclusive("config", configFileFlagName)
 
 	cobra.CheckErr(cmd.MarkFlagRequired(linkFlagName))
 
@@ -70,17 +75,22 @@ func (c *mirrorCommand) create(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	configFile, err := cmd.Flags().GetString(configFileFlagName)
+	config, err := cmd.Flags().GetStringSlice("config")
 	if err != nil {
 		return err
 	}
 
-	configMap := make(map[string]string)
+	configFile, err := cmd.Flags().GetString(configFileFlagName)
+	if err != nil {
+		return err
+	}
 	if configFile != "" {
-		configMap, err = properties.FileToMap(configFile)
-		if err != nil {
-			return err
-		}
+		config = []string{configFile}
+	}
+
+	configMap, err := properties.GetMap(config)
+	if err != nil {
+		return err
 	}
 
 	kafkaREST, err := c.GetKafkaREST()

--- a/internal/cmd/kafka/command_topic_create_onprem.go
+++ b/internal/cmd/kafka/command_topic_create_onprem.go
@@ -44,7 +44,7 @@ func (c *command) newCreateCommandOnPrem() *cobra.Command {
 	cmd.Flags().AddFlagSet(pcmd.OnPremKafkaRestSet())
 	cmd.Flags().Uint32("partitions", 0, "Number of topic partitions.")
 	cmd.Flags().Uint32("replication-factor", 0, "Number of replicas.")
-	cmd.Flags().StringSlice("config", nil, `A comma-separated list of topic configuration ("key=value") overrides for the topic being created.`)
+	pcmd.AddConfigFlag(cmd)
 	cmd.Flags().Bool("if-not-exists", false, "Exit gracefully if topic already exists.")
 
 	return cmd
@@ -86,7 +86,7 @@ func CreateTopic(cmd *cobra.Command, restClient *kafkarestv3.APIClient, restCont
 	if err != nil {
 		return err
 	}
-	configMap, err := properties.ConfigFlagToMap(configs)
+	configMap, err := properties.GetMap(configs)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/kafka/command_topic_update.go
+++ b/internal/cmd/kafka/command_topic_update.go
@@ -40,13 +40,13 @@ func (c *command) newUpdateCommand() *cobra.Command {
 		Example: examples.BuildExampleString(
 			examples.Example{
 				Text: `Modify the "my_topic" topic to have a retention period of 3 days (259200000 milliseconds).`,
-				Code: `confluent kafka topic update my_topic --config "retention.ms=259200000"`,
+				Code: "confluent kafka topic update my_topic --config retention.ms=259200000",
 			},
 		),
 		Annotations: map[string]string{pcmd.RunRequirement: pcmd.RequireNonAPIKeyCloudLogin},
 	}
 
-	cmd.Flags().StringSlice("config", nil, `A comma-separated list of configuration overrides with form "key=value".`)
+	pcmd.AddConfigFlag(cmd)
 	pcmd.AddDryRunFlag(cmd)
 	pcmd.AddClusterFlag(cmd, c.AuthenticatedCLICommand)
 	pcmd.AddContextFlag(cmd, c.CLICommand)
@@ -63,8 +63,7 @@ func (c *command) update(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-
-	configMap, err := properties.ConfigFlagToMap(configs)
+	configMap, err := properties.GetMap(configs)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/kafka/command_topic_update_onprem.go
+++ b/internal/cmd/kafka/command_topic_update_onprem.go
@@ -36,7 +36,7 @@ func (c *command) newUpdateCommandOnPrem() *cobra.Command {
 	}
 
 	cmd.Flags().AddFlagSet(pcmd.OnPremKafkaRestSet())
-	cmd.Flags().StringSlice("config", nil, `A comma-separated list of topics configuration ("key=value") overrides for the topic being created.`)
+	pcmd.AddConfigFlag(cmd)
 	pcmd.AddOutputFlag(cmd)
 
 	return cmd
@@ -58,12 +58,11 @@ func (c *command) updateOnPrem(cmd *cobra.Command, args []string) error {
 }
 
 func UpdateTopic(cmd *cobra.Command, restClient *kafkarestv3.APIClient, restContext context.Context, topicName, clusterId string) error {
-	// Update Config
-	configs, err := cmd.Flags().GetStringSlice("config") // handle config parsing errors
+	configs, err := cmd.Flags().GetStringSlice("config")
 	if err != nil {
 		return err
 	}
-	configMap, err := properties.ConfigFlagToMap(configs)
+	configMap, err := properties.GetMap(configs)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/local/command_kafka_topic_create.go
+++ b/internal/cmd/local/command_kafka_topic_create.go
@@ -6,6 +6,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/confluentinc/cli/internal/cmd/kafka"
+	pcmd "github.com/confluentinc/cli/internal/pkg/cmd"
 	"github.com/confluentinc/cli/internal/pkg/errors"
 	"github.com/confluentinc/cli/internal/pkg/examples"
 )
@@ -26,7 +27,7 @@ func (c *Command) newKafkaTopicCreateCommand() *cobra.Command {
 
 	cmd.Flags().Uint32("partitions", 0, "Number of topic partitions.")
 	cmd.Flags().Uint32("replication-factor", 0, "Number of replicas.")
-	cmd.Flags().StringSlice("config", nil, `A comma-separated list of topic configuration ("key=value") overrides for the topic being created.`)
+	pcmd.AddConfigFlag(cmd)
 	cmd.Flags().Bool("if-not-exists", false, "Exit gracefully if topic already exists.")
 
 	return cmd

--- a/internal/cmd/schema-registry/command_exporter_create.go
+++ b/internal/cmd/schema-registry/command_exporter_create.go
@@ -98,17 +98,23 @@ func (c *command) exporterCreate(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	configFile, err := cmd.Flags().GetString("config-file")
+	config, err := cmd.Flags().GetStringSlice("config")
 	if err != nil {
 		return err
 	}
 
-	configMap := make(map[string]string)
+	// Deprecated
+	configFile, err := cmd.Flags().GetString("config-file")
+	if err != nil {
+		return err
+	}
 	if configFile != "" {
-		configMap, err = properties.FileToMap(configFile)
-		if err != nil {
-			return err
-		}
+		config = []string{configFile}
+	}
+
+	configMap, err := properties.GetMap(config)
+	if err != nil {
+		return err
 	}
 
 	req := srsdk.CreateExporterRequest{

--- a/internal/cmd/schema-registry/command_exporter_create.go
+++ b/internal/cmd/schema-registry/command_exporter_create.go
@@ -27,14 +27,14 @@ func (c *command) newExporterCreateCommand(cfg *v1.Config) *cobra.Command {
 
 	example := examples.Example{
 		Text: "Create a new schema exporter.",
-		Code: `confluent schema-registry exporter create my-exporter --config-file config.txt --subjects my-subject1,my-subject2 --subject-format my-\${subject} --context-type custom --context-name my-context`,
+		Code: `confluent schema-registry exporter create my-exporter --config config.txt --subjects my-subject1,my-subject2 --subject-format my-\${subject} --context-type custom --context-name my-context`,
 	}
 	if cfg.IsOnPremLogin() {
 		example.Code += " " + onPremAuthenticationMsg
 	}
 	cmd.Example = examples.BuildExampleString(example)
 
-	cmd.Flags().String("config-file", "", "Exporter configuration file.")
+	pcmd.AddConfigFlag(cmd)
 	cmd.Flags().StringSlice("subjects", []string{"*"}, "A comma-separated list of exporter subjects.")
 	cmd.Flags().String("subject-format", "${subject}", "Exporter subject rename format. The format string can contain ${subject}, which will be replaced with the default subject name.")
 	addContextTypeFlag(cmd)
@@ -48,6 +48,11 @@ func (c *command) newExporterCreateCommand(cfg *v1.Config) *cobra.Command {
 	}
 	pcmd.AddOutputFlag(cmd)
 
+	// Deprecated
+	cmd.Flags().String("config-file", "", "Exporter configuration file.")
+	cobra.CheckErr(cmd.Flags().MarkHidden("config-file"))
+	cmd.MarkFlagsMutuallyExclusive("config", "config-file")
+
 	if cfg.IsCloudLogin() {
 		// Deprecated
 		pcmd.AddApiKeyFlag(cmd, c.AuthenticatedCLICommand)
@@ -57,8 +62,6 @@ func (c *command) newExporterCreateCommand(cfg *v1.Config) *cobra.Command {
 		pcmd.AddApiSecretFlag(cmd)
 		cobra.CheckErr(cmd.Flags().MarkHidden("api-secret"))
 	}
-
-	cobra.CheckErr(cmd.MarkFlagRequired("config-file"))
 
 	return cmd
 }

--- a/internal/cmd/schema-registry/command_exporter_update.go
+++ b/internal/cmd/schema-registry/command_exporter_update.go
@@ -38,7 +38,7 @@ func (c *command) newExporterUpdateCommand(cfg *v1.Config) *cobra.Command {
 	}
 	cmd.Example = examples.BuildExampleString(example1, example2)
 
-	cmd.Flags().String("config-file", "", "Exporter configuration file.")
+	pcmd.AddConfigFlag(cmd)
 	cmd.Flags().StringSlice("subjects", []string{}, "A comma-separated list of exporter subjects.")
 	cmd.Flags().String("subject-format", "${subject}", "Exporter subject rename format. The format string can contain ${subject}, which will be replaced with the default subject name.")
 	addContextTypeFlag(cmd)
@@ -51,6 +51,11 @@ func (c *command) newExporterUpdateCommand(cfg *v1.Config) *cobra.Command {
 		addSchemaRegistryEndpointFlag(cmd)
 	}
 	pcmd.AddOutputFlag(cmd)
+
+	// Deprecated
+	cmd.Flags().String("config-file", "", "Exporter configuration file.")
+	cobra.CheckErr(cmd.Flags().MarkHidden("config-file"))
+	cmd.MarkFlagsMutuallyExclusive("config", "config-file")
 
 	if cfg.IsCloudLogin() {
 		// Deprecated
@@ -114,16 +119,25 @@ func (c *command) exporterUpdate(cmd *cobra.Command, args []string) error {
 		updateRequest.SubjectRenameFormat = subjectFormat
 	}
 
-	configFile, err := cmd.Flags().GetString("config-file")
+	config, err := cmd.Flags().GetStringSlice("config")
 	if err != nil {
 		return err
 	}
 
+	configFile, err := cmd.Flags().GetString("config-file")
+	if err != nil {
+		return err
+	}
 	if configFile != "" {
-		updateRequest.Config, err = properties.FileToMap(configFile)
-		if err != nil {
-			return err
-		}
+		config = []string{configFile}
+	}
+
+	configMap, err := properties.GetMap(config)
+	if err != nil {
+		return err
+	}
+	if len(configMap) > 0 {
+		updateRequest.Config = configMap
 	}
 
 	if _, err := client.PutExporter(args[0], updateRequest); err != nil {

--- a/internal/cmd/schema-registry/command_exporter_update.go
+++ b/internal/cmd/schema-registry/command_exporter_update.go
@@ -30,7 +30,7 @@ func (c *command) newExporterUpdateCommand(cfg *v1.Config) *cobra.Command {
 	}
 	example2 := examples.Example{
 		Text: "Update schema exporter configuration.",
-		Code: "confluent schema-registry exporter update my-exporter --config-file config.txt",
+		Code: "confluent schema-registry exporter update my-exporter --config config.txt",
 	}
 	if cfg.IsOnPremLogin() {
 		example1.Code += " " + onPremAuthenticationMsg

--- a/internal/pkg/cmd/flags.go
+++ b/internal/pkg/cmd/flags.go
@@ -123,6 +123,10 @@ func AutocompleteClusters(environmentId string, client *ccloudv2.Client) []strin
 	return suggestions
 }
 
+func AddConfigFlag(cmd *cobra.Command) {
+	cmd.Flags().StringSlice("config", []string{}, `A comma-separated list of "key=value" pairs, or path to a configuration file containing "key=value" pairs.`)
+}
+
 func AddContextFlag(cmd *cobra.Command, command *CLICommand) {
 	cmd.Flags().String("context", "", "CLI context name.")
 

--- a/internal/pkg/cmd/flags.go
+++ b/internal/pkg/cmd/flags.go
@@ -124,7 +124,7 @@ func AutocompleteClusters(environmentId string, client *ccloudv2.Client) []strin
 }
 
 func AddConfigFlag(cmd *cobra.Command) {
-	cmd.Flags().StringSlice("config", []string{}, `A comma-separated list of "key=value" pairs, or path to a configuration file containing "key=value" pairs.`)
+	cmd.Flags().StringSlice("config", []string{}, `A comma-separated list of "key=value" pairs, or path to a configuration file containing a newline-separated list of "key=value" pairs.`)
 }
 
 func AddContextFlag(cmd *cobra.Command, command *CLICommand) {

--- a/internal/pkg/errors/error_message.go
+++ b/internal/pkg/errors/error_message.go
@@ -185,9 +185,6 @@ const (
 		"If your topic is compacted, ensure you are producing a record with a key."
 	ExceedPartitionLimitSuggestions = "The total partition limit for a dedicated cluster may be increased by expanding its CKU count using `confluent kafka cluster update <id> --cku <count>`."
 
-	// Cluster Link commands
-	EmptyConfigErrorMsg = "config file name is empty or config file is empty"
-
 	// serialization/deserialization commands
 	JsonSchemaInvalidErrorMsg         = "the JSON schema is invalid"
 	JsonDocumentInvalidErrorMsg       = "the JSON document is invalid"

--- a/internal/pkg/properties/properties.go
+++ b/internal/pkg/properties/properties.go
@@ -6,7 +6,18 @@ import (
 	"os"
 	"sort"
 	"strings"
+
+	"github.com/confluentinc/cli/internal/pkg/utils"
 )
+
+// GetMap reads newline-separated configuration files or comma-separated lists of key=value pairs, and supports configuration values containing commas.
+func GetMap(config []string) (map[string]string, error) {
+	if len(config) == 1 && utils.FileExists(config[0]) {
+		return FileToMap(config[0])
+	}
+
+	return ConfigFlagToMap(config)
+}
 
 // FileToMap reads key=value pairs from a properties file, ignoring comments and empty lines.
 func FileToMap(filename string) (map[string]string, error) {

--- a/internal/pkg/properties/properties.go
+++ b/internal/pkg/properties/properties.go
@@ -13,21 +13,14 @@ import (
 // GetMap reads newline-separated configuration files or comma-separated lists of key=value pairs, and supports configuration values containing commas.
 func GetMap(config []string) (map[string]string, error) {
 	if len(config) == 1 && utils.FileExists(config[0]) {
-		m, err := FileToMap(config[0])
-		if err != nil {
-			return nil, err
-		}
-		if len(m) == 0 {
-			return nil, fmt.Errorf(`configuration file "%s" is empty`, config[0])
-		}
-		return m, nil
+		return fileToMap(config[0])
 	}
 
 	return ConfigFlagToMap(config)
 }
 
-// FileToMap reads key=value pairs from a properties file, ignoring comments and empty lines.
-func FileToMap(filename string) (map[string]string, error) {
+// fileToMap reads key=value pairs from a properties file, ignoring comments and empty lines.
+func fileToMap(filename string) (map[string]string, error) {
 	buf, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, err

--- a/internal/pkg/properties/properties.go
+++ b/internal/pkg/properties/properties.go
@@ -13,7 +13,14 @@ import (
 // GetMap reads newline-separated configuration files or comma-separated lists of key=value pairs, and supports configuration values containing commas.
 func GetMap(config []string) (map[string]string, error) {
 	if len(config) == 1 && utils.FileExists(config[0]) {
-		return FileToMap(config[0])
+		m, err := FileToMap(config[0])
+		if err != nil {
+			return nil, err
+		}
+		if len(m) == 0 {
+			return nil, fmt.Errorf(`configuration file "%s" is empty`, config[0])
+		}
+		return m, nil
 	}
 
 	return ConfigFlagToMap(config)

--- a/test/fixtures/input/kafka/broker/update.properties
+++ b/test/fixtures/input/kafka/broker/update.properties
@@ -1,0 +1,2 @@
+compression.type=zip
+sasl_mechanism=SASL/PLAIN

--- a/test/fixtures/input/kafka/cluster/configuration/update.properties
+++ b/test/fixtures/input/kafka/cluster/configuration/update.properties
@@ -1,0 +1,1 @@
+auto.create.topics.enable=true

--- a/test/fixtures/output/kafka/broker/update-help-onprem.golden
+++ b/test/fixtures/output/kafka/broker/update-help-onprem.golden
@@ -13,7 +13,7 @@ Update configuration values for all brokers in the cluster.
   $ confluent kafka broker update --all --config min.insync.replicas=2,num.partitions=2
 
 Flags:
-      --config strings            REQUIRED: A comma-separated list of configuration overrides ("key=value") for the broker being updated.
+      --config strings            REQUIRED: A comma-separated list of "key=value" pairs, or path to a configuration file containing a newline-separated list of "key=value" pairs.
       --all                       Apply configuration update to all brokers in the cluster.
       --url string                Base URL of REST Proxy Endpoint of Kafka Cluster (include "/kafka" for embedded Rest Proxy). Must set flag or CONFLUENT_REST_URL.
       --ca-cert-path string       Path to a PEM-encoded CA to verify the Confluent REST Proxy.

--- a/test/fixtures/output/kafka/cluster/configuration/update-help.golden
+++ b/test/fixtures/output/kafka/cluster/configuration/update-help.golden
@@ -9,7 +9,7 @@ Update Kafka cluster configuration "auto.create.topics.enable" to "true".
   $ confluent kafka cluster configuration update --config auto.create.topics.enable=true
 
 Flags:
-      --config strings       REQUIRED: A comma-separated list of configuration overrides with form "key=value".
+      --config strings       REQUIRED: A comma-separated list of "key=value" pairs, or path to a configuration file containing a newline-separated list of "key=value" pairs.
       --context string       CLI context name.
       --environment string   Environment ID.
       --cluster string       Kafka cluster ID.

--- a/test/fixtures/output/kafka/link/configuration/update-help-onprem.golden
+++ b/test/fixtures/output/kafka/link/configuration/update-help-onprem.golden
@@ -6,10 +6,10 @@ Usage:
 Examples:
 Update configuration values for the cluster link "my-link".
 
-  $ confluent kafka link configuration update my-link --config-file my-config.txt
+  $ confluent kafka link configuration update my-link --config my-config.txt
 
 Flags:
-      --config-file string        REQUIRED: Name of the file containing link configuration overrides. Each property key-value pair should have the format of key=value. Properties are separated by new-line characters.
+      --config strings            A comma-separated list of "key=value" pairs, or path to a configuration file containing a newline-separated list of "key=value" pairs.
       --url string                Base URL of REST Proxy Endpoint of Kafka Cluster (include "/kafka" for embedded Rest Proxy). Must set flag or CONFLUENT_REST_URL.
       --ca-cert-path string       Path to a PEM-encoded CA to verify the Confluent REST Proxy.
       --client-cert-path string   Path to client cert to be verified by Confluent REST Proxy, include for mTLS authentication.

--- a/test/fixtures/output/kafka/link/configuration/update-help.golden
+++ b/test/fixtures/output/kafka/link/configuration/update-help.golden
@@ -6,10 +6,10 @@ Usage:
 Examples:
 Update configuration values for the cluster link "my-link".
 
-  $ confluent kafka link configuration update my-link --config-file my-config.txt
+  $ confluent kafka link configuration update my-link --config my-config.txt
 
 Flags:
-      --config-file string   REQUIRED: Name of the file containing link configuration overrides. Each property key-value pair should have the format of key=value. Properties are separated by new-line characters.
+      --config strings       A comma-separated list of "key=value" pairs, or path to a configuration file containing a newline-separated list of "key=value" pairs.
       --cluster string       Kafka cluster ID.
       --environment string   Environment ID.
       --context string       CLI context name.

--- a/test/fixtures/output/kafka/link/create-help-onprem.golden
+++ b/test/fixtures/output/kafka/link/create-help-onprem.golden
@@ -6,7 +6,7 @@ Usage:
 Examples:
 Create a cluster link, using a configuration file.
 
-  $ confluent kafka link create my-link --destination-cluster 123456789 --config-file config.txt
+  $ confluent kafka link create my-link --destination-cluster 123456789 --config config.txt
 
 Create a cluster link using command line flags.
 
@@ -19,7 +19,7 @@ Flags:
       --source-api-secret string              An API secret for the source cluster. For links at destination cluster, this is used for remote cluster authentication. For links at source cluster, this is used for local cluster authentication. If specified, the cluster will use SASL_SSL with PLAIN SASL as its mechanism for authentication. If you wish to use another authentication mechanism, do not specify this flag, and add the security configurations in the configuration file.
       --destination-api-key string            An API key for the destination cluster. This is used for remote cluster authentication links at the source cluster. If specified, the cluster will use SASL_SSL with PLAIN SASL as its mechanism for authentication. If you wish to use another authentication mechanism, do not specify this flag, and add the security configurations in the configuration file.
       --destination-api-secret string         An API secret for the destination cluster. This is used for remote cluster authentication for links at the source cluster. If specified, the cluster will use SASL_SSL with PLAIN SASL as its mechanism for authentication. If you wish to use another authentication mechanism, do not specify this flag, and add the security configurations in the configuration file.
-      --config-file string                    Name of the file containing link configuration. Each property key-value pair should have the format of key=value. Properties are separated by new-line characters.
+      --config strings                        A comma-separated list of "key=value" pairs, or path to a configuration file containing a newline-separated list of "key=value" pairs.
       --dry-run                               Validate a link, but do not create it.
       --no-validate                           Create a link even if the source cluster cannot be reached.
       --url string                            Base URL of REST Proxy Endpoint of Kafka Cluster (include "/kafka" for embedded Rest Proxy). Must set flag or CONFLUENT_REST_URL.

--- a/test/fixtures/output/kafka/link/create-help.golden
+++ b/test/fixtures/output/kafka/link/create-help.golden
@@ -6,7 +6,7 @@ Usage:
 Examples:
 Create a cluster link, using a configuration file.
 
-  $ confluent kafka link create my-link --source-cluster lkc-123456 --config-file config.txt
+  $ confluent kafka link create my-link --source-cluster lkc-123456 --config config.txt
 
 Create a cluster link using command line flags.
 
@@ -27,7 +27,7 @@ Flags:
       --remote-api-secret string              An API secret for the remote cluster for bidirectional links. This is used for remote cluster authentication. If specified, the cluster will use SASL_SSL with PLAIN SASL as its mechanism for authentication. If you wish to use another authentication mechanism, do not specify this flag, and add the security configurations in the configuration file.
       --local-api-key string                  An API key for the local cluster for bidirectional links. This is used for local cluster authentication if remote link's connection mode is Inbound. If specified, the cluster will use SASL_SSL with PLAIN SASL as its mechanism for authentication. If you wish to use another authentication mechanism, do not specify this flag, and add the security configurations in the configuration file.
       --local-api-secret string               An API secret for the local cluster for bidirectional links. This is used for local cluster authentication if remote link's connection mode is Inbound. If specified, the cluster will use SASL_SSL with PLAIN SASL as its mechanism for authentication. If you wish to use another authentication mechanism, do not specify this flag, and add the security configurations in the configuration file.
-      --config-file string                    Name of the file containing link configuration. Each property key-value pair should have the format of key=value. Properties are separated by new-line characters.
+      --config strings                        A comma-separated list of "key=value" pairs, or path to a configuration file containing a newline-separated list of "key=value" pairs.
       --dry-run                               Validate a link, but do not create it.
       --no-validate                           Create a link even if the source cluster cannot be reached.
       --cluster string                        Kafka cluster ID.

--- a/test/fixtures/output/kafka/mirror/create-help.golden
+++ b/test/fixtures/output/kafka/mirror/create-help.golden
@@ -10,7 +10,7 @@ Create a mirror topic "my-topic" under cluster link "my-link":
 
 Create a mirror topic with a custom replication factor and configuration file:
 
-  $ confluent kafka mirror create my-topic --link my-link --replication-factor 5 --config-file my-config.txt
+  $ confluent kafka mirror create my-topic --link my-link --replication-factor 5 --config my-config.txt
 
 Create a mirror topic "src_my-topic" where "src_" is the prefix configured on the link:
 
@@ -19,7 +19,7 @@ Create a mirror topic "src_my-topic" where "src_" is the prefix configured on th
 Flags:
       --link string                REQUIRED: Name of cluster link.
       --replication-factor int32   Replication factor. (default 3)
-      --config-file string         Name of a file with additional topic configuration. Each property should be on its own line with the format: key=value.
+      --config strings             A comma-separated list of "key=value" pairs, or path to a configuration file containing a newline-separated list of "key=value" pairs.
       --source-topic string        Name of the source topic to be mirrored over the cluster link. Only required when there is a prefix configured on the link.
       --cluster string             Kafka cluster ID.
       --context string             CLI context name.

--- a/test/fixtures/output/kafka/topic/create-help-onprem.golden
+++ b/test/fixtures/output/kafka/topic/create-help-onprem.golden
@@ -25,7 +25,7 @@ Flags:
       --prompt                      Bypass use of available login credentials and prompt for Kafka Rest credentials.
       --partitions uint32           Number of topic partitions.
       --replication-factor uint32   Number of replicas.
-      --config strings              A comma-separated list of topic configuration ("key=value") overrides for the topic being created.
+      --config strings              A comma-separated list of "key=value" pairs, or path to a configuration file containing a newline-separated list of "key=value" pairs.
       --if-not-exists               Exit gracefully if topic already exists.
 
 Global Flags:

--- a/test/fixtures/output/kafka/topic/create-negative-partitions.golden
+++ b/test/fixtures/output/kafka/topic/create-negative-partitions.golden
@@ -24,7 +24,7 @@ Flags:
       --prompt                      Bypass use of available login credentials and prompt for Kafka Rest credentials.
       --partitions uint32           Number of topic partitions.
       --replication-factor uint32   Number of replicas.
-      --config strings              A comma-separated list of topic configuration ("key=value") overrides for the topic being created.
+      --config strings              A comma-separated list of "key=value" pairs, or path to a configuration file containing a newline-separated list of "key=value" pairs.
       --if-not-exists               Exit gracefully if topic already exists.
 
 Global Flags:

--- a/test/fixtures/output/kafka/topic/create-negative-replication-factor.golden
+++ b/test/fixtures/output/kafka/topic/create-negative-replication-factor.golden
@@ -24,7 +24,7 @@ Flags:
       --prompt                      Bypass use of available login credentials and prompt for Kafka Rest credentials.
       --partitions uint32           Number of topic partitions.
       --replication-factor uint32   Number of replicas.
-      --config strings              A comma-separated list of topic configuration ("key=value") overrides for the topic being created.
+      --config strings              A comma-separated list of "key=value" pairs, or path to a configuration file containing a newline-separated list of "key=value" pairs.
       --if-not-exists               Exit gracefully if topic already exists.
 
 Global Flags:

--- a/test/fixtures/output/kafka/topic/update-help-onprem.golden
+++ b/test/fixtures/output/kafka/topic/update-help-onprem.golden
@@ -19,7 +19,7 @@ Flags:
       --client-key-path string    Path to client private key, include for mTLS authentication.
       --no-authentication         Include if requests should be made without authentication headers, and user will not be prompted for credentials.
       --prompt                    Bypass use of available login credentials and prompt for Kafka Rest credentials.
-      --config strings            A comma-separated list of topics configuration ("key=value") overrides for the topic being created.
+      --config strings            A comma-separated list of "key=value" pairs, or path to a configuration file containing a newline-separated list of "key=value" pairs.
   -o, --output string             Specify the output format as "human", "json", or "yaml". (default "human")
 
 Global Flags:

--- a/test/fixtures/output/kafka/topic/update-help.golden
+++ b/test/fixtures/output/kafka/topic/update-help.golden
@@ -6,10 +6,10 @@ Usage:
 Examples:
 Modify the "my_topic" topic to have a retention period of 3 days (259200000 milliseconds).
 
-  $ confluent kafka topic update my_topic --config "retention.ms=259200000"
+  $ confluent kafka topic update my_topic --config retention.ms=259200000
 
 Flags:
-      --config strings       A comma-separated list of configuration overrides with form "key=value".
+      --config strings       A comma-separated list of "key=value" pairs, or path to a configuration file containing a newline-separated list of "key=value" pairs.
       --dry-run              Run the command without committing changes.
       --cluster string       Kafka cluster ID.
       --context string       CLI context name.

--- a/test/fixtures/output/local/kafka/topic/create-help-onprem.golden
+++ b/test/fixtures/output/local/kafka/topic/create-help-onprem.golden
@@ -11,7 +11,7 @@ Create a topic named "test" with specified configuration parameters.
 Flags:
       --partitions uint32           Number of topic partitions.
       --replication-factor uint32   Number of replicas.
-      --config strings              A comma-separated list of topic configuration ("key=value") overrides for the topic being created.
+      --config strings              A comma-separated list of "key=value" pairs, or path to a configuration file containing a newline-separated list of "key=value" pairs.
       --if-not-exists               Exit gracefully if topic already exists.
 
 Global Flags:

--- a/test/fixtures/output/local/kafka/topic/create-help.golden
+++ b/test/fixtures/output/local/kafka/topic/create-help.golden
@@ -11,7 +11,7 @@ Create a topic named "test" with specified configuration parameters.
 Flags:
       --partitions uint32           Number of topic partitions.
       --replication-factor uint32   Number of replicas.
-      --config strings              A comma-separated list of topic configuration ("key=value") overrides for the topic being created.
+      --config strings              A comma-separated list of "key=value" pairs, or path to a configuration file containing a newline-separated list of "key=value" pairs.
       --if-not-exists               Exit gracefully if topic already exists.
 
 Global Flags:

--- a/test/fixtures/output/local/services/help-onprem.golden
+++ b/test/fixtures/output/local/services/help-onprem.golden
@@ -5,7 +5,6 @@ Usage:
 
 Available Commands:
   connect         Manage Connect.
-  control-center  Manage Control Center.
   kafka           Manage Apache Kafka®.
   kafka-rest      Manage Kafka REST.
   ksql-server     Manage ksqlDB Server.

--- a/test/fixtures/output/local/services/help-onprem.golden
+++ b/test/fixtures/output/local/services/help-onprem.golden
@@ -5,6 +5,7 @@ Usage:
 
 Available Commands:
   connect         Manage Connect.
+  control-center  Manage Control Center.
   kafka           Manage Apache Kafka®.
   kafka-rest      Manage Kafka REST.
   ksql-server     Manage ksqlDB Server.

--- a/test/fixtures/output/local/services/help.golden
+++ b/test/fixtures/output/local/services/help.golden
@@ -5,7 +5,6 @@ Usage:
 
 Available Commands:
   connect         Manage Connect.
-  control-center  Manage Control Center.
   kafka           Manage Apache Kafka®.
   kafka-rest      Manage Kafka REST.
   ksql-server     Manage ksqlDB Server.

--- a/test/fixtures/output/local/services/help.golden
+++ b/test/fixtures/output/local/services/help.golden
@@ -5,6 +5,7 @@ Usage:
 
 Available Commands:
   connect         Manage Connect.
+  control-center  Manage Control Center.
   kafka           Manage Apache Kafka®.
   kafka-rest      Manage Kafka REST.
   ksql-server     Manage ksqlDB Server.

--- a/test/fixtures/output/schema-registry/exporter/create-help-onprem.golden
+++ b/test/fixtures/output/schema-registry/exporter/create-help-onprem.golden
@@ -6,10 +6,10 @@ Usage:
 Examples:
 Create a new schema exporter.
 
-  $ confluent schema-registry exporter create my-exporter --config-file config.txt --subjects my-subject1,my-subject2 --subject-format my-\${subject} --context-type custom --context-name my-context --ca-location <ca-file-location> --schema-registry-endpoint <schema-registry-endpoint>
+  $ confluent schema-registry exporter create my-exporter --config config.txt --subjects my-subject1,my-subject2 --subject-format my-\${subject} --context-type custom --context-name my-context --ca-location <ca-file-location> --schema-registry-endpoint <schema-registry-endpoint>
 
 Flags:
-      --config-file string                REQUIRED: Exporter configuration file.
+      --config strings                    A comma-separated list of "key=value" pairs, or path to a configuration file containing a newline-separated list of "key=value" pairs.
       --subjects strings                  A comma-separated list of exporter subjects. (default [*])
       --subject-format string             Exporter subject rename format. The format string can contain ${subject}, which will be replaced with the default subject name. (default "${subject}")
       --context-type string               Exporter context type. One of "auto", "custom", or "none". (default "auto")

--- a/test/fixtures/output/schema-registry/exporter/create-help.golden
+++ b/test/fixtures/output/schema-registry/exporter/create-help.golden
@@ -6,10 +6,10 @@ Usage:
 Examples:
 Create a new schema exporter.
 
-  $ confluent schema-registry exporter create my-exporter --config-file config.txt --subjects my-subject1,my-subject2 --subject-format my-\${subject} --context-type custom --context-name my-context
+  $ confluent schema-registry exporter create my-exporter --config config.txt --subjects my-subject1,my-subject2 --subject-format my-\${subject} --context-type custom --context-name my-context
 
 Flags:
-      --config-file string      REQUIRED: Exporter configuration file.
+      --config strings          A comma-separated list of "key=value" pairs, or path to a configuration file containing a newline-separated list of "key=value" pairs.
       --subjects strings        A comma-separated list of exporter subjects. (default [*])
       --subject-format string   Exporter subject rename format. The format string can contain ${subject}, which will be replaced with the default subject name. (default "${subject}")
       --context-type string     Exporter context type. One of "auto", "custom", or "none". (default "auto")

--- a/test/fixtures/output/schema-registry/exporter/update-help-onprem.golden
+++ b/test/fixtures/output/schema-registry/exporter/update-help-onprem.golden
@@ -10,10 +10,10 @@ Update schema exporter information.
 
 Update schema exporter configuration.
 
-  $ confluent schema-registry exporter update my-exporter --config-file config.txt --ca-location <ca-file-location> --schema-registry-endpoint <schema-registry-endpoint>
+  $ confluent schema-registry exporter update my-exporter --config config.txt --ca-location <ca-file-location> --schema-registry-endpoint <schema-registry-endpoint>
 
 Flags:
-      --config-file string                Exporter configuration file.
+      --config strings                    A comma-separated list of "key=value" pairs, or path to a configuration file containing a newline-separated list of "key=value" pairs.
       --subjects strings                  A comma-separated list of exporter subjects.
       --subject-format string             Exporter subject rename format. The format string can contain ${subject}, which will be replaced with the default subject name. (default "${subject}")
       --context-type string               Exporter context type. One of "auto", "custom", or "none". (default "auto")

--- a/test/fixtures/output/schema-registry/exporter/update-help.golden
+++ b/test/fixtures/output/schema-registry/exporter/update-help.golden
@@ -10,10 +10,10 @@ Update schema exporter information.
 
 Update schema exporter configuration.
 
-  $ confluent schema-registry exporter update my-exporter --config-file config.txt
+  $ confluent schema-registry exporter update my-exporter --config config.txt
 
 Flags:
-      --config-file string      Exporter configuration file.
+      --config strings          A comma-separated list of "key=value" pairs, or path to a configuration file containing a newline-separated list of "key=value" pairs.
       --subjects strings        A comma-separated list of exporter subjects.
       --subject-format string   Exporter subject rename format. The format string can contain ${subject}, which will be replaced with the default subject name. (default "${subject}")
       --context-type string     Exporter context type. One of "auto", "custom", or "none". (default "auto")

--- a/test/kafka_test.go
+++ b/test/kafka_test.go
@@ -124,8 +124,8 @@ func (s *CLITestSuite) TestKafka() {
 		{args: "kafka topic update topic-exist-rest --config num.partitions=6", useKafka: "lkc-describe-topic", fixture: "kafka/topic/update-success-rest-partitions-count.golden"},
 
 		// Cluster linking
-		{args: "kafka link create my_link --source-cluster lkc-describe-topic --source-bootstrap-server myhost:1234 --config-file " + getCreateLinkConfigFile(), fixture: "kafka/link/create-link.golden", useKafka: "lkc-describe-topic"},
-		{args: "kafka link create bidirectional_link --remote-cluster lkc-describe-topic --local-api-key local-api-key123 --local-api-secret local-api-secret-123 --remote-api-key remote-api-key-123 --remote-api-secret remote-api-secret-123 --remote-bootstrap-server myhost:1234 --config-file " + getCreateBidirectionalLinkConfigFile(), fixture: "kafka/link/create-bidirectional-link.golden", useKafka: "lkc-describe-topic"},
+		{args: "kafka link create my_link --source-cluster lkc-describe-topic --source-bootstrap-server myhost:1234 --config " + getCreateLinkConfigFile(), fixture: "kafka/link/create-link.golden", useKafka: "lkc-describe-topic"},
+		{args: "kafka link create bidirectional_link --remote-cluster lkc-describe-topic --local-api-key local-api-key123 --local-api-secret local-api-secret-123 --remote-api-key remote-api-key-123 --remote-api-secret remote-api-secret-123 --remote-bootstrap-server myhost:1234 --config " + getCreateBidirectionalLinkConfigFile(), fixture: "kafka/link/create-bidirectional-link.golden", useKafka: "lkc-describe-topic"},
 		{args: "kafka link list --cluster lkc-describe-topic", fixture: "kafka/link/list-link-plain.golden", useKafka: "lkc-describe-topic"},
 		{args: "kafka link list --cluster lkc-describe-topic -o json", fixture: "kafka/link/list-link-json.golden", useKafka: "lkc-describe-topic"},
 		{args: "kafka link list --cluster lkc-describe-topic -o yaml", fixture: "kafka/link/list-link-yaml.golden", useKafka: "lkc-describe-topic"},
@@ -205,6 +205,7 @@ func (s *CLITestSuite) TestKafkaClusterConfiguration() {
 		{args: "kafka cluster use lkc-12345"},
 		{args: "kafka cluster configuration describe compression.type", fixture: "kafka/cluster/configuration/describe.golden"},
 		{args: "kafka cluster configuration update --config auto.create.topics.enable=true", fixture: "kafka/cluster/configuration/update.golden"},
+		{args: "kafka cluster configuration update --config test/fixtures/input/kafka/cluster/configuration/update.properties", fixture: "kafka/cluster/configuration/update.golden"},
 		{args: "kafka cluster configuration list", fixture: "kafka/cluster/configuration/list.golden"},
 	}
 

--- a/test/kafka_test.go
+++ b/test/kafka_test.go
@@ -273,8 +273,8 @@ func (s *CLITestSuite) TestKafkaBroker() {
 		{args: "kafka broker describe --all --config-name compression.type -o json", fixture: "kafka/broker/describe-all-config-json.golden"},
 		{args: "kafka broker describe 1 --all", exitCode: 1, fixture: "kafka/broker/err-all-and-arg.golden"},
 
-		{args: "kafka broker update --config compression.type=zip,sasl_mechanism=SASL/PLAIN --all", fixture: "kafka/broker/update-all.golden"},
-		{args: "kafka broker update 1 --config compression.type=zip,sasl_mechanism=SASL/PLAIN", fixture: "kafka/broker/update-1.golden"},
+		{args: "kafka broker update --all --config compression.type=zip,sasl_mechanism=SASL/PLAIN", fixture: "kafka/broker/update-all.golden"},
+		{args: "kafka broker update 1 --config test/fixtures/input/kafka/broker/update.properties", fixture: "kafka/broker/update-1.golden"},
 		{args: "kafka broker update --config compression.type=zip,sasl_mechanism=SASL/PLAIN", exitCode: 1, fixture: "kafka/broker/err-need-all-or-arg.golden"},
 
 		{args: "kafka broker delete 1 --force", fixture: "kafka/broker/delete.golden"},

--- a/test/schema_registry_test.go
+++ b/test/schema_registry_test.go
@@ -71,7 +71,7 @@ func (s *CLITestSuite) TestSchemaRegistryExporter() {
 
 	tests := []CLITest{
 		{args: fmt.Sprintf("schema-registry exporter list --environment %s", testserver.SRApiEnvId), fixture: "schema-registry/exporter/list.golden"},
-		{args: fmt.Sprintf(`schema-registry exporter create myexporter --subjects foo,bar --context-type AUTO --subject-format my-\\${subject} --config-file %s --environment %s`, exporterConfigPath, testserver.SRApiEnvId), fixture: "schema-registry/exporter/create.golden"},
+		{args: fmt.Sprintf(`schema-registry exporter create myexporter --subjects foo,bar --context-type AUTO --subject-format my-\\${subject} --config %s --environment %s`, exporterConfigPath, testserver.SRApiEnvId), fixture: "schema-registry/exporter/create.golden"},
 		{args: fmt.Sprintf("schema-registry exporter describe myexporter --environment %s", testserver.SRApiEnvId), fixture: "schema-registry/exporter/describe.golden"},
 		{args: fmt.Sprintf(`schema-registry exporter update myexporter --subjects foo,bar,test --subject-format my-\\${subject} --environment %s`, testserver.SRApiEnvId), fixture: "schema-registry/exporter/update.golden"},
 		{args: fmt.Sprintf("schema-registry exporter delete myexporter --environment %s --force", testserver.SRApiEnvId), fixture: "schema-registry/exporter/delete.golden"},


### PR DESCRIPTION
Release Notes
-------------
Breaking Changes
- PLACEHOLDER

New Features
- Add support for both strings and files for the `--config` flag, in all relevant `confluent kafka` and `confluent schema-registry` commands

Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
Certain commands only supported comma-delimited strings (`--config`) and others only supported files (`--config-file`). Combine both into `--config` and use everywhere.

Test & Review
-------------
Add missing integration tests where needed