### PR TITLE
[TRAFFIC-9068] - Add `confluent network update` command

### DIFF
--- a/internal/network/command.go
+++ b/internal/network/command.go
@@ -1,10 +1,41 @@
 package network
 
 import (
+	"strings"
+
 	"github.com/spf13/cobra"
 
+	networkingv1 "github.com/confluentinc/ccloud-sdk-go-v2/networking/v1"
+
 	pcmd "github.com/confluentinc/cli/v3/pkg/cmd"
+	"github.com/confluentinc/cli/v3/pkg/output"
 )
+
+type humanOut struct {
+	Id                    string `human:"ID"`
+	EnvironmentId         string `human:"Environment ID"`
+	Name                  string `human:"Name"`
+	Cloud                 string `human:"Cloud"`
+	Region                string `human:"Region"`
+	Cidr                  string `human:"CIDR"`
+	Zones                 string `human:"Zones"`
+	DnsResolution         string `human:"DNS Resolution"`
+	Phase                 string `human:"Phase"`
+	ActiveConnectionTypes string `human:"Active Connection Types"`
+}
+
+type serializedOut struct {
+	Id                    string   `serialized:"id"`
+	EnvironmentId         string   `serialized:"environment_id"`
+	Name                  string   `serialized:"name"`
+	Cloud                 string   `serialized:"cloud"`
+	Region                string   `serialized:"region"`
+	Cidr                  string   `serialized:"cidr"`
+	Zones                 []string `serialized:"zones"`
+	DnsResolution         string   `serialized:"dns_resolution"`
+	Phase                 string   `serialized:"phase"`
+	ActiveConnectionTypes []string `serialized:"active_connection_types"`
+}
 
 type command struct {
 	*pcmd.AuthenticatedCLICommand
@@ -23,4 +54,41 @@ func New(prerunner pcmd.PreRunner) *cobra.Command {
 	cmd.AddCommand(c.newUpdateCommand())
 
 	return cmd
+}
+
+func printTable(cmd *cobra.Command, network networkingv1.NetworkingV1Network) error {
+	table := output.NewTable(cmd)
+
+	zones := network.Spec.GetZones()
+	activeConnectionTypes := network.Status.GetActiveConnectionTypes().Items
+
+	if output.GetFormat(cmd) == output.Human {
+		table.Add(&humanOut{
+			Id:                    network.GetId(),
+			EnvironmentId:         network.Spec.Environment.GetId(),
+			Name:                  network.Spec.GetDisplayName(),
+			Cloud:                 network.Spec.GetCloud(),
+			Region:                network.Spec.GetRegion(),
+			Cidr:                  network.Spec.GetCidr(),
+			Zones:                 strings.Join(zones, ", "),
+			DnsResolution:         network.Spec.DnsConfig.GetResolution(),
+			Phase:                 network.Status.GetPhase(),
+			ActiveConnectionTypes: strings.Join(activeConnectionTypes, ", "),
+		})
+	} else {
+		table.Add(&serializedOut{
+			Id:                    network.GetId(),
+			EnvironmentId:         network.Spec.Environment.GetId(),
+			Name:                  network.Spec.GetDisplayName(),
+			Cloud:                 network.Spec.GetCloud(),
+			Region:                network.Spec.GetRegion(),
+			Cidr:                  network.Spec.GetCidr(),
+			Zones:                 zones,
+			DnsResolution:         network.Spec.DnsConfig.GetResolution(),
+			Phase:                 network.Status.GetPhase(),
+			ActiveConnectionTypes: activeConnectionTypes,
+		})
+	}
+
+	return table.Print()
 }

--- a/internal/network/command.go
+++ b/internal/network/command.go
@@ -13,7 +13,7 @@ import (
 
 type humanOut struct {
 	Id                    string `human:"ID"`
-	EnvironmentId         string `human:"Environment ID"`
+	EnvironmentId         string `human:"Environment"`
 	Name                  string `human:"Name"`
 	Cloud                 string `human:"Cloud"`
 	Region                string `human:"Region"`

--- a/internal/network/command.go
+++ b/internal/network/command.go
@@ -20,6 +20,7 @@ func New(prerunner pcmd.PreRunner) *cobra.Command {
 	c := &command{pcmd.NewAuthenticatedCLICommand(cmd, prerunner)}
 	cmd.AddCommand(c.newDeleteCommand())
 	cmd.AddCommand(c.newDescribeCommand())
+	cmd.AddCommand(c.newUpdateCommand())
 
 	return cmd
 }

--- a/internal/network/command_describe.go
+++ b/internal/network/command_describe.go
@@ -1,42 +1,11 @@
 package network
 
 import (
-	"strings"
-
 	"github.com/spf13/cobra"
-
-	networkingv1 "github.com/confluentinc/ccloud-sdk-go-v2/networking/v1"
 
 	pcmd "github.com/confluentinc/cli/v3/pkg/cmd"
 	"github.com/confluentinc/cli/v3/pkg/examples"
-	"github.com/confluentinc/cli/v3/pkg/output"
 )
-
-type humanOut struct {
-	Id                    string `human:"ID"`
-	EnvironmentId         string `human:"Environment ID"`
-	Name                  string `human:"Name"`
-	Cloud                 string `human:"Cloud"`
-	Region                string `human:"Region"`
-	Cidr                  string `human:"CIDR"`
-	Zones                 string `human:"Zones"`
-	DnsResolution         string `human:"DNS Resolution"`
-	Phase                 string `human:"Phase"`
-	ActiveConnectionTypes string `human:"Active Connection Types"`
-}
-
-type serializedOut struct {
-	Id                    string   `serialized:"id"`
-	EnvironmentId         string   `serialized:"environment_id"`
-	Name                  string   `serialized:"name"`
-	Cloud                 string   `serialized:"cloud"`
-	Region                string   `serialized:"region"`
-	Cidr                  string   `serialized:"cidr"`
-	Zones                 []string `serialized:"zones"`
-	DnsResolution         string   `serialized:"dns_resolution"`
-	Phase                 string   `serialized:"phase"`
-	ActiveConnectionTypes []string `serialized:"active_connection_types"`
-}
 
 func (c *command) newDescribeCommand() *cobra.Command {
 	cmd := &cobra.Command{
@@ -54,6 +23,7 @@ func (c *command) newDescribeCommand() *cobra.Command {
 		),
 	}
 
+	pcmd.AddContextFlag(cmd, c.CLICommand)
 	pcmd.AddEnvironmentFlag(cmd, c.AuthenticatedCLICommand)
 	pcmd.AddOutputFlag(cmd)
 
@@ -72,41 +42,4 @@ func (c *command) describe(cmd *cobra.Command, args []string) error {
 	}
 
 	return printTable(cmd, network)
-}
-
-func printTable(cmd *cobra.Command, network networkingv1.NetworkingV1Network) error {
-	table := output.NewTable(cmd)
-
-	zones := network.Spec.GetZones()
-	activeConnectionTypes := network.Status.GetActiveConnectionTypes().Items
-
-	if output.GetFormat(cmd) == output.Human {
-		table.Add(&humanOut{
-			Id:                    network.GetId(),
-			EnvironmentId:         network.Spec.Environment.GetId(),
-			Name:                  network.Spec.GetDisplayName(),
-			Cloud:                 network.Spec.GetCloud(),
-			Region:                network.Spec.GetRegion(),
-			Cidr:                  network.Spec.GetCidr(),
-			Zones:                 strings.Join(zones, ","),
-			DnsResolution:         network.Spec.DnsConfig.GetResolution(),
-			Phase:                 network.Status.GetPhase(),
-			ActiveConnectionTypes: strings.Join(activeConnectionTypes, ","),
-		})
-	} else {
-		table.Add(&serializedOut{
-			Id:                    network.GetId(),
-			EnvironmentId:         network.Spec.Environment.GetId(),
-			Name:                  network.Spec.GetDisplayName(),
-			Cloud:                 network.Spec.GetCloud(),
-			Region:                network.Spec.GetRegion(),
-			Cidr:                  network.Spec.GetCidr(),
-			Zones:                 zones,
-			DnsResolution:         network.Spec.DnsConfig.GetResolution(),
-			Phase:                 network.Status.GetPhase(),
-			ActiveConnectionTypes: activeConnectionTypes,
-		})
-	}
-
-	return table.Print()
 }

--- a/internal/network/command_describe.go
+++ b/internal/network/command_describe.go
@@ -10,7 +10,7 @@ import (
 func (c *command) newDescribeCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "describe <id>",
-		Short: "Desribe a network.",
+		Short: "Describe a network.",
 		Args:  cobra.ExactArgs(1),
 		// TODO: Implement autocompletion after List Network is implemented.
 		// ValidArgsFunction: pcmd.NewValidArgsFunction(c.validArgs),

--- a/internal/network/command_update.go
+++ b/internal/network/command_update.go
@@ -6,7 +6,6 @@ import (
 	networkingv1 "github.com/confluentinc/ccloud-sdk-go-v2/networking/v1"
 
 	pcmd "github.com/confluentinc/cli/v3/pkg/cmd"
-	"github.com/confluentinc/cli/v3/pkg/errors"
 	"github.com/confluentinc/cli/v3/pkg/examples"
 )
 
@@ -20,7 +19,7 @@ func (c *command) newUpdateCommand() *cobra.Command {
 		RunE: c.update,
 		Example: examples.BuildExampleString(
 			examples.Example{
-				Text: `Update the name of the network "n-123456".`,
+				Text: `Update the name of network "n-123456".`,
 				Code: `confluent network update n-123456 --name "new name"`,
 			},
 		),
@@ -37,13 +36,6 @@ func (c *command) newUpdateCommand() *cobra.Command {
 }
 
 func (c *command) update(cmd *cobra.Command, args []string) error {
-	flags := []string{
-		"name",
-	}
-	if err := errors.CheckNoUpdate(cmd.Flags(), flags...); err != nil {
-		return err
-	}
-
 	environmentId, err := c.Context.EnvironmentId()
 	if err != nil {
 		return err
@@ -54,10 +46,11 @@ func (c *command) update(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	updateNetwork := networkingv1.NetworkingV1NetworkUpdate{Spec: &networkingv1.NetworkingV1NetworkSpecUpdate{}}
-
-	if name != "" {
-		updateNetwork.Spec.SetDisplayName(name)
+	updateNetwork := networkingv1.NetworkingV1NetworkUpdate{
+		Spec: &networkingv1.NetworkingV1NetworkSpecUpdate{
+			DisplayName: networkingv1.PtrString(name),
+			Environment: &networkingv1.ObjectReference{Id: environmentId},
+		},
 	}
 
 	network, err := c.V2Client.UpdateNetwork(environmentId, args[0], updateNetwork)

--- a/internal/network/command_update.go
+++ b/internal/network/command_update.go
@@ -1,0 +1,68 @@
+package network
+
+import (
+	"github.com/spf13/cobra"
+
+	networkingv1 "github.com/confluentinc/ccloud-sdk-go-v2/networking/v1"
+
+	pcmd "github.com/confluentinc/cli/v3/pkg/cmd"
+	"github.com/confluentinc/cli/v3/pkg/errors"
+	"github.com/confluentinc/cli/v3/pkg/examples"
+)
+
+func (c *command) newUpdateCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "update <id>",
+		Short: "Update an existing network.",
+		Args:  cobra.ExactArgs(1),
+		// TODO: Implement autocompletion after List Network is implemented.
+		// ValidArgsFunction: pcmd.NewValidArgsFunction(c.validArgs),
+		RunE: c.update,
+		Example: examples.BuildExampleString(
+			examples.Example{
+				Text: `Update the name of the network "n-abcde1" with a new name.`,
+				Code: "confluent network update n-abcde1 --name new-test-network",
+			},
+		),
+	}
+
+	cmd.Flags().String("name", "", "Name of the network.")
+
+	pcmd.AddContextFlag(cmd, c.CLICommand)
+	pcmd.AddEnvironmentFlag(cmd, c.AuthenticatedCLICommand)
+	pcmd.AddOutputFlag(cmd)
+
+	return cmd
+}
+
+func (c *command) update(cmd *cobra.Command, args []string) error {
+	flags := []string{
+		"name",
+	}
+	if err := errors.CheckNoUpdate(cmd.Flags(), flags...); err != nil {
+		return err
+	}
+
+	environmentId, err := c.Context.EnvironmentId()
+	if err != nil {
+		return err
+	}
+
+	name, err := cmd.Flags().GetString("name")
+	if err != nil {
+		return err
+	}
+
+	updateNetwork := networkingv1.NetworkingV1NetworkUpdate{Spec: &networkingv1.NetworkingV1NetworkSpecUpdate{}}
+
+	if name != "" {
+		updateNetwork.Spec.SetDisplayName(name)
+	}
+
+	network, err := c.V2Client.UpdateNetwork(environmentId, args[0], updateNetwork)
+	if err != nil {
+		return err
+	}
+
+	return printTable(cmd, network)
+}

--- a/internal/network/command_update.go
+++ b/internal/network/command_update.go
@@ -20,17 +20,18 @@ func (c *command) newUpdateCommand() *cobra.Command {
 		RunE: c.update,
 		Example: examples.BuildExampleString(
 			examples.Example{
-				Text: `Update the name of the network "n-abcde1" with a new name.`,
-				Code: "confluent network update n-abcde1 --name new-test-network",
+				Text: `Update the name of the network "n-123456".`,
+				Code: `confluent network update n-123456 --name "new name"`,
 			},
 		),
 	}
 
 	cmd.Flags().String("name", "", "Name of the network.")
-
 	pcmd.AddContextFlag(cmd, c.CLICommand)
 	pcmd.AddEnvironmentFlag(cmd, c.AuthenticatedCLICommand)
 	pcmd.AddOutputFlag(cmd)
+
+	cobra.CheckErr(cmd.MarkFlagRequired("name"))
 
 	return cmd
 }

--- a/pkg/ccloudv2/networking.go
+++ b/pkg/ccloudv2/networking.go
@@ -32,9 +32,7 @@ func (c *Client) DeleteNetwork(envId, id string) error {
 	return errors.CatchCCloudV2Error(err, httpResp)
 }
 
-func (c *Client) UpdateNetwork(envId, id string, update networkingv1.NetworkingV1NetworkUpdate) (networkingv1.NetworkingV1Network, error) {
-	update.Spec.SetEnvironment(networkingv1.ObjectReference{Id: envId})
-
-	resp, httpResp, err := c.NetworkingClient.NetworksNetworkingV1Api.UpdateNetworkingV1Network(c.networkingApiContext(), id).NetworkingV1NetworkUpdate(update).Execute()
+func (c *Client) UpdateNetwork(envId, id string, updateReq networkingv1.NetworkingV1NetworkUpdate) (networkingv1.NetworkingV1Network, error) {
+	resp, httpResp, err := c.NetworkingClient.NetworksNetworkingV1Api.UpdateNetworkingV1Network(c.networkingApiContext(), id).NetworkingV1NetworkUpdate(updateReq).Execute()
 	return resp, errors.CatchCCloudV2Error(err, httpResp)
 }

--- a/pkg/ccloudv2/networking.go
+++ b/pkg/ccloudv2/networking.go
@@ -31,3 +31,10 @@ func (c *Client) DeleteNetwork(envId, id string) error {
 	httpResp, err := c.NetworkingClient.NetworksNetworkingV1Api.DeleteNetworkingV1Network(c.networkingApiContext(), id).Environment(envId).Execute()
 	return errors.CatchCCloudV2Error(err, httpResp)
 }
+
+func (c *Client) UpdateNetwork(envId, id string, update networkingv1.NetworkingV1NetworkUpdate) (networkingv1.NetworkingV1Network, error) {
+	update.Spec.SetEnvironment(networkingv1.ObjectReference{Id: envId})
+
+	resp, httpResp, err := c.NetworkingClient.NetworksNetworkingV1Api.UpdateNetworkingV1Network(c.networkingApiContext(), id).NetworkingV1NetworkUpdate(update).Execute()
+	return resp, errors.CatchCCloudV2Error(err, httpResp)
+}

--- a/test/fixtures/output/network/describe-help.golden
+++ b/test/fixtures/output/network/describe-help.golden
@@ -1,4 +1,4 @@
-Desribe a network.
+Describe a network.
 
 Usage:
   confluent network describe <id> [flags]

--- a/test/fixtures/output/network/describe-help.golden
+++ b/test/fixtures/output/network/describe-help.golden
@@ -9,6 +9,7 @@ Describe Confluent network "n-abcde1".
   $ confluent network describe n-abcde1
 
 Flags:
+      --context string       CLI context name.
       --environment string   Environment ID.
   -o, --output string        Specify the output format as "human", "json", or "yaml". (default "human")
 

--- a/test/fixtures/output/network/describe-missing-id.golden
+++ b/test/fixtures/output/network/describe-missing-id.golden
@@ -8,6 +8,7 @@ Describe Confluent network "n-abcde1".
   $ confluent network describe n-abcde1
 
 Flags:
+      --context string       CLI context name.
       --environment string   Environment ID.
   -o, --output string        Specify the output format as "human", "json", or "yaml". (default "human")
 

--- a/test/fixtures/output/network/describe.golden
+++ b/test/fixtures/output/network/describe.golden
@@ -1,12 +1,12 @@
-+-------------------------+----------------------------+
-| ID                      | n-abcde1                   |
-| Environment ID          | env-00000                  |
-| Name                    | prod-aws-us-east1          |
-| Cloud                   | AWS                        |
-| Region                  | us-east-1                  |
-| CIDR                    | 10.200.0.0/16              |
-| Zones                   | use1-az1,use1-az2,use1-az3 |
-| DNS Resolution          | CHASED_PRIVATE             |
-| Phase                   | READY                      |
-| Active Connection Types | PRIVATELINK,TRANSITGATEWAY |
-+-------------------------+----------------------------+
++-------------------------+------------------------------+
+| ID                      | n-abcde1                     |
+| Environment ID          | env-00000                    |
+| Name                    | prod-aws-us-east1            |
+| Cloud                   | AWS                          |
+| Region                  | us-east-1                    |
+| CIDR                    | 10.200.0.0/16                |
+| Zones                   | use1-az1, use1-az2, use1-az3 |
+| DNS Resolution          | CHASED_PRIVATE               |
+| Phase                   | READY                        |
+| Active Connection Types | PRIVATELINK, TRANSITGATEWAY  |
++-------------------------+------------------------------+

--- a/test/fixtures/output/network/describe.golden
+++ b/test/fixtures/output/network/describe.golden
@@ -1,6 +1,6 @@
 +-------------------------+------------------------------+
 | ID                      | n-abcde1                     |
-| Environment ID          | env-00000                    |
+| Environment             | env-00000                    |
 | Name                    | prod-aws-us-east1            |
 | Cloud                   | AWS                          |
 | Region                  | us-east-1                    |

--- a/test/fixtures/output/network/help.golden
+++ b/test/fixtures/output/network/help.golden
@@ -5,7 +5,7 @@ Usage:
 
 Available Commands:
   delete      Delete a network.
-  describe    Desribe a network.
+  describe    Describe a network.
   update      Update an existing network.
 
 Global Flags:

--- a/test/fixtures/output/network/help.golden
+++ b/test/fixtures/output/network/help.golden
@@ -6,6 +6,7 @@ Usage:
 Available Commands:
   delete      Delete a network.
   describe    Desribe a network.
+  update      Update an existing network.
 
 Global Flags:
   -h, --help            Show help for this command.

--- a/test/fixtures/output/network/update-help.golden
+++ b/test/fixtures/output/network/update-help.golden
@@ -4,7 +4,7 @@ Usage:
   confluent network update <id> [flags]
 
 Examples:
-Update the name of the network "n-123456".
+Update the name of network "n-123456".
 
   $ confluent network update n-123456 --name "new name"
 

--- a/test/fixtures/output/network/update-help.golden
+++ b/test/fixtures/output/network/update-help.golden
@@ -1,0 +1,20 @@
+Update an existing network.
+
+Usage:
+  confluent network update <id> [flags]
+
+Examples:
+Update the name of the network "n-abcde1" with a new name.
+
+  $ confluent network update n-abcde1 --name new-test-network
+
+Flags:
+      --name string          Name of the network.
+      --context string       CLI context name.
+      --environment string   Environment ID.
+  -o, --output string        Specify the output format as "human", "json", or "yaml". (default "human")
+
+Global Flags:
+  -h, --help            Show help for this command.
+      --unsafe-trace    Equivalent to -vvvv, but also log HTTP requests and responses which might contain plaintext secrets.
+  -v, --verbose count   Increase verbosity (-v for warn, -vv for info, -vvv for debug, -vvvv for trace).

--- a/test/fixtures/output/network/update-help.golden
+++ b/test/fixtures/output/network/update-help.golden
@@ -4,12 +4,12 @@ Usage:
   confluent network update <id> [flags]
 
 Examples:
-Update the name of the network "n-abcde1" with a new name.
+Update the name of the network "n-123456".
 
-  $ confluent network update n-abcde1 --name new-test-network
+  $ confluent network update n-123456 --name "new name"
 
 Flags:
-      --name string          Name of the network.
+      --name string          REQUIRED: Name of the network.
       --context string       CLI context name.
       --environment string   Environment ID.
   -o, --output string        Specify the output format as "human", "json", or "yaml". (default "human")

--- a/test/fixtures/output/network/update-missing-args.golden
+++ b/test/fixtures/output/network/update-missing-args.golden
@@ -3,7 +3,7 @@ Usage:
   confluent network update <id> [flags]
 
 Examples:
-Update the name of the network "n-123456".
+Update the name of network "n-123456".
 
   $ confluent network update n-123456 --name "new name"
 

--- a/test/fixtures/output/network/update-missing-args.golden
+++ b/test/fixtures/output/network/update-missing-args.golden
@@ -3,9 +3,9 @@ Usage:
   confluent network update <id> [flags]
 
 Examples:
-Update the name of the network "n-abcde1" with a new name.
+Update the name of the network "n-123456".
 
-  $ confluent network update n-abcde1 --name new-test-network
+  $ confluent network update n-123456 --name "new name"
 
 Flags:
       --name string          Name of the network.

--- a/test/fixtures/output/network/update-missing-args.golden
+++ b/test/fixtures/output/network/update-missing-args.golden
@@ -1,0 +1,20 @@
+Error: accepts 1 arg(s), received 0
+Usage:
+  confluent network update <id> [flags]
+
+Examples:
+Update the name of the network "n-abcde1" with a new name.
+
+  $ confluent network update n-abcde1 --name new-test-network
+
+Flags:
+      --name string          Name of the network.
+      --context string       CLI context name.
+      --environment string   Environment ID.
+  -o, --output string        Specify the output format as "human", "json", or "yaml". (default "human")
+
+Global Flags:
+  -h, --help            Show help for this command.
+      --unsafe-trace    Equivalent to -vvvv, but also log HTTP requests and responses which might contain plaintext secrets.
+  -v, --verbose count   Increase verbosity (-v for warn, -vv for info, -vvv for debug, -vvvv for trace).
+

--- a/test/fixtures/output/network/update-missing-flags.golden
+++ b/test/fixtures/output/network/update-missing-flags.golden
@@ -1,1 +1,20 @@
-Error: at least one of the following flags must be set: `--name`
+Error: required flag(s) "name" not set
+Usage:
+  confluent network update <id> [flags]
+
+Examples:
+Update the name of the network "n-123456".
+
+  $ confluent network update n-123456 --name "new name"
+
+Flags:
+      --name string          REQUIRED: Name of the network.
+      --context string       CLI context name.
+      --environment string   Environment ID.
+  -o, --output string        Specify the output format as "human", "json", or "yaml". (default "human")
+
+Global Flags:
+  -h, --help            Show help for this command.
+      --unsafe-trace    Equivalent to -vvvv, but also log HTTP requests and responses which might contain plaintext secrets.
+  -v, --verbose count   Increase verbosity (-v for warn, -vv for info, -vvv for debug, -vvvv for trace).
+

--- a/test/fixtures/output/network/update-missing-flags.golden
+++ b/test/fixtures/output/network/update-missing-flags.golden
@@ -3,7 +3,7 @@ Usage:
   confluent network update <id> [flags]
 
 Examples:
-Update the name of the network "n-123456".
+Update the name of network "n-123456".
 
   $ confluent network update n-123456 --name "new name"
 

--- a/test/fixtures/output/network/update-missing-flags.golden
+++ b/test/fixtures/output/network/update-missing-flags.golden
@@ -1,0 +1,1 @@
+Error: at least one of the following flags must be set: `--name`

--- a/test/fixtures/output/network/update-network-not-exist.golden
+++ b/test/fixtures/output/network/update-network-not-exist.golden
@@ -1,0 +1,1 @@
+Error: The network n-invalid was not found.: 404 Not Found

--- a/test/fixtures/output/network/update.golden
+++ b/test/fixtures/output/network/update.golden
@@ -1,0 +1,12 @@
++-------------------------+------------------------------+
+| ID                      | n-abcde1                     |
+| Environment ID          | env-00000                    |
+| Name                    | new-prod-aws-us-east1        |
+| Cloud                   | AWS                          |
+| Region                  | us-east-1                    |
+| CIDR                    | 10.200.0.0/16                |
+| Zones                   | use1-az1, use1-az2, use1-az3 |
+| DNS Resolution          | CHASED_PRIVATE               |
+| Phase                   | READY                        |
+| Active Connection Types | PRIVATELINK, TRANSITGATEWAY  |
++-------------------------+------------------------------+

--- a/test/fixtures/output/network/update.golden
+++ b/test/fixtures/output/network/update.golden
@@ -1,6 +1,6 @@
 +-------------------------+------------------------------+
 | ID                      | n-abcde1                     |
-| Environment ID          | env-00000                    |
+| Environment             | env-00000                    |
 | Name                    | new-prod-aws-us-east1        |
 | Cloud                   | AWS                          |
 | Region                  | us-east-1                    |

--- a/test/network_test.go
+++ b/test/network_test.go
@@ -25,3 +25,17 @@ func (s *CLITestSuite) TestNetworkDelete() {
 		s.runIntegrationTest(test)
 	}
 }
+
+func (s *CLITestSuite) TestNetworkUpdate() {
+	tests := []CLITest{
+		{args: "network update", fixture: "network/update-missing-args.golden", exitCode: 1},
+		{args: "network update n-abcde1", fixture: "network/update-missing-flags.golden", exitCode: 1},
+		{args: "network update n-abcde1 --name new-network-name", fixture: "network/update.golden"},
+		{args: "network update n-invalid --name new-network-name", fixture: "network/update-network-not-exist.golden", exitCode: 1},
+	}
+
+	for _, test := range tests {
+		test.login = "cloud"
+		s.runIntegrationTest(test)
+	}
+}


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->
Note that this is merging into the feature branch https://github.com/confluentinc/cli/tree/traffic-8850-network-cli. We will merge commits into main from this feature branch after all of the commands for network are implemented

* Added the `confluent network update` command. Note that there is a `--zones-info` flag in the original design and it's a mistake. The network update API does not support updating `zonesInfo`, there's a mistake in the API documentation.
* Updated the `printTable` function to print a space after the delimiting commas.
* Moved the `printTable` function for better readability and reusability.

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->
[CLI Commands Design](https://confluentinc.atlassian.net/wiki/spaces/PM/pages/2987394300/1-pager+--+Network+CLI)
[Implementation 1-Pager](https://confluentinc.atlassian.net/wiki/spaces/~712020463029eabbac401bbe1b033ce0d3a00e/pages/3136749631/Network+CLI)

Test & Review
-------------
<!--
Has it been tested? How?
Copy and paste any instructions or steps that can save the reviewer time.
-->
Add integration tests

Performed manual tests
1. Created a network in DEVEL
2. Successfully described the network
3. Updated the network

Open Questions / Follow-ups
---------------------------
<!--
Optional: Anything open to discussion for the reviewer, out of scope of this PR, or follow-ups.
-->
