### PR TITLE
Show single-resource API keys for multicluster enabled orgs

### DIFF
--- a/internal/cmd/api-key/command_list.go
+++ b/internal/cmd/api-key/command_list.go
@@ -119,7 +119,7 @@ func (c *command) list(cmd *cobra.Command, _ []string) error {
 		resources := []apikeysv2.ObjectReference{apiKey.Spec.GetResource()}
 
 		// Check if multicluster keys are enabled, and if so check the resources field
-		if featureflags.Manager.BoolVariation("cli.multicluster-api-keys.enable", c.Context, config.CliLaunchDarklyClient, true, false) {
+		if featureflags.Manager.BoolVariation("cli.multicluster-api-keys.enable", c.Context, config.CliLaunchDarklyClient, true, false) && len(apiKey.Spec.GetResources()) > 0 {
 			resources = apiKey.Spec.GetResources()
 		}
 

--- a/test/api_key_test.go
+++ b/test/api_key_test.go
@@ -140,7 +140,7 @@ func (s *CLITestSuite) TestApiKey() {
 
 		// test multicluster keys
 		{name: "listing multicluster API keys", args: "api-key list", login: "cloud", env: []string{fmt.Sprintf("%s=multicluster-key-org", pauth.ConfluentCloudOrganizationId)}, fixture: "api-key/56.golden"},
-		{name: "listing multicluster API keys with --resource field", args: "api-key list --resource lsrc-abc", login: "cloud", env: []string{fmt.Sprintf("%s=multicluster-key-org", pauth.ConfluentCloudOrganizationId)}, fixture: "api-key/57.golden"},
+		{name: "listing multicluster API keys with --resource field", args: "api-key list --resource lsrc-1234", login: "cloud", env: []string{fmt.Sprintf("%s=multicluster-key-org", pauth.ConfluentCloudOrganizationId)}, fixture: "api-key/57.golden"},
 		{name: "listing multicluster API keys with --current-user field", args: "api-key list --current-user", login: "cloud", env: []string{fmt.Sprintf("%s=multicluster-key-org", pauth.ConfluentCloudOrganizationId)}, fixture: "api-key/58.golden"},
 		{name: "listing multicluster API keys with --service-account field", args: "api-key list --service-account sa-12345", login: "cloud", env: []string{fmt.Sprintf("%s=multicluster-key-org", pauth.ConfluentCloudOrganizationId)}, fixture: "api-key/59.golden"},
 	}

--- a/test/fixtures/output/api-key/56.golden
+++ b/test/fixtures/output/api-key/56.golden
@@ -1,12 +1,33 @@
-  Current |       Key        |          Description           |  Owner   |    Owner Email    |  Resource Type  |  Resource   |       Created         
-----------+------------------+--------------------------------+----------+-------------------+-----------------+-------------+-----------------------
-          | MULTICLUSTERKEY1 | works for two clusters         | u-44ddd  | mhe@confluent.io  | kafka           | lkc-abc     | 1999-02-24T00:00:00Z  
-          | MULTICLUSTERKEY1 | works for two clusters         | u-44ddd  | mhe@confluent.io  | schema-registry | lsrc-1234   | 1999-02-24T00:00:00Z  
-          | MULTICLUSTERKEY2 | works for two clusters but on  | u-44ddd  | mhe@confluent.io  | kafka           | lkc-abc     | 1999-02-24T00:00:00Z  
-          |                  | a different sr cluster         |          |                   |                 |             |                       
-          | MULTICLUSTERKEY2 | works for two clusters but on  | u-44ddd  | mhe@confluent.io  | schema-registry | lsrc-abc123 | 1999-02-24T00:00:00Z  
-          |                  | a different sr cluster         |          |                   |                 |             |                       
-          | MULTICLUSTERKEY3 | works for two clusters and     | sa-12345 | <service account> | kafka           | lkc-abc     | 1999-02-24T00:00:00Z  
-          |                  | owned by service account       |          |                   |                 |             |                       
-          | MULTICLUSTERKEY3 | works for two clusters and     | sa-12345 | <service account> | schema-registry | lsrc-1234   | 1999-02-24T00:00:00Z  
-          |                  | owned by service account       |          |                   |                 |             |                       
+  Current |        Key         |          Description           |  Owner   |        Owner Email         |  Resource Type  |   Resource   |       Created         
+----------+--------------------+--------------------------------+----------+----------------------------+-----------------+--------------+-----------------------
+          | DEACTIVATEDUSERKEY |                                | sa-6666  | <deactivated user>         | kafka           | lkc-bob      | 1999-02-24T00:00:00Z  
+          | MULTICLUSTERKEY1   | works for two clusters         | u-44ddd  | mhe@confluent.io           | kafka           | lkc-abc      | 1999-02-24T00:00:00Z  
+          | MULTICLUSTERKEY1   | works for two clusters         | u-44ddd  | mhe@confluent.io           | schema-registry | lsrc-1234    | 1999-02-24T00:00:00Z  
+          | MULTICLUSTERKEY2   | works for two clusters but on  | u-44ddd  | mhe@confluent.io           | kafka           | lkc-abc      | 1999-02-24T00:00:00Z  
+          |                    | a different sr cluster         |          |                            |                 |              |                       
+          | MULTICLUSTERKEY2   | works for two clusters but on  | u-44ddd  | mhe@confluent.io           | schema-registry | lsrc-abc123  | 1999-02-24T00:00:00Z  
+          |                    | a different sr cluster         |          |                            |                 |              |                       
+          | MULTICLUSTERKEY3   | works for two clusters and     | sa-12345 | <service account>          | kafka           | lkc-abc      | 1999-02-24T00:00:00Z  
+          |                    | owned by service account       |          |                            |                 |              |                       
+          | MULTICLUSTERKEY3   | works for two clusters and     | sa-12345 | <service account>          | schema-registry | lsrc-1234    | 1999-02-24T00:00:00Z  
+          |                    | owned by service account       |          |                            |                 |              |                       
+          | MYKEY1             | first-key                      | u11      | bstrauch@confluent.io      | kafka           | lkc-bob      | 1999-02-24T00:00:00Z  
+          | MYKEY10            |                                | sa-12345 | <service account>          | kafka           | lkc-cool1    | 1999-02-24T00:00:00Z  
+          | MYKEY11            | auditlog-key                   | sa-1337  | <auditlog service account> | kafka           | lkc-cool1    | 1999-02-24T00:00:00Z  
+          | MYKEY12            | auditlog-key                   | sa-1337  | <auditlog service account> | kafka           | lkc-cool1    | 1999-02-24T00:00:00Z  
+          | MYKEY13            | human-output                   | u-44ddd  | mhe@confluent.io           | kafka           | lkc-other1   | 1999-02-24T00:00:00Z  
+          | MYKEY14            | json-output                    | u-44ddd  | mhe@confluent.io           | kafka           | lkc-other1   | 1999-02-24T00:00:00Z  
+          | MYKEY15            | yaml-output                    | u-44ddd  | mhe@confluent.io           | kafka           | lkc-other1   | 1999-02-24T00:00:00Z  
+          | MYKEY16            | my-cool-app                    | u-44ddd  | mhe@confluent.io           | kafka           | lkc-cool1    | 1999-02-24T00:00:00Z  
+          | MYKEY2             |                                | u-17     | mtodzo@confluent.io        | kafka           | lkc-abc      | 1999-02-24T00:00:00Z  
+          | MYKEY3             |                                | u-44ddd  | mhe@confluent.io           | kafka           | lkc-bob      | 1999-02-24T00:00:00Z  
+          | MYKEY4             | my-cool-app                    | u-44ddd  | mhe@confluent.io           | kafka           | lkc-cool1    | 1999-02-24T00:00:00Z  
+          | MYKEY6             | my-ksql-app                    | u-44ddd  | mhe@confluent.io           | ksql            | lksqlc-ksql1 | 1999-02-24T00:00:00Z  
+          | MYKEY7             |                                | u-44ddd  | mhe@confluent.io           | schema-registry | lsrc-1234    | 1999-02-24T00:00:00Z  
+          | MYKEY8             |                                | u-44ddd  | mhe@confluent.io           | cloud           |              | 1999-02-24T00:00:00Z  
+          | MYKEY9             |                                | sa-12345 | <service account>          | kafka           | lkc-cool1    | 1999-02-24T00:00:00Z  
+          | SERVICEACCOUNTKEY1 |                                | sa-12345 | <service account>          | kafka           | lkc-bob      | 1999-02-24T00:00:00Z  
+          | UIAPIKEY100        |                                | u-22bbb  | u-22bbb@confluent.io       | kafka           | lkc-cool1    | 1999-02-24T00:00:00Z  
+          | UIAPIKEY101        |                                | u-22bbb  | u-22bbb@confluent.io       | kafka           | lkc-other1   | 1999-02-24T00:00:00Z  
+          | UIAPIKEY102        |                                | u-22bbb  | u-22bbb@confluent.io       | ksql            | lksqlc-ksql1 | 1999-02-24T00:00:00Z  
+          | UIAPIKEY103        |                                | u-22bbb  | u-22bbb@confluent.io       | kafka           | lkc-cool1    | 1999-02-24T00:00:00Z  

--- a/test/fixtures/output/api-key/57.golden
+++ b/test/fixtures/output/api-key/57.golden
@@ -6,3 +6,4 @@
           |                  | owned by service account       |          |                   |                 |           |                       
           | MULTICLUSTERKEY3 | works for two clusters and     | sa-12345 | <service account> | schema-registry | lsrc-1234 | 1999-02-24T00:00:00Z  
           |                  | owned by service account       |          |                   |                 |           |                       
+          | MYKEY7           |                                | u-44ddd  | mhe@confluent.io  | schema-registry | lsrc-1234 | 1999-02-24T00:00:00Z  

--- a/test/fixtures/output/api-key/58.golden
+++ b/test/fixtures/output/api-key/58.golden
@@ -1,8 +1,17 @@
-  Current |       Key        |          Description           |  Owner  |   Owner Email    |  Resource Type  |  Resource   |       Created         
-----------+------------------+--------------------------------+---------+------------------+-----------------+-------------+-----------------------
-          | MULTICLUSTERKEY1 | works for two clusters         | u-44ddd | mhe@confluent.io | kafka           | lkc-abc     | 1999-02-24T00:00:00Z  
-          | MULTICLUSTERKEY1 | works for two clusters         | u-44ddd | mhe@confluent.io | schema-registry | lsrc-1234   | 1999-02-24T00:00:00Z  
-          | MULTICLUSTERKEY2 | works for two clusters but on  | u-44ddd | mhe@confluent.io | kafka           | lkc-abc     | 1999-02-24T00:00:00Z  
-          |                  | a different sr cluster         |         |                  |                 |             |                       
-          | MULTICLUSTERKEY2 | works for two clusters but on  | u-44ddd | mhe@confluent.io | schema-registry | lsrc-abc123 | 1999-02-24T00:00:00Z  
-          |                  | a different sr cluster         |         |                  |                 |             |                       
+  Current |       Key        |          Description           |  Owner  |   Owner Email    |  Resource Type  |   Resource   |       Created         
+----------+------------------+--------------------------------+---------+------------------+-----------------+--------------+-----------------------
+          | MULTICLUSTERKEY1 | works for two clusters         | u-44ddd | mhe@confluent.io | kafka           | lkc-abc      | 1999-02-24T00:00:00Z  
+          | MULTICLUSTERKEY1 | works for two clusters         | u-44ddd | mhe@confluent.io | schema-registry | lsrc-1234    | 1999-02-24T00:00:00Z  
+          | MULTICLUSTERKEY2 | works for two clusters but on  | u-44ddd | mhe@confluent.io | kafka           | lkc-abc      | 1999-02-24T00:00:00Z  
+          |                  | a different sr cluster         |         |                  |                 |              |                       
+          | MULTICLUSTERKEY2 | works for two clusters but on  | u-44ddd | mhe@confluent.io | schema-registry | lsrc-abc123  | 1999-02-24T00:00:00Z  
+          |                  | a different sr cluster         |         |                  |                 |              |                       
+          | MYKEY13          | human-output                   | u-44ddd | mhe@confluent.io | kafka           | lkc-other1   | 1999-02-24T00:00:00Z  
+          | MYKEY14          | json-output                    | u-44ddd | mhe@confluent.io | kafka           | lkc-other1   | 1999-02-24T00:00:00Z  
+          | MYKEY15          | yaml-output                    | u-44ddd | mhe@confluent.io | kafka           | lkc-other1   | 1999-02-24T00:00:00Z  
+          | MYKEY16          | my-cool-app                    | u-44ddd | mhe@confluent.io | kafka           | lkc-cool1    | 1999-02-24T00:00:00Z  
+          | MYKEY3           |                                | u-44ddd | mhe@confluent.io | kafka           | lkc-bob      | 1999-02-24T00:00:00Z  
+          | MYKEY4           | my-cool-app                    | u-44ddd | mhe@confluent.io | kafka           | lkc-cool1    | 1999-02-24T00:00:00Z  
+          | MYKEY6           | my-ksql-app                    | u-44ddd | mhe@confluent.io | ksql            | lksqlc-ksql1 | 1999-02-24T00:00:00Z  
+          | MYKEY7           |                                | u-44ddd | mhe@confluent.io | schema-registry | lsrc-1234    | 1999-02-24T00:00:00Z  
+          | MYKEY8           |                                | u-44ddd | mhe@confluent.io | cloud           |              | 1999-02-24T00:00:00Z  

--- a/test/fixtures/output/api-key/59.golden
+++ b/test/fixtures/output/api-key/59.golden
@@ -1,6 +1,9 @@
-  Current |       Key        |          Description           |  Owner   |    Owner Email    |  Resource Type  | Resource  |       Created         
-----------+------------------+--------------------------------+----------+-------------------+-----------------+-----------+-----------------------
-          | MULTICLUSTERKEY3 | works for two clusters and     | sa-12345 | <service account> | kafka           | lkc-abc   | 1999-02-24T00:00:00Z  
-          |                  | owned by service account       |          |                   |                 |           |                       
-          | MULTICLUSTERKEY3 | works for two clusters and     | sa-12345 | <service account> | schema-registry | lsrc-1234 | 1999-02-24T00:00:00Z  
-          |                  | owned by service account       |          |                   |                 |           |                       
+  Current |        Key         |          Description           |  Owner   |    Owner Email    |  Resource Type  | Resource  |       Created         
+----------+--------------------+--------------------------------+----------+-------------------+-----------------+-----------+-----------------------
+          | MULTICLUSTERKEY3   | works for two clusters and     | sa-12345 | <service account> | kafka           | lkc-abc   | 1999-02-24T00:00:00Z  
+          |                    | owned by service account       |          |                   |                 |           |                       
+          | MULTICLUSTERKEY3   | works for two clusters and     | sa-12345 | <service account> | schema-registry | lsrc-1234 | 1999-02-24T00:00:00Z  
+          |                    | owned by service account       |          |                   |                 |           |                       
+          | MYKEY10            |                                | sa-12345 | <service account> | kafka           | lkc-cool1 | 1999-02-24T00:00:00Z  
+          | MYKEY9             |                                | sa-12345 | <service account> | kafka           | lkc-cool1 | 1999-02-24T00:00:00Z  
+          | SERVICEACCOUNTKEY1 |                                | sa-12345 | <service account> | kafka           | lkc-bob   | 1999-02-24T00:00:00Z  

--- a/test/test-server/srcm_handlers.go
+++ b/test/test-server/srcm_handlers.go
@@ -51,6 +51,12 @@ func handleSchemaRegistryClusters(t *testing.T) http.HandlerFunc {
 
 func handleSchemaRegistryCluster(t *testing.T) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		id := mux.Vars(r)["id"]
+		if id != srClusterId {
+			err := writeResourceNotFoundError(w)
+			require.NoError(t, err)
+			return
+		}
 		switch r.Method {
 		case http.MethodPatch:
 			req := new(srcmv2.SrcmV2ClusterUpdate)


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- PLACEHOLDER

New Features
- PLACEHOLDER

Bug Fixes
- PLACEHOLDER

Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
Some system tests recently failed because API keys with a single resource don't show up in `confluent api-key list`. The cause is that the associated resource is listed in the `Resource` field of the http response and not in the `Resources` field, which is given preference for multicluster enabled orgs.

This PR only uses the list in `Resources` if it is non-empty.

I also added a check on the test handler for `/srcm/v2/clusters/{id}` to verify that the `{id}` matches the test backend SR cluster id. There was previously a confusing golden file where the SR cluster given to the `--resource` flag did not match the actual cluster printed in the output.

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
Tested using a stag org and a prod org.

Open Questions / Follow-ups
---------------------------
<!--
Optional: Anything open to discussion for the reviewer, out of scope of this PR, or follow-ups.
-->
