### PR TITLE
feat: update SET config options to reflect recent backend changes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,6 @@
 *                   @confluentinc/cli
-internal/pkg/flink/ @confluentinc/cloud-surfaces
-internal/pkg/ccloudv2/flink.go @confluentinc/cli @confluentinc/cloud-surfaces
-internal/pkg/ccloudv2/flink_gateway.go @confluentinc/cli @confluentinc/cloud-surfaces
+pkg/flink/ @confluentinc/cloud-surfaces
+pkg/ccloudv2/flink.go @confluentinc/cli @confluentinc/cloud-surfaces
+pkg/ccloudv2/flink_gateway.go @confluentinc/cli @confluentinc/cloud-surfaces
 go.mod @confluentinc/cli @confluentinc/cloud-surfaces
 go.sum @confluentinc/cli @confluentinc/cloud-surfaces

--- a/pkg/flink/config/local_statements.go
+++ b/pkg/flink/config/local_statements.go
@@ -10,8 +10,8 @@ const (
 	ConfigStatementTerminator = ";"
 
 	// keys
-	ConfigKeyCatalog        = "catalog"
-	ConfigKeyDatabase       = "default_database"
-	ConfigKeyLocalTimeZone  = "table.local-time-zone"
-	ConfigKeyResultsTimeout = "table.results-timeout"
+	ConfigKeyCatalog        = "sql.current-catalog"
+	ConfigKeyDatabase       = "sql.current-database"
+	ConfigKeyLocalTimeZone  = "sql.local-time-zone"
+	ConfigKeyResultsTimeout = "client.results-timeout"
 )

--- a/pkg/flink/internal/autocomplete/.snapshots/TestSetAutoCompletionSnapshot
+++ b/pkg/flink/internal/autocomplete/.snapshots/TestSetAutoCompletionSnapshot
@@ -5,6 +5,6 @@
   },
   (prompt.Suggest) {
     Text: (string) (len=44) "SET 'sql.local-time-zone' = 'Europe/Berlin';",
-    Description: (string) (len=48) "Used to set the timezone for the current session"
+    Description: (string) (len=129) "Used to set the timezone for the current session either with a TZID ('Europe/Berlin'), a fixed offset ('GMT+02:00') or just 'UTC'"
   }
 }

--- a/pkg/flink/internal/autocomplete/.snapshots/TestSetAutoCompletionSnapshot
+++ b/pkg/flink/internal/autocomplete/.snapshots/TestSetAutoCompletionSnapshot
@@ -1,10 +1,10 @@
 ([]prompt.Suggest) (len=2) {
   (prompt.Suggest) {
-    Text: (string) (len=36) "SET 'table.results-timeout' = '600';",
-    Description: (string) (len=102) "Total amount of time in seconds to wait before timing out the request waiting for results to be ready."
+    Text: (string) (len=39) "SET 'client.results-timeout' = '10000';",
+    Description: (string) (len=107) "Total amount of time in milliseconds to wait before timing out the request waiting for results to be ready."
   },
   (prompt.Suggest) {
-    Text: (string) (len=47) "SET 'table.local-time-zone;' = 'Europe/Berlin';",
-    Description: (string) (len=58) "Used to modify the configuration or list the configuration"
+    Text: (string) (len=44) "SET 'sql.local-time-zone' = 'Europe/Berlin';",
+    Description: (string) (len=48) "Used to set the timezone for the current session"
   }
 }

--- a/pkg/flink/internal/autocomplete/set_completer.go
+++ b/pkg/flink/internal/autocomplete/set_completer.go
@@ -11,7 +11,7 @@ import (
 func SetCompleter(in prompt.Document) []prompt.Suggest {
 	s := []prompt.Suggest{
 		{Text: fmt.Sprintf("SET '%s' = '10000';", config.ConfigKeyResultsTimeout), Description: "Total amount of time in milliseconds to wait before timing out the request waiting for results to be ready."},
-		{Text: fmt.Sprintf("SET '%s' = 'Europe/Berlin';", config.ConfigKeyLocalTimeZone), Description: "Used to set the timezone for the current session"},
+		{Text: fmt.Sprintf("SET '%s' = 'Europe/Berlin';", config.ConfigKeyLocalTimeZone), Description: "Used to set the timezone for the current session either with a TZID ('Europe/Berlin'), a fixed offset ('GMT+02:00') or just 'UTC'"},
 	}
 
 	return SuggestFromPrefix(s, in.TextBeforeCursor())

--- a/pkg/flink/internal/autocomplete/set_completer.go
+++ b/pkg/flink/internal/autocomplete/set_completer.go
@@ -2,8 +2,10 @@ package autocomplete
 
 import (
 	"fmt"
+
+	"github.com/confluentinc/go-prompt"
+
 	"github.com/confluentinc/cli/v3/pkg/flink/config"
-	prompt "github.com/confluentinc/go-prompt"
 )
 
 func SetCompleter(in prompt.Document) []prompt.Suggest {

--- a/pkg/flink/internal/autocomplete/set_completer.go
+++ b/pkg/flink/internal/autocomplete/set_completer.go
@@ -1,13 +1,15 @@
 package autocomplete
 
 import (
+	"fmt"
+	"github.com/confluentinc/cli/v3/pkg/flink/config"
 	prompt "github.com/confluentinc/go-prompt"
 )
 
 func SetCompleter(in prompt.Document) []prompt.Suggest {
 	s := []prompt.Suggest{
-		{Text: "SET 'table.results-timeout' = '600';", Description: "Total amount of time in seconds to wait before timing out the request waiting for results to be ready."},
-		{Text: "SET 'table.local-time-zone;' = 'Europe/Berlin';", Description: "Used to modify the configuration or list the configuration"},
+		{Text: fmt.Sprintf("SET '%s' = '10000';", config.ConfigKeyResultsTimeout), Description: "Total amount of time in milliseconds to wait before timing out the request waiting for results to be ready."},
+		{Text: fmt.Sprintf("SET '%s' = 'Europe/Berlin';", config.ConfigKeyLocalTimeZone), Description: "Used to set the timezone for the current session"},
 	}
 
 	return SuggestFromPrefix(s, in.TextBeforeCursor())

--- a/pkg/flink/internal/store/.snapshots/TestProcessSetStatement-should_return_all_keys_and_values_from_config_if_configKey_is_empty
+++ b/pkg/flink/internal/store/.snapshots/TestProcessSetStatement-should_return_all_keys_and_values_from_config_if_configKey_is_empty
@@ -9,7 +9,7 @@
       Fields: ([]types.StatementResultField) (len=2) {
         (types.AtomicStatementResultField) {
           Type: (types.StatementResultFieldType) (len=7) "VARCHAR",
-          Value: (string) (len=7) "catalog"
+          Value: (string) (len=19) "sql.current-catalog"
         },
         (types.AtomicStatementResultField) {
           Type: (types.StatementResultFieldType) (len=7) "VARCHAR",
@@ -22,7 +22,7 @@
       Fields: ([]types.StatementResultField) (len=2) {
         (types.AtomicStatementResultField) {
           Type: (types.StatementResultFieldType) (len=7) "VARCHAR",
-          Value: (string) (len=16) "default_database"
+          Value: (string) (len=20) "sql.current-database"
         },
         (types.AtomicStatementResultField) {
           Type: (types.StatementResultFieldType) (len=7) "VARCHAR",
@@ -35,7 +35,7 @@
       Fields: ([]types.StatementResultField) (len=2) {
         (types.AtomicStatementResultField) {
           Type: (types.StatementResultFieldType) (len=7) "VARCHAR",
-          Value: (string) (len=21) "table.local-time-zone"
+          Value: (string) (len=19) "sql.local-time-zone"
         },
         (types.AtomicStatementResultField) {
           Type: (types.StatementResultFieldType) (len=7) "VARCHAR",

--- a/pkg/flink/internal/store/.snapshots/TestProcessSetStatement-should_return_all_keys_and_values_from_config_if_configKey_is_empty_after_updates
+++ b/pkg/flink/internal/store/.snapshots/TestProcessSetStatement-should_return_all_keys_and_values_from_config_if_configKey_is_empty_after_updates
@@ -3,33 +3,7 @@
     (string) (len=3) "Key",
     (string) (len=5) "Value"
   },
-  Rows: ([]types.StatementResultRow) (len=5) {
-    (types.StatementResultRow) {
-      Operation: (types.StatementResultOperation) +I,
-      Fields: ([]types.StatementResultField) (len=2) {
-        (types.AtomicStatementResultField) {
-          Type: (types.StatementResultFieldType) (len=7) "VARCHAR",
-          Value: (string) (len=7) "catalog"
-        },
-        (types.AtomicStatementResultField) {
-          Type: (types.StatementResultFieldType) (len=7) "VARCHAR",
-          Value: (string) (len=4) "job1"
-        }
-      }
-    },
-    (types.StatementResultRow) {
-      Operation: (types.StatementResultOperation) +I,
-      Fields: ([]types.StatementResultField) (len=2) {
-        (types.AtomicStatementResultField) {
-          Type: (types.StatementResultFieldType) (len=7) "VARCHAR",
-          Value: (string) (len=16) "default_database"
-        },
-        (types.AtomicStatementResultField) {
-          Type: (types.StatementResultFieldType) (len=7) "VARCHAR",
-          Value: (string) (len=17) "<unset> (default)"
-        }
-      }
-    },
+  Rows: ([]types.StatementResultRow) (len=4) {
     (types.StatementResultRow) {
       Operation: (types.StatementResultOperation) +I,
       Fields: ([]types.StatementResultField) (len=2) {
@@ -48,11 +22,11 @@
       Fields: ([]types.StatementResultField) (len=2) {
         (types.AtomicStatementResultField) {
           Type: (types.StatementResultFieldType) (len=7) "VARCHAR",
-          Value: (string) (len=21) "table.local-time-zone"
+          Value: (string) (len=19) "sql.current-catalog"
         },
         (types.AtomicStatementResultField) {
           Type: (types.StatementResultFieldType) (len=7) "VARCHAR",
-          Value: (string) (len=10) "London/GMT"
+          Value: (string) (len=17) "<unset> (default)"
         }
       }
     },
@@ -61,11 +35,24 @@
       Fields: ([]types.StatementResultField) (len=2) {
         (types.AtomicStatementResultField) {
           Type: (types.StatementResultFieldType) (len=7) "VARCHAR",
-          Value: (string) (len=7) "timeout"
+          Value: (string) (len=20) "sql.current-database"
         },
         (types.AtomicStatementResultField) {
           Type: (types.StatementResultFieldType) (len=7) "VARCHAR",
-          Value: (string) (len=2) "30"
+          Value: (string) (len=17) "<unset> (default)"
+        }
+      }
+    },
+    (types.StatementResultRow) {
+      Operation: (types.StatementResultOperation) +I,
+      Fields: ([]types.StatementResultField) (len=2) {
+        (types.AtomicStatementResultField) {
+          Type: (types.StatementResultFieldType) (len=7) "VARCHAR",
+          Value: (string) (len=19) "sql.local-time-zone"
+        },
+        (types.AtomicStatementResultField) {
+          Type: (types.StatementResultFieldType) (len=7) "VARCHAR",
+          Value: (string) (len=10) "London/GMT"
         }
       }
     }

--- a/pkg/flink/internal/store/store.go
+++ b/pkg/flink/internal/store/store.go
@@ -225,8 +225,8 @@ func (s *Store) waitForPendingStatement(ctx context.Context, statementName strin
 	}
 
 	return nil, &types.StatementError{
-		Message: fmt.Sprintf("statement is still pending after %f seconds. If you want to increase the timeout for the client, you can run \"SET table.results-timeout=1200;\" to adjust the maximum timeout in seconds.",
-			timeout.Seconds()),
+		Message: fmt.Sprintf("statement is still pending after %f seconds. If you want to increase the timeout for the client, you can run \"SET '%s'='10000';\" to adjust the maximum timeout in milliseconds.",
+			timeout.Seconds(), config.ConfigKeyResultsTimeout),
 		FailureMessage: errorsMsg,
 	}
 }

--- a/pkg/flink/internal/store/store_test.go
+++ b/pkg/flink/internal/store/store_test.go
@@ -127,7 +127,8 @@ func TestWaitForPendingTimesout(t *testing.T) {
 		},
 	}
 	expectedError := &types.StatementError{
-		Message:        fmt.Sprintf("statement is still pending after %f seconds. If you want to increase the timeout for the client, you can run \"SET table.results-timeout=1200;\" to adjust the maximum timeout in seconds.", timeout.Seconds()),
+		Message: fmt.Sprintf("statement is still pending after %f seconds. If you want to increase the timeout for the client, you can run \"SET '%s'='10000';\" to adjust the maximum timeout in milliseconds.",
+			timeout.Seconds(), config.ConfigKeyResultsTimeout),
 		FailureMessage: fmt.Sprintf("captured retryable errors: %s", statusDetailMessage),
 	}
 	client.EXPECT().GetStatement("envId", statementName, "orgId").Return(statementObj, nil).AnyTimes()
@@ -966,7 +967,7 @@ func TestTimeout(t *testing.T) {
 		{
 			name: "results-timeout property set",
 			properties: map[string]string{
-				config.ConfigKeyResultsTimeout: "10", // timeout in seconds
+				config.ConfigKeyResultsTimeout: "10000", // timeout in milliseconds
 			},
 			expected: 10 * time.Second,
 		},

--- a/pkg/flink/internal/store/store_utils.go
+++ b/pkg/flink/internal/store/store_utils.go
@@ -395,8 +395,8 @@ func parseStatementType(statement string) StatementType {
 	}
 }
 
-// This returns the local timezone as a custom timezone along with the offset to UTC
-// Example: UTC+02:00 or UTC-08:00
+// This returns the local timezone as a custom timezone along with the offset to UTC/GMT
+// Example: GMT+02:00 or GMT-08:00
 func getLocalTimezone() string {
 	_, offsetSeconds := time.Now().Zone()
 	return formatUTCOffsetToTimezone(offsetSeconds)
@@ -410,7 +410,7 @@ func formatUTCOffsetToTimezone(offsetSeconds int) string {
 		timeOffset *= -1
 	}
 	offsetStr := fmt.Sprintf("%02d:%02d", int(timeOffset.Hours()), int(timeOffset.Minutes())%60)
-	return fmt.Sprintf("UTC%s%s", sign, offsetStr)
+	return fmt.Sprintf("GMT%s%s", sign, offsetStr)
 }
 
 // This increases function calculates a wait time that starts at 300 ms and increases 300 ms every 10 retries.
@@ -425,10 +425,10 @@ func calcWaitTime(retries int) time.Duration {
 // We either use the value set by user using set or use a default value of 10 minutes (as of today)
 func (s *Store) getTimeout() time.Duration {
 	if s.Properties.HasKey(config.ConfigKeyResultsTimeout) {
-		timeoutInSeconds, err := strconv.Atoi(s.Properties.Get(config.ConfigKeyResultsTimeout))
+		timeoutInMilliseconds, err := strconv.Atoi(s.Properties.Get(config.ConfigKeyResultsTimeout))
 		if err == nil {
 			// TODO - check for error when setting the property so user knows he hasn't set the results-timeout property properly
-			return time.Duration(timeoutInSeconds) * time.Second
+			return time.Duration(timeoutInMilliseconds) * time.Millisecond
 		} else {
 			return config.DefaultTimeoutDuration
 		}

--- a/pkg/flink/internal/store/store_utils_test.go
+++ b/pkg/flink/internal/store/store_utils_test.go
@@ -95,11 +95,10 @@ func TestProcessSetStatement(t *testing.T) {
 		result, err := s.processSetStatement("set")
 		assert.Nil(t, err)
 		assert.EqualValues(t, types.COMPLETED, result.Status)
-		cupaloy.SnapshotT(t, result.StatementResults)
 
-		// Add some key-value pairs to the config
-		s.Properties.Set("catalog", "job1")
-		s.Properties.Set("timeout", "30")
+		assert.Equal(t, 2, len(result.StatementResults.Headers))
+		assert.Equal(t, len(s.Properties.GetProperties()), len(result.StatementResults.Rows))
+		cupaloy.SnapshotT(t, result.StatementResults)
 	})
 
 	t.Run("should update config for valid configKey", func(t *testing.T) {
@@ -114,13 +113,9 @@ func TestProcessSetStatement(t *testing.T) {
 		result, err := s.processSetStatement("set")
 		assert.Nil(t, err)
 		assert.EqualValues(t, types.COMPLETED, result.Status)
-		expectedKeyValuePairs := map[string]string{"catalog": "job1", "timeout": "30", "location": "USA"}
 
-		// check row and column lengths match
 		assert.Equal(t, 2, len(result.StatementResults.Headers))
-		// + 2 for the other default properties apart from catalog
-		assert.Equal(t, len(expectedKeyValuePairs)+2, len(result.StatementResults.Rows))
-		// check if all expected key value pairs are in the results
+		assert.Equal(t, len(s.Properties.GetProperties()), len(result.StatementResults.Rows))
 		cupaloy.SnapshotT(t, result.StatementResults)
 	})
 }
@@ -246,23 +241,23 @@ func TestFormatUTCOffsetToTimezone(t *testing.T) {
 	}{
 		{
 			offsetSeconds: hoursToSeconds(5.5),
-			expected:      "UTC+05:30",
+			expected:      "GMT+05:30",
 		},
 		{
 			offsetSeconds: hoursToSeconds(-6),
-			expected:      "UTC-06:00",
+			expected:      "GMT-06:00",
 		},
 		{
 			offsetSeconds: hoursToSeconds(0),
-			expected:      "UTC+00:00",
+			expected:      "GMT+00:00",
 		},
 		{
 			offsetSeconds: hoursToSeconds(-2.25),
-			expected:      "UTC-02:15",
+			expected:      "GMT-02:15",
 		},
 		{
 			offsetSeconds: hoursToSeconds(3.75),
-			expected:      "UTC+03:45",
+			expected:      "GMT+03:45",
 		},
 	}
 


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->
We changed the names of some of the config options we accept in the backend, this PR is to reflect those changes in the sql client. Included changes:
- `catalog` is now named `sql.current-catalog`
- `default_database` is now named `sql.current-database`
- `table.local-time-zone` is now named `sql.local-time-zone` and has a GMT instead of a UTC prefix for the timezone offset
- `table.results-timeout` is now named `client.results-timeout` and is set in milliseconds instead of seconds

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->
Config options doc:
https://confluentinc.atlassian.net/wiki/spaces/FLINK/pages/3022523030/WIP+SET+USE+Configuration 
