### PR TITLE
Recover from panic when opening dev/ttv and format error

### DIFF
--- a/internal/pkg/flink/app/application.go
+++ b/internal/pkg/flink/app/application.go
@@ -124,7 +124,7 @@ func (a *Application) panicRecovery() {
 
 func (a *Application) isAuthenticated() bool {
 	if authErr := a.refreshToken(); authErr != nil {
-		utils.OutputErrf("Error: %v", authErr)
+		utils.OutputErrf("Error: %v\n", authErr)
 		a.appController.ExitApplication()
 		return false
 	}

--- a/internal/pkg/flink/app/application.go
+++ b/internal/pkg/flink/app/application.go
@@ -53,7 +53,7 @@ func StartApp(client ccloudv2.GatewayClientInterface, tokenRefreshFunc func() er
 	stdinBefore := utils.GetStdin()
 	consoleParser := utils.GetConsoleParser()
 	if consoleParser == nil {
-		utils.OutputErr("Error: failed to set initialize console parser")
+		utils.OutputErr("Error: failed to initialize console parser")
 		return
 	}
 	appController.AddCleanupFunction(func() {

--- a/internal/pkg/flink/app/application.go
+++ b/internal/pkg/flink/app/application.go
@@ -52,6 +52,10 @@ func StartApp(client ccloudv2.GatewayClientInterface, tokenRefreshFunc func() er
 
 	stdinBefore := utils.GetStdin()
 	consoleParser := utils.GetConsoleParser()
+	if consoleParser == nil {
+		utils.OutputErr("Error: failed to set initialize console parser")
+		return
+	}
 	appController.AddCleanupFunction(func() {
 		utils.TearDownConsoleParser(consoleParser)
 		utils.RestoreStdin(stdinBefore)

--- a/internal/pkg/flink/app/application.go
+++ b/internal/pkg/flink/app/application.go
@@ -124,7 +124,7 @@ func (a *Application) panicRecovery() {
 
 func (a *Application) isAuthenticated() bool {
 	if authErr := a.refreshToken(); authErr != nil {
-		utils.OutputErrf("Error: %v\n", authErr)
+		utils.OutputErrf("Error: %v", authErr)
 		a.appController.ExitApplication()
 		return false
 	}

--- a/internal/pkg/flink/internal/autocomplete/docs_completer.go
+++ b/internal/pkg/flink/internal/autocomplete/docs_completer.go
@@ -17,7 +17,7 @@ func loadSnippetSuggestions() []prompt.Suggest {
 	var snippetSuggestions []prompt.Suggest
 	var payload map[string]any
 	if err := json.Unmarshal(codeSnippets, &payload); err != nil {
-		log.CliLogger.Warnf("Couldn't unmarshal code snippets. Error: %v\n", err)
+		log.CliLogger.Warnf("Couldn't unmarshal code snippets: %v", err)
 	}
 
 	for _, value := range payload {

--- a/internal/pkg/flink/internal/history/history.go
+++ b/internal/pkg/flink/internal/history/history.go
@@ -34,11 +34,11 @@ func loadFromPath(history *History) *History {
 	}
 
 	if err != nil {
-		log.CliLogger.Warnf("Couldn't load past statements history: unable to read file Error: " + err.Error())
+		log.CliLogger.Warnf("Couldn't load past statements history: unable to read file Error: %v", err)
 	}
 
 	if err := json.Unmarshal(jsonFile, history); err != nil {
-		log.CliLogger.Warnf("Couldn't load past statements history. Error: " + err.Error())
+		log.CliLogger.Warnf("Couldn't load past statements history. Error: %v", err)
 	}
 	return history
 }
@@ -46,7 +46,7 @@ func loadFromPath(history *History) *History {
 func initPath() *History {
 	home, osHomedirErr := os.UserHomeDir()
 	if osHomedirErr != nil {
-		log.CliLogger.Warnf("Couldn't get homedir with os.UserHomeDir(). Error: " + osHomedirErr.Error())
+		log.CliLogger.Warnf("Couldn't get homedir with os.UserHomeDir(). Error: %v", osHomedirErr)
 		return nil
 	}
 
@@ -73,24 +73,24 @@ func (history *History) Save() {
 	// Convert struct to JSON
 	b, err := json.Marshal(history)
 	if err != nil {
-		log.CliLogger.Warnf("Couldn't save past statements history: couldn't marhsal history. Error: " + err.Error())
+		log.CliLogger.Warnf("Couldn't save past statements history: couldn't marhsal history. Error: %v", err)
 	}
 
 	if err := os.Mkdir(history.confluentPath, os.ModePerm); err != nil {
 		if !errors.Is(err, os.ErrExist) {
-			log.CliLogger.Warnf("Couldn't save past statements history: couldn't create directory. Error: " + err.Error())
+			log.CliLogger.Warnf("Couldn't save past statements history: couldn't create directory. Error: %v", err)
 		}
 	}
 
 	// Write JSON to file
 	f, err := os.Create(history.historyPath)
 	if err != nil {
-		log.CliLogger.Warnf("Couldn't save past statements history: couldn't create file. Error: " + err.Error())
+		log.CliLogger.Warnf("Couldn't save past statements history: couldn't create file. Error: %v", err)
 	}
 	defer f.Close()
 
 	if _, err := f.Write(b); err != nil {
-		log.CliLogger.Warnf("Couldn't save past statements history: couldn't write to file. Error: " + err.Error())
+		log.CliLogger.Warnf("Couldn't save past statements history: couldn't write to file. Error: %v", err)
 	}
 }
 

--- a/internal/pkg/flink/internal/history/history.go
+++ b/internal/pkg/flink/internal/history/history.go
@@ -29,16 +29,16 @@ func loadFromPath(history *History) *History {
 	}
 	jsonFile, err := os.ReadFile(history.historyPath)
 	if errors.Is(err, os.ErrNotExist) {
-		log.CliLogger.Warnf("Couldn't load past statements: file doesn't exist: %s. This is expected if that's the first time you're using the Flink SQL Client! Error: %v", history.historyPath, err)
+		log.CliLogger.Warnf("Couldn't load past statements: file doesn't exist: %s. This is expected if that's the first time you're using the Flink SQL Client!", history.historyPath)
 		return history
 	}
 
 	if err != nil {
-		log.CliLogger.Warnf("Couldn't load past statements history: unable to read file Error: %v", err)
+		log.CliLogger.Warnf("Couldn't load past statements history: unable to read file: %v", err)
 	}
 
 	if err := json.Unmarshal(jsonFile, history); err != nil {
-		log.CliLogger.Warnf("Couldn't load past statements history. Error: %v", err)
+		log.CliLogger.Warnf("Couldn't load past statements history: %v", err)
 	}
 	return history
 }
@@ -46,7 +46,7 @@ func loadFromPath(history *History) *History {
 func initPath() *History {
 	home, osHomedirErr := os.UserHomeDir()
 	if osHomedirErr != nil {
-		log.CliLogger.Warnf("Couldn't get homedir with os.UserHomeDir(). Error: %v", osHomedirErr)
+		log.CliLogger.Warnf("Couldn't get homedir with os.UserHomeDir(): %v", osHomedirErr)
 		return nil
 	}
 
@@ -73,24 +73,24 @@ func (history *History) Save() {
 	// Convert struct to JSON
 	b, err := json.Marshal(history)
 	if err != nil {
-		log.CliLogger.Warnf("Couldn't save past statements history: couldn't marhsal history. Error: %v", err)
+		log.CliLogger.Warnf("Couldn't save past statements history: couldn't marshal history: %v", err)
 	}
 
 	if err := os.Mkdir(history.confluentPath, os.ModePerm); err != nil {
 		if !errors.Is(err, os.ErrExist) {
-			log.CliLogger.Warnf("Couldn't save past statements history: couldn't create directory. Error: %v", err)
+			log.CliLogger.Warnf("Couldn't save past statements history: couldn't create directory: %v", err)
 		}
 	}
 
 	// Write JSON to file
 	f, err := os.Create(history.historyPath)
 	if err != nil {
-		log.CliLogger.Warnf("Couldn't save past statements history: couldn't create file. Error: %v", err)
+		log.CliLogger.Warnf("Couldn't save past statements history: couldn't create file: %v", err)
 	}
 	defer f.Close()
 
 	if _, err := f.Write(b); err != nil {
-		log.CliLogger.Warnf("Couldn't save past statements history: couldn't write to file. Error: %v", err)
+		log.CliLogger.Warnf("Couldn't save past statements history: couldn't write to file: %v", err)
 	}
 }
 

--- a/internal/pkg/flink/internal/utils/input.go
+++ b/internal/pkg/flink/internal/utils/input.go
@@ -13,7 +13,7 @@ import (
 func GetStdin() *term.State {
 	state, err := term.GetState(int(os.Stdin.Fd()))
 	if err != nil {
-		log.CliLogger.Warnf("Couldn't get stdin state with term.GetState. Error: %v", err)
+		log.CliLogger.Warnf("Couldn't get stdin state with term.GetState: %v", err)
 		return nil
 	}
 	return state
@@ -21,7 +21,7 @@ func GetStdin() *term.State {
 
 func GetConsoleParser() prompt.ConsoleParser {
 	if fileInfo, err := os.Stat("/dev/tty"); err != nil {
-		log.CliLogger.Warnf(`Couldn't open "/dev/tty" file. Error: %v`, err)
+		log.CliLogger.Warnf(`Couldn't open "/dev/tty" file: %v`, err)
 		return nil
 	} else if fileInfo.Mode().Perm()&0444 == 0 {
 		log.CliLogger.Warn(`Couldn't read "/dev/tty" file because read permissions are not set.`)
@@ -30,7 +30,7 @@ func GetConsoleParser() prompt.ConsoleParser {
 	consoleParser := prompt.NewStandardInputParser()
 	err := consoleParser.Setup()
 	if err != nil {
-		log.CliLogger.Warnf("Couldn't setup console parser. Error: %v", err)
+		log.CliLogger.Warnf("Couldn't setup console parser: %v", err)
 	}
 	return consoleParser
 }
@@ -38,7 +38,7 @@ func GetConsoleParser() prompt.ConsoleParser {
 func TearDownConsoleParser(consoleParser prompt.ConsoleParser) {
 	err := consoleParser.TearDown()
 	if err != nil {
-		log.CliLogger.Warnf("Couldn't tear down console parser. Error: %v", err)
+		log.CliLogger.Warnf("Couldn't tear down console parser: %v", err)
 	}
 }
 

--- a/internal/pkg/flink/internal/utils/input.go
+++ b/internal/pkg/flink/internal/utils/input.go
@@ -13,32 +13,32 @@ import (
 func GetStdin() *term.State {
 	state, err := term.GetState(int(os.Stdin.Fd()))
 	if err != nil {
-		log.CliLogger.Warnf("Couldn't get stdin state with term.GetState. Error: %v\n", err)
+		log.CliLogger.Warnf("Couldn't get stdin state with term.GetState. Error: ", err.Error())
 		return nil
 	}
 	return state
 }
 
 func GetConsoleParser() prompt.ConsoleParser {
-	if fileInfo, err := os.Stat("/dev/tty"); err != nil || fileInfo.Mode().Perm()&0444 == 0 {
-		log.CliLogger.Warnf(`Couldn't open "/dev/tty" file because it either doesn't exist or doesn't have read permissions.`)
+	if fileInfo, err := os.Stat("/dev/tty"); err != nil {
+		log.CliLogger.Warnf(`Couldn't open "/dev/tty" file. Error: `, err.Error())
+		return nil
+	} else if fileInfo.Mode().Perm()&0444 == 0 {
+		log.CliLogger.Warn(`Couldn't read "/dev/tty" file because read permissions are not set.`)
 		return nil
 	}
 	consoleParser := prompt.NewStandardInputParser()
 	err := consoleParser.Setup()
 	if err != nil {
-		log.CliLogger.Warnf("Couldn't setup console parser. Error: %v\n", err)
+		log.CliLogger.Warnf("Couldn't setup console parser. Error: ", err.Error())
 	}
 	return consoleParser
 }
 
 func TearDownConsoleParser(consoleParser prompt.ConsoleParser) {
-	if consoleParser == nil {
-		return
-	}
 	err := consoleParser.TearDown()
 	if err != nil {
-		log.CliLogger.Warnf("Couldn't tear down console parser. Error: %v\n", err)
+		log.CliLogger.Warnf("Couldn't tear down console parser. Error: ", err.Error())
 	}
 }
 

--- a/internal/pkg/flink/internal/utils/input.go
+++ b/internal/pkg/flink/internal/utils/input.go
@@ -20,6 +20,11 @@ func GetStdin() *term.State {
 }
 
 func GetConsoleParser() prompt.ConsoleParser {
+	defer func() {
+		if r := recover(); r != nil {
+			log.CliLogger.Warnf("Couldn't open \"/dev/ttv\" file. Error: %v\n", r)
+		}
+	}()
 	consoleParser := prompt.NewStandardInputParser()
 	err := consoleParser.Setup()
 	if err != nil {

--- a/internal/pkg/flink/internal/utils/input.go
+++ b/internal/pkg/flink/internal/utils/input.go
@@ -33,6 +33,9 @@ func GetConsoleParser() prompt.ConsoleParser {
 }
 
 func TearDownConsoleParser(consoleParser prompt.ConsoleParser) {
+	if consoleParser == nil {
+		return
+	}
 	err := consoleParser.TearDown()
 	if err != nil {
 		log.CliLogger.Warnf("Couldn't tear down console parser. Error: %v\n", err)

--- a/internal/pkg/flink/internal/utils/input.go
+++ b/internal/pkg/flink/internal/utils/input.go
@@ -20,11 +20,9 @@ func GetStdin() *term.State {
 }
 
 func GetConsoleParser() prompt.ConsoleParser {
-	if fileInfo, err := os.Stat("/dev/tty"); err != nil {
-		log.CliLogger.Warnf("Couldn't open \"/dev/tty\" file because it doesn't exist. Error: %v\n", err)
-	} else if fileInfo.Mode().Perm()&0444 != 0 {
-		// Checks if any read permissions are set for "/dev/tty" file
-		log.CliLogger.Warnf("Error: No read permissions are not set for \"/dev/tty\".")
+	if fileInfo, err := os.Stat("/dev/tty"); err != nil || fileInfo.Mode().Perm()&0444 == 0 {
+		log.CliLogger.Warnf("Couldn't open \"/dev/tty\" file because it either doesn't exist or doesn't have read permissions.\n")
+		return nil
 	}
 	consoleParser := prompt.NewStandardInputParser()
 	err := consoleParser.Setup()

--- a/internal/pkg/flink/internal/utils/input.go
+++ b/internal/pkg/flink/internal/utils/input.go
@@ -21,7 +21,7 @@ func GetStdin() *term.State {
 
 func GetConsoleParser() prompt.ConsoleParser {
 	if fileInfo, err := os.Stat("/dev/tty"); err != nil || fileInfo.Mode().Perm()&0444 == 0 {
-		log.CliLogger.Warnf("Couldn't open \"/dev/tty\" file because it either doesn't exist or doesn't have read permissions.\n")
+		log.CliLogger.Warnf(`Couldn't open "/dev/tty" file because it either doesn't exist or doesn't have read permissions.`)
 		return nil
 	}
 	consoleParser := prompt.NewStandardInputParser()

--- a/internal/pkg/flink/internal/utils/input.go
+++ b/internal/pkg/flink/internal/utils/input.go
@@ -13,7 +13,7 @@ import (
 func GetStdin() *term.State {
 	state, err := term.GetState(int(os.Stdin.Fd()))
 	if err != nil {
-		log.CliLogger.Warn("Couldn't get stdin state with term.GetState. Error: " + err.Error())
+		log.CliLogger.Warnf("Couldn't get stdin state with term.GetState. Error: %v", err)
 		return nil
 	}
 	return state
@@ -21,7 +21,7 @@ func GetStdin() *term.State {
 
 func GetConsoleParser() prompt.ConsoleParser {
 	if fileInfo, err := os.Stat("/dev/tty"); err != nil {
-		log.CliLogger.Warn(`Couldn't open "/dev/tty" file. Error: ` + err.Error())
+		log.CliLogger.Warnf(`Couldn't open "/dev/tty" file. Error: %v`, err)
 		return nil
 	} else if fileInfo.Mode().Perm()&0444 == 0 {
 		log.CliLogger.Warn(`Couldn't read "/dev/tty" file because read permissions are not set.`)
@@ -30,7 +30,7 @@ func GetConsoleParser() prompt.ConsoleParser {
 	consoleParser := prompt.NewStandardInputParser()
 	err := consoleParser.Setup()
 	if err != nil {
-		log.CliLogger.Warn("Couldn't setup console parser. Error: " + err.Error())
+		log.CliLogger.Warnf("Couldn't setup console parser. Error: %v", err)
 	}
 	return consoleParser
 }
@@ -38,7 +38,7 @@ func GetConsoleParser() prompt.ConsoleParser {
 func TearDownConsoleParser(consoleParser prompt.ConsoleParser) {
 	err := consoleParser.TearDown()
 	if err != nil {
-		log.CliLogger.Warn("Couldn't tear down console parser. Error: " + err.Error())
+		log.CliLogger.Warnf("Couldn't tear down console parser. Error: %v", err)
 	}
 }
 

--- a/internal/pkg/flink/internal/utils/input.go
+++ b/internal/pkg/flink/internal/utils/input.go
@@ -13,7 +13,7 @@ import (
 func GetStdin() *term.State {
 	state, err := term.GetState(int(os.Stdin.Fd()))
 	if err != nil {
-		log.CliLogger.Warnf("Couldn't get stdin state with term.GetState. Error: ", err.Error())
+		log.CliLogger.Warn("Couldn't get stdin state with term.GetState. Error: " + err.Error())
 		return nil
 	}
 	return state
@@ -21,7 +21,7 @@ func GetStdin() *term.State {
 
 func GetConsoleParser() prompt.ConsoleParser {
 	if fileInfo, err := os.Stat("/dev/tty"); err != nil {
-		log.CliLogger.Warnf(`Couldn't open "/dev/tty" file. Error: `, err.Error())
+		log.CliLogger.Warn(`Couldn't open "/dev/tty" file. Error: ` + err.Error())
 		return nil
 	} else if fileInfo.Mode().Perm()&0444 == 0 {
 		log.CliLogger.Warn(`Couldn't read "/dev/tty" file because read permissions are not set.`)
@@ -30,7 +30,7 @@ func GetConsoleParser() prompt.ConsoleParser {
 	consoleParser := prompt.NewStandardInputParser()
 	err := consoleParser.Setup()
 	if err != nil {
-		log.CliLogger.Warnf("Couldn't setup console parser. Error: ", err.Error())
+		log.CliLogger.Warn("Couldn't setup console parser. Error: " + err.Error())
 	}
 	return consoleParser
 }
@@ -38,7 +38,7 @@ func GetConsoleParser() prompt.ConsoleParser {
 func TearDownConsoleParser(consoleParser prompt.ConsoleParser) {
 	err := consoleParser.TearDown()
 	if err != nil {
-		log.CliLogger.Warnf("Couldn't tear down console parser. Error: ", err.Error())
+		log.CliLogger.Warn("Couldn't tear down console parser. Error: " + err.Error())
 	}
 }
 

--- a/internal/pkg/flink/internal/utils/input.go
+++ b/internal/pkg/flink/internal/utils/input.go
@@ -20,11 +20,12 @@ func GetStdin() *term.State {
 }
 
 func GetConsoleParser() prompt.ConsoleParser {
-	defer func() {
-		if r := recover(); r != nil {
-			log.CliLogger.Warnf("Couldn't open \"/dev/ttv\" file. Error: %v\n", r)
-		}
-	}()
+	if fileInfo, err := os.Stat("/dev/tty"); err != nil {
+		log.CliLogger.Warnf("Couldn't open \"/dev/tty\" file because it doesn't exist. Error: %v\n", err)
+	} else if fileInfo.Mode().Perm()&0444 != 0 {
+		// Checks if any read permissions are set for "/dev/tty" file
+		log.CliLogger.Warnf("Error: No read permissions are not set for \"/dev/tty\".")
+	}
 	consoleParser := prompt.NewStandardInputParser()
 	err := consoleParser.Setup()
 	if err != nil {


### PR DESCRIPTION
Release Notes
-------------
Bug Fixes
- Resolve `confluent flink shell` panic when `/dev/tty` is inaccessible

Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
When starting a flink application via the `confluent flink shell` command, [this function](https://github.com/confluentinc/go-prompt/blob/master/input_posix.go#L69) can panic if the file `/dev/tty` is inaccessible (e.g. running cli in containerized environment, or cli doesn’t have permission). Since the panicking function is used outside of CLI source, we should `recover()` and format an error for the user.

References
----------
https://confluentinc.atlassian.net/browse/CLI-2683
