### PR TITLE
[CLI-2642] Resolve race condition resulting in double channel close panic in `topic produce` commands

### DIFF
--- a/internal/kafka/command_topic.go
+++ b/internal/kafka/command_topic.go
@@ -17,6 +17,9 @@ import (
 
 const numPartitionsKey = "num.partitions"
 
+// EOF Unicode encoding for Ctrl+D (^D) character
+var EOF = "\u0004"
+
 type command struct {
 	*pcmd.AuthenticatedCLICommand
 	clientID string

--- a/internal/kafka/command_topic.go
+++ b/internal/kafka/command_topic.go
@@ -2,6 +2,9 @@ package kafka
 
 import (
 	"fmt"
+	"os"
+	"os/signal"
+	"runtime"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -13,13 +16,14 @@ import (
 	"github.com/confluentinc/cli/v3/pkg/config"
 	"github.com/confluentinc/cli/v3/pkg/errors"
 	"github.com/confluentinc/cli/v3/pkg/log"
+	"github.com/confluentinc/cli/v3/pkg/output"
+	"github.com/confluentinc/cli/v3/pkg/serdes"
 )
 
-const (
-	// EOF Unicode encoding for Ctrl+D (^D) character
-	EOF              = "\u0004"
-	numPartitionsKey = "num.partitions"
-)
+// EOF Unicode encoding for Ctrl+D (^D) character
+const EOF = "\u0004"
+
+const numPartitionsKey = "num.partitions"
 
 type command struct {
 	*pcmd.AuthenticatedCLICommand
@@ -161,4 +165,59 @@ func addApiKeyToCluster(cmd *cobra.Command, cluster *config.KafkaClusterConfig) 
 	}
 
 	return nil
+}
+
+func ProduceToTopic(cmd *cobra.Command, keyMetaInfo []byte, valueMetaInfo []byte, topic string, keySerializer serdes.SerializationProvider, valueSerializer serdes.SerializationProvider, producer *ckafka.Producer) error {
+	if runtime.GOOS == "windows" {
+		output.ErrPrintf(errors.StartingProducerMsg, "Ctrl-C")
+	} else {
+		output.ErrPrintf(errors.StartingProducerMsg, "Ctrl-C or Ctrl-D")
+	}
+
+	var scanErr error
+	input, scan := PrepareInputChannel(&scanErr)
+
+	// Trap SIGINT to trigger a shutdown.
+	signals := make(chan os.Signal, 1)
+	signal.Notify(signals, os.Interrupt)
+	go func() {
+		<-signals
+		input <- EOF
+	}()
+	// Prime reader
+	go scan()
+
+	deliveryChan := make(chan ckafka.Event)
+	for data := range input {
+		if data == "" {
+			if scanErr != nil {
+				break
+			}
+			go scan()
+			continue
+		} else if data == EOF {
+			break
+		}
+
+		message, err := GetProduceMessage(cmd, keyMetaInfo, valueMetaInfo, topic, data, keySerializer, valueSerializer)
+		if err != nil {
+			return err
+		}
+		if err := producer.Produce(message, deliveryChan); err != nil {
+			isProduceToCompactedTopicError, err := errors.CatchProduceToCompactedTopicError(err, topic)
+			if isProduceToCompactedTopicError {
+				scanErr = err
+				break
+			}
+			output.ErrPrintf(errors.FailedToProduceErrorMsg, message.TopicPartition.Offset, err)
+		}
+
+		e := <-deliveryChan                // read a ckafka event from the channel
+		m := e.(*ckafka.Message)           // extract the message from the event
+		if m.TopicPartition.Error != nil { // catch all other errors
+			output.ErrPrintf(errors.FailedToProduceErrorMsg, m.TopicPartition.Offset, m.TopicPartition.Error)
+		}
+		go scan()
+	}
+	return scanErr
 }

--- a/internal/kafka/command_topic.go
+++ b/internal/kafka/command_topic.go
@@ -15,10 +15,11 @@ import (
 	"github.com/confluentinc/cli/v3/pkg/log"
 )
 
-const numPartitionsKey = "num.partitions"
-
-// EOF Unicode encoding for Ctrl+D (^D) character
-var EOF = "\u0004"
+const (
+	// EOF Unicode encoding for Ctrl+D (^D) character
+	EOF              = "\u0004"
+	numPartitionsKey = "num.partitions"
+)
 
 type command struct {
 	*pcmd.AuthenticatedCLICommand

--- a/internal/kafka/command_topic_produce.go
+++ b/internal/kafka/command_topic_produce.go
@@ -4,8 +4,6 @@ import (
 	"bufio"
 	"fmt"
 	"os"
-	"os/signal"
-	"runtime"
 	"strconv"
 	"strings"
 
@@ -18,7 +16,6 @@ import (
 	pcmd "github.com/confluentinc/cli/v3/pkg/cmd"
 	"github.com/confluentinc/cli/v3/pkg/errors"
 	"github.com/confluentinc/cli/v3/pkg/log"
-	"github.com/confluentinc/cli/v3/pkg/output"
 	"github.com/confluentinc/cli/v3/pkg/serdes"
 )
 
@@ -118,58 +115,7 @@ func (c *command) produce(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if runtime.GOOS == "windows" {
-		output.ErrPrintf(errors.StartingProducerMsg, "Ctrl-C")
-	} else {
-		output.ErrPrintf(errors.StartingProducerMsg, "Ctrl-C or Ctrl-D")
-	}
-
-	var scanErr error
-	input, scan := PrepareInputChannel(&scanErr)
-
-	// Trap SIGINT to trigger a shutdown.
-	signals := make(chan os.Signal, 1)
-	signal.Notify(signals, os.Interrupt)
-	go func() {
-		<-signals
-		input <- EOF
-	}()
-	// Prime reader
-	go scan()
-
-	deliveryChan := make(chan ckafka.Event)
-	for data := range input {
-		if data == "" {
-			if scanErr != nil {
-				break
-			}
-			go scan()
-			continue
-		} else if data == EOF {
-			break
-		}
-
-		message, err := GetProduceMessage(cmd, keyMetaInfo, valueMetaInfo, topic, data, keySerializer, valueSerializer)
-		if err != nil {
-			return err
-		}
-		if err := producer.Produce(message, deliveryChan); err != nil {
-			isProduceToCompactedTopicError, err := errors.CatchProduceToCompactedTopicError(err, topic)
-			if isProduceToCompactedTopicError {
-				scanErr = err
-				break
-			}
-			output.ErrPrintf(errors.FailedToProduceErrorMsg, message.TopicPartition.Offset, err)
-		}
-
-		e := <-deliveryChan                // read a ckafka event from the channel
-		m := e.(*ckafka.Message)           // extract the message from the event
-		if m.TopicPartition.Error != nil { // catch all other errors
-			output.ErrPrintf(errors.FailedToProduceErrorMsg, m.TopicPartition.Offset, m.TopicPartition.Error)
-		}
-		go scan()
-	}
-	return scanErr
+	return ProduceToTopic(cmd, keyMetaInfo, valueMetaInfo, topic, keySerializer, valueSerializer, producer)
 }
 
 func (c *command) registerSchema(cmd *cobra.Command, schemaCfg *sr.RegisterSchemaConfigs) ([]byte, map[string]string, error) {

--- a/internal/kafka/command_topic_produce_onprem.go
+++ b/internal/kafka/command_topic_produce_onprem.go
@@ -3,7 +3,6 @@ package kafka
 import (
 	"fmt"
 	"os"
-	"os/signal"
 
 	"github.com/spf13/cobra"
 
@@ -14,7 +13,6 @@ import (
 	"github.com/confluentinc/cli/v3/pkg/errors"
 	"github.com/confluentinc/cli/v3/pkg/examples"
 	"github.com/confluentinc/cli/v3/pkg/log"
-	"github.com/confluentinc/cli/v3/pkg/output"
 	"github.com/confluentinc/cli/v3/pkg/serdes"
 	"github.com/confluentinc/cli/v3/pkg/types"
 )
@@ -162,52 +160,7 @@ func (c *command) produceOnPrem(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	output.ErrPrintf(errors.StartingProducerMsg, "Ctrl-C or Ctrl-D")
-
-	var scanErr error
-	input, scan := PrepareInputChannel(&scanErr)
-
-	signals := make(chan os.Signal, 1) // Trap SIGINT to trigger a shutdown.
-	signal.Notify(signals, os.Interrupt)
-	go func() {
-		<-signals
-		input <- EOF
-	}()
-	go scan() // Prime reader
-
-	deliveryChan := make(chan ckafka.Event)
-	for data := range input {
-		if data == "" {
-			if scanErr != nil {
-				break
-			}
-			go scan()
-			continue
-		} else if data == EOF {
-			break
-		}
-
-		msg, err := GetProduceMessage(cmd, keyMetaInfo, valueMetaInfo, topic, data, keySerializer, valueSerializer)
-		if err != nil {
-			return err
-		}
-		if err := producer.Produce(msg, deliveryChan); err != nil {
-			output.ErrPrintf(errors.FailedToProduceErrorMsg, msg.TopicPartition.Offset, err)
-		}
-
-		e := <-deliveryChan                // read a ckafka event from the channel
-		m := e.(*ckafka.Message)           // extract the message from the event
-		if m.TopicPartition.Error != nil { // catch all other errors
-			isProduceToCompactedTopicError, err := errors.CatchProduceToCompactedTopicError(err, topic)
-			if isProduceToCompactedTopicError {
-				scanErr = err
-				break
-			}
-			output.ErrPrintf(errors.FailedToProduceErrorMsg, m.TopicPartition.Offset, m.TopicPartition.Error)
-		}
-		go scan()
-	}
-	return scanErr
+	return ProduceToTopic(cmd, keyMetaInfo, valueMetaInfo, topic, keySerializer, valueSerializer, producer)
 }
 
 func prepareSerializer(cmd *cobra.Command, topic, mode string) (string, string, serdes.SerializationProvider, error) {

--- a/internal/local/command_kafka_topic_produce.go
+++ b/internal/local/command_kafka_topic_produce.go
@@ -2,8 +2,6 @@ package local
 
 import (
 	"fmt"
-	"os"
-	"os/signal"
 
 	"github.com/spf13/cobra"
 
@@ -14,7 +12,6 @@ import (
 	"github.com/confluentinc/cli/v3/pkg/errors"
 	"github.com/confluentinc/cli/v3/pkg/examples"
 	"github.com/confluentinc/cli/v3/pkg/log"
-	"github.com/confluentinc/cli/v3/pkg/output"
 	"github.com/confluentinc/cli/v3/pkg/serdes"
 )
 
@@ -73,54 +70,7 @@ func (c *Command) kafkaTopicProduce(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	output.ErrPrintf(errors.StartingProducerMsg, "Ctrl-C or Ctrl-D")
-	output.ErrPrintln("Type a message and press ENTER to produce to the topic.")
-
-	var scanErr error
-	input, scan := kafka.PrepareInputChannel(&scanErr)
-
-	signals := make(chan os.Signal, 1) // Trap SIGINT to trigger a shutdown.
-	signal.Notify(signals, os.Interrupt)
-	go func() {
-		<-signals
-		input <- kafka.EOF
-	}()
-	go scan() // Prime reader
-
-	deliveryChan := make(chan ckafka.Event)
-	for data := range input {
-		if data == "" {
-			if scanErr != nil {
-				break
-			}
-			go scan()
-			continue
-		} else if data == kafka.EOF {
-			break
-		}
-
-		msg, err := kafka.GetProduceMessage(cmd, make([]byte, 4), make([]byte, 4), topicName, data, nil, serializationProvider)
-		if err != nil {
-			return err
-		}
-		err = producer.Produce(msg, deliveryChan)
-		if err != nil {
-			output.ErrPrintf(errors.FailedToProduceErrorMsg, msg.TopicPartition.Offset, err)
-		}
-
-		e := <-deliveryChan                // read a ckafka event from the channel
-		m := e.(*ckafka.Message)           // extract the message from the event
-		if m.TopicPartition.Error != nil { // catch all other errors
-			isProduceToCompactedTopicError, err := errors.CatchProduceToCompactedTopicError(err, topicName)
-			if isProduceToCompactedTopicError {
-				scanErr = err
-				break
-			}
-			output.ErrPrintf(errors.FailedToProduceErrorMsg, m.TopicPartition.Offset, m.TopicPartition.Error)
-		}
-		go scan()
-	}
-	return scanErr
+	return kafka.ProduceToTopic(cmd, make([]byte, 4), make([]byte, 4), topicName, nil, serializationProvider, producer)
 }
 
 func newOnPremProducer(cmd *cobra.Command, bootstrap string) (*ckafka.Producer, error) {


### PR DESCRIPTION
Release Notes
-------------
Bug Fixes
- Resolved a close of closed channel panic in `topic produce`.

Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
Building off of the ideas in https://github.com/confluentinc/cli/pull/2199, this race condition seems to have been resolved. 

Basically, sending an interrupt signal via `^C` now writes `\u0004` (Unicode encoding of `^D`) to the `input` channel, which can normally never receive this value, since writing `^D` to `stdIn` will just close the channel. 

Now, in the loop over `input`, we `break` if we get an error from the Scanner or if the value received from the `input` channel is `^D` (meaning a shutdown has been triggered with `^C`). This means the `input` channel is only closed once, when the user explicitly types `^D` into `stdIn`. 

References
----------
https://confluentinc.atlassian.net/browse/CLI-2642

Test & Review
-------------
Passes `make test` and manual testing. So far I haven't been able to recreate the `panic` and `topic produce` otherwise works as intended.
