### PR TITLE
Revert sdk change for `confluent kafka mirror list` and `describe`

### DIFF
--- a/internal/cmd/kafka/command_mirror.go
+++ b/internal/cmd/kafka/command_mirror.go
@@ -1,7 +1,10 @@
 package kafka
 
 import (
+	"github.com/antihax/optional"
 	"github.com/spf13/cobra"
+
+	"github.com/confluentinc/kafka-rest-sdk-go/kafkarestv3"
 
 	pcmd "github.com/confluentinc/cli/internal/pkg/cmd"
 )
@@ -79,14 +82,15 @@ func (c *mirrorCommand) autocompleteMirrorTopics(cmd *cobra.Command) []string {
 		return nil
 	}
 
-	mirrors, err := kafkaREST.CloudClient.ListKafkaMirrorTopicsUnderLink(linkName, nil)
+	opts := &kafkarestv3.ListKafkaMirrorTopicsUnderLinkOpts{MirrorStatus: optional.EmptyInterface()}
+	listMirrorTopicsResponseDataList, _, err := kafkaREST.Client.ClusterLinkingV3Api.ListKafkaMirrorTopicsUnderLink(kafkaREST.Context, kafkaREST.GetClusterId(), linkName, opts)
 	if err != nil {
 		return nil
 	}
 
-	suggestions := make([]string, len(mirrors.GetData()))
-	for i, mirror := range mirrors.GetData() {
-		suggestions[i] = mirror.GetMirrorTopicName()
+	suggestions := make([]string, len(listMirrorTopicsResponseDataList.Data))
+	for i, mirrorTopic := range listMirrorTopicsResponseDataList.Data {
+		suggestions[i] = mirrorTopic.MirrorTopicName
 	}
 	return suggestions
 }

--- a/internal/cmd/kafka/command_mirror_describe.go
+++ b/internal/cmd/kafka/command_mirror_describe.go
@@ -5,6 +5,7 @@ import (
 
 	pcmd "github.com/confluentinc/cli/internal/pkg/cmd"
 	"github.com/confluentinc/cli/internal/pkg/examples"
+	"github.com/confluentinc/cli/internal/pkg/kafkarest"
 	"github.com/confluentinc/cli/internal/pkg/output"
 )
 
@@ -47,22 +48,22 @@ func (c *mirrorCommand) describe(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	mirror, err := kafkaREST.CloudClient.ReadKafkaMirrorTopic(linkName, mirrorTopicName)
+	mirror, httpResp, err := kafkaREST.Client.ClusterLinkingV3Api.ReadKafkaMirrorTopic(kafkaREST.Context, kafkaREST.GetClusterId(), linkName, mirrorTopicName)
 	if err != nil {
-		return err
+		return kafkarest.NewError(kafkaREST.CloudClient.GetUrl(), err, httpResp)
 	}
 
 	list := output.NewList(cmd)
-	for _, partitionLag := range mirror.GetMirrorLags().Items {
+	for _, partitionLag := range mirror.MirrorLags {
 		list.Add(&mirrorOut{
-			LinkName:              mirror.GetLinkName(),
-			MirrorTopicName:       mirror.GetMirrorTopicName(),
-			SourceTopicName:       mirror.GetSourceTopicName(),
-			MirrorStatus:          string(mirror.GetMirrorStatus()),
-			StatusTimeMs:          mirror.GetStateTimeMs(),
-			Partition:             partitionLag.GetPartition(),
-			PartitionMirrorLag:    partitionLag.GetLag(),
-			LastSourceFetchOffset: partitionLag.GetLastSourceFetchOffset(),
+			LinkName:              mirror.LinkName,
+			MirrorTopicName:       mirror.MirrorTopicName,
+			SourceTopicName:       mirror.SourceTopicName,
+			MirrorStatus:          string(mirror.MirrorStatus),
+			StatusTimeMs:          mirror.StateTimeMs,
+			Partition:             partitionLag.Partition,
+			PartitionMirrorLag:    partitionLag.Lag,
+			LastSourceFetchOffset: partitionLag.LastSourceFetchOffset,
 		})
 	}
 	list.Filter([]string{"LinkName", "MirrorTopicName", "Partition", "PartitionMirrorLag", "SourceTopicName", "MirrorStatus", "StatusTimeMs", "LastSourceFetchOffset"})


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- PLACEHOLDER

New Features
- PLACEHOLDER

Bug Fixes
- Prevent errors for certain statuses in `confluent kafka mirror describe` and `confluent kafka mirror list`

Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
The ccloud-sdk-go-v2 version of the kafkarest sdk enforces a requirement that the mirror status be one of `active`, `failed`, `paused`, `stopped`, or `pending_stopped`. However, the backend can return additional statuses `source_unavailable`, `link_failed`, or `link_stopped`.

This PR reverts the SDK switch for `mirror list`, `mirror describe`, and the mirror autocompletion.

This is meant to be temporary until the SDK is updated to account for this.

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
Ran all tests
Manually checked that mirror commands still work as intended for typical statuses.

Open Questions / Follow-ups
---------------------------
<!--
Optional: Anything open to discussion for the reviewer, out of scope of this PR, or follow-ups.
-->
