### PR TITLE
Check environment variables and keychain during token refresh

### DIFF
--- a/internal/login/command.go
+++ b/internal/login/command.go
@@ -384,7 +384,7 @@ func (c *command) saveLoginToKeychain(isCloud bool, url string, credentials *pau
 		return err
 	}
 
-	output.ErrPrintf(errors.WroteCredentialsToKeychainMsg)
+	output.ErrPrintln("Wrote login credentials to keychain.")
 
 	return nil
 }

--- a/pkg/cmd/prerunner_test.go
+++ b/pkg/cmd/prerunner_test.go
@@ -168,7 +168,7 @@ func TestPreRun_TokenExpires(t *testing.T) {
 	require.Nil(t, cfg.Context().State.Auth)
 }
 
-func Test_UpdateToken(t *testing.T) {
+func TestUpdateToken(t *testing.T) {
 	tests := []struct {
 		name      string
 		isCloud   bool
@@ -257,6 +257,11 @@ func Test_UpdateToken(t *testing.T) {
 					}
 				},
 				GetOnPremPrerunCredentialsFromNetrcFunc: func(_ *cobra.Command, _ netrc.NetrcMachineParams) func() (*pauth.Credentials, error) {
+					return func() (*pauth.Credentials, error) {
+						return nil, nil
+					}
+				},
+				GetOnPremCredentialsFromEnvVarFunc: func() func() (*pauth.Credentials, error) {
 					return func() (*pauth.Credentials, error) {
 						return nil, nil
 					}

--- a/pkg/cmd/token_validator.go
+++ b/pkg/cmd/token_validator.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/confluentinc/cli/v3/pkg/config"
 	"github.com/confluentinc/cli/v3/pkg/errors"
-	"github.com/confluentinc/cli/v3/pkg/log"
 	"github.com/confluentinc/cli/v3/pkg/version"
 )
 
@@ -34,6 +33,7 @@ func (v *JWTValidatorImpl) Validate(context *config.Context) error {
 	if context != nil {
 		authToken = context.State.AuthToken
 	}
+
 	var claims map[string]any
 	token, err := jwt.ParseSigned(authToken)
 	if err != nil {
@@ -42,13 +42,15 @@ func (v *JWTValidatorImpl) Validate(context *config.Context) error {
 	if err := token.UnsafeClaimsWithoutVerification(&claims); err != nil {
 		return err
 	}
+
 	exp, ok := claims["exp"].(float64)
 	if !ok {
-		return errors.New(errors.MalformedJWTNoExprErrorMsg)
+		return errors.New("malformed token: no expiration")
 	}
+
 	if float64(v.Clock.Now().Unix()) > exp {
-		log.CliLogger.Debug("Token expired.")
-		return new(ccloudv1.ExpiredTokenError)
+		return errors.NewErrorWithSuggestions(errors.ExpiredTokenErrorMsg, errors.ExpiredTokenSuggestions)
 	}
+
 	return nil
 }

--- a/pkg/errors/catcher.go
+++ b/pkg/errors/catcher.go
@@ -113,8 +113,6 @@ func catchCCloudTokenErrors(err error) error {
 		return NewErrorWithSuggestions(InvalidLoginErrorMsg, InvalidLoginErrorSuggestions)
 	case *ccloudv1.InvalidTokenError:
 		return NewErrorWithSuggestions(CorruptedTokenErrorMsg, CorruptedTokenSuggestions)
-	case *ccloudv1.ExpiredTokenError:
-		return NewErrorWithSuggestions(ExpiredTokenErrorMsg, ExpiredTokenSuggestions)
 	}
 	return err
 }

--- a/pkg/errors/error_message.go
+++ b/pkg/errors/error_message.go
@@ -263,7 +263,6 @@ const (
 	SRNotEnabledErrorMsg    = "Schema Registry not enabled"
 	SRNotEnabledSuggestions = "Schema Registry must be enabled for the environment in order to run the command.\n" +
 		"You can enable Schema Registry for this environment with `confluent schema-registry cluster enable`."
-	MalformedJWTNoExprErrorMsg = "malformed JWT claims: no expiration"
 
 	// config package
 	CorruptedConfigErrorPrefix = "corrupted CLI config"
@@ -404,7 +403,7 @@ const (
 
 	// Special error handling
 	QuotaExceededSuggestions = "Look up Confluent Cloud service quota limits with `confluent service-quota list`."
-	AvoidTimeoutSuggestions  = "To avoid session timeouts, non-SSO users can save their credentials to the netrc file with `confluent login --save`."
+	AvoidTimeoutSuggestions  = "To avoid session timeouts, non-SSO users can save their credentials with `confluent login --save`."
 	NotLoggedInErrorMsg      = "not logged in"
 	AuthTokenSuggestions     = "You must be logged in to retrieve an oauthbearer token.\n" +
 		"An oauthbearer token is required to authenticate OAUTHBEARER mechanism and Schema Registry."

--- a/pkg/errors/strings.go
+++ b/pkg/errors/strings.go
@@ -6,15 +6,14 @@ const (
 	UseAPIKeyMsg    = "Using API Key \"%s\".\n"
 
 	// auth commands
-	LoggedInAsMsg                 = "Logged in as \"%s\".\n"
-	LoggedInAsMsgWithOrg          = "Logged in as \"%s\" for organization \"%s\" (\"%s\").\n"
-	LoggedInUsingEnvMsg           = "Using environment \"%s\".\n"
-	LoggedOutMsg                  = "You are now logged out."
-	WroteCredentialsToKeychainMsg = "Wrote login credentials to keychain\n"
-	RemoveNetrcCredentialsMsg     = "Removed credentials for user \"%s\" from netrc file \"%s\"\n"
-	RemoveKeychainCredentialsMsg  = "Removed credentials for user \"%s\" from keychain\n"
-	StopNonInteractiveMsg         = "(remove these credentials or use the `--prompt` flag to bypass non-interactive login)"
-	FoundEnvCredMsg               = "Found credentials for user \"%s\" from environment variables \"%s\" and \"%s\" " +
+	LoggedInAsMsg                = "Logged in as \"%s\".\n"
+	LoggedInAsMsgWithOrg         = "Logged in as \"%s\" for organization \"%s\" (\"%s\").\n"
+	LoggedInUsingEnvMsg          = "Using environment \"%s\".\n"
+	LoggedOutMsg                 = "You are now logged out."
+	RemoveNetrcCredentialsMsg    = "Removed credentials for user \"%s\" from netrc file \"%s\"\n"
+	RemoveKeychainCredentialsMsg = "Removed credentials for user \"%s\" from keychain\n"
+	StopNonInteractiveMsg        = "(remove these credentials or use the `--prompt` flag to bypass non-interactive login)"
+	FoundEnvCredMsg              = "Found credentials for user \"%s\" from environment variables \"%s\" and \"%s\" " +
 		StopNonInteractiveMsg + ".\n"
 	FoundNetrcCredMsg = "Found credentials for user \"%s\" from netrc file \"%s\" " +
 		StopNonInteractiveMsg + ".\n"


### PR DESCRIPTION
Release Notes
-------------
Bug Fixes
- After session has timed out, correctly refresh credentials with environment variables or credentials saved with `confluent login --save`

Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
When the user's refresh token expires (5 minutes), check the user's environment variables and keychain to refresh the token. This is a sub-optimal solution, since we should try refreshing the auth token with the auth refresh token first, but that will require a major rewrite- I'll open a separate ticket for that.

Minor: Also remove reference to deprecated netrc file in error suggestion

Test & Review
-------------
Manually tested all paths.