### PR TITLE
[CLI-2701] fixing confluent iam rbac role-binding list panic

### DIFF
--- a/internal/iam/command_rbac_role_binding_list.go
+++ b/internal/iam/command_rbac_role_binding_list.go
@@ -333,7 +333,7 @@ func (c *roleBindingCommand) listMyRoleBindings(cmd *cobra.Command, listRoleBind
 	}
 
 	if currentUser {
-		listRoleBinding.Principal = mdsv2.PtrString("User:" + c.Context.State.Auth.User.GetResourceId())
+		listRoleBinding.Principal = mdsv2.PtrString("User:" + c.Context.State.Auth.GetUser().GetResourceId())
 	}
 
 	inclusive, err := cmd.Flags().GetBool("inclusive")

--- a/pkg/config/auth_config.go
+++ b/pkg/config/auth_config.go
@@ -9,3 +9,10 @@ type AuthConfig struct {
 	Account      *ccloudv1.Account      `json:"account,omitempty"`
 	Accounts     []*ccloudv1.Account    `json:"accounts,omitempty"`
 }
+
+func (a *AuthConfig) GetUser() *ccloudv1.User {
+	if a != nil {
+		return a.User
+	}
+	return nil
+}


### PR DESCRIPTION
Release Notes
-------------
Bug Fixes
- Resolve a panic in `confluent iam rbac role-binding list`

Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
Now using a panic-safe getter to retrieve the `User` field of an `AuthConfig` struct.

References
----------
https://confluentinc.atlassian.net/browse/CLI-2701