### PR TITLE
[DON'T MERGE] update to sqlv1beta1 gateway client and drop identityPool support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/confluentinc/ccloud-sdk-go-v2/cmk v0.10.0
 	github.com/confluentinc/ccloud-sdk-go-v2/connect v0.3.0
 	github.com/confluentinc/ccloud-sdk-go-v2/flink v0.4.0
-	github.com/confluentinc/ccloud-sdk-go-v2/flink-gateway v0.5.0
+	github.com/confluentinc/ccloud-sdk-go-v2/flink-gateway v0.6.0
 	github.com/confluentinc/ccloud-sdk-go-v2/iam v0.10.0
 	github.com/confluentinc/ccloud-sdk-go-v2/identity-provider v0.2.0
 	github.com/confluentinc/ccloud-sdk-go-v2/kafka-quotas v0.4.0

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/confluentinc/ccloud-sdk-go-v2/cmk v0.10.0
 	github.com/confluentinc/ccloud-sdk-go-v2/connect v0.3.0
 	github.com/confluentinc/ccloud-sdk-go-v2/flink v0.4.0
-	github.com/confluentinc/ccloud-sdk-go-v2/flink-gateway v0.4.0
+	github.com/confluentinc/ccloud-sdk-go-v2/flink-gateway v0.5.0
 	github.com/confluentinc/ccloud-sdk-go-v2/iam v0.10.0
 	github.com/confluentinc/ccloud-sdk-go-v2/identity-provider v0.2.0
 	github.com/confluentinc/ccloud-sdk-go-v2/kafka-quotas v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -126,6 +126,10 @@ github.com/confluentinc/ccloud-sdk-go-v2/flink v0.4.0 h1:ueXax5e70pLN6yQ6vSJVBlA
 github.com/confluentinc/ccloud-sdk-go-v2/flink v0.4.0/go.mod h1:x+8kpYsJHRlvGuIB/tV0afPNyjKst3MsNOE6XsjgAl0=
 github.com/confluentinc/ccloud-sdk-go-v2/flink-gateway v0.5.0 h1:lCjlaRJZPWP8Icw8HZ0bAQ9ZtmMB5horUIVE1z1eyN4=
 github.com/confluentinc/ccloud-sdk-go-v2/flink-gateway v0.5.0/go.mod h1:FbtaMRXDaT+521+m24TmCdmL1iqe6TVEmMEBa8nSUSg=
+github.com/confluentinc/ccloud-sdk-go-v2/flink-gateway v0.5.1-0.20230906140554-944b25aea8ac h1:dElBcaedD54UBPw7JaSr/hiujA7IgKFEwYPq8k7X0EU=
+github.com/confluentinc/ccloud-sdk-go-v2/flink-gateway v0.5.1-0.20230906140554-944b25aea8ac/go.mod h1:FbtaMRXDaT+521+m24TmCdmL1iqe6TVEmMEBa8nSUSg=
+github.com/confluentinc/ccloud-sdk-go-v2/flink-gateway v0.6.0 h1:dk965gvStsDtccopzMBp9lbB9H5yzkMj2DeZsFtG05E=
+github.com/confluentinc/ccloud-sdk-go-v2/flink-gateway v0.6.0/go.mod h1:FbtaMRXDaT+521+m24TmCdmL1iqe6TVEmMEBa8nSUSg=
 github.com/confluentinc/ccloud-sdk-go-v2/iam v0.10.0 h1:AV0bGk01bGfKzNq5IVqRi2iEc6YTeBbl//IYvQ/j8ag=
 github.com/confluentinc/ccloud-sdk-go-v2/iam v0.10.0/go.mod h1:2Lm82ly9Yh5LLhp8OTnUGqjz4JdIXAZ5a0/u9T+rGGU=
 github.com/confluentinc/ccloud-sdk-go-v2/identity-provider v0.2.0 h1:9TT8UCFRc5zUdsE7UgMz7hqN+2KYnIkBcAKCaiZJrXw=

--- a/go.sum
+++ b/go.sum
@@ -124,8 +124,8 @@ github.com/confluentinc/ccloud-sdk-go-v2/connect v0.3.0 h1:hnYc/T55dGEqhFBYJIGBf
 github.com/confluentinc/ccloud-sdk-go-v2/connect v0.3.0/go.mod h1:vzL/maQvg76G8BMXM9Mx0FNrXI1ctdBr46/EbZ0VJso=
 github.com/confluentinc/ccloud-sdk-go-v2/flink v0.4.0 h1:ueXax5e70pLN6yQ6vSJVBlAAGrb0Js+tJO7kYzxoAU8=
 github.com/confluentinc/ccloud-sdk-go-v2/flink v0.4.0/go.mod h1:x+8kpYsJHRlvGuIB/tV0afPNyjKst3MsNOE6XsjgAl0=
-github.com/confluentinc/ccloud-sdk-go-v2/flink-gateway v0.4.0 h1:1o0ksbMdXagJsViNRNyZXC+FBfWWTT/PuFHzjy7up4M=
-github.com/confluentinc/ccloud-sdk-go-v2/flink-gateway v0.4.0/go.mod h1:FbtaMRXDaT+521+m24TmCdmL1iqe6TVEmMEBa8nSUSg=
+github.com/confluentinc/ccloud-sdk-go-v2/flink-gateway v0.5.0 h1:lCjlaRJZPWP8Icw8HZ0bAQ9ZtmMB5horUIVE1z1eyN4=
+github.com/confluentinc/ccloud-sdk-go-v2/flink-gateway v0.5.0/go.mod h1:FbtaMRXDaT+521+m24TmCdmL1iqe6TVEmMEBa8nSUSg=
 github.com/confluentinc/ccloud-sdk-go-v2/iam v0.10.0 h1:AV0bGk01bGfKzNq5IVqRi2iEc6YTeBbl//IYvQ/j8ag=
 github.com/confluentinc/ccloud-sdk-go-v2/iam v0.10.0/go.mod h1:2Lm82ly9Yh5LLhp8OTnUGqjz4JdIXAZ5a0/u9T+rGGU=
 github.com/confluentinc/ccloud-sdk-go-v2/identity-provider v0.2.0 h1:9TT8UCFRc5zUdsE7UgMz7hqN+2KYnIkBcAKCaiZJrXw=

--- a/internal/flink/command_statement.go
+++ b/internal/flink/command_statement.go
@@ -75,7 +75,7 @@ func (c *command) validStatementArgsMultiple(cmd *cobra.Command, args []string) 
 
 	suggestions := make([]string, len(statements))
 	for i, statement := range statements {
-		suggestions[i] = fmt.Sprintf("%s\t%s", statement.Spec.GetStatementName(), statement.Spec.GetStatement())
+		suggestions[i] = fmt.Sprintf("%s\t%s", statement.GetName(), statement.Spec.GetStatement())
 	}
 	return suggestions
 }

--- a/internal/flink/command_statement_describe.go
+++ b/internal/flink/command_statement_describe.go
@@ -41,7 +41,7 @@ func (c *command) statementDescribe(cmd *cobra.Command, args []string) error {
 	list := output.NewList(cmd)
 	list.Add(&statementOut{
 		CreationDate: statement.Metadata.GetCreatedAt(),
-		Name:         statement.Spec.GetStatementName(),
+		Name:         statement.GetName(),
 		Statement:    statement.Spec.GetStatement(),
 		ComputePool:  statement.Spec.GetComputePoolId(),
 		Status:       statement.Status.GetPhase(),

--- a/internal/flink/command_statement_list.go
+++ b/internal/flink/command_statement_list.go
@@ -49,7 +49,7 @@ func (c *command) statementList(cmd *cobra.Command, args []string) error {
 	for _, statement := range statements {
 		list.Add(&statementOut{
 			CreationDate: statement.Metadata.GetCreatedAt(),
-			Name:         statement.Spec.GetStatementName(),
+			Name:         statement.GetName(),
 			Statement:    statement.Spec.GetStatement(),
 			ComputePool:  statement.Spec.GetComputePoolId(),
 			Status:       statement.Status.GetPhase(),

--- a/pkg/ccloudv2/flink_gateway.go
+++ b/pkg/ccloudv2/flink_gateway.go
@@ -105,10 +105,7 @@ func (c *FlinkGatewayClient) ListAllStatements(environmentId, orgId, computePool
 func (c *FlinkGatewayClient) CreateStatement(statement flinkgatewayv1beta1.SqlV1beta1Statement, serviceAccountId, identityPoolId, environmentId, orgId string) (flinkgatewayv1beta1.SqlV1beta1Statement, error) {
 	if serviceAccountId != "" {
 		// add the service account header and remove it after the request
-		statement.Principal = &serviceAccountId
-	} else {
-		// if this is also empty we have the interactive query/AUMP case
-		statement.Spec.IdentityPoolId = &identityPoolId
+		statement.Spec.Principal = &serviceAccountId
 	}
 	resp, httpResp, err := c.StatementsSqlV1beta1Api.CreateSqlv1beta1Statement(c.flinkGatewayApiContext(), orgId, environmentId).SqlV1beta1Statement(statement).Execute()
 	return resp, flink.CatchError(err, httpResp)

--- a/pkg/ccloudv2/flink_gateway.go
+++ b/pkg/ccloudv2/flink_gateway.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/google/uuid"
 
-	flinkgatewayv1alpha1 "github.com/confluentinc/ccloud-sdk-go-v2/flink-gateway/v1alpha1"
+	flinkgatewayv1beta1 "github.com/confluentinc/ccloud-sdk-go-v2/flink-gateway/v1beta1"
 
 	"github.com/confluentinc/cli/v3/pkg/errors/flink"
 	"github.com/confluentinc/cli/v3/pkg/log"
@@ -15,20 +15,20 @@ import (
 
 type GatewayClientInterface interface {
 	DeleteStatement(environmentId, statementName, orgId string) error
-	GetStatement(environmentId, statementName, orgId string) (flinkgatewayv1alpha1.SqlV1alpha1Statement, error)
-	ListStatements(environmentId, orgId, pageToken, computePoolId string) (flinkgatewayv1alpha1.SqlV1alpha1StatementList, error)
-	CreateStatement(statement, computePoolId string, properties map[string]string, serviceAccountId, identityPoolId, environmentId, orgId string) (flinkgatewayv1alpha1.SqlV1alpha1Statement, error)
-	GetStatementResults(environmentId, statementId, orgId, pageToken string) (flinkgatewayv1alpha1.SqlV1alpha1StatementResult, error)
-	GetExceptions(environmentId, statementId, orgId string) (flinkgatewayv1alpha1.SqlV1alpha1StatementExceptionList, error)
+	GetStatement(environmentId, statementName, orgId string) (flinkgatewayv1beta1.SqlV1beta1Statement, error)
+	ListStatements(environmentId, orgId, pageToken, computePoolId string) (flinkgatewayv1beta1.SqlV1beta1StatementList, error)
+	CreateStatement(statement, computePoolId string, properties map[string]string, serviceAccountId, identityPoolId, environmentId, orgId string) (flinkgatewayv1beta1.SqlV1beta1Statement, error)
+	GetStatementResults(environmentId, statementId, orgId, pageToken string) (flinkgatewayv1beta1.SqlV1beta1StatementResult, error)
+	GetExceptions(environmentId, statementId, orgId string) (flinkgatewayv1beta1.SqlV1beta1StatementExceptionList, error)
 }
 
 type FlinkGatewayClient struct {
-	*flinkgatewayv1alpha1.APIClient
+	*flinkgatewayv1beta1.APIClient
 	AuthToken string
 }
 
 func NewFlinkGatewayClient(url, userAgent string, unsafeTrace bool, authToken string) *FlinkGatewayClient {
-	cfg := flinkgatewayv1alpha1.NewConfiguration()
+	cfg := flinkgatewayv1beta1.NewConfiguration()
 	cfg.Debug = unsafeTrace
 	cfg.HTTPClient = NewRetryableHttpClientWithRedirect(unsafeTrace,
 		func(req *http.Request, via []*http.Request) error {
@@ -47,34 +47,35 @@ func NewFlinkGatewayClient(url, userAgent string, unsafeTrace bool, authToken st
 
 			return nil
 		})
-	cfg.Servers = flinkgatewayv1alpha1.ServerConfigurations{{URL: url}}
+	cfg.HTTPClient = NewRetryableHttpClient(unsafeTrace)
+	cfg.Servers = flinkgatewayv1beta1.ServerConfigurations{{URL: url}}
 	cfg.UserAgent = userAgent
 
 	return &FlinkGatewayClient{
-		APIClient: flinkgatewayv1alpha1.NewAPIClient(cfg),
+		APIClient: flinkgatewayv1beta1.NewAPIClient(cfg),
 		AuthToken: authToken,
 	}
 }
 
 func (c *FlinkGatewayClient) flinkGatewayApiContext() context.Context {
-	return context.WithValue(context.Background(), flinkgatewayv1alpha1.ContextAccessToken, c.AuthToken)
+	return context.WithValue(context.Background(), flinkgatewayv1beta1.ContextAccessToken, c.AuthToken)
 }
 
 func (c *FlinkGatewayClient) DeleteStatement(environmentId, statementName, orgId string) error {
-	httpResp, err := c.StatementsSqlV1alpha1Api.DeleteSqlV1alpha1Statement(c.flinkGatewayApiContext(), environmentId, statementName).OrgId(orgId).Execute()
+	httpResp, err := c.StatementsSqlV1beta1Api.DeleteSqlv1beta1Statement(c.flinkGatewayApiContext(), orgId, environmentId, statementName).Execute()
 	return flink.CatchError(err, httpResp)
 }
 
-func (c *FlinkGatewayClient) GetStatement(environmentId, statementName, orgId string) (flinkgatewayv1alpha1.SqlV1alpha1Statement, error) {
-	resp, httpResp, err := c.StatementsSqlV1alpha1Api.GetSqlV1alpha1Statement(c.flinkGatewayApiContext(), environmentId, statementName).OrgId(orgId).Execute()
+func (c *FlinkGatewayClient) GetStatement(environmentId, statementName, orgId string) (flinkgatewayv1beta1.SqlV1beta1Statement, error) {
+	resp, httpResp, err := c.StatementsSqlV1beta1Api.GetSqlv1beta1Statement(c.flinkGatewayApiContext(), orgId, environmentId, statementName).Execute()
 	return resp, flink.CatchError(err, httpResp)
 }
 
-func (c *FlinkGatewayClient) ListStatements(environmentId, orgId, pageToken, computePoolId string) (flinkgatewayv1alpha1.SqlV1alpha1StatementList, error) {
-	req := c.StatementsSqlV1alpha1Api.ListSqlV1alpha1Statements(c.flinkGatewayApiContext(), environmentId).OrgId(orgId).PageSize(ccloudV2ListPageSize)
+func (c *FlinkGatewayClient) ListStatements(environmentId, orgId, pageToken, computePoolId string) (flinkgatewayv1beta1.SqlV1beta1StatementList, error) {
+	req := c.StatementsSqlV1beta1Api.ListSqlv1beta1Statements(c.flinkGatewayApiContext(), orgId, environmentId).PageSize(ccloudV2ListPageSize)
 
 	if computePoolId != "" {
-		req = req.ComputePoolId(computePoolId)
+		req = req.SpecComputePoolId(computePoolId)
 	}
 
 	if pageToken != "" {
@@ -84,8 +85,8 @@ func (c *FlinkGatewayClient) ListStatements(environmentId, orgId, pageToken, com
 	return resp, flink.CatchError(err, httpResp)
 }
 
-func (c *FlinkGatewayClient) ListAllStatements(environmentId, orgId, computePoolId string) ([]flinkgatewayv1alpha1.SqlV1alpha1Statement, error) {
-	var allStatements []flinkgatewayv1alpha1.SqlV1alpha1Statement
+func (c *FlinkGatewayClient) ListAllStatements(environmentId, orgId, computePoolId string) ([]flinkgatewayv1beta1.SqlV1beta1Statement, error) {
+	var allStatements []flinkgatewayv1beta1.SqlV1beta1Statement
 	pageToken := ""
 	done := false
 	for !done {
@@ -95,7 +96,7 @@ func (c *FlinkGatewayClient) ListAllStatements(environmentId, orgId, computePool
 		}
 		allStatements = append(allStatements, statementListResponse.GetData()...)
 		nextUrl := statementListResponse.Metadata.GetNext()
-		pageToken, done, err = extractNextPageToken(flinkgatewayv1alpha1.NewNullableString(&nextUrl))
+		pageToken, done, err = extractNextPageToken(flinkgatewayv1beta1.NewNullableString(&nextUrl))
 		if err != nil {
 			return nil, err
 		}
@@ -103,12 +104,12 @@ func (c *FlinkGatewayClient) ListAllStatements(environmentId, orgId, computePool
 	return allStatements, nil
 }
 
-func (c *FlinkGatewayClient) CreateStatement(statement, computePoolId string, properties map[string]string, serviceAccountId, identityPoolId, environmentId, orgId string) (flinkgatewayv1alpha1.SqlV1alpha1Statement, error) {
+func (c *FlinkGatewayClient) CreateStatement(statement, computePoolId string, properties map[string]string, serviceAccountId, identityPoolId, environmentId, orgId string) (flinkgatewayv1beta1.SqlV1beta1Statement, error) {
 	statementName := uuid.New().String()[:18]
 
-	statementObj := flinkgatewayv1alpha1.SqlV1alpha1Statement{
-		Spec: &flinkgatewayv1alpha1.SqlV1alpha1StatementSpec{
-			StatementName: &statementName,
+	statementObj := flinkgatewayv1beta1.SqlV1beta1Statement{
+		Name: &statementName,
+		Spec: &flinkgatewayv1beta1.SqlV1beta1StatementSpec{
 			Statement:     &statement,
 			ComputePoolId: &computePoolId,
 			Properties:    &properties,
@@ -116,18 +117,17 @@ func (c *FlinkGatewayClient) CreateStatement(statement, computePoolId string, pr
 	}
 	if serviceAccountId != "" {
 		// add the service account header and remove it after the request
-		c.GetConfig().AddDefaultHeader("Service-Account-Id", serviceAccountId)
-		defer delete(c.GetConfig().DefaultHeader, "Service-Account-Id")
+		statementObj.Principal = &serviceAccountId
 	} else {
 		// if this is also empty we have the interactive query/AUMP case
 		statementObj.Spec.IdentityPoolId = &identityPoolId
 	}
-	resp, httpResp, err := c.StatementsSqlV1alpha1Api.CreateSqlV1alpha1Statement(c.flinkGatewayApiContext(), environmentId).SqlV1alpha1Statement(statementObj).OrgId(orgId).Execute()
+	resp, httpResp, err := c.StatementsSqlV1beta1Api.CreateSqlv1beta1Statement(c.flinkGatewayApiContext(), orgId, environmentId).SqlV1beta1Statement(statementObj).Execute()
 	return resp, flink.CatchError(err, httpResp)
 }
 
-func (c *FlinkGatewayClient) GetStatementResults(environmentId, statementId, orgId, pageToken string) (flinkgatewayv1alpha1.SqlV1alpha1StatementResult, error) {
-	req := c.StatementResultSqlV1alpha1Api.GetSqlV1alpha1StatementResult(c.flinkGatewayApiContext(), environmentId, statementId).OrgId(orgId)
+func (c *FlinkGatewayClient) GetStatementResults(environmentId, statementName, orgId, pageToken string) (flinkgatewayv1beta1.SqlV1beta1StatementResult, error) {
+	req := c.StatementResultSqlV1beta1Api.GetSqlv1beta1StatementResult(c.flinkGatewayApiContext(), orgId, environmentId, statementName)
 	if pageToken != "" {
 		req = req.PageToken(pageToken)
 	}
@@ -135,7 +135,7 @@ func (c *FlinkGatewayClient) GetStatementResults(environmentId, statementId, org
 	return resp, flink.CatchError(err, httpResp)
 }
 
-func (c *FlinkGatewayClient) GetExceptions(environmentId, statementId, orgId string) (flinkgatewayv1alpha1.SqlV1alpha1StatementExceptionList, error) {
-	resp, httpResp, err := c.StatementExceptionsSqlV1alpha1Api.GetSqlV1alpha1StatementExceptions(c.flinkGatewayApiContext(), environmentId, statementId).OrgId(orgId).Execute()
+func (c *FlinkGatewayClient) GetExceptions(environmentId, statementName, orgId string) (flinkgatewayv1beta1.SqlV1beta1StatementExceptionList, error) {
+	resp, httpResp, err := c.StatementExceptionsSqlV1beta1Api.GetSqlv1beta1StatementExceptions(c.flinkGatewayApiContext(), orgId, environmentId, statementName).Execute()
 	return resp, flink.CatchError(err, httpResp)
 }

--- a/pkg/ccloudv2/flink_gateway.go
+++ b/pkg/ccloudv2/flink_gateway.go
@@ -5,8 +5,6 @@ import (
 	"errors"
 	"net/http"
 
-	"github.com/google/uuid"
-
 	flinkgatewayv1beta1 "github.com/confluentinc/ccloud-sdk-go-v2/flink-gateway/v1beta1"
 
 	"github.com/confluentinc/cli/v3/pkg/errors/flink"
@@ -17,7 +15,7 @@ type GatewayClientInterface interface {
 	DeleteStatement(environmentId, statementName, orgId string) error
 	GetStatement(environmentId, statementName, orgId string) (flinkgatewayv1beta1.SqlV1beta1Statement, error)
 	ListStatements(environmentId, orgId, pageToken, computePoolId string) (flinkgatewayv1beta1.SqlV1beta1StatementList, error)
-	CreateStatement(statement, computePoolId string, properties map[string]string, serviceAccountId, identityPoolId, environmentId, orgId string) (flinkgatewayv1beta1.SqlV1beta1Statement, error)
+	CreateStatement(statement flinkgatewayv1beta1.SqlV1beta1Statement, serviceAccountId, identityPoolId, environmentId, orgId string) (flinkgatewayv1beta1.SqlV1beta1Statement, error)
 	GetStatementResults(environmentId, statementId, orgId, pageToken string) (flinkgatewayv1beta1.SqlV1beta1StatementResult, error)
 	GetExceptions(environmentId, statementId, orgId string) (flinkgatewayv1beta1.SqlV1beta1StatementExceptionList, error)
 }
@@ -104,25 +102,15 @@ func (c *FlinkGatewayClient) ListAllStatements(environmentId, orgId, computePool
 	return allStatements, nil
 }
 
-func (c *FlinkGatewayClient) CreateStatement(statement, computePoolId string, properties map[string]string, serviceAccountId, identityPoolId, environmentId, orgId string) (flinkgatewayv1beta1.SqlV1beta1Statement, error) {
-	statementName := uuid.New().String()[:18]
-
-	statementObj := flinkgatewayv1beta1.SqlV1beta1Statement{
-		Name: &statementName,
-		Spec: &flinkgatewayv1beta1.SqlV1beta1StatementSpec{
-			Statement:     &statement,
-			ComputePoolId: &computePoolId,
-			Properties:    &properties,
-		},
-	}
+func (c *FlinkGatewayClient) CreateStatement(statement flinkgatewayv1beta1.SqlV1beta1Statement, serviceAccountId, identityPoolId, environmentId, orgId string) (flinkgatewayv1beta1.SqlV1beta1Statement, error) {
 	if serviceAccountId != "" {
 		// add the service account header and remove it after the request
-		statementObj.Principal = &serviceAccountId
+		statement.Principal = &serviceAccountId
 	} else {
 		// if this is also empty we have the interactive query/AUMP case
-		statementObj.Spec.IdentityPoolId = &identityPoolId
+		statement.Spec.IdentityPoolId = &identityPoolId
 	}
-	resp, httpResp, err := c.StatementsSqlV1beta1Api.CreateSqlv1beta1Statement(c.flinkGatewayApiContext(), orgId, environmentId).SqlV1beta1Statement(statementObj).Execute()
+	resp, httpResp, err := c.StatementsSqlV1beta1Api.CreateSqlv1beta1Statement(c.flinkGatewayApiContext(), orgId, environmentId).SqlV1beta1Statement(statement).Execute()
 	return resp, flink.CatchError(err, httpResp)
 }
 

--- a/pkg/flink/app/application.go
+++ b/pkg/flink/app/application.go
@@ -123,8 +123,8 @@ func (a *Application) panicRecovery() {
 }
 
 func (a *Application) isAuthenticated() bool {
-	if authErr := a.refreshToken(); authErr != nil {
-		utils.OutputErrf("Error: %v", authErr)
+	if err := a.refreshToken(); err != nil {
+		utils.OutputErrf("Error: %v", err)
 		a.appController.ExitApplication()
 		return false
 	}

--- a/pkg/flink/internal/controller/.snapshots/TestStatementControllerTestSuite-TestExecuteStatementPrintsWarningWhenNoServiceAccountIsUsed
+++ b/pkg/flink/internal/controller/.snapshots/TestStatementControllerTestSuite-TestExecuteStatementPrintsWarningWhenNoServiceAccountIsUsed
@@ -1,7 +1,7 @@
 Statement name: test-statement
 Statement successfully submitted.
 Waiting for statement to be ready. Statement phase is PENDING.
-[WARN] to ensure that your statements run continuously, switch to using a service account instead of your user identity by running "SET 'client.service-account'='sa-123';". Otherwise, statements will stop running after 4 hours.
+[WARN] To ensure that your statements run continuously, switch to using a service account instead of your user identity by running "SET 'client.service-account'='sa-123';". Otherwise, statements will stop running after 4 hours.
 Statement phase is COMPLETED.
 status detail message.
 

--- a/pkg/flink/internal/controller/.snapshots/TestStatementControllerTestSuite-TestExecuteStatementPrintsWarningWhenNoServiceAccountIsUsed
+++ b/pkg/flink/internal/controller/.snapshots/TestStatementControllerTestSuite-TestExecuteStatementPrintsWarningWhenNoServiceAccountIsUsed
@@ -1,7 +1,7 @@
 Statement name: test-statement
 Statement successfully submitted.
 Waiting for statement to be ready. Statement phase is PENDING.
-Warning: to ensure that your statements run continuously, switch to using a service account instead of your user identity by running "SET 'client.service-account'='sa-123';". Otherwise, statements will stop running after 4 hours.
+[WARN] to ensure that your statements run continuously, switch to using a service account instead of your user identity by running "SET 'client.service-account'='sa-123';". Otherwise, statements will stop running after 4 hours.
 Statement phase is COMPLETED.
 status detail message.
 

--- a/pkg/flink/internal/controller/basic_output_controller_test.go
+++ b/pkg/flink/internal/controller/basic_output_controller_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/suite"
 
-	flinkgatewayv1alpha1 "github.com/confluentinc/ccloud-sdk-go-v2/flink-gateway/v1alpha1"
+	flinkgatewayv1beta1 "github.com/confluentinc/ccloud-sdk-go-v2/flink-gateway/v1beta1"
 
 	"github.com/confluentinc/cli/v3/pkg/flink/test"
 	"github.com/confluentinc/cli/v3/pkg/flink/test/mock"
@@ -65,7 +65,7 @@ func (s *BasicOutputControllerTestSuite) TestVisualizeResultsShouldPrintTable() 
 func getStatementWithResultsExample() types.ProcessedStatement {
 	statement := types.ProcessedStatement{
 		StatementName: "example-statement",
-		ResultSchema:  flinkgatewayv1alpha1.SqlV1alpha1ResultSchema{},
+		ResultSchema:  flinkgatewayv1beta1.SqlV1beta1ResultSchema{},
 		StatementResults: &types.StatementResults{
 			Headers: []string{"Count"},
 			Rows:    []types.StatementResultRow{},

--- a/pkg/flink/internal/controller/statement_controller.go
+++ b/pkg/flink/internal/controller/statement_controller.go
@@ -42,7 +42,7 @@ func (c *StatementController) ExecuteStatement(statementToExecute string) (*type
 	processedStatement.PrintStatusMessage()
 
 	if !processedStatement.IsLocalStatement && processedStatement.ServiceAccount == "" && processedStatement.IdentityPool == "" {
-		utils.OutputWarnf(`Warning: to ensure that your statements run continuously, switch to using a service account instead of your user identity by running "SET '%s'='sa-123';". Otherwise, statements will stop running after 4 hours.`,
+		utils.OutputWarnf(`[WARN] to ensure that your statements run continuously, switch to using a service account instead of your user identity by running "SET '%s'='sa-123';". Otherwise, statements will stop running after 4 hours.`,
 			config.ConfigKeyServiceAcount)
 	}
 

--- a/pkg/flink/internal/controller/statement_controller.go
+++ b/pkg/flink/internal/controller/statement_controller.go
@@ -42,7 +42,7 @@ func (c *StatementController) ExecuteStatement(statementToExecute string) (*type
 	processedStatement.PrintStatusMessage()
 
 	if !processedStatement.IsLocalStatement && processedStatement.ServiceAccount == "" && processedStatement.IdentityPool == "" {
-		utils.OutputWarnf(`[WARN] to ensure that your statements run continuously, switch to using a service account instead of your user identity by running "SET '%s'='sa-123';". Otherwise, statements will stop running after 4 hours.`,
+		utils.OutputWarnf(`[WARN] To ensure that your statements run continuously, switch to using a service account instead of your user identity by running "SET '%s'='sa-123';". Otherwise, statements will stop running after 4 hours.`,
 			config.ConfigKeyServiceAcount)
 	}
 

--- a/pkg/flink/internal/results/converter.go
+++ b/pkg/flink/internal/results/converter.go
@@ -1,7 +1,7 @@
 package results
 
 import (
-	flinkgatewayv1alpha1 "github.com/confluentinc/ccloud-sdk-go-v2/flink-gateway/v1alpha1"
+	flinkgatewayv1alpha1 "github.com/confluentinc/ccloud-sdk-go-v2/flink-gateway/v1beta1"
 
 	"github.com/confluentinc/cli/v3/pkg/flink/types"
 )

--- a/pkg/flink/internal/results/result_converter.go
+++ b/pkg/flink/internal/results/result_converter.go
@@ -3,12 +3,12 @@ package results
 import (
 	"errors"
 
-	flinkgatewayv1alpha1 "github.com/confluentinc/ccloud-sdk-go-v2/flink-gateway/v1alpha1"
+	flinkgatewayv1beta1 "github.com/confluentinc/ccloud-sdk-go-v2/flink-gateway/v1beta1"
 
 	"github.com/confluentinc/cli/v3/pkg/flink/types"
 )
 
-func convertToInternalField(field any, details flinkgatewayv1alpha1.ColumnDetails) types.StatementResultField {
+func convertToInternalField(field any, details flinkgatewayv1beta1.ColumnDetails) types.StatementResultField {
 	converter := GetConverterForType(details.GetType())
 	if converter != nil {
 		return converter(field)
@@ -20,7 +20,7 @@ func convertToInternalField(field any, details flinkgatewayv1alpha1.ColumnDetail
 	}
 }
 
-func ConvertToInternalResults(results []any, resultSchema flinkgatewayv1alpha1.SqlV1alpha1ResultSchema) (*types.StatementResults, error) {
+func ConvertToInternalResults(results []any, resultSchema flinkgatewayv1beta1.SqlV1beta1ResultSchema) (*types.StatementResults, error) {
 	headers := make([]string, len(resultSchema.GetColumns()))
 	for idx, column := range resultSchema.GetColumns() {
 		headers[idx] = column.GetName()

--- a/pkg/flink/internal/results/result_converter_test.go
+++ b/pkg/flink/internal/results/result_converter_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/suite"
 	"pgregory.net/rapid"
 
-	flinkgatewayv1alpha1 "github.com/confluentinc/ccloud-sdk-go-v2/flink-gateway/v1alpha1"
+	flinkgatewayv1beta1 "github.com/confluentinc/ccloud-sdk-go-v2/flink-gateway/v1beta1"
 
 	"github.com/confluentinc/cli/v3/pkg/flink/test/generators"
 	"github.com/confluentinc/cli/v3/pkg/flink/types"
@@ -26,7 +26,7 @@ func (s *ResultConverterTestSuite) TestConvertField() {
 		maxNestingDepth := rapid.IntRange(0, 5).Draw(t, "max nesting depth")
 		dataType := generators.DataType(maxNestingDepth).Draw(t, "data type")
 		field := generators.GetResultItemGeneratorForType(dataType).Draw(t, "a field")
-		resultField := convertToInternalField(field, flinkgatewayv1alpha1.ColumnDetails{
+		resultField := convertToInternalField(field, flinkgatewayv1beta1.ColumnDetails{
 			Name: "Test Column",
 			Type: dataType,
 		})
@@ -42,7 +42,7 @@ func (s *ResultConverterTestSuite) TestConvertField() {
 func (s *ResultConverterTestSuite) TestConvertFieldFailsForMissingDataType() {
 	dataType := generators.DataType(0).Example()
 	field := generators.GetResultItemGeneratorForType(dataType).Example()
-	resultField := convertToInternalField(field, flinkgatewayv1alpha1.ColumnDetails{
+	resultField := convertToInternalField(field, flinkgatewayv1beta1.ColumnDetails{
 		Name: "Test Column",
 	})
 	require.NotNil(s.T(), resultField)
@@ -53,9 +53,9 @@ func (s *ResultConverterTestSuite) TestConvertFieldFailsForMissingDataType() {
 func (s *ResultConverterTestSuite) TestConvertFieldFailsForEmptyDataType() {
 	dataType := generators.DataType(0).Example()
 	field := generators.GetResultItemGeneratorForType(dataType).Example()
-	resultField := convertToInternalField(field, flinkgatewayv1alpha1.ColumnDetails{
+	resultField := convertToInternalField(field, flinkgatewayv1beta1.ColumnDetails{
 		Name: "Test Column",
-		Type: flinkgatewayv1alpha1.DataType{},
+		Type: flinkgatewayv1beta1.DataType{},
 	})
 	require.NotNil(s.T(), resultField)
 	require.Equal(s.T(), types.NULL, resultField.GetType())
@@ -63,17 +63,17 @@ func (s *ResultConverterTestSuite) TestConvertFieldFailsForEmptyDataType() {
 }
 
 func (s *ResultConverterTestSuite) TestConvertFieldFailsIfDataTypesDiffer() {
-	varcharType := flinkgatewayv1alpha1.DataType{
+	varcharType := flinkgatewayv1beta1.DataType{
 		Nullable: false,
 		Type:     "VARCHAR",
 	}
-	arrayType := flinkgatewayv1alpha1.DataType{
+	arrayType := flinkgatewayv1beta1.DataType{
 		Nullable:    false,
 		Type:        "ARRAY",
 		ElementType: &varcharType,
 	}
 	arrayField := generators.GetResultItemGeneratorForType(arrayType).Example()
-	resultField := convertToInternalField(arrayField, flinkgatewayv1alpha1.ColumnDetails{
+	resultField := convertToInternalField(arrayField, flinkgatewayv1beta1.ColumnDetails{
 		Name: "Test Column",
 		Type: varcharType,
 	})
@@ -112,7 +112,7 @@ func (s *ResultConverterTestSuite) TestConvertResults() {
 func (s *ResultConverterTestSuite) TestConvertResultsFailsWhenSchemaAndResultsDoNotMatch() {
 	results := generators.MockResults(5, -1).Example()
 	statementResults := results.StatementResults.GetResults()
-	resultSchema := flinkgatewayv1alpha1.SqlV1alpha1ResultSchema{Columns: &[]flinkgatewayv1alpha1.ColumnDetails{}}
+	resultSchema := flinkgatewayv1beta1.SqlV1beta1ResultSchema{Columns: &[]flinkgatewayv1beta1.ColumnDetails{}}
 	internalResults, err := ConvertToInternalResults(statementResults.GetData(), resultSchema)
 	require.Nil(s.T(), internalResults)
 	require.Error(s.T(), err)

--- a/pkg/flink/internal/results/result_fetcher_test.go
+++ b/pkg/flink/internal/results/result_fetcher_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
-	flinkgatewayv1alpha1 "github.com/confluentinc/ccloud-sdk-go-v2/flink-gateway/v1alpha1"
+	flinkgatewayv1beta1 "github.com/confluentinc/ccloud-sdk-go-v2/flink-gateway/v1beta1"
 
 	"github.com/confluentinc/cli/v3/pkg/flink/test/generators"
 	"github.com/confluentinc/cli/v3/pkg/flink/test/mock"
@@ -214,7 +214,7 @@ func (s *ResultFetcherTestSuite) TestReturnHeadersFromResultSchema() {
 	mockStatement := getStatementWithResultsExample()
 	mockStatement.StatementResults.Headers = nil
 	columnDetails := generators.MockResultColumns(2, 1).Example()
-	mockStatement.ResultSchema = flinkgatewayv1alpha1.SqlV1alpha1ResultSchema{Columns: &columnDetails}
+	mockStatement.ResultSchema = flinkgatewayv1beta1.SqlV1beta1ResultSchema{Columns: &columnDetails}
 	headers := make([]string, len(mockStatement.ResultSchema.GetColumns()))
 	for idx, column := range mockStatement.ResultSchema.GetColumns() {
 		headers[idx] = column.GetName()

--- a/pkg/flink/internal/results/result_formatter_test.go
+++ b/pkg/flink/internal/results/result_formatter_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/suite"
 	"pgregory.net/rapid"
 
-	flinkgatewayv1alpha1 "github.com/confluentinc/ccloud-sdk-go-v2/flink-gateway/v1alpha1"
+	flinkgatewayv1alpha1 "github.com/confluentinc/ccloud-sdk-go-v2/flink-gateway/v1beta1"
 
 	"github.com/confluentinc/cli/v3/pkg/flink/test/generators"
 	"github.com/confluentinc/cli/v3/pkg/flink/types"

--- a/pkg/flink/internal/store/store.go
+++ b/pkg/flink/internal/store/store.go
@@ -11,6 +11,7 @@ import (
 	"github.com/google/uuid"
 
 	flinkgatewayv1beta1 "github.com/confluentinc/ccloud-sdk-go-v2/flink-gateway/v1beta1"
+
 	"github.com/confluentinc/cli/v3/pkg/ccloudv2"
 	"github.com/confluentinc/cli/v3/pkg/flink/config"
 	"github.com/confluentinc/cli/v3/pkg/flink/internal/results"

--- a/pkg/flink/internal/store/store.go
+++ b/pkg/flink/internal/store/store.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	_ "embed"
 	"fmt"
-	"github.com/google/uuid"
 	"net/url"
 	"strings"
 	"time"
+
+	"github.com/google/uuid"
 
 	flinkgatewayv1beta1 "github.com/confluentinc/ccloud-sdk-go-v2/flink-gateway/v1beta1"
 	"github.com/confluentinc/cli/v3/pkg/ccloudv2"
@@ -83,14 +84,7 @@ func (s *Store) ProcessStatement(statement string) (*types.ProcessedStatement, *
 	properties := s.Properties.GetSqlProperties()
 
 	statementObj, err := s.authenticatedGatewayClient().CreateStatement(
-		flinkgatewayv1beta1.SqlV1beta1Statement{
-			Name: &statementName,
-			Spec: &flinkgatewayv1beta1.SqlV1beta1StatementSpec{
-				Statement:     &statement,
-				ComputePoolId: &computePoolId,
-				Properties:    &properties,
-			},
-		},
+		createSqlV1beta1Statement(statement, statementName, computePoolId, properties),
 		s.Properties.Get(config.ConfigKeyServiceAcount),
 		s.appOptions.GetIdentityPoolId(),
 		s.appOptions.GetEnvironmentId(),
@@ -101,6 +95,17 @@ func (s *Store) ProcessStatement(statement string) (*types.ProcessedStatement, *
 		return nil, types.NewStatementErrorFailureMsg(err, status.GetDetail())
 	}
 	return types.NewProcessedStatement(statementObj), nil
+}
+
+func createSqlV1beta1Statement(statement string, statementName string, computePoolId string, properties map[string]string) flinkgatewayv1beta1.SqlV1beta1Statement {
+	return flinkgatewayv1beta1.SqlV1beta1Statement{
+		Name: &statementName,
+		Spec: &flinkgatewayv1beta1.SqlV1beta1StatementSpec{
+			Statement:     &statement,
+			ComputePoolId: &computePoolId,
+			Properties:    &properties,
+		},
+	}
 }
 
 func (s *Store) WaitPendingStatement(ctx context.Context, statement types.ProcessedStatement) (*types.ProcessedStatement, *types.StatementError) {

--- a/pkg/flink/internal/store/store_test.go
+++ b/pkg/flink/internal/store/store_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
-	flinkgatewayv1alpha1 "github.com/confluentinc/ccloud-sdk-go-v2/flink-gateway/v1alpha1"
+	flinkgatewayv1beta1 "github.com/confluentinc/ccloud-sdk-go-v2/flink-gateway/v1beta1"
 
 	"github.com/confluentinc/cli/v3/pkg/ccloudv2"
 	"github.com/confluentinc/cli/v3/pkg/errors/flink"
@@ -90,10 +90,10 @@ func TestWaitForPendingStatement3(t *testing.T) {
 	}
 
 	// Test case 1: Statement is not pending
-	statementObj := flinkgatewayv1alpha1.SqlV1alpha1Statement{
-		Status: &flinkgatewayv1alpha1.SqlV1alpha1StatementStatus{
+	statementObj := flinkgatewayv1beta1.SqlV1beta1Statement{
+		Status: &flinkgatewayv1beta1.SqlV1beta1StatementStatus{
 			Phase:  "COMPLETED",
-			Detail: flinkgatewayv1alpha1.PtrString("Test status detail message"),
+			Detail: flinkgatewayv1beta1.PtrString("Test status detail message"),
 		},
 	}
 	client.EXPECT().GetStatement("envId", statementName, "orgId").Return(statementObj, nil)
@@ -120,8 +120,8 @@ func TestWaitForPendingTimesout(t *testing.T) {
 	}
 
 	statusDetailMessage := "test status detail message"
-	statementObj := flinkgatewayv1alpha1.SqlV1alpha1Statement{
-		Status: &flinkgatewayv1alpha1.SqlV1alpha1StatementStatus{
+	statementObj := flinkgatewayv1beta1.SqlV1beta1Statement{
+		Status: &flinkgatewayv1beta1.SqlV1beta1StatementStatus{
 			Phase:  "PENDING",
 			Detail: &statusDetailMessage,
 		},
@@ -154,8 +154,8 @@ func TestWaitForPendingHitsErrorRetryLimit(t *testing.T) {
 	}
 
 	statusDetailMessage := "test status detail message"
-	statementObj := flinkgatewayv1alpha1.SqlV1alpha1Statement{
-		Status: &flinkgatewayv1alpha1.SqlV1alpha1StatementStatus{
+	statementObj := flinkgatewayv1beta1.SqlV1beta1Statement{
+		Status: &flinkgatewayv1beta1.SqlV1beta1StatementStatus{
 			Phase:  "PENDING",
 			Detail: &statusDetailMessage,
 		},
@@ -186,16 +186,16 @@ func TestWaitForPendingEventuallyCompletes(t *testing.T) {
 	}
 
 	transientStatusDetailMessage := "Transient status detail message"
-	statementObj := flinkgatewayv1alpha1.SqlV1alpha1Statement{
-		Status: &flinkgatewayv1alpha1.SqlV1alpha1StatementStatus{
+	statementObj := flinkgatewayv1beta1.SqlV1beta1Statement{
+		Status: &flinkgatewayv1beta1.SqlV1beta1StatementStatus{
 			Phase:  "PENDING",
 			Detail: &transientStatusDetailMessage,
 		},
 	}
 
 	finalStatusDetailMessage := "Final status detail message"
-	statementObjCompleted := flinkgatewayv1alpha1.SqlV1alpha1Statement{
-		Status: &flinkgatewayv1alpha1.SqlV1alpha1StatementStatus{
+	statementObjCompleted := flinkgatewayv1beta1.SqlV1beta1Statement{
+		Status: &flinkgatewayv1beta1.SqlV1beta1StatementStatus{
 			Phase:  "COMPLETED",
 			Detail: &finalStatusDetailMessage,
 		},
@@ -223,8 +223,8 @@ func TestWaitForPendingStatementErrors(t *testing.T) {
 		tokenRefreshFunc: tokenRefreshFunc,
 	}
 	statusDetailMessage := "Test status detail message"
-	statementObj := flinkgatewayv1alpha1.SqlV1alpha1Statement{
-		Status: &flinkgatewayv1alpha1.SqlV1alpha1StatementStatus{
+	statementObj := flinkgatewayv1beta1.SqlV1beta1Statement{
+		Status: &flinkgatewayv1beta1.SqlV1beta1StatementStatus{
 			Phase:  "COMPLETED",
 			Detail: &statusDetailMessage,
 		},
@@ -257,18 +257,18 @@ func TestCancelPendingStatement(t *testing.T) {
 		tokenRefreshFunc: tokenRefreshFunc,
 	}
 
-	statementObj := flinkgatewayv1alpha1.SqlV1alpha1Statement{
-		Spec: &flinkgatewayv1alpha1.SqlV1alpha1StatementSpec{
-			StatementName: &statementName,
-		},
-		Status: &flinkgatewayv1alpha1.SqlV1alpha1StatementStatus{
+	statementObj := flinkgatewayv1beta1.SqlV1beta1Statement{
+		Name: &statementName,
+		Status: &flinkgatewayv1beta1.SqlV1beta1StatementStatus{
 			Phase: "PENDING",
 		},
 	}
 
+	flinkError := flink.NewFlinkError("error", "", http.StatusInternalServerError)
 	expectedErr := &types.StatementError{Message: "result retrieval aborted. Statement will be deleted", StatusCode: http.StatusInternalServerError}
 	client.EXPECT().GetStatement("envId", statementName, "orgId").Return(statementObj, nil).AnyTimes()
 	client.EXPECT().DeleteStatement("envId", statementName, "orgId").Return(nil).AnyTimes()
+	client.EXPECT().GetExceptions("envId", statementName, "orgId").Return(flinkgatewayv1beta1.SqlV1beta1StatementExceptionList{}, flinkError).AnyTimes()
 
 	// Schedule routine to cancel context
 	go func() {
@@ -701,7 +701,7 @@ func (s *StoreTestSuite) TestProcessHttpErrors() {
 	// given
 	res := &http.Response{
 		StatusCode: http.StatusUnauthorized,
-		Body:       generateCloserFromObject(flinkgatewayv1alpha1.NewError()),
+		Body:       generateCloserFromObject(flinkgatewayv1beta1.NewError()),
 	}
 
 	// when
@@ -714,7 +714,7 @@ func (s *StoreTestSuite) TestProcessHttpErrors() {
 	// given
 	title := "invalid syntax"
 	detail := "you should provide a table for select"
-	statementErr := &flinkgatewayv1alpha1.Error{Title: &title, Detail: &detail}
+	statementErr := &flinkgatewayv1beta1.Error{Title: &title, Detail: &detail}
 	res = &http.Response{
 		StatusCode: http.StatusBadRequest,
 		Body:       generateCloserFromObject(statementErr),
@@ -830,9 +830,9 @@ func (s *StoreTestSuite) TestFetchResultsNoRetryWithCompletedStatement() {
 		StatementName: "TEST_STATEMENT",
 		Status:        types.COMPLETED,
 	}
-	statementResultObj := flinkgatewayv1alpha1.SqlV1alpha1StatementResult{
-		Metadata: flinkgatewayv1alpha1.ResultListMeta{},
-		Results:  &flinkgatewayv1alpha1.SqlV1alpha1StatementResultResults{},
+	statementResultObj := flinkgatewayv1beta1.SqlV1beta1StatementResult{
+		Metadata: flinkgatewayv1beta1.ResultListMeta{},
+		Results:  &flinkgatewayv1beta1.SqlV1beta1StatementResultResults{},
 	}
 	client.EXPECT().GetStatementResults("envId", statement.StatementName, "orgId", statement.PageToken).Return(statementResultObj, nil)
 
@@ -859,9 +859,9 @@ func (s *StoreTestSuite) TestFetchResultsWithRunningStatement() {
 		StatementName: "TEST_STATEMENT",
 		Status:        types.RUNNING,
 	}
-	statementResultObj := flinkgatewayv1alpha1.SqlV1alpha1StatementResult{
-		Metadata: flinkgatewayv1alpha1.ResultListMeta{},
-		Results:  &flinkgatewayv1alpha1.SqlV1alpha1StatementResultResults{},
+	statementResultObj := flinkgatewayv1beta1.SqlV1beta1StatementResult{
+		Metadata: flinkgatewayv1beta1.ResultListMeta{},
+		Results:  &flinkgatewayv1beta1.SqlV1beta1StatementResultResults{},
 	}
 	client.EXPECT().GetStatementResults("envId", statement.StatementName, "orgId", statement.PageToken).Return(statementResultObj, nil)
 
@@ -889,9 +889,9 @@ func (s *StoreTestSuite) TestFetchResultsNoRetryWhenPageTokenExists() {
 		Status:        types.RUNNING,
 	}
 	nextPage := "https://devel.cpdev.cloud/some/results?page_token=eyJWZX"
-	statementResultObj := flinkgatewayv1alpha1.SqlV1alpha1StatementResult{
-		Metadata: flinkgatewayv1alpha1.ResultListMeta{Next: &nextPage},
-		Results:  &flinkgatewayv1alpha1.SqlV1alpha1StatementResultResults{},
+	statementResultObj := flinkgatewayv1beta1.SqlV1beta1StatementResult{
+		Metadata: flinkgatewayv1beta1.ResultListMeta{Next: &nextPage},
+		Results:  &flinkgatewayv1beta1.SqlV1beta1StatementResultResults{},
 	}
 	client.EXPECT().GetStatementResults("envId", statement.StatementName, "orgId", statement.PageToken).Return(statementResultObj, nil)
 
@@ -918,9 +918,9 @@ func (s *StoreTestSuite) TestFetchResultsNoRetryWhenResultsExist() {
 		StatementName: "TEST_STATEMENT",
 		Status:        types.RUNNING,
 	}
-	statementResultObj := flinkgatewayv1alpha1.SqlV1alpha1StatementResult{
-		Metadata: flinkgatewayv1alpha1.ResultListMeta{},
-		Results:  &flinkgatewayv1alpha1.SqlV1alpha1StatementResultResults{Data: &[]any{map[string]any{"op": 0}}},
+	statementResultObj := flinkgatewayv1beta1.SqlV1beta1StatementResult{
+		Metadata: flinkgatewayv1beta1.ResultListMeta{},
+		Results:  &flinkgatewayv1beta1.SqlV1beta1StatementResultResults{Data: &[]any{map[string]any{"op": 0}}},
 	}
 	client.EXPECT().GetStatementResults("envId", statement.StatementName, "orgId", statement.PageToken).Return(statementResultObj, nil)
 
@@ -1007,8 +1007,8 @@ func (s *StoreTestSuite) TestProcessStatementWithIdentityPool() {
 	}
 
 	statusDetailMessage := "Test status detail message"
-	statementObj := flinkgatewayv1alpha1.SqlV1alpha1Statement{
-		Status: &flinkgatewayv1alpha1.SqlV1alpha1StatementStatus{
+	statementObj := flinkgatewayv1beta1.SqlV1beta1Statement{
+		Status: &flinkgatewayv1beta1.SqlV1beta1StatementStatus{
 			Phase:  "PENDING",
 			Detail: &statusDetailMessage,
 		},
@@ -1039,8 +1039,9 @@ func (s *StoreTestSuite) TestProcessStatementWithServiceAccount() {
 	}
 
 	statusDetailMessage := "Test status detail message"
-	statementObj := flinkgatewayv1alpha1.SqlV1alpha1Statement{
-		Status: &flinkgatewayv1alpha1.SqlV1alpha1StatementStatus{
+	statementObj := flinkgatewayv1beta1.SqlV1beta1Statement{
+		Principal: &serviceAccountId,
+		Status: &flinkgatewayv1beta1.SqlV1beta1StatementStatus{
 			Phase:  "PENDING",
 			Detail: &statusDetailMessage,
 		},
@@ -1052,9 +1053,7 @@ func (s *StoreTestSuite) TestProcessStatementWithServiceAccount() {
 
 	processedStatement, err := store.ProcessStatement(statement)
 	require.Nil(s.T(), err)
-	expectedStatement := types.NewProcessedStatement(statementObj)
-	expectedStatement.ServiceAccount = serviceAccountId
-	require.Equal(s.T(), expectedStatement, processedStatement)
+	require.Equal(s.T(), types.NewProcessedStatement(statementObj), processedStatement)
 }
 
 func (s *StoreTestSuite) TestProcessStatementWithNeitherIdentityPoolNorServiceAccount() {
@@ -1072,8 +1071,8 @@ func (s *StoreTestSuite) TestProcessStatementWithNeitherIdentityPoolNorServiceAc
 	}
 
 	statusDetailMessage := "Test status detail message"
-	statementObj := flinkgatewayv1alpha1.SqlV1alpha1Statement{
-		Status: &flinkgatewayv1alpha1.SqlV1alpha1StatementStatus{
+	statementObj := flinkgatewayv1beta1.SqlV1beta1Statement{
+		Status: &flinkgatewayv1beta1.SqlV1beta1StatementStatus{
 			Phase:  "PENDING",
 			Detail: &statusDetailMessage,
 		},
@@ -1104,8 +1103,8 @@ func (s *StoreTestSuite) TestProcessStatementFailsOnError() {
 	}
 
 	statusDetailMessage := "test status detail message"
-	statementObj := flinkgatewayv1alpha1.SqlV1alpha1Statement{
-		Status: &flinkgatewayv1alpha1.SqlV1alpha1StatementStatus{
+	statementObj := flinkgatewayv1beta1.SqlV1beta1Statement{
+		Status: &flinkgatewayv1beta1.SqlV1beta1StatementStatus{
 			Detail: &statusDetailMessage,
 		},
 	}
@@ -1139,11 +1138,9 @@ func (s *StoreTestSuite) TestWaitPendingStatement() {
 
 	statementName := "Test Statement"
 	statusDetailMessage := "Test status detail message"
-	statementObj := flinkgatewayv1alpha1.SqlV1alpha1Statement{
-		Spec: &flinkgatewayv1alpha1.SqlV1alpha1StatementSpec{
-			StatementName: &statementName,
-		},
-		Status: &flinkgatewayv1alpha1.SqlV1alpha1StatementStatus{
+	statementObj := flinkgatewayv1beta1.SqlV1beta1Statement{
+		Name: &statementName,
+		Status: &flinkgatewayv1beta1.SqlV1beta1StatementStatus{
 			Phase:  "COMPLETED",
 			Detail: &statusDetailMessage,
 		},
@@ -1203,11 +1200,9 @@ func (s *StoreTestSuite) TestWaitPendingStatementFailsOnWaitError() {
 
 	statementName := "Test Statement"
 	statusDetailMessage := "Test status detail message"
-	statementObj := flinkgatewayv1alpha1.SqlV1alpha1Statement{
-		Spec: &flinkgatewayv1alpha1.SqlV1alpha1StatementSpec{
-			StatementName: &statementName,
-		},
-		Status: &flinkgatewayv1alpha1.SqlV1alpha1StatementStatus{
+	statementObj := flinkgatewayv1beta1.SqlV1beta1Statement{
+		Name: &statementName,
+		Status: &flinkgatewayv1beta1.SqlV1beta1StatementStatus{
 			Detail: &statusDetailMessage,
 		},
 	}
@@ -1241,11 +1236,9 @@ func (s *StoreTestSuite) TestWaitPendingStatementFailsOnNonCompletedOrRunningSta
 
 	statementName := "Test Statement"
 	statusDetailMessage := "Test status detail message"
-	statementObj := flinkgatewayv1alpha1.SqlV1alpha1Statement{
-		Spec: &flinkgatewayv1alpha1.SqlV1alpha1StatementSpec{
-			StatementName: &statementName,
-		},
-		Status: &flinkgatewayv1alpha1.SqlV1alpha1StatementStatus{
+	statementObj := flinkgatewayv1beta1.SqlV1beta1Statement{
+		Name: &statementName,
+		Status: &flinkgatewayv1beta1.SqlV1beta1StatementStatus{
 			Phase:  "FAILED",
 			Detail: &statusDetailMessage,
 		},
@@ -1265,62 +1258,227 @@ func (s *StoreTestSuite) TestWaitPendingStatementFailsOnNonCompletedOrRunningSta
 	require.Equal(s.T(), expectedError, err)
 }
 
+func (s *StoreTestSuite) TestWaitPendingStatementFetchesExceptionOnFailedStatementWithEmptyStatusDetail() {
+	client := mock.NewMockGatewayClientInterface(gomock.NewController(s.T()))
+	appOptions := &types.ApplicationOptions{
+		OrgResourceId: "orgId",
+		EnvironmentId: "envId",
+	}
+	store := Store{
+		Properties:       NewUserProperties(map[string]string{"TestProp": "TestVal"}),
+		client:           client,
+		appOptions:       appOptions,
+		tokenRefreshFunc: tokenRefreshFunc,
+	}
+
+	statementName := "Test Statement"
+	statementObj := flinkgatewayv1beta1.SqlV1beta1Statement{
+		Name: &statementName,
+		Status: &flinkgatewayv1beta1.SqlV1beta1StatementStatus{
+			Phase: "FAILED",
+		},
+	}
+	exception1 := "Exception 1"
+	exception2 := "Exception 2"
+	exceptionsResponse := flinkgatewayv1beta1.SqlV1beta1StatementExceptionList{
+		Data: []flinkgatewayv1beta1.SqlV1beta1StatementException{
+			{Stacktrace: &exception1},
+			{Stacktrace: &exception2},
+		},
+	}
+	expectedError := &types.StatementError{
+		Message:        fmt.Sprintf("can't fetch results. Statement phase is: %s", statementObj.Status.Phase),
+		FailureMessage: exception1,
+	}
+
+	client.EXPECT().GetStatement("envId", statementName, "orgId").Return(statementObj, nil)
+	client.EXPECT().GetExceptions("envId", statementName, "orgId").Return(exceptionsResponse, nil)
+
+	processedStatement, err := store.WaitPendingStatement(context.Background(), types.ProcessedStatement{
+		StatementName: statementName,
+		Status:        types.PENDING,
+	})
+	require.Nil(s.T(), processedStatement)
+	require.Equal(s.T(), expectedError, err)
+}
+
+func (s *StoreTestSuite) TestGetStatusDetail() {
+	client := mock.NewMockGatewayClientInterface(gomock.NewController(s.T()))
+	appOptions := &types.ApplicationOptions{
+		OrgResourceId: "orgId",
+		EnvironmentId: "envId",
+	}
+	store := Store{
+		Properties:       NewUserProperties(map[string]string{"TestProp": "TestVal"}),
+		client:           client,
+		appOptions:       appOptions,
+		tokenRefreshFunc: tokenRefreshFunc,
+	}
+
+	statementName := "Test Statement"
+	statementObj := flinkgatewayv1beta1.SqlV1beta1Statement{
+		Name: &statementName,
+		Status: &flinkgatewayv1beta1.SqlV1beta1StatementStatus{
+			Phase: "FAILED",
+		},
+	}
+	exception1 := "Exception 1"
+	exception2 := "Exception 2"
+	exceptionsResponse := flinkgatewayv1beta1.SqlV1beta1StatementExceptionList{
+		Data: []flinkgatewayv1beta1.SqlV1beta1StatementException{
+			{Stacktrace: &exception1},
+			{Stacktrace: &exception2},
+		},
+	}
+
+	client.EXPECT().GetExceptions("envId", statementName, "orgId").Return(exceptionsResponse, nil).Times(2)
+
+	require.Equal(s.T(), exception1, store.getStatusDetail(statementObj))
+	statementObj.Status.Phase = "FAILING"
+	require.Equal(s.T(), exception1, store.getStatusDetail(statementObj))
+}
+
+func (s *StoreTestSuite) TestGetStatusDetailReturnsWhenStatusNoFailedOrFailing() {
+	client := mock.NewMockGatewayClientInterface(gomock.NewController(s.T()))
+	appOptions := &types.ApplicationOptions{
+		OrgResourceId: "orgId",
+		EnvironmentId: "envId",
+	}
+	store := Store{
+		Properties:       NewUserProperties(map[string]string{"TestProp": "TestVal"}),
+		client:           client,
+		appOptions:       appOptions,
+		tokenRefreshFunc: tokenRefreshFunc,
+	}
+
+	testStatusDetailMessage := "Test Status Detail Message"
+	statementObj := flinkgatewayv1beta1.SqlV1beta1Statement{
+		Name: flinkgatewayv1beta1.PtrString("Test Statement"),
+		Status: &flinkgatewayv1beta1.SqlV1beta1StatementStatus{
+			Phase:  "PENDING",
+			Detail: &testStatusDetailMessage,
+		},
+	}
+
+	require.Equal(s.T(), testStatusDetailMessage, store.getStatusDetail(statementObj))
+	statementObj.Status.Phase = "COMPLETED"
+	require.Equal(s.T(), testStatusDetailMessage, store.getStatusDetail(statementObj))
+	statementObj.Status.Phase = "RUNNING"
+	require.Equal(s.T(), testStatusDetailMessage, store.getStatusDetail(statementObj))
+	statementObj.Status.Phase = "DELETED"
+	require.Equal(s.T(), testStatusDetailMessage, store.getStatusDetail(statementObj))
+}
+
+func (s *StoreTestSuite) TestGetStatusDetailReturnsWhenStatusDetailFilled() {
+	client := mock.NewMockGatewayClientInterface(gomock.NewController(s.T()))
+	appOptions := &types.ApplicationOptions{
+		OrgResourceId: "orgId",
+		EnvironmentId: "envId",
+	}
+	store := Store{
+		Properties:       NewUserProperties(map[string]string{"TestProp": "TestVal"}),
+		client:           client,
+		appOptions:       appOptions,
+		tokenRefreshFunc: tokenRefreshFunc,
+	}
+
+	testStatusDetailMessage := "Test Status Detail Message"
+	statementObj := flinkgatewayv1beta1.SqlV1beta1Statement{
+		Name: flinkgatewayv1beta1.PtrString("Test Statement"),
+		Status: &flinkgatewayv1beta1.SqlV1beta1StatementStatus{
+			Phase:  "FAILED",
+			Detail: &testStatusDetailMessage,
+		},
+	}
+
+	require.Equal(s.T(), testStatusDetailMessage, store.getStatusDetail(statementObj))
+}
+
+func (s *StoreTestSuite) TestGetStatusDetailReturnsEmptyWhenNoExceptionsAvailable() {
+	client := mock.NewMockGatewayClientInterface(gomock.NewController(s.T()))
+	appOptions := &types.ApplicationOptions{
+		OrgResourceId: "orgId",
+		EnvironmentId: "envId",
+	}
+	store := Store{
+		Properties:       NewUserProperties(map[string]string{"TestProp": "TestVal"}),
+		client:           client,
+		appOptions:       appOptions,
+		tokenRefreshFunc: tokenRefreshFunc,
+	}
+
+	statementName := "Test Statement"
+	statementObj := flinkgatewayv1beta1.SqlV1beta1Statement{
+		Name: &statementName,
+		Status: &flinkgatewayv1beta1.SqlV1beta1StatementStatus{
+			Phase: "FAILED",
+		},
+	}
+	exceptionsResponse := flinkgatewayv1beta1.SqlV1beta1StatementExceptionList{
+		Data: []flinkgatewayv1beta1.SqlV1beta1StatementException{},
+	}
+
+	client.EXPECT().GetExceptions("envId", statementName, "orgId").Return(exceptionsResponse, nil)
+
+	require.Equal(s.T(), "", store.getStatusDetail(statementObj))
+}
+
 func (s *StoreTestSuite) TestNewProcessedStatementSetsIsSelectStatement() {
 	tests := []struct {
 		name              string
-		statement         flinkgatewayv1alpha1.SqlV1alpha1Statement
+		statement         flinkgatewayv1beta1.SqlV1beta1Statement
 		isSelectStatement bool
 	}{
 		{
 			name: "select lowercase",
-			statement: flinkgatewayv1alpha1.SqlV1alpha1Statement{
-				Spec: &flinkgatewayv1alpha1.SqlV1alpha1StatementSpec{
-					Statement: flinkgatewayv1alpha1.PtrString("select * FROM table"),
+			statement: flinkgatewayv1beta1.SqlV1beta1Statement{
+				Spec: &flinkgatewayv1beta1.SqlV1beta1StatementSpec{
+					Statement: flinkgatewayv1beta1.PtrString("select * FROM table"),
 				},
 			},
 			isSelectStatement: true,
 		},
 		{
 			name: "select uppercase",
-			statement: flinkgatewayv1alpha1.SqlV1alpha1Statement{
-				Spec: &flinkgatewayv1alpha1.SqlV1alpha1StatementSpec{
-					Statement: flinkgatewayv1alpha1.PtrString("SELECT * FROM table"),
+			statement: flinkgatewayv1beta1.SqlV1beta1Statement{
+				Spec: &flinkgatewayv1beta1.SqlV1beta1StatementSpec{
+					Statement: flinkgatewayv1beta1.PtrString("SELECT * FROM table"),
 				},
 			},
 			isSelectStatement: true,
 		},
 		{
 			name: "select random case",
-			statement: flinkgatewayv1alpha1.SqlV1alpha1Statement{
-				Spec: &flinkgatewayv1alpha1.SqlV1alpha1StatementSpec{
-					Statement: flinkgatewayv1alpha1.PtrString("SeLeCt * FROM table"),
+			statement: flinkgatewayv1beta1.SqlV1beta1Statement{
+				Spec: &flinkgatewayv1beta1.SqlV1beta1StatementSpec{
+					Statement: flinkgatewayv1beta1.PtrString("SeLeCt * FROM table"),
 				},
 			},
 			isSelectStatement: true,
 		},
 		{
 			name: "leading white space",
-			statement: flinkgatewayv1alpha1.SqlV1alpha1Statement{
-				Spec: &flinkgatewayv1alpha1.SqlV1alpha1StatementSpec{
-					Statement: flinkgatewayv1alpha1.PtrString("   select * FROM table"),
+			statement: flinkgatewayv1beta1.SqlV1beta1Statement{
+				Spec: &flinkgatewayv1beta1.SqlV1beta1StatementSpec{
+					Statement: flinkgatewayv1beta1.PtrString("   select * FROM table"),
 				},
 			},
 			isSelectStatement: true,
 		},
 		{
 			name: "missing last char",
-			statement: flinkgatewayv1alpha1.SqlV1alpha1Statement{
-				Spec: &flinkgatewayv1alpha1.SqlV1alpha1StatementSpec{
-					Statement: flinkgatewayv1alpha1.PtrString("selec * FROM table"),
+			statement: flinkgatewayv1beta1.SqlV1beta1Statement{
+				Spec: &flinkgatewayv1beta1.SqlV1beta1StatementSpec{
+					Statement: flinkgatewayv1beta1.PtrString("selec * FROM table"),
 				},
 			},
 			isSelectStatement: false,
 		},
 		{
 			name: "missing last char",
-			statement: flinkgatewayv1alpha1.SqlV1alpha1Statement{
-				Spec: &flinkgatewayv1alpha1.SqlV1alpha1StatementSpec{
-					Statement: flinkgatewayv1alpha1.PtrString("insert into table values (1, 2)"),
+			statement: flinkgatewayv1beta1.SqlV1beta1Statement{
+				Spec: &flinkgatewayv1beta1.SqlV1beta1StatementSpec{
+					Statement: flinkgatewayv1beta1.PtrString("insert into table values (1, 2)"),
 				},
 			},
 			isSelectStatement: false,
@@ -1366,16 +1524,14 @@ func TestWaitForTerminalStateStopsWhenTerminalState(t *testing.T) {
 		tokenRefreshFunc: tokenRefreshFunc,
 	}
 
-	statementObj := flinkgatewayv1alpha1.SqlV1alpha1Statement{
-		Spec: &flinkgatewayv1alpha1.SqlV1alpha1StatementSpec{
-			StatementName: flinkgatewayv1alpha1.PtrString("statement-name"),
-		},
-		Status: &flinkgatewayv1alpha1.SqlV1alpha1StatementStatus{
+	statementObj := flinkgatewayv1beta1.SqlV1beta1Statement{
+		Name: flinkgatewayv1beta1.PtrString("statement-name"),
+		Status: &flinkgatewayv1beta1.SqlV1beta1StatementStatus{
 			Phase:  "COMPLETED",
-			Detail: flinkgatewayv1alpha1.PtrString("Test status detail message"),
+			Detail: flinkgatewayv1beta1.PtrString("Test status detail message"),
 		},
 	}
-	client.EXPECT().GetStatement("envId", statementObj.Spec.GetStatementName(), "orgId").Return(statementObj, nil)
+	client.EXPECT().GetStatement("envId", statementObj.GetName(), "orgId").Return(statementObj, nil)
 	processedStatement := types.NewProcessedStatement(statementObj)
 	processedStatement.Status = types.RUNNING
 
@@ -1396,16 +1552,14 @@ func TestWaitForTerminalStateStopsWhenUserDetaches(t *testing.T) {
 		appOptions:       &appOptions,
 		tokenRefreshFunc: tokenRefreshFunc,
 	}
-	statementObj := flinkgatewayv1alpha1.SqlV1alpha1Statement{
-		Spec: &flinkgatewayv1alpha1.SqlV1alpha1StatementSpec{
-			StatementName: flinkgatewayv1alpha1.PtrString("statement-name"),
-		},
-		Status: &flinkgatewayv1alpha1.SqlV1alpha1StatementStatus{
+	statementObj := flinkgatewayv1beta1.SqlV1beta1Statement{
+		Name: flinkgatewayv1beta1.PtrString("statement-name"),
+		Status: &flinkgatewayv1beta1.SqlV1beta1StatementStatus{
 			Phase:  "RUNNING",
-			Detail: flinkgatewayv1alpha1.PtrString("Test status detail message"),
+			Detail: flinkgatewayv1beta1.PtrString("Test status detail message"),
 		},
 	}
-	client.EXPECT().GetStatement("envId", statementObj.Spec.GetStatementName(), "orgId").Return(statementObj, nil).AnyTimes()
+	client.EXPECT().GetStatement("envId", statementObj.GetName(), "orgId").Return(statementObj, nil).AnyTimes()
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	go func() {
 		time.Sleep(2 * time.Second)
@@ -1430,16 +1584,14 @@ func TestWaitForTerminalStateStopsOnError(t *testing.T) {
 		appOptions:       &appOptions,
 		tokenRefreshFunc: tokenRefreshFunc,
 	}
-	statementObj := flinkgatewayv1alpha1.SqlV1alpha1Statement{
-		Spec: &flinkgatewayv1alpha1.SqlV1alpha1StatementSpec{
-			StatementName: flinkgatewayv1alpha1.PtrString("statement-name"),
-		},
-		Status: &flinkgatewayv1alpha1.SqlV1alpha1StatementStatus{
+	statementObj := flinkgatewayv1beta1.SqlV1beta1Statement{
+		Name: flinkgatewayv1beta1.PtrString("statement-name"),
+		Status: &flinkgatewayv1beta1.SqlV1beta1StatementStatus{
 			Phase:  "RUNNING",
-			Detail: flinkgatewayv1alpha1.PtrString("Test status detail message"),
+			Detail: flinkgatewayv1beta1.PtrString("Test status detail message"),
 		},
 	}
-	client.EXPECT().GetStatement("envId", statementObj.Spec.GetStatementName(), "orgId").Return(statementObj, errors.New("error"))
+	client.EXPECT().GetStatement("envId", statementObj.GetName(), "orgId").Return(statementObj, errors.New("error"))
 
 	_, err := s.WaitForTerminalStatementState(context.Background(), *types.NewProcessedStatement(statementObj))
 

--- a/pkg/flink/internal/store/store_utils.go
+++ b/pkg/flink/internal/store/store_utils.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"time"
 
-	flinkgatewayv1alpha1 "github.com/confluentinc/ccloud-sdk-go-v2/flink-gateway/v1alpha1"
+	flinkgatewayv1alpha1 "github.com/confluentinc/ccloud-sdk-go-v2/flink-gateway/v1beta1"
 
 	"github.com/confluentinc/cli/v3/pkg/flink/config"
 	"github.com/confluentinc/cli/v3/pkg/flink/types"

--- a/pkg/flink/internal/utils/output.go
+++ b/pkg/flink/internal/utils/output.go
@@ -22,7 +22,7 @@ func OutputInfo(s string) {
 }
 
 func OutputInfof(s string, args ...any) {
-	output.Printf(s+"\n", args...)
+	output.Printf(s, args...)
 }
 
 func OutputWarn(s string) {

--- a/pkg/flink/test/generators/results.go
+++ b/pkg/flink/test/generators/results.go
@@ -7,12 +7,12 @@ import (
 
 	"pgregory.net/rapid"
 
-	flinkgatewayv1alpha1 "github.com/confluentinc/ccloud-sdk-go-v2/flink-gateway/v1alpha1"
+	flinkgatewayv1beta1 "github.com/confluentinc/ccloud-sdk-go-v2/flink-gateway/v1beta1"
 
 	"github.com/confluentinc/cli/v3/pkg/flink/types"
 )
 
-func GetResultItemGeneratorForType(dataType flinkgatewayv1alpha1.DataType) *rapid.Generator[any] {
+func GetResultItemGeneratorForType(dataType flinkgatewayv1beta1.DataType) *rapid.Generator[any] {
 	fieldType := types.NewResultFieldType(dataType)
 	switch fieldType {
 	case types.ARRAY:
@@ -20,7 +20,7 @@ func GetResultItemGeneratorForType(dataType flinkgatewayv1alpha1.DataType) *rapi
 		return ArrayResultItem(elementType)
 	case types.MULTISET:
 		keyType := dataType.GetElementType()
-		valueType := flinkgatewayv1alpha1.DataType{
+		valueType := flinkgatewayv1beta1.DataType{
 			Nullable: false,
 			Type:     "INTEGER",
 		}
@@ -80,7 +80,7 @@ func AtomicResultItem(fieldType types.StatementResultFieldType) *rapid.Generator
 }
 
 // ArrayResultItem generates a random ARRAY field
-func ArrayResultItem(elementDataType flinkgatewayv1alpha1.DataType) *rapid.Generator[any] {
+func ArrayResultItem(elementDataType flinkgatewayv1beta1.DataType) *rapid.Generator[any] {
 	return rapid.Custom(func(t *rapid.T) any {
 		var arrayItems []any
 		arraySize := rapid.IntRange(1, 3).Draw(t, "array size")
@@ -93,7 +93,7 @@ func ArrayResultItem(elementDataType flinkgatewayv1alpha1.DataType) *rapid.Gener
 }
 
 // MapResultItem generates a random MAP field
-func MapResultItem(keyType, valueType flinkgatewayv1alpha1.DataType) *rapid.Generator[any] {
+func MapResultItem(keyType, valueType flinkgatewayv1beta1.DataType) *rapid.Generator[any] {
 	return rapid.Custom(func(t *rapid.T) any {
 		var mapItems []any
 		arraySize := rapid.IntRange(1, 3).Draw(t, "map size")
@@ -109,7 +109,7 @@ func MapResultItem(keyType, valueType flinkgatewayv1alpha1.DataType) *rapid.Gene
 }
 
 // RowResultItem generates a random ROW field
-func RowResultItem(fieldTypes []flinkgatewayv1alpha1.RowFieldType) *rapid.Generator[any] {
+func RowResultItem(fieldTypes []flinkgatewayv1beta1.RowFieldType) *rapid.Generator[any] {
 	return rapid.Custom(func(t *rapid.T) any {
 		var arrayItems []any
 		for i := range fieldTypes {
@@ -121,7 +121,7 @@ func RowResultItem(fieldTypes []flinkgatewayv1alpha1.RowFieldType) *rapid.Genera
 }
 
 // MockResultRow creates a row with random fields adhering to the provided column schema
-func MockResultRow(columnDetails []flinkgatewayv1alpha1.ColumnDetails) *rapid.Generator[any] {
+func MockResultRow(columnDetails []flinkgatewayv1beta1.ColumnDetails) *rapid.Generator[any] {
 	return rapid.Custom(func(t *rapid.T) any {
 		var items []any
 		for _, column := range columnDetails {
@@ -164,7 +164,7 @@ var AtomicResultFieldTypes = []types.StatementResultFieldType{
 	types.NULL,
 }
 
-func getDataTypeGeneratorForType(fieldType types.StatementResultFieldType, maxNestingDepth int) *rapid.Generator[flinkgatewayv1alpha1.DataType] {
+func getDataTypeGeneratorForType(fieldType types.StatementResultFieldType, maxNestingDepth int) *rapid.Generator[flinkgatewayv1beta1.DataType] {
 	if maxNestingDepth <= 0 {
 		return AtomicDataType()
 	}
@@ -183,24 +183,24 @@ func getDataTypeGeneratorForType(fieldType types.StatementResultFieldType, maxNe
 }
 
 // AtomicDataType generates a random atomic data type
-func AtomicDataType() *rapid.Generator[flinkgatewayv1alpha1.DataType] {
-	return rapid.Custom(func(t *rapid.T) flinkgatewayv1alpha1.DataType {
+func AtomicDataType() *rapid.Generator[flinkgatewayv1beta1.DataType] {
+	return rapid.Custom(func(t *rapid.T) flinkgatewayv1beta1.DataType {
 		resultFieldType := rapid.SampledFrom(AtomicResultFieldTypes).Draw(t, "atomic result field type")
 		dataTypeJson := fmt.Sprintf(`{"type": "%s"}`, string(resultFieldType))
-		dataType := flinkgatewayv1alpha1.NewNullableDataType(nil)
+		dataType := flinkgatewayv1beta1.NewNullableDataType(nil)
 		if err := dataType.UnmarshalJSON([]byte(dataTypeJson)); err != nil {
-			return flinkgatewayv1alpha1.DataType{}
+			return flinkgatewayv1beta1.DataType{}
 		}
 		return *dataType.Get()
 	})
 }
 
 // ArrayDataType generates a random array data type
-func ArrayDataType(maxNestingDepth int) *rapid.Generator[flinkgatewayv1alpha1.DataType] {
-	return rapid.Custom(func(t *rapid.T) flinkgatewayv1alpha1.DataType {
+func ArrayDataType(maxNestingDepth int) *rapid.Generator[flinkgatewayv1beta1.DataType] {
+	return rapid.Custom(func(t *rapid.T) flinkgatewayv1beta1.DataType {
 		resultFieldType := GenResultFieldType().Draw(t, "result field type")
 		elementType := getDataTypeGeneratorForType(resultFieldType, maxNestingDepth).Draw(t, "element type")
-		return flinkgatewayv1alpha1.DataType{
+		return flinkgatewayv1beta1.DataType{
 			Nullable:    false,
 			Type:        "ARRAY",
 			ElementType: &elementType,
@@ -209,13 +209,13 @@ func ArrayDataType(maxNestingDepth int) *rapid.Generator[flinkgatewayv1alpha1.Da
 }
 
 // MapDataType generates a random map data type
-func MapDataType(maxNestingDepth int) *rapid.Generator[flinkgatewayv1alpha1.DataType] {
-	return rapid.Custom(func(t *rapid.T) flinkgatewayv1alpha1.DataType {
+func MapDataType(maxNestingDepth int) *rapid.Generator[flinkgatewayv1beta1.DataType] {
+	return rapid.Custom(func(t *rapid.T) flinkgatewayv1beta1.DataType {
 		resultFieldKeyType := GenResultFieldType().Draw(t, "result field type")
 		resultFieldValueType := GenResultFieldType().Draw(t, "result field type")
 		keyType := getDataTypeGeneratorForType(resultFieldKeyType, maxNestingDepth).Draw(t, "element type")
 		valueType := getDataTypeGeneratorForType(resultFieldValueType, maxNestingDepth).Draw(t, "element type")
-		return flinkgatewayv1alpha1.DataType{
+		return flinkgatewayv1beta1.DataType{
 			Nullable:  false,
 			Type:      "MAP",
 			KeyType:   &keyType,
@@ -225,11 +225,11 @@ func MapDataType(maxNestingDepth int) *rapid.Generator[flinkgatewayv1alpha1.Data
 }
 
 // MultisetDataType generates a random map data type
-func MultisetDataType(maxNestingDepth int) *rapid.Generator[flinkgatewayv1alpha1.DataType] {
-	return rapid.Custom(func(t *rapid.T) flinkgatewayv1alpha1.DataType {
+func MultisetDataType(maxNestingDepth int) *rapid.Generator[flinkgatewayv1beta1.DataType] {
+	return rapid.Custom(func(t *rapid.T) flinkgatewayv1beta1.DataType {
 		resultFieldType := GenResultFieldType().Draw(t, "result field type")
 		elementType := getDataTypeGeneratorForType(resultFieldType, maxNestingDepth).Draw(t, "element type")
-		return flinkgatewayv1alpha1.DataType{
+		return flinkgatewayv1beta1.DataType{
 			Nullable:    false,
 			Type:        "MULTISET",
 			ElementType: &elementType,
@@ -238,19 +238,19 @@ func MultisetDataType(maxNestingDepth int) *rapid.Generator[flinkgatewayv1alpha1
 }
 
 // RowDataType generates a random row data type
-func RowDataType(maxNestingDepth int) *rapid.Generator[flinkgatewayv1alpha1.DataType] {
-	return rapid.Custom(func(t *rapid.T) flinkgatewayv1alpha1.DataType {
-		var fieldTypes []flinkgatewayv1alpha1.RowFieldType
+func RowDataType(maxNestingDepth int) *rapid.Generator[flinkgatewayv1beta1.DataType] {
+	return rapid.Custom(func(t *rapid.T) flinkgatewayv1beta1.DataType {
+		var fieldTypes []flinkgatewayv1beta1.RowFieldType
 		rowSize := rapid.IntRange(1, 3).Draw(t, "array size")
 		for i := 0; i < rowSize; i++ {
 			resultFieldType := GenResultFieldType().Draw(t, "result field type")
 			elementType := getDataTypeGeneratorForType(resultFieldType, maxNestingDepth).Draw(t, "element type")
-			fieldTypes = append(fieldTypes, flinkgatewayv1alpha1.RowFieldType{
+			fieldTypes = append(fieldTypes, flinkgatewayv1beta1.RowFieldType{
 				Name:      strconv.Itoa(i),
 				FieldType: elementType,
 			})
 		}
-		return flinkgatewayv1alpha1.DataType{
+		return flinkgatewayv1beta1.DataType{
 			Nullable: false,
 			Type:     "ROW",
 			Fields:   &fieldTypes,
@@ -269,19 +269,19 @@ func GenResultFieldType() *rapid.Generator[types.StatementResultFieldType] {
 	})
 }
 
-func DataType(maxNestingDepth int) *rapid.Generator[flinkgatewayv1alpha1.DataType] {
-	return rapid.Custom(func(t *rapid.T) flinkgatewayv1alpha1.DataType {
+func DataType(maxNestingDepth int) *rapid.Generator[flinkgatewayv1beta1.DataType] {
+	return rapid.Custom(func(t *rapid.T) flinkgatewayv1beta1.DataType {
 		resultFieldType := GenResultFieldType().Draw(t, "result field type")
 		return getDataTypeGeneratorForType(resultFieldType, maxNestingDepth).Draw(t, "data type")
 	})
 }
 
-func MockResultColumns(numColumns, maxNestingDepth int) *rapid.Generator[[]flinkgatewayv1alpha1.ColumnDetails] {
-	return rapid.Custom(func(t *rapid.T) []flinkgatewayv1alpha1.ColumnDetails {
-		var columnDetails []flinkgatewayv1alpha1.ColumnDetails
+func MockResultColumns(numColumns, maxNestingDepth int) *rapid.Generator[[]flinkgatewayv1beta1.ColumnDetails] {
+	return rapid.Custom(func(t *rapid.T) []flinkgatewayv1beta1.ColumnDetails {
+		var columnDetails []flinkgatewayv1beta1.ColumnDetails
 		for i := 0; i < numColumns; i++ {
 			dataType := DataType(maxNestingDepth).Draw(t, "column type")
-			columnDetails = append(columnDetails, flinkgatewayv1alpha1.ColumnDetails{
+			columnDetails = append(columnDetails, flinkgatewayv1beta1.ColumnDetails{
 				Name: string(types.NewResultFieldType(dataType)),
 				Type: dataType,
 			})
@@ -303,9 +303,9 @@ func MockResults(maxNumColumns, maxNestingDepth int) *rapid.Generator[types.Mock
 		resultData := rapid.SliceOfN(MockResultRow(columnDetails), 20, 50).Draw(t, "result data")
 
 		return types.MockStatementResult{
-			ResultSchema: flinkgatewayv1alpha1.SqlV1alpha1ResultSchema{Columns: &columnDetails},
-			StatementResults: flinkgatewayv1alpha1.SqlV1alpha1StatementResult{
-				Results: &flinkgatewayv1alpha1.SqlV1alpha1StatementResultResults{Data: &resultData},
+			ResultSchema: flinkgatewayv1beta1.SqlV1beta1ResultSchema{Columns: &columnDetails},
+			StatementResults: flinkgatewayv1beta1.SqlV1beta1StatementResult{
+				Results: &flinkgatewayv1beta1.SqlV1beta1StatementResultResults{Data: &resultData},
 			},
 		}
 	})

--- a/pkg/flink/test/mock/gateway_client_fake.go
+++ b/pkg/flink/test/mock/gateway_client_fake.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"time"
 
-	flinkgatewayv1alpha1 "github.com/confluentinc/ccloud-sdk-go-v2/flink-gateway/v1alpha1"
+	flinkgatewayv1beta1 "github.com/confluentinc/ccloud-sdk-go-v2/flink-gateway/v1beta1"
 	"github.com/confluentinc/cli/v3/pkg/ccloudv2"
 	"github.com/confluentinc/cli/v3/pkg/flink/test/generators"
 	"github.com/google/uuid"
@@ -21,8 +21,8 @@ const (
 )
 
 type FakeFlinkGatewayClient struct {
-	statement  flinkgatewayv1alpha1.SqlV1alpha1Statement
-	statements []flinkgatewayv1alpha1.SqlV1alpha1Statement
+	statement  flinkgatewayv1beta1.SqlV1beta1Statement
+	statements []flinkgatewayv1beta1.SqlV1beta1Statement
 	fakeCount  int
 }
 
@@ -34,41 +34,41 @@ func (c *FakeFlinkGatewayClient) DeleteStatement(environmentId, statementName, o
 	return nil
 }
 
-func (c *FakeFlinkGatewayClient) GetStatement(environmentId, statementName, orgId string) (flinkgatewayv1alpha1.SqlV1alpha1Statement, error) {
+func (c *FakeFlinkGatewayClient) GetStatement(environmentId, statementName, orgId string) (flinkgatewayv1beta1.SqlV1beta1Statement, error) {
 	secondsToWait := time.Duration(rapid.IntRange(1, 3).Example())
 	time.Sleep(secondsToWait * time.Second)
 	c.statement.Status.Phase = "RUNNING"
 	return c.statement, nil
 }
 
-func (c *FakeFlinkGatewayClient) ListStatements(environmentId, orgId, pageToken, computePoolId string) (flinkgatewayv1alpha1.SqlV1alpha1StatementList, error) {
-	return flinkgatewayv1alpha1.SqlV1alpha1StatementList{Data: c.statements}, nil
+func (c *FakeFlinkGatewayClient) ListStatements(environmentId, orgId, pageToken, computePoolId string) (flinkgatewayv1beta1.SqlV1beta1StatementList, error) {
+	return flinkgatewayv1beta1.SqlV1beta1StatementList{Data: c.statements}, nil
 }
 
-func (c *FakeFlinkGatewayClient) CreateStatement(statement, computePoolId string, properties map[string]string, serviceAccountId, identityPoolId, environmentId, orgId string) (flinkgatewayv1alpha1.SqlV1alpha1Statement, error) {
+func (c *FakeFlinkGatewayClient) CreateStatement(statement, computePoolId string, properties map[string]string, serviceAccountId, identityPoolId, environmentId, orgId string) (flinkgatewayv1beta1.SqlV1beta1Statement, error) {
 	columnDetails := c.getFakeResultSchema(statement)
 	statementName := uuid.New().String()[:20]
 
 	c.fakeCount = 0
 	creationTime := time.Now()
-	c.statement = flinkgatewayv1alpha1.SqlV1alpha1Statement{
+	c.statement = flinkgatewayv1beta1.SqlV1beta1Statement{
+		Name:       &statementName,
 		ApiVersion: nil,
 		Kind:       nil,
-		Metadata: &flinkgatewayv1alpha1.ObjectMeta{
+		Metadata: &flinkgatewayv1beta1.ObjectMeta{
 			Self:      "",
 			CreatedAt: &creationTime,
 			UpdatedAt: nil,
 		},
-		Spec: &flinkgatewayv1alpha1.SqlV1alpha1StatementSpec{
-			StatementName:  &statementName,
+		Spec: &flinkgatewayv1beta1.SqlV1beta1StatementSpec{
 			Statement:      &statement,
 			Properties:     &properties,
 			ComputePoolId:  &computePoolId,
 			IdentityPoolId: &identityPoolId,
 		},
-		Status: &flinkgatewayv1alpha1.SqlV1alpha1StatementStatus{
+		Status: &flinkgatewayv1beta1.SqlV1beta1StatementStatus{
 			Phase:        "PENDING",
-			ResultSchema: &flinkgatewayv1alpha1.SqlV1alpha1ResultSchema{Columns: &columnDetails},
+			ResultSchema: &flinkgatewayv1beta1.SqlV1beta1ResultSchema{Columns: &columnDetails},
 			Detail:       nil,
 		},
 	}
@@ -77,7 +77,7 @@ func (c *FakeFlinkGatewayClient) CreateStatement(statement, computePoolId string
 	return c.statement, nil
 }
 
-func (c *FakeFlinkGatewayClient) getFakeResultSchema(statement string) []flinkgatewayv1alpha1.ColumnDetails {
+func (c *FakeFlinkGatewayClient) getFakeResultSchema(statement string) []flinkgatewayv1beta1.ColumnDetails {
 	switch statement {
 	case staticQuery:
 		return c.getStaticFakeResultSchema()
@@ -87,15 +87,15 @@ func (c *FakeFlinkGatewayClient) getFakeResultSchema(statement string) []flinkga
 	return nil
 }
 
-func (c *FakeFlinkGatewayClient) getStaticFakeResultSchema() []flinkgatewayv1alpha1.ColumnDetails {
+func (c *FakeFlinkGatewayClient) getStaticFakeResultSchema() []flinkgatewayv1beta1.ColumnDetails {
 	return generators.MockResultColumns(5, 2).Example()
 }
 
-func (c *FakeFlinkGatewayClient) getDynamicFakeResultSchema() []flinkgatewayv1alpha1.ColumnDetails {
-	return []flinkgatewayv1alpha1.ColumnDetails{
+func (c *FakeFlinkGatewayClient) getDynamicFakeResultSchema() []flinkgatewayv1beta1.ColumnDetails {
+	return []flinkgatewayv1beta1.ColumnDetails{
 		{
 			Name: "Count",
-			Type: flinkgatewayv1alpha1.DataType{
+			Type: flinkgatewayv1beta1.DataType{
 				Nullable: false,
 				Type:     "INTEGER",
 			},
@@ -103,17 +103,17 @@ func (c *FakeFlinkGatewayClient) getDynamicFakeResultSchema() []flinkgatewayv1al
 	}
 }
 
-func (c *FakeFlinkGatewayClient) GetStatementResults(environmentId, statementId, orgId, pageToken string) (flinkgatewayv1alpha1.SqlV1alpha1StatementResult, error) {
+func (c *FakeFlinkGatewayClient) GetStatementResults(environmentId, statementId, orgId, pageToken string) (flinkgatewayv1beta1.SqlV1beta1StatementResult, error) {
 	resultData, nextUrl := c.getFakeResults()
-	return flinkgatewayv1alpha1.SqlV1alpha1StatementResult{
+	return flinkgatewayv1beta1.SqlV1beta1StatementResult{
 		ApiVersion: "",
 		Kind:       "",
-		Metadata: flinkgatewayv1alpha1.ResultListMeta{
+		Metadata: flinkgatewayv1beta1.ResultListMeta{
 			Self:      nil,
 			Next:      &nextUrl,
 			CreatedAt: nil,
 		},
-		Results: &flinkgatewayv1alpha1.SqlV1alpha1StatementResultResults{Data: &resultData},
+		Results: &flinkgatewayv1beta1.SqlV1beta1StatementResultResults{Data: &resultData},
 	}, nil
 }
 
@@ -158,6 +158,6 @@ func (c *FakeFlinkGatewayClient) getFakeResultsRunningCounter() ([]any, string) 
 	return results, fmt.Sprintf("https://devel.cpdev.cloud/some/results?page_token=%s", "not-empty")
 }
 
-func (c *FakeFlinkGatewayClient) GetExceptions(environmentId, statementId, orgId string) (flinkgatewayv1alpha1.SqlV1alpha1StatementExceptionList, error) {
-	return flinkgatewayv1alpha1.SqlV1alpha1StatementExceptionList{}, nil
+func (c *FakeFlinkGatewayClient) GetExceptions(environmentId, statementId, orgId string) (flinkgatewayv1beta1.SqlV1beta1StatementExceptionList, error) {
+	return flinkgatewayv1beta1.SqlV1beta1StatementExceptionList{}, nil
 }

--- a/pkg/flink/test/mock/gateway_client_fake.go
+++ b/pkg/flink/test/mock/gateway_client_fake.go
@@ -7,7 +7,6 @@ import (
 	flinkgatewayv1beta1 "github.com/confluentinc/ccloud-sdk-go-v2/flink-gateway/v1beta1"
 	"github.com/confluentinc/cli/v3/pkg/ccloudv2"
 	"github.com/confluentinc/cli/v3/pkg/flink/test/generators"
-	"github.com/google/uuid"
 	"pgregory.net/rapid"
 )
 
@@ -45,33 +44,9 @@ func (c *FakeFlinkGatewayClient) ListStatements(environmentId, orgId, pageToken,
 	return flinkgatewayv1beta1.SqlV1beta1StatementList{Data: c.statements}, nil
 }
 
-func (c *FakeFlinkGatewayClient) CreateStatement(statement, computePoolId string, properties map[string]string, serviceAccountId, identityPoolId, environmentId, orgId string) (flinkgatewayv1beta1.SqlV1beta1Statement, error) {
-	columnDetails := c.getFakeResultSchema(statement)
-	statementName := uuid.New().String()[:20]
-
+func (c *FakeFlinkGatewayClient) CreateStatement(statement flinkgatewayv1beta1.SqlV1beta1Statement, serviceAccountId, identityPoolId, environmentId, orgId string) (flinkgatewayv1beta1.SqlV1beta1Statement, error) {
 	c.fakeCount = 0
-	creationTime := time.Now()
-	c.statement = flinkgatewayv1beta1.SqlV1beta1Statement{
-		Name:       &statementName,
-		ApiVersion: nil,
-		Kind:       nil,
-		Metadata: &flinkgatewayv1beta1.ObjectMeta{
-			Self:      "",
-			CreatedAt: &creationTime,
-			UpdatedAt: nil,
-		},
-		Spec: &flinkgatewayv1beta1.SqlV1beta1StatementSpec{
-			Statement:      &statement,
-			Properties:     &properties,
-			ComputePoolId:  &computePoolId,
-			IdentityPoolId: &identityPoolId,
-		},
-		Status: &flinkgatewayv1beta1.SqlV1beta1StatementStatus{
-			Phase:        "PENDING",
-			ResultSchema: &flinkgatewayv1beta1.SqlV1beta1ResultSchema{Columns: &columnDetails},
-			Detail:       nil,
-		},
-	}
+	c.statement = statement
 	c.statements = append(c.statements, c.statement)
 
 	return c.statement, nil

--- a/pkg/flink/test/mock/gateway_client_mock.go
+++ b/pkg/flink/test/mock/gateway_client_mock.go
@@ -7,7 +7,7 @@ package mock
 import (
 	reflect "reflect"
 
-	v1alpha1 "github.com/confluentinc/ccloud-sdk-go-v2/flink-gateway/v1alpha1"
+	v1beta1 "github.com/confluentinc/ccloud-sdk-go-v2/flink-gateway/v1beta1"
 	gomock "github.com/golang/mock/gomock"
 )
 
@@ -35,10 +35,10 @@ func (m *MockGatewayClientInterface) EXPECT() *MockGatewayClientInterfaceMockRec
 }
 
 // CreateStatement mocks base method.
-func (m *MockGatewayClientInterface) CreateStatement(arg0, arg1 string, arg2 map[string]string, arg3, arg4, arg5, arg6 string) (v1alpha1.SqlV1alpha1Statement, error) {
+func (m *MockGatewayClientInterface) CreateStatement(arg0, arg1 string, arg2 map[string]string, arg3, arg4, arg5, arg6 string) (v1beta1.SqlV1beta1Statement, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateStatement", arg0, arg1, arg2, arg3, arg4, arg5, arg6)
-	ret0, _ := ret[0].(v1alpha1.SqlV1alpha1Statement)
+	ret0, _ := ret[0].(v1beta1.SqlV1beta1Statement)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -64,10 +64,10 @@ func (mr *MockGatewayClientInterfaceMockRecorder) DeleteStatement(arg0, arg1, ar
 }
 
 // GetExceptions mocks base method.
-func (m *MockGatewayClientInterface) GetExceptions(arg0, arg1, arg2 string) (v1alpha1.SqlV1alpha1StatementExceptionList, error) {
+func (m *MockGatewayClientInterface) GetExceptions(arg0, arg1, arg2 string) (v1beta1.SqlV1beta1StatementExceptionList, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetExceptions", arg0, arg1, arg2)
-	ret0, _ := ret[0].(v1alpha1.SqlV1alpha1StatementExceptionList)
+	ret0, _ := ret[0].(v1beta1.SqlV1beta1StatementExceptionList)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -79,10 +79,10 @@ func (mr *MockGatewayClientInterfaceMockRecorder) GetExceptions(arg0, arg1, arg2
 }
 
 // GetStatement mocks base method.
-func (m *MockGatewayClientInterface) GetStatement(arg0, arg1, arg2 string) (v1alpha1.SqlV1alpha1Statement, error) {
+func (m *MockGatewayClientInterface) GetStatement(arg0, arg1, arg2 string) (v1beta1.SqlV1beta1Statement, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetStatement", arg0, arg1, arg2)
-	ret0, _ := ret[0].(v1alpha1.SqlV1alpha1Statement)
+	ret0, _ := ret[0].(v1beta1.SqlV1beta1Statement)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -94,10 +94,10 @@ func (mr *MockGatewayClientInterfaceMockRecorder) GetStatement(arg0, arg1, arg2 
 }
 
 // GetStatementResults mocks base method.
-func (m *MockGatewayClientInterface) GetStatementResults(arg0, arg1, arg2, arg3 string) (v1alpha1.SqlV1alpha1StatementResult, error) {
+func (m *MockGatewayClientInterface) GetStatementResults(arg0, arg1, arg2, arg3 string) (v1beta1.SqlV1beta1StatementResult, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetStatementResults", arg0, arg1, arg2, arg3)
-	ret0, _ := ret[0].(v1alpha1.SqlV1alpha1StatementResult)
+	ret0, _ := ret[0].(v1beta1.SqlV1beta1StatementResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -109,10 +109,10 @@ func (mr *MockGatewayClientInterfaceMockRecorder) GetStatementResults(arg0, arg1
 }
 
 // ListStatements mocks base method.
-func (m *MockGatewayClientInterface) ListStatements(arg0, arg1, arg2, arg3 string) (v1alpha1.SqlV1alpha1StatementList, error) {
+func (m *MockGatewayClientInterface) ListStatements(arg0, arg1, arg2, arg3 string) (v1beta1.SqlV1beta1StatementList, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListStatements", arg0, arg1, arg2, arg3)
-	ret0, _ := ret[0].(v1alpha1.SqlV1alpha1StatementList)
+	ret0, _ := ret[0].(v1beta1.SqlV1beta1StatementList)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/pkg/flink/test/mock/gateway_client_mock.go
+++ b/pkg/flink/test/mock/gateway_client_mock.go
@@ -35,18 +35,18 @@ func (m *MockGatewayClientInterface) EXPECT() *MockGatewayClientInterfaceMockRec
 }
 
 // CreateStatement mocks base method.
-func (m *MockGatewayClientInterface) CreateStatement(arg0, arg1 string, arg2 map[string]string, arg3, arg4, arg5, arg6 string) (v1beta1.SqlV1beta1Statement, error) {
+func (m *MockGatewayClientInterface) CreateStatement(arg0 v1beta1.SqlV1beta1Statement, arg1, arg2, arg3, arg4 string) (v1beta1.SqlV1beta1Statement, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateStatement", arg0, arg1, arg2, arg3, arg4, arg5, arg6)
+	ret := m.ctrl.Call(m, "CreateStatement", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(v1beta1.SqlV1beta1Statement)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CreateStatement indicates an expected call of CreateStatement.
-func (mr *MockGatewayClientInterfaceMockRecorder) CreateStatement(arg0, arg1, arg2, arg3, arg4, arg5, arg6 interface{}) *gomock.Call {
+func (mr *MockGatewayClientInterfaceMockRecorder) CreateStatement(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateStatement", reflect.TypeOf((*MockGatewayClientInterface)(nil).CreateStatement), arg0, arg1, arg2, arg3, arg4, arg5, arg6)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateStatement", reflect.TypeOf((*MockGatewayClientInterface)(nil).CreateStatement), arg0, arg1, arg2, arg3, arg4)
 }
 
 // DeleteStatement mocks base method.

--- a/pkg/flink/types/result_fields.go
+++ b/pkg/flink/types/result_fields.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	flinkgatewayv1alpha1 "github.com/confluentinc/ccloud-sdk-go-v2/flink-gateway/v1alpha1"
+	flinkgatewayv1alpha1 "github.com/confluentinc/ccloud-sdk-go-v2/flink-gateway/v1beta1"
 )
 
 const (

--- a/pkg/flink/types/statement.go
+++ b/pkg/flink/types/statement.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	flinkgatewayv1alpha1 "github.com/confluentinc/ccloud-sdk-go-v2/flink-gateway/v1alpha1"
+	flinkgatewayv1beta1 "github.com/confluentinc/ccloud-sdk-go-v2/flink-gateway/v1beta1"
 
 	"github.com/confluentinc/cli/v3/pkg/flink/internal/utils"
 	"github.com/confluentinc/cli/v3/pkg/output"
@@ -33,18 +33,17 @@ type ProcessedStatement struct {
 	IsLocalStatement  bool
 	IsSelectStatement bool
 	PageToken         string
-	ResultSchema      flinkgatewayv1alpha1.SqlV1alpha1ResultSchema
+	ResultSchema      flinkgatewayv1beta1.SqlV1beta1ResultSchema
 	StatementResults  *StatementResults
 }
 
-func NewProcessedStatement(statementObj flinkgatewayv1alpha1.SqlV1alpha1Statement) *ProcessedStatement {
+func NewProcessedStatement(statementObj flinkgatewayv1beta1.SqlV1beta1Statement) *ProcessedStatement {
 	statement := strings.ToLower(strings.TrimSpace(statementObj.Spec.GetStatement()))
 	return &ProcessedStatement{
-		StatementName: statementObj.Spec.GetStatementName(),
-		ComputePool:   statementObj.Spec.GetComputePoolId(),
-		IdentityPool:  statementObj.Spec.GetIdentityPoolId(),
-		//TODO: add when v1beta1 statement SDK is ready
-		//ServiceAccount:    statementObj.Spec.GetServiceAccountId(),
+		StatementName:     statementObj.GetName(),
+		ComputePool:       statementObj.Spec.GetComputePoolId(),
+		IdentityPool:      statementObj.Spec.GetIdentityPoolId(),
+		ServiceAccount:    statementObj.GetPrincipal(),
 		StatusDetail:      statementObj.Status.GetDetail(),
 		Status:            PHASE(statementObj.Status.GetPhase()),
 		ResultSchema:      statementObj.Status.GetResultSchema(),

--- a/pkg/flink/types/statement.go
+++ b/pkg/flink/types/statement.go
@@ -42,8 +42,7 @@ func NewProcessedStatement(statementObj flinkgatewayv1beta1.SqlV1beta1Statement)
 	return &ProcessedStatement{
 		StatementName:     statementObj.GetName(),
 		ComputePool:       statementObj.Spec.GetComputePoolId(),
-		IdentityPool:      statementObj.Spec.GetIdentityPoolId(),
-		ServiceAccount:    statementObj.GetPrincipal(),
+		ServiceAccount:    statementObj.Spec.GetPrincipal(),
 		StatusDetail:      statementObj.Status.GetDetail(),
 		Status:            PHASE(statementObj.Status.GetPhase()),
 		ResultSchema:      statementObj.Status.GetResultSchema(),

--- a/pkg/flink/types/statement.go
+++ b/pkg/flink/types/statement.go
@@ -69,7 +69,7 @@ func (s ProcessedStatement) printStatusMessageOfLocalStatement() {
 
 func (s ProcessedStatement) printStatusMessageOfNonLocalStatement() {
 	if s.StatementName != "" {
-		utils.OutputInfof("Statement name: %s", s.StatementName)
+		utils.OutputInfof("Statement name: %s\n", s.StatementName)
 	}
 	if s.Status == "FAILED" {
 		utils.OutputErr(fmt.Sprintf("Error: %s", "statement submission failed"))

--- a/pkg/flink/types/statement_results.go
+++ b/pkg/flink/types/statement_results.go
@@ -3,7 +3,7 @@ package types
 import (
 	"strings"
 
-	flinkgatewayv1alpha1 "github.com/confluentinc/ccloud-sdk-go-v2/flink-gateway/v1alpha1"
+	flinkgatewayv1beta1 "github.com/confluentinc/ccloud-sdk-go-v2/flink-gateway/v1beta1"
 )
 
 type StatementResults struct {
@@ -77,6 +77,6 @@ func (s StatementResultOperation) String() string {
 }
 
 type MockStatementResult struct {
-	ResultSchema     flinkgatewayv1alpha1.SqlV1alpha1ResultSchema
-	StatementResults flinkgatewayv1alpha1.SqlV1alpha1StatementResult
+	ResultSchema     flinkgatewayv1beta1.SqlV1beta1ResultSchema
+	StatementResults flinkgatewayv1beta1.SqlV1beta1StatementResult
 }

--- a/test/test-server/flink_gateway_router.go
+++ b/test/test-server/flink_gateway_router.go
@@ -9,13 +9,13 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/require"
 
-	flinkgatewayv1alpha1 "github.com/confluentinc/ccloud-sdk-go-v2/flink-gateway/v1alpha1"
+	flinkgatewayv1beta1 "github.com/confluentinc/ccloud-sdk-go-v2/flink-gateway/v1beta1"
 )
 
 var flinkGatewayRoutes = []route{
-	{"/sql/v1alpha1/environments/{environment}/statements", handleSqlEnvironmentsEnvironmentStatements},
-	{"/sql/v1alpha1/environments/{environment}/statements/{statement}", handleSqlEnvironmentsEnvironmentStatementsStatement},
-	{"/sql/v1alpha1/environments/{environment}/statements/{statement}/exceptions", handleSqlEnvironmentsEnvironmentStatementExceptions},
+	{"/sql/v1beta1/organizations/{organization_id}/environments/{environment}/statements", handleSqlEnvironmentsEnvironmentStatements},
+	{"/sql/v1beta1/organizations/{organization_id}/environments/{environment}/statements/{statement}", handleSqlEnvironmentsEnvironmentStatementsStatement},
+	{"/sql/v1beta1/organizations/{organization_id}/environments/{environment}/statements/{statement}/exceptions", handleSqlEnvironmentsEnvironmentStatementExceptions},
 }
 
 func NewFlinkGatewayRouter(t *testing.T) *mux.Router {
@@ -33,30 +33,30 @@ func handleSqlEnvironmentsEnvironmentStatements(t *testing.T) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		creationDateStatement1 := time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC)
 		creationDateStatement2 := time.Date(2022, 1, 1, 0, 0, 0, 0, time.UTC)
-		statements := flinkgatewayv1alpha1.SqlV1alpha1StatementList{Data: []flinkgatewayv1alpha1.SqlV1alpha1Statement{
+		statements := flinkgatewayv1beta1.SqlV1beta1StatementList{Data: []flinkgatewayv1beta1.SqlV1beta1Statement{
 			{
-				Spec: &flinkgatewayv1alpha1.SqlV1alpha1StatementSpec{
-					StatementName: flinkgatewayv1alpha1.PtrString("11111111-1111-1111-1"),
-					Statement:     flinkgatewayv1alpha1.PtrString("CREATE TABLE test;"),
-					ComputePoolId: flinkgatewayv1alpha1.PtrString("lfcp-123456"),
+				Name: flinkgatewayv1beta1.PtrString("11111111-1111-1111-1"),
+				Spec: &flinkgatewayv1beta1.SqlV1beta1StatementSpec{
+					Statement:     flinkgatewayv1beta1.PtrString("CREATE TABLE test;"),
+					ComputePoolId: flinkgatewayv1beta1.PtrString("lfcp-123456"),
 				},
-				Status: &flinkgatewayv1alpha1.SqlV1alpha1StatementStatus{
+				Status: &flinkgatewayv1beta1.SqlV1beta1StatementStatus{
 					Phase:  "COMPLETED",
-					Detail: flinkgatewayv1alpha1.PtrString("SQL statement is completed"),
+					Detail: flinkgatewayv1beta1.PtrString("SQL statement is completed"),
 				},
-				Metadata: &flinkgatewayv1alpha1.ObjectMeta{CreatedAt: &creationDateStatement1},
+				Metadata: &flinkgatewayv1beta1.ObjectMeta{CreatedAt: &creationDateStatement1},
 			},
 			{
-				Spec: &flinkgatewayv1alpha1.SqlV1alpha1StatementSpec{
-					StatementName: flinkgatewayv1alpha1.PtrString("22222222-2222-2222-2"),
-					Statement:     flinkgatewayv1alpha1.PtrString("CREATE TABLE test;"),
-					ComputePoolId: flinkgatewayv1alpha1.PtrString("lfcp-123456"),
+				Name: flinkgatewayv1beta1.PtrString("22222222-2222-2222-2"),
+				Spec: &flinkgatewayv1beta1.SqlV1beta1StatementSpec{
+					Statement:     flinkgatewayv1beta1.PtrString("CREATE TABLE test;"),
+					ComputePoolId: flinkgatewayv1beta1.PtrString("lfcp-123456"),
 				},
-				Status: &flinkgatewayv1alpha1.SqlV1alpha1StatementStatus{
+				Status: &flinkgatewayv1beta1.SqlV1beta1StatementStatus{
 					Phase:  "COMPLETED",
-					Detail: flinkgatewayv1alpha1.PtrString("SQL statement is completed"),
+					Detail: flinkgatewayv1beta1.PtrString("SQL statement is completed"),
 				},
-				Metadata: &flinkgatewayv1alpha1.ObjectMeta{CreatedAt: &creationDateStatement2},
+				Metadata: &flinkgatewayv1beta1.ObjectMeta{CreatedAt: &creationDateStatement2},
 			},
 		}}
 
@@ -70,15 +70,15 @@ func handleSqlEnvironmentsEnvironmentStatementExceptions(t *testing.T) http.Hand
 		statementExceptionCreatedAt := time.Date(2022, 1, 1, 0, 0, 0, 0, time.UTC)
 		statementExceptionCreatedAt2 := time.Date(2022, 1, 1, 0, 0, 0, 0, time.UTC)
 		if r.Method == http.MethodGet {
-			statement := flinkgatewayv1alpha1.SqlV1alpha1StatementExceptionList{
-				Data: []flinkgatewayv1alpha1.SqlV1alpha1StatementException{{
+			statement := flinkgatewayv1beta1.SqlV1beta1StatementExceptionList{
+				Data: []flinkgatewayv1beta1.SqlV1beta1StatementException{{
 					Timestamp:  &statementExceptionCreatedAt,
-					Name:       flinkgatewayv1alpha1.PtrString("Bad exception"),
-					Stacktrace: flinkgatewayv1alpha1.PtrString("exception in foo.go"),
+					Name:       flinkgatewayv1beta1.PtrString("Bad exception"),
+					Stacktrace: flinkgatewayv1beta1.PtrString("exception in foo.go"),
 				}, {
 					Timestamp:  &statementExceptionCreatedAt2,
-					Name:       flinkgatewayv1alpha1.PtrString("another Bad exception"),
-					Stacktrace: flinkgatewayv1alpha1.PtrString("exception in bar.go"),
+					Name:       flinkgatewayv1beta1.PtrString("another Bad exception"),
+					Stacktrace: flinkgatewayv1beta1.PtrString("exception in bar.go"),
 				}},
 			}
 			err := json.NewEncoder(w).Encode(statement)
@@ -91,17 +91,17 @@ func handleSqlEnvironmentsEnvironmentStatementsStatement(t *testing.T) http.Hand
 	return func(w http.ResponseWriter, r *http.Request) {
 		statementCreatedAt := time.Date(2022, 1, 1, 0, 0, 0, 0, time.UTC)
 		if r.Method == http.MethodGet {
-			statement := flinkgatewayv1alpha1.SqlV1alpha1Statement{
-				Spec: &flinkgatewayv1alpha1.SqlV1alpha1StatementSpec{
-					StatementName: flinkgatewayv1alpha1.PtrString(mux.Vars(r)["statement"]),
-					Statement:     flinkgatewayv1alpha1.PtrString("CREATE TABLE test;"),
-					ComputePoolId: flinkgatewayv1alpha1.PtrString("pool-123456"),
+			statement := flinkgatewayv1beta1.SqlV1beta1Statement{
+				Name: flinkgatewayv1beta1.PtrString(mux.Vars(r)["statement"]),
+				Spec: &flinkgatewayv1beta1.SqlV1beta1StatementSpec{
+					Statement:     flinkgatewayv1beta1.PtrString("CREATE TABLE test;"),
+					ComputePoolId: flinkgatewayv1beta1.PtrString("pool-123456"),
 				},
-				Status: &flinkgatewayv1alpha1.SqlV1alpha1StatementStatus{
+				Status: &flinkgatewayv1beta1.SqlV1beta1StatementStatus{
 					Phase:  "TODO",
-					Detail: flinkgatewayv1alpha1.PtrString("TODO"),
+					Detail: flinkgatewayv1beta1.PtrString("TODO"),
 				},
-				Metadata: &flinkgatewayv1alpha1.ObjectMeta{CreatedAt: &statementCreatedAt},
+				Metadata: &flinkgatewayv1beta1.ObjectMeta{CreatedAt: &statementCreatedAt},
 			}
 			err := json.NewEncoder(w).Encode(statement)
 			require.NoError(t, err)


### PR DESCRIPTION

Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * no: DO NOT MERGE until the required features are live in prod  

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->
- adds support for using service accounts. When users want to run an interactive query with just their user identity, we display a warning, to let them know their statements will timeout after 4h.
- switches to v1beta1 SDK which supports service account in body

Merge after: #2210 and after https://github.com/confluentinc/cc-flink-gateway-service-v2/pull/326
