### PR TITLE
[CLI-2686] Deprecate "schema_registry_clusters" configuration field

### DIFF
--- a/internal/api-key/command.go
+++ b/internal/api-key/command.go
@@ -206,6 +206,16 @@ func (c *command) resolveResourceId(cmd *cobra.Command, v2Client *ccloudv2.Clien
 			return "", "", "", errors.CatchResourceNotFoundError(err, resource)
 		}
 		clusterId = cluster.GetId()
+	case presource.SchemaRegistryCluster:
+		environmentId, err := c.Context.EnvironmentId()
+		if err != nil {
+			return "", "", "", err
+		}
+		cluster, err := v2Client.GetSchemaRegistryClusterById(resource, environmentId)
+		if err != nil {
+			return "", "", "", errors.CatchResourceNotFoundError(err, resource)
+		}
+		clusterId = cluster.GetId()
 	default:
 		return "", "", "", fmt.Errorf(`unsupported resource type for resource "%s"`, resource)
 	}

--- a/internal/api-key/command.go
+++ b/internal/api-key/command.go
@@ -206,15 +206,6 @@ func (c *command) resolveResourceId(cmd *cobra.Command, v2Client *ccloudv2.Clien
 			return "", "", "", errors.CatchResourceNotFoundError(err, resource)
 		}
 		clusterId = cluster.GetId()
-	case presource.SchemaRegistryCluster:
-		cluster, err := c.Context.SchemaRegistryCluster(cmd)
-		if err != nil {
-			return "", "", "", errors.CatchResourceNotFoundError(err, resource)
-		}
-		clusterId = cluster.Id
-		if cluster.SrCredentials != nil {
-			apiKey = cluster.SrCredentials.Key
-		}
 	default:
 		return "", "", "", fmt.Errorf(`unsupported resource type for resource "%s"`, resource)
 	}

--- a/internal/schema-registry/command_cluster_delete.go
+++ b/internal/schema-registry/command_cluster_delete.go
@@ -61,10 +61,6 @@ func (c *command) clusterDelete(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	ctx := c.Config.Context()
-	ctx.SchemaRegistryClusters[environmentId] = nil
-	_ = ctx.Save()
-
 	output.Printf("Deleted Schema Registry cluster for environment \"%s\".\n", environmentId)
 	return nil
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -115,25 +115,17 @@ func SetupTestInputs(isCloud bool) *TestInputs {
 		CredentialName:     loginCredential.Name,
 		CurrentEnvironment: environmentId,
 		Environments:       map[string]*EnvironmentContext{environmentId: {}},
-		SchemaRegistryClusters: map[string]*SchemaRegistryCluster{
-			environmentId: {
-				Id:                     "lsrc-123",
-				SchemaRegistryEndpoint: "http://some-lsrc-endpoint",
-				SrCredentials:          nil,
-			},
-		},
-		State: regularOrgContextState,
+		State:              regularOrgContextState,
 	}
 	statelessContext := &Context{
-		Name:                   contextName,
-		Platform:               platform,
-		PlatformName:           platform.Name,
-		Credential:             apiCredential,
-		CredentialName:         apiCredential.Name,
-		Environments:           map[string]*EnvironmentContext{},
-		SchemaRegistryClusters: map[string]*SchemaRegistryCluster{},
-		State:                  &ContextState{},
-		Config:                 &Config{SavedCredentials: savedCredentials},
+		Name:           contextName,
+		Platform:       platform,
+		PlatformName:   platform.Name,
+		Credential:     apiCredential,
+		CredentialName: apiCredential.Name,
+		Environments:   map[string]*EnvironmentContext{},
+		State:          &ContextState{},
+		Config:         &Config{SavedCredentials: savedCredentials},
 	}
 	twoEnvStatefulContext := &Context{
 		Name:               contextName,
@@ -145,12 +137,6 @@ func SetupTestInputs(isCloud bool) *TestInputs {
 		Environments: map[string]*EnvironmentContext{
 			"acc-123":  {},
 			"env-flag": {},
-		},
-		SchemaRegistryClusters: map[string]*SchemaRegistryCluster{
-			environmentId: {
-				Id:                     "lsrc-123",
-				SchemaRegistryEndpoint: "http://some-lsrc-endpoint",
-			},
 		},
 		State: regularOrgContextState,
 	}

--- a/pkg/config/context.go
+++ b/pkg/config/context.go
@@ -14,16 +14,18 @@ import (
 
 // Context represents a specific CLI context.
 type Context struct {
-	Name                   string                            `json:"name"`
-	NetrcMachineName       string                            `json:"netrc_machine_name"`
-	PlatformName           string                            `json:"platform"`
-	CredentialName         string                            `json:"credential"`
-	CurrentEnvironment     string                            `json:"current_environment,omitempty"`
-	Environments           map[string]*EnvironmentContext    `json:"environments,omitempty"`
-	KafkaClusterContext    *KafkaClusterContext              `json:"kafka_cluster_context"`
-	SchemaRegistryClusters map[string]*SchemaRegistryCluster `json:"schema_registry_clusters"`
-	LastOrgId              string                            `json:"last_org_id,omitempty"`
-	FeatureFlags           *FeatureFlags                     `json:"feature_flags,omitempty"`
+	Name                string                         `json:"name"`
+	NetrcMachineName    string                         `json:"netrc_machine_name"`
+	PlatformName        string                         `json:"platform"`
+	CredentialName      string                         `json:"credential"`
+	CurrentEnvironment  string                         `json:"current_environment,omitempty"`
+	Environments        map[string]*EnvironmentContext `json:"environments,omitempty"`
+	KafkaClusterContext *KafkaClusterContext           `json:"kafka_cluster_context"`
+	LastOrgId           string                         `json:"last_org_id,omitempty"`
+	FeatureFlags        *FeatureFlags                  `json:"feature_flags,omitempty"`
+
+	// Deprecated
+	SchemaRegistryClusters map[string]*SchemaRegistryCluster `json:"schema_registry_clusters,omitempty"`
 
 	Platform   *Platform     `json:"-"`
 	Credential *Credential   `json:"-"`
@@ -33,18 +35,17 @@ type Context struct {
 
 func newContext(name string, platform *Platform, credential *Credential, kafkaClusters map[string]*KafkaClusterConfig, kafka string, state *ContextState, config *Config, orgResourceId, envId string) (*Context, error) {
 	ctx := &Context{
-		Name:                   name,
-		NetrcMachineName:       name,
-		Platform:               platform,
-		PlatformName:           platform.Name,
-		Credential:             credential,
-		CredentialName:         credential.Name,
-		CurrentEnvironment:     envId,
-		Environments:           map[string]*EnvironmentContext{},
-		SchemaRegistryClusters: map[string]*SchemaRegistryCluster{},
-		State:                  state,
-		Config:                 config,
-		LastOrgId:              orgResourceId,
+		Name:               name,
+		NetrcMachineName:   name,
+		Platform:           platform,
+		PlatformName:       platform.Name,
+		Credential:         credential,
+		CredentialName:     credential.Name,
+		CurrentEnvironment: envId,
+		Environments:       map[string]*EnvironmentContext{},
+		State:              state,
+		Config:             config,
+		LastOrgId:          orgResourceId,
 	}
 	ctx.KafkaClusterContext = NewKafkaClusterContext(ctx, kafka, kafkaClusters)
 	if err := ctx.validate(); err != nil {
@@ -65,9 +66,6 @@ func (c *Context) validate() error {
 	}
 	if c.Environments == nil {
 		c.Environments = map[string]*EnvironmentContext{}
-	}
-	if c.SchemaRegistryClusters == nil {
-		c.SchemaRegistryClusters = map[string]*SchemaRegistryCluster{}
 	}
 	if c.State == nil {
 		c.State = new(ContextState)

--- a/pkg/config/schema_registry_cluster.go
+++ b/pkg/config/schema_registry_cluster.go
@@ -1,14 +1,8 @@
 package config
 
+// Deprecated
 type SchemaRegistryCluster struct {
 	Id                     string      `json:"id"`
 	SchemaRegistryEndpoint string      `json:"schema_registry_endpoint"`
 	SrCredentials          *APIKeyPair `json:"schema_registry_credentials"`
-}
-
-func (s *SchemaRegistryCluster) GetId() string {
-	if s == nil {
-		return ""
-	}
-	return s.Id
 }

--- a/pkg/config/test_json/account_overwrite.json
+++ b/pkg/config/test_json/account_overwrite.json
@@ -64,13 +64,6 @@
             }
           }
         }
-      },
-      "schema_registry_clusters": {
-        "acc-123": {
-          "id": "lsrc-123",
-          "schema_registry_endpoint": "http://some-lsrc-endpoint",
-          "schema_registry_credentials": null
-        }
       }
     }
   },

--- a/pkg/config/test_json/stateful_cloud.json
+++ b/pkg/config/test_json/stateful_cloud.json
@@ -59,13 +59,6 @@
             }
           }
         }
-      },
-      "schema_registry_clusters": {
-        "acc-123": {
-          "id": "lsrc-123",
-          "schema_registry_endpoint": "http://some-lsrc-endpoint",
-          "schema_registry_credentials": null
-        }
       }
     }
   },

--- a/pkg/config/test_json/stateful_cloud_save.json
+++ b/pkg/config/test_json/stateful_cloud_save.json
@@ -63,13 +63,6 @@
             }
           }
         }
-      },
-      "schema_registry_clusters": {
-        "acc-123": {
-          "id": "lsrc-123",
-          "schema_registry_endpoint": "http://some-lsrc-endpoint",
-          "schema_registry_credentials": null
-        }
       }
     }
   },

--- a/pkg/config/test_json/stateful_onprem.json
+++ b/pkg/config/test_json/stateful_onprem.json
@@ -55,13 +55,6 @@
             "last_update": "0001-01-01T00:00:00Z"
           }
         }
-      },
-      "schema_registry_clusters": {
-        "acc-123": {
-          "id": "lsrc-123",
-          "schema_registry_endpoint": "http://some-lsrc-endpoint",
-          "schema_registry_credentials": null
-        }
       }
     }
   },

--- a/pkg/config/test_json/stateful_onprem_save.json
+++ b/pkg/config/test_json/stateful_onprem_save.json
@@ -59,13 +59,6 @@
             "last_update": "0001-01-01T00:00:00Z"
           }
         }
-      },
-      "schema_registry_clusters": {
-        "acc-123": {
-          "id": "lsrc-123",
-          "schema_registry_endpoint": "http://some-lsrc-endpoint",
-          "schema_registry_credentials": null
-        }
       }
     }
   },

--- a/pkg/config/test_json/stateless_cloud.json
+++ b/pkg/config/test_json/stateless_cloud.json
@@ -55,8 +55,7 @@
             "last_update": "0001-01-01T00:00:00Z"
           }
         }
-      },
-      "schema_registry_clusters": {}
+      }
     }
   },
   "context_states": {

--- a/pkg/config/test_json/stateless_onprem.json
+++ b/pkg/config/test_json/stateless_onprem.json
@@ -55,8 +55,7 @@
             "last_update": "0001-01-01T00:00:00Z"
           }
         }
-      },
-      "schema_registry_clusters": {}
+      }
     }
   },
   "context_states": {


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
Thanks @MuweiHe for pointing out that as of #2134, we are essentially not using Schema Registry API keys in the CLI anymore. Rewrote `confluent kafka client-config create` to grab the Schema Registry cluster from the backend (this improves consistency) instead of the configuration file, and stopped marking Schema Registry API keys as "current" in `api-key list`. This allows us to deprecate the Schema Registry field in the configuration file!

Test & Review
-------------
Tests still pass