### PR TITLE
[TRAFFIC-9067] - Add `confluent network delete` command

### DIFF
--- a/internal/network/command.go
+++ b/internal/network/command.go
@@ -19,6 +19,7 @@ func New(prerunner pcmd.PreRunner) *cobra.Command {
 
 	c := &command{pcmd.NewAuthenticatedCLICommand(cmd, prerunner)}
 	cmd.AddCommand(c.newDescribeCommand())
+	cmd.AddCommand(c.newDeleteCommand())
 
 	return cmd
 }

--- a/internal/network/command.go
+++ b/internal/network/command.go
@@ -18,8 +18,8 @@ func New(prerunner pcmd.PreRunner) *cobra.Command {
 	}
 
 	c := &command{pcmd.NewAuthenticatedCLICommand(cmd, prerunner)}
-	cmd.AddCommand(c.newDescribeCommand())
 	cmd.AddCommand(c.newDeleteCommand())
+	cmd.AddCommand(c.newDescribeCommand())
 
 	return cmd
 }

--- a/internal/network/command_delete.go
+++ b/internal/network/command_delete.go
@@ -30,7 +30,7 @@ func (c *command) newDeleteCommand() *cobra.Command {
 	}
 
 	pcmd.AddForceFlag(cmd)
-	pcmd.AddClusterFlag(cmd, c.AuthenticatedCLICommand)
+	pcmd.AddContextFlag(cmd, c.CLICommand)
 	pcmd.AddEnvironmentFlag(cmd, c.AuthenticatedCLICommand)
 
 	return cmd

--- a/internal/network/command_delete.go
+++ b/internal/network/command_delete.go
@@ -1,0 +1,57 @@
+package network
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	pcmd "github.com/confluentinc/cli/v3/pkg/cmd"
+	"github.com/confluentinc/cli/v3/pkg/errors"
+	"github.com/confluentinc/cli/v3/pkg/examples"
+	"github.com/confluentinc/cli/v3/pkg/form"
+	"github.com/confluentinc/cli/v3/pkg/output"
+	"github.com/confluentinc/cli/v3/pkg/resource"
+)
+
+func (c *command) newDeleteCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "delete <id>",
+		Short: "Delete a network.",
+		Args:  cobra.ExactArgs(1),
+		// TODO: Implement autocompletion after List Network is implemented.
+		// ValidArgsFunction: pcmd.NewValidArgsFunction(c.validArgs),
+		RunE: c.delete,
+		Example: examples.BuildExampleString(
+			examples.Example{
+				Text: `Delete Confluent network "n-abcde1".`,
+				Code: `confluent network delete n-abcde1`,
+			},
+		),
+	}
+
+	pcmd.AddForceFlag(cmd)
+	pcmd.AddClusterFlag(cmd, c.AuthenticatedCLICommand)
+	pcmd.AddEnvironmentFlag(cmd, c.AuthenticatedCLICommand)
+
+	return cmd
+}
+
+func (c *command) delete(cmd *cobra.Command, args []string) error {
+	id := args[0]
+	environmentId, err := c.Context.EnvironmentId()
+	if err != nil {
+		return err
+	}
+
+	promptMsg := fmt.Sprintf(errors.DeleteResourceConfirmYesNoMsg, resource.Network, id)
+	if ok, err := form.ConfirmDeletion(cmd, promptMsg, ""); err != nil || !ok {
+		return err
+	}
+
+	if err := c.V2Client.DeleteNetwork(environmentId, id); err != nil {
+		return err
+	}
+
+	output.Printf(errors.DeletedResourceMsg, resource.Network, id)
+	return nil
+}

--- a/internal/network/command_delete.go
+++ b/internal/network/command_delete.go
@@ -7,7 +7,6 @@ import (
 
 	pcmd "github.com/confluentinc/cli/v3/pkg/cmd"
 	"github.com/confluentinc/cli/v3/pkg/errors"
-	"github.com/confluentinc/cli/v3/pkg/examples"
 	"github.com/confluentinc/cli/v3/pkg/form"
 	"github.com/confluentinc/cli/v3/pkg/output"
 	"github.com/confluentinc/cli/v3/pkg/resource"
@@ -21,12 +20,6 @@ func (c *command) newDeleteCommand() *cobra.Command {
 		// TODO: Implement autocompletion after List Network is implemented.
 		// ValidArgsFunction: pcmd.NewValidArgsFunction(c.validArgs),
 		RunE: c.delete,
-		Example: examples.BuildExampleString(
-			examples.Example{
-				Text: `Delete Confluent network "n-abcde1".`,
-				Code: `confluent network delete n-abcde1`,
-			},
-		),
 	}
 
 	pcmd.AddForceFlag(cmd)
@@ -43,7 +36,12 @@ func (c *command) delete(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	promptMsg := fmt.Sprintf(errors.DeleteResourceConfirmYesNoMsg, resource.Network, id)
+	network, err := c.V2Client.GetNetwork(environmentId, id)
+	if err != nil {
+		return err
+	}
+
+	promptMsg := fmt.Sprintf(errors.DeleteResourceConfirmYesNoMsg, resource.Network, network.GetId())
 	if ok, err := form.ConfirmDeletion(cmd, promptMsg, ""); err != nil || !ok {
 		return err
 	}

--- a/pkg/ccloudv2/networking.go
+++ b/pkg/ccloudv2/networking.go
@@ -26,3 +26,8 @@ func (c *Client) GetNetwork(envId, id string) (networkingv1.NetworkingV1Network,
 	resp, httpResp, err := c.NetworkingClient.NetworksNetworkingV1Api.GetNetworkingV1Network(c.networkingApiContext(), id).Environment(envId).Execute()
 	return resp, errors.CatchCCloudV2Error(err, httpResp)
 }
+
+func (c *Client) DeleteNetwork(envId, id string) error {
+	httpResp, err := c.NetworkingClient.NetworksNetworkingV1Api.DeleteNetworkingV1Network(c.networkingApiContext(), id).Environment(envId).Execute()
+	return errors.CatchCCloudV2Error(err, httpResp)
+}

--- a/pkg/resource/resource.go
+++ b/pkg/resource/resource.go
@@ -24,6 +24,7 @@ const (
 	KafkaCluster          = "Kafka cluster"
 	KsqlCluster           = "KSQL cluster"
 	MirrorTopic           = "mirror topic"
+	Network               = "network"
 	Organization          = "organization"
 	ProviderShare         = "provider share"
 	Pipeline              = "pipeline"

--- a/test/fixtures/output/network/delete-help.golden
+++ b/test/fixtures/output/network/delete-help.golden
@@ -3,11 +3,6 @@ Delete a network.
 Usage:
   confluent network delete <id> [flags]
 
-Examples:
-Delete Confluent network "n-abcde1".
-
-  $ confluent network delete n-abcde1
-
 Flags:
       --force                Skip the deletion confirmation prompt.
       --context string       CLI context name.

--- a/test/fixtures/output/network/delete-help.golden
+++ b/test/fixtures/output/network/delete-help.golden
@@ -1,0 +1,19 @@
+Delete a network.
+
+Usage:
+  confluent network delete <id> [flags]
+
+Examples:
+Delete Confluent network "n-abcde1".
+
+  $ confluent network delete n-abcde1
+
+Flags:
+      --force                Skip the deletion confirmation prompt.
+      --context string       CLI context name.
+      --environment string   Environment ID.
+
+Global Flags:
+  -h, --help            Show help for this command.
+      --unsafe-trace    Equivalent to -vvvv, but also log HTTP requests and responses which might contain plaintext secrets.
+  -v, --verbose count   Increase verbosity (-v for warn, -vv for info, -vvv for debug, -vvvv for trace).

--- a/test/fixtures/output/network/delete-network-not-exist.golden
+++ b/test/fixtures/output/network/delete-network-not-exist.golden
@@ -1,0 +1,1 @@
+Error: The network n-invalid was not found.: 404 Not Found

--- a/test/fixtures/output/network/delete-network-with-dependency.golden
+++ b/test/fixtures/output/network/delete-network-with-dependency.golden
@@ -1,0 +1,1 @@
+Error: Network deletion not allowed due to existing dependencies. Please delete the following dependent resources before attempting to delete the network again: pla-1abcde: 409 Conflict

--- a/test/fixtures/output/network/delete-prompt.golden
+++ b/test/fixtures/output/network/delete-prompt.golden
@@ -1,0 +1,1 @@
+Are you sure you want to delete network "n-abcde1"? (y/n): Deleted network "n-abcde1".

--- a/test/fixtures/output/network/delete.golden
+++ b/test/fixtures/output/network/delete.golden
@@ -1,0 +1,1 @@
+Deleted network "n-abcde1".

--- a/test/fixtures/output/network/help.golden
+++ b/test/fixtures/output/network/help.golden
@@ -4,6 +4,7 @@ Usage:
   confluent network [command]
 
 Available Commands:
+  delete      Delete a network.
   describe    Desribe a network.
 
 Global Flags:

--- a/test/network_test.go
+++ b/test/network_test.go
@@ -12,3 +12,16 @@ func (s *CLITestSuite) TestNetworkDescribe() {
 		s.runIntegrationTest(test)
 	}
 }
+
+func (s *CLITestSuite) TestNetworkDelete() {
+	tests := []CLITest{
+		{args: "network delete n-abcde1 --force", fixture: "network/delete.golden"},
+		{args: "network delete n-abcde1", input: "y\n", fixture: "network/delete-prompt.golden"},
+		{args: "network delete n-dependency --force", fixture: "network/delete-network-with-dependency.golden", exitCode: 1},
+		{args: "network delete n-invalid --force", fixture: "network/delete-network-not-exist.golden", exitCode: 1},
+	}
+	for _, test := range tests {
+		test.login = "cloud"
+		s.runIntegrationTest(test)
+	}
+}

--- a/test/test-server/networking_handlers.go
+++ b/test/test-server/networking_handlers.go
@@ -18,6 +18,8 @@ func handleNetworkingNetwork(t *testing.T) http.HandlerFunc {
 		switch r.Method {
 		case http.MethodGet:
 			handleNetworkingNetworkGet(t, id)(w, r)
+		case http.MethodDelete:
+			handleNetworkingNetworkDelete(t, id)(w, r)
 		}
 	}
 }
@@ -48,6 +50,23 @@ func handleNetworkingNetworkGet(t *testing.T, id string) http.HandlerFunc {
 			}
 			err := json.NewEncoder(w).Encode(network)
 			require.NoError(t, err)
+		}
+	}
+}
+
+func handleNetworkingNetworkDelete(t *testing.T, id string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		switch id {
+		case "n-invalid":
+			w.WriteHeader(http.StatusNotFound)
+			err := writeErrorJson(w, "The network n-invalid was not found.")
+			require.NoError(t, err)
+		case "n-dependency":
+			w.WriteHeader(http.StatusConflict)
+			err := writeErrorJson(w, "Network deletion not allowed due to existing dependencies. Please delete the following dependent resources before attempting to delete the network again: pla-1abcde")
+			require.NoError(t, err)
+		case "n-abcde1":
+			w.WriteHeader(http.StatusNoContent)
 		}
 	}
 }


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

New Features
* Add `confluent network delete` to delete a specific network.

Note that this is merging into the feature branch https://github.com/confluentinc/cli/tree/traffic-8850-network-cli. We will merge commits into main from this feature branch after all of the commands for network are implemented

Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->
Added the `confluent network delete` command

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->
[CLI Commands Design](https://confluentinc.atlassian.net/wiki/spaces/PM/pages/2987394300/1-pager+--+Network+CLI)
[Implementation 1-Pager](https://confluentinc.atlassian.net/wiki/spaces/~712020463029eabbac401bbe1b033ce0d3a00e/pages/3136749631/Network+CLI)

Test & Review
-------------
<!--
Has it been tested? How?
Copy and paste any instructions or steps that can save the reviewer time.
-->
Added integration tests.

Performed manual tests
1. Created a network in DEVEL
2. Successfully described the network
3. Removed the network
4. Described the network and expected an error / Checked DEVEL UI to make sure the network was deleted

Open Questions / Follow-ups
---------------------------
<!--
Optional: Anything open to discussion for the reviewer, out of scope of this PR, or follow-ups.
-->
