### PR TITLE
Simplify KafkaREST setup for on-prem commands

### DIFF
--- a/internal/kafka/command_acl_create_onprem.go
+++ b/internal/kafka/command_acl_create_onprem.go
@@ -60,12 +60,7 @@ func (c *aclCommand) createOnPrem(cmd *cobra.Command, _ []string) error {
 		return acl.Errors
 	}
 
-	restClient, restContext, err := initKafkaRest(c.AuthenticatedCLICommand, cmd)
-	if err != nil {
-		return err
-	}
-
-	clusterId, err := getClusterIdForRestRequests(restClient, restContext)
+	restClient, restContext, clusterId, err := initKafkaRest(c.AuthenticatedCLICommand, cmd)
 	if err != nil {
 		return err
 	}

--- a/internal/kafka/command_acl_delete_onprem.go
+++ b/internal/kafka/command_acl_delete_onprem.go
@@ -53,12 +53,7 @@ func (c *aclCommand) deleteOnPrem(cmd *cobra.Command, _ []string) error {
 		return acl.Errors
 	}
 
-	restClient, restContext, err := initKafkaRest(c.AuthenticatedCLICommand, cmd)
-	if err != nil {
-		return err
-	}
-
-	clusterId, err := getClusterIdForRestRequests(restClient, restContext)
+	restClient, restContext, clusterId, err := initKafkaRest(c.AuthenticatedCLICommand, cmd)
 	if err != nil {
 		return err
 	}

--- a/internal/kafka/command_acl_list_onprem.go
+++ b/internal/kafka/command_acl_list_onprem.go
@@ -45,12 +45,7 @@ func (c *aclCommand) listOnPrem(cmd *cobra.Command, _ []string) error {
 		return acl.Errors
 	}
 
-	restClient, restContext, err := initKafkaRest(c.AuthenticatedCLICommand, cmd)
-	if err != nil {
-		return err
-	}
-
-	clusterId, err := getClusterIdForRestRequests(restClient, restContext)
+	restClient, restContext, clusterId, err := initKafkaRest(c.AuthenticatedCLICommand, cmd)
 	if err != nil {
 		return err
 	}

--- a/internal/kafka/command_broker_delete.go
+++ b/internal/kafka/command_broker_delete.go
@@ -37,12 +37,7 @@ func (c *brokerCommand) delete(cmd *cobra.Command, args []string) error {
 	}
 	brokerId := int32(i)
 
-	restClient, restContext, err := initKafkaRest(c.AuthenticatedCLICommand, cmd)
-	if err != nil {
-		return err
-	}
-
-	clusterId, err := getClusterIdForRestRequests(restClient, restContext)
+	restClient, restContext, clusterId, err := initKafkaRest(c.AuthenticatedCLICommand, cmd)
 	if err != nil {
 		return err
 	}

--- a/internal/kafka/command_broker_describe.go
+++ b/internal/kafka/command_broker_describe.go
@@ -63,12 +63,7 @@ func (c *brokerCommand) describe(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	restClient, restContext, err := initKafkaRest(c.AuthenticatedCLICommand, cmd)
-	if err != nil {
-		return err
-	}
-
-	clusterId, err := getClusterIdForRestRequests(restClient, restContext)
+	restClient, restContext, clusterId, err := initKafkaRest(c.AuthenticatedCLICommand, cmd)
 	if err != nil {
 		return err
 	}

--- a/internal/kafka/command_broker_gettasks.go
+++ b/internal/kafka/command_broker_gettasks.go
@@ -71,12 +71,7 @@ func (c *brokerCommand) getTasks(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	restClient, restContext, err := initKafkaRest(c.AuthenticatedCLICommand, cmd)
-	if err != nil {
-		return err
-	}
-
-	clusterId, err := getClusterIdForRestRequests(restClient, restContext)
+	restClient, restContext, clusterId, err := initKafkaRest(c.AuthenticatedCLICommand, cmd)
 	if err != nil {
 		return err
 	}

--- a/internal/kafka/command_broker_list.go
+++ b/internal/kafka/command_broker_list.go
@@ -30,12 +30,7 @@ func (c *brokerCommand) newListCommand() *cobra.Command {
 }
 
 func (c *brokerCommand) list(cmd *cobra.Command, _ []string) error {
-	restClient, restContext, err := initKafkaRest(c.AuthenticatedCLICommand, cmd)
-	if err != nil {
-		return err
-	}
-
-	clusterId, err := getClusterIdForRestRequests(restClient, restContext)
+	restClient, restContext, clusterId, err := initKafkaRest(c.AuthenticatedCLICommand, cmd)
 	if err != nil {
 		return err
 	}

--- a/internal/kafka/command_broker_update.go
+++ b/internal/kafka/command_broker_update.go
@@ -48,12 +48,7 @@ func (c *brokerCommand) update(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	restClient, restContext, err := initKafkaRest(c.AuthenticatedCLICommand, cmd)
-	if err != nil {
-		return err
-	}
-
-	clusterId, err := getClusterIdForRestRequests(restClient, restContext)
+	restClient, restContext, clusterId, err := initKafkaRest(c.AuthenticatedCLICommand, cmd)
 	if err != nil {
 		return err
 	}

--- a/internal/kafka/command_link_configuration_list_onprem.go
+++ b/internal/kafka/command_link_configuration_list_onprem.go
@@ -25,12 +25,7 @@ func (c *linkCommand) newConfigurationListCommandOnPrem() *cobra.Command {
 func (c *linkCommand) configurationListOnPrem(cmd *cobra.Command, args []string) error {
 	linkName := args[0]
 
-	client, ctx, err := initKafkaRest(c.AuthenticatedCLICommand, cmd)
-	if err != nil {
-		return err
-	}
-
-	clusterId, err := getClusterIdForRestRequests(client, ctx)
+	client, ctx, clusterId, err := initKafkaRest(c.AuthenticatedCLICommand, cmd)
 	if err != nil {
 		return err
 	}

--- a/internal/kafka/command_link_configuration_update_onprem.go
+++ b/internal/kafka/command_link_configuration_update_onprem.go
@@ -62,12 +62,7 @@ func (c *linkCommand) configurationUpdateOnPrem(cmd *cobra.Command, args []strin
 		return err
 	}
 
-	client, ctx, err := initKafkaRest(c.AuthenticatedCLICommand, cmd)
-	if err != nil {
-		return err
-	}
-
-	clusterId, err := getClusterIdForRestRequests(client, ctx)
+	client, ctx, clusterId, err := initKafkaRest(c.AuthenticatedCLICommand, cmd)
 	if err != nil {
 		return err
 	}

--- a/internal/kafka/command_link_create_onprem.go
+++ b/internal/kafka/command_link_create_onprem.go
@@ -123,12 +123,7 @@ func (c *linkCommand) createOnPrem(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	client, ctx, err := initKafkaRest(c.AuthenticatedCLICommand, cmd)
-	if err != nil {
-		return err
-	}
-
-	clusterId, err := getClusterIdForRestRequests(client, ctx)
+	client, ctx, clusterId, err := initKafkaRest(c.AuthenticatedCLICommand, cmd)
 	if err != nil {
 		return err
 	}

--- a/internal/kafka/command_link_delete_onprem.go
+++ b/internal/kafka/command_link_delete_onprem.go
@@ -26,12 +26,7 @@ func (c *linkCommand) newDeleteCommandOnPrem() *cobra.Command {
 func (c *linkCommand) deleteOnPrem(cmd *cobra.Command, args []string) error {
 	linkName := args[0]
 
-	client, ctx, err := initKafkaRest(c.AuthenticatedCLICommand, cmd)
-	if err != nil {
-		return err
-	}
-
-	clusterId, err := getClusterIdForRestRequests(client, ctx)
+	client, ctx, clusterId, err := initKafkaRest(c.AuthenticatedCLICommand, cmd)
 	if err != nil {
 		return err
 	}

--- a/internal/kafka/command_link_describe_onprem.go
+++ b/internal/kafka/command_link_describe_onprem.go
@@ -26,12 +26,7 @@ func (c *linkCommand) newDescribeCommandOnPrem() *cobra.Command {
 func (c *linkCommand) describeOnPrem(cmd *cobra.Command, args []string) error {
 	linkName := args[0]
 
-	client, ctx, err := initKafkaRest(c.AuthenticatedCLICommand, cmd)
-	if err != nil {
-		return err
-	}
-
-	clusterId, err := getClusterIdForRestRequests(client, ctx)
+	client, ctx, clusterId, err := initKafkaRest(c.AuthenticatedCLICommand, cmd)
 	if err != nil {
 		return err
 	}

--- a/internal/kafka/command_link_list_onprem.go
+++ b/internal/kafka/command_link_list_onprem.go
@@ -49,12 +49,7 @@ func (c *linkCommand) listOnPrem(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	client, ctx, err := initKafkaRest(c.AuthenticatedCLICommand, cmd)
-	if err != nil {
-		return err
-	}
-
-	clusterId, err := getClusterIdForRestRequests(client, ctx)
+	client, ctx, clusterId, err := initKafkaRest(c.AuthenticatedCLICommand, cmd)
 	if err != nil {
 		return err
 	}

--- a/internal/kafka/command_partition_describe.go
+++ b/internal/kafka/command_partition_describe.go
@@ -45,12 +45,7 @@ func (c *partitionCommand) describe(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	restClient, restContext, err := initKafkaRest(c.AuthenticatedCLICommand, cmd)
-	if err != nil {
-		return err
-	}
-
-	clusterId, err := getClusterIdForRestRequests(restClient, restContext)
+	restClient, restContext, clusterId, err := initKafkaRest(c.AuthenticatedCLICommand, cmd)
 	if err != nil {
 		return err
 	}

--- a/internal/kafka/command_partition_list.go
+++ b/internal/kafka/command_partition_list.go
@@ -34,12 +34,7 @@ func (c *partitionCommand) newListCommand() *cobra.Command {
 }
 
 func (c *partitionCommand) list(cmd *cobra.Command, _ []string) error {
-	restClient, restContext, err := initKafkaRest(c.AuthenticatedCLICommand, cmd)
-	if err != nil {
-		return err
-	}
-
-	clusterId, err := getClusterIdForRestRequests(restClient, restContext)
+	restClient, restContext, clusterId, err := initKafkaRest(c.AuthenticatedCLICommand, cmd)
 	if err != nil {
 		return err
 	}

--- a/internal/kafka/command_partition_reassignment_list.go
+++ b/internal/kafka/command_partition_reassignment_list.go
@@ -53,14 +53,11 @@ func (c *partitionCommand) newReassignmentListCommand() *cobra.Command {
 }
 
 func (c *partitionCommand) reassignmentList(cmd *cobra.Command, args []string) error {
-	restClient, restContext, err := initKafkaRest(c.AuthenticatedCLICommand, cmd)
+	restClient, restContext, clusterId, err := initKafkaRest(c.AuthenticatedCLICommand, cmd)
 	if err != nil {
 		return err
 	}
-	clusterId, err := getClusterIdForRestRequests(restClient, restContext)
-	if err != nil {
-		return err
-	}
+
 	topic, err := cmd.Flags().GetString("topic")
 	if err != nil {
 		return err

--- a/internal/kafka/command_replica_list.go
+++ b/internal/kafka/command_replica_list.go
@@ -83,12 +83,7 @@ func (c *replicaCommand) list(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	restClient, restContext, err := initKafkaRest(c.AuthenticatedCLICommand, cmd)
-	if err != nil {
-		return err
-	}
-
-	clusterId, err := getClusterIdForRestRequests(restClient, restContext)
+	restClient, restContext, clusterId, err := initKafkaRest(c.AuthenticatedCLICommand, cmd)
 	if err != nil {
 		return err
 	}

--- a/internal/kafka/command_topic_create_onprem.go
+++ b/internal/kafka/command_topic_create_onprem.go
@@ -53,12 +53,7 @@ func (c *command) newCreateCommandOnPrem() *cobra.Command {
 func (c *command) createOnPrem(cmd *cobra.Command, args []string) error {
 	topicName := args[0]
 
-	restClient, restContext, err := initKafkaRest(c.AuthenticatedCLICommand, cmd)
-	if err != nil {
-		return err
-	}
-
-	clusterId, err := getClusterIdForRestRequests(restClient, restContext)
+	restClient, restContext, clusterId, err := initKafkaRest(c.AuthenticatedCLICommand, cmd)
 	if err != nil {
 		return err
 	}

--- a/internal/kafka/command_topic_delete_onprem.go
+++ b/internal/kafka/command_topic_delete_onprem.go
@@ -42,11 +42,7 @@ func (c *command) newDeleteCommandOnPrem() *cobra.Command {
 
 func (c *command) deleteOnPrem(cmd *cobra.Command, args []string) error {
 	topicName := args[0]
-	restClient, restContext, err := initKafkaRest(c.AuthenticatedCLICommand, cmd)
-	if err != nil {
-		return err
-	}
-	clusterId, err := getClusterIdForRestRequests(restClient, restContext)
+	restClient, restContext, clusterId, err := initKafkaRest(c.AuthenticatedCLICommand, cmd)
 	if err != nil {
 		return err
 	}

--- a/internal/kafka/command_topic_describe_onprem.go
+++ b/internal/kafka/command_topic_describe_onprem.go
@@ -58,11 +58,7 @@ func (c *command) describeOnPrem(cmd *cobra.Command, args []string) error {
 	// Parse Args
 	topicName := args[0]
 
-	restClient, restContext, err := initKafkaRest(c.AuthenticatedCLICommand, cmd)
-	if err != nil {
-		return err
-	}
-	clusterId, err := getClusterIdForRestRequests(restClient, restContext)
+	restClient, restContext, clusterId, err := initKafkaRest(c.AuthenticatedCLICommand, cmd)
 	if err != nil {
 		return err
 	}

--- a/internal/kafka/command_topic_list_onprem.go
+++ b/internal/kafka/command_topic_list_onprem.go
@@ -40,11 +40,7 @@ func (c *command) newListCommandOnPrem() *cobra.Command {
 }
 
 func (c *command) listOnPrem(cmd *cobra.Command, _ []string) error {
-	restClient, restContext, err := initKafkaRest(c.AuthenticatedCLICommand, cmd)
-	if err != nil {
-		return err
-	}
-	clusterId, err := getClusterIdForRestRequests(restClient, restContext)
+	restClient, restContext, clusterId, err := initKafkaRest(c.AuthenticatedCLICommand, cmd)
 	if err != nil {
 		return err
 	}

--- a/internal/kafka/command_topic_onprem.go
+++ b/internal/kafka/command_topic_onprem.go
@@ -1,28 +1,14 @@
 package kafka
 
 import (
-	"context"
 	"fmt"
 	"time"
 
 	ckafka "github.com/confluentinc/confluent-kafka-go/kafka"
-	"github.com/confluentinc/kafka-rest-sdk-go/kafkarestv3"
 
 	"github.com/confluentinc/cli/v3/pkg/errors"
-	"github.com/confluentinc/cli/v3/pkg/kafkarest"
 	"github.com/confluentinc/cli/v3/pkg/log"
 )
-
-func getClusterIdForRestRequests(client *kafkarestv3.APIClient, ctx context.Context) (string, error) {
-	clusters, resp, err := client.ClusterV3Api.ClustersGet(ctx)
-	if err != nil {
-		return "", kafkarest.NewError(client.GetConfig().BasePath, err, resp)
-	}
-	if clusters.Data == nil || len(clusters.Data) == 0 {
-		return "", errors.NewErrorWithSuggestions(errors.NoClustersFoundErrorMsg, errors.NoClustersFoundSuggestions)
-	}
-	return clusters.Data[0].ClusterId, nil
-}
 
 // validate that a topic exists before attempting to produce/consume messages
 func ValidateTopic(adminClient *ckafka.AdminClient, topic string) error {

--- a/internal/kafka/command_topic_update_onprem.go
+++ b/internal/kafka/command_topic_update_onprem.go
@@ -45,11 +45,7 @@ func (c *command) newUpdateCommandOnPrem() *cobra.Command {
 func (c *command) updateOnPrem(cmd *cobra.Command, args []string) error {
 	topicName := args[0]
 
-	restClient, restContext, err := initKafkaRest(c.AuthenticatedCLICommand, cmd)
-	if err != nil {
-		return err
-	}
-	clusterId, err := getClusterIdForRestRequests(restClient, restContext)
+	restClient, restContext, clusterId, err := initKafkaRest(c.AuthenticatedCLICommand, cmd)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- PLACEHOLDER

New Features
- PLACEHOLDER

Bug Fixes
- PLACEHOLDER

Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
I noticed that `getClusterIdForRestRequests` and `initKafkaRest` are always called together for (non-local) commands.

So I rolled the logic of `getClusterIdForRestRequests` into `initKafkaRest` to save an extra function call across all of the onprem commands.

This is also a small step towards unifying the cloud and onprem command implementations.

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
<!--
Has it been tested? How?
Copy and paste any instructions or steps that can save the reviewer time.
-->

Open Questions / Follow-ups
---------------------------
<!--
Optional: Anything open to discussion for the reviewer, out of scope of this PR, or follow-ups.
-->
