### PR TITLE
Try adding linux/arm64 support for CP

### DIFF
--- a/debian/Makefile
+++ b/debian/Makefile
@@ -56,7 +56,7 @@ install: apply-patches
 	chmod 755 $(DESTDIR)$(BINPATH)/confluent
 
 	cd $(DESTDIR)$(LIBPATH); \
-	for dir in darwin_amd64 darwin_arm64 linux_amd64 windows_amd64; do \
+	for dir in darwin_amd64 darwin_arm64 linux_amd64 linux_arm64 windows_amd64; do \
 		mkdir -p $${dir}; \
 		ext=""; if [[ $${dir} =~ windows_.+ ]]; then ext=".exe"; fi; \
 		filepath=$${dir}/confluent$${ext}; \

--- a/debian/control
+++ b/debian/control
@@ -7,6 +7,6 @@ Standards-Version: 3.9.3
 Homepage: http://confluent.io
 
 Package: confluent-cli
-Architecture: any
+Architecture: all
 Depends: ${misc:Depends}
 Description: Command Line Interface for managing Confluent Platform

--- a/debian/patches/standard_build_layout.patch
+++ b/debian/patches/standard_build_layout.patch
@@ -1,5 +1,5 @@
---- cli/Makefile	2023-08-17 08:17:03.168828613 -0700
-+++ debian/Makefile	2023-07-07 11:26:58.304825004 -0700
+--- cli/Makefile	2023-08-21 09:55:36.335812643 -0700
++++ debian/Makefile	2023-08-23 14:14:07.398823015 -0700
 @@ -1,120 +1,130 @@
 -SHELL := /bin/bash
 -GORELEASER_VERSION := v1.17.2
@@ -118,7 +118,7 @@
 +	chmod 755 $(DESTDIR)$(BINPATH)/confluent
 +
 +	cd $(DESTDIR)$(LIBPATH); \
-+	for dir in darwin_amd64 darwin_arm64 linux_amd64 windows_amd64; do \
++	for dir in darwin_amd64 darwin_arm64 linux_amd64 linux_arm64 windows_amd64; do \
 +		mkdir -p $${dir}; \
 +		ext=""; if [[ $${dir} =~ windows_.+ ]]; then ext=".exe"; fi; \
 +		filepath=$${dir}/confluent$${ext}; \


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
As per @rahejaprince's suggestion, we should try setting `Architecture: all` to enable linux/arm64 support for CP.

Test & Review
-------------
Unclear how we can test this, other than include this change in the nightly release. Any ideas @rahejaprince?