### PR TITLE
[TRAFFIC-9317] - Add `confluent network peering list` command

### DIFF
--- a/internal/network/command.go
+++ b/internal/network/command.go
@@ -76,9 +76,8 @@ func New(prerunner pcmd.PreRunner) *cobra.Command {
 	cmd.AddCommand(c.newDeleteCommand())
 	cmd.AddCommand(c.newDescribeCommand())
 	cmd.AddCommand(c.newListCommand())
-	cmd.AddCommand(c.newUpdateCommand())
-
 	cmd.AddCommand(newPeeringCommand(prerunner))
+	cmd.AddCommand(c.newUpdateCommand())
 
 	return cmd
 }

--- a/internal/network/command.go
+++ b/internal/network/command.go
@@ -71,11 +71,14 @@ func New(prerunner pcmd.PreRunner) *cobra.Command {
 	}
 
 	c := &command{pcmd.NewAuthenticatedCLICommand(cmd, prerunner)}
+
 	cmd.AddCommand(c.newCreateCommand())
 	cmd.AddCommand(c.newDeleteCommand())
 	cmd.AddCommand(c.newDescribeCommand())
 	cmd.AddCommand(c.newListCommand())
 	cmd.AddCommand(c.newUpdateCommand())
+
+	cmd.AddCommand(newPeeringCommand(prerunner))
 
 	return cmd
 }

--- a/internal/network/command_list.go
+++ b/internal/network/command_list.go
@@ -14,7 +14,7 @@ import (
 func (c *command) newListCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
-		Short: "Display networks in the current environment.",
+		Short: "List networks.",
 		Args:  cobra.NoArgs,
 		RunE:  c.list,
 	}

--- a/internal/network/command_peering.go
+++ b/internal/network/command_peering.go
@@ -1,0 +1,53 @@
+package network
+
+import (
+	"github.com/spf13/cobra"
+
+	networkingv1 "github.com/confluentinc/ccloud-sdk-go-v2/networking/v1"
+
+	pcmd "github.com/confluentinc/cli/v3/pkg/cmd"
+)
+
+type peeringCommand struct {
+	*pcmd.AuthenticatedCLICommand
+}
+
+type peeringHumanOut struct {
+	Id        string `human:"ID"`
+	Name      string `human:"Name"`
+	NetworkId string `human:"Network ID"`
+	Cloud     string `human:"Cloud"`
+	Phase     string `human:"Phase"`
+}
+
+type peeringSerializedOut struct {
+	Id        string `serialized:"id"`
+	Name      string `serialized:"name"`
+	NetworkId string `serialized:"network_id"`
+	Cloud     string `serialized:"cloud"`
+	Phase     string `serialized:"phase"`
+}
+
+func newPeeringCommand(prerunner pcmd.PreRunner) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:         "peering",
+		Short:       "Manage peering connections.",
+		Args:        cobra.NoArgs,
+		Annotations: map[string]string{pcmd.RunRequirement: pcmd.RequireNonAPIKeyCloudLogin},
+	}
+
+	c := &peeringCommand{AuthenticatedCLICommand: pcmd.NewAuthenticatedCLICommand(cmd, prerunner)}
+
+	cmd.AddCommand(c.newPeeringListCommand())
+
+	return cmd
+}
+
+func (c *peeringCommand) getPeerings() ([]networkingv1.NetworkingV1Peering, error) {
+	environmentId, err := c.Context.EnvironmentId()
+	if err != nil {
+		return nil, err
+	}
+
+	return c.V2Client.ListPeerings(environmentId)
+}

--- a/internal/network/command_peering.go
+++ b/internal/network/command_peering.go
@@ -46,10 +46,9 @@ type peeringSerializedOut struct {
 
 func newPeeringCommand(prerunner pcmd.PreRunner) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:         "peering",
-		Short:       "Manage peering connections.",
-		Args:        cobra.NoArgs,
-		Annotations: map[string]string{pcmd.RunRequirement: pcmd.RequireNonAPIKeyCloudLogin},
+		Use:   "peering",
+		Short: "Manage peering connections.",
+		Args:  cobra.NoArgs,
 	}
 
 	c := &peeringCommand{AuthenticatedCLICommand: pcmd.NewAuthenticatedCLICommand(cmd, prerunner)}

--- a/internal/network/command_peering.go
+++ b/internal/network/command_peering.go
@@ -13,19 +13,35 @@ type peeringCommand struct {
 }
 
 type peeringHumanOut struct {
-	Id        string `human:"ID"`
-	Name      string `human:"Name"`
-	NetworkId string `human:"Network ID"`
-	Cloud     string `human:"Cloud"`
-	Phase     string `human:"Phase"`
+	Id            string `human:"ID"`
+	Name          string `human:"Name"`
+	NetworkId     string `human:"Network ID"`
+	Cloud         string `human:"Cloud"`
+	Phase         string `human:"Phase"`
+	CustomRegion  string `human:"Custom Region,omitempty"`
+	AwsVpc        string `human:"AWS VPC,omitempty"`
+	AwsAccount    string `human:"AWS Account,omitempty"`
+	AwsRoutes     string `human:"AWS Routes,omitempty"`
+	GcpProject    string `human:"GCP Project,omitempty"`
+	GcpVpcNetwork string `human:"GCP VPC Network,omitempty"`
+	AzureVNet     string `human:"Azure VNet,omitempty"`
+	AzureTenant   string `human:"Azure Tenant,omitempty"`
 }
 
 type peeringSerializedOut struct {
-	Id        string `serialized:"id"`
-	Name      string `serialized:"name"`
-	NetworkId string `serialized:"network_id"`
-	Cloud     string `serialized:"cloud"`
-	Phase     string `serialized:"phase"`
+	Id            string   `serialized:"id"`
+	Name          string   `serialized:"name"`
+	NetworkId     string   `serialized:"network_id"`
+	Cloud         string   `serialized:"cloud"`
+	Phase         string   `serialized:"phase"`
+	CustomRegion  string   `serialized:"custom_region,omitempty"`
+	AwsVpc        string   `serialized:"aws_vpc,omitempty"`
+	AwsAccount    string   `serialized:"aws_account,omitempty"`
+	AwsRoutes     []string `serialized:"aws_routes,omitempty"`
+	GcpProject    string   `serialized:"gcp_project,omitempty"`
+	GcpVpcNetwork string   `serialized:"gcp_vpc_network,omitempty"`
+	AzureVNet     string   `serialized:"azure_vnet,omitempty"`
+	AzureTenant   string   `serialized:"azure_tenant,omitempty"`
 }
 
 func newPeeringCommand(prerunner pcmd.PreRunner) *cobra.Command {

--- a/internal/network/command_peering_list.go
+++ b/internal/network/command_peering_list.go
@@ -65,6 +65,7 @@ func (c *peeringCommand) list(cmd *cobra.Command, _ []string) error {
 			})
 		}
 	}
+	list.Filter([]string{"Id", "Name", "NetworkId", "Cloud", "Phase"})
 	return list.Print()
 }
 

--- a/internal/network/command_peering_list.go
+++ b/internal/network/command_peering_list.go
@@ -1,0 +1,83 @@
+package network
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	networkingv1 "github.com/confluentinc/ccloud-sdk-go-v2/networking/v1"
+
+	pcmd "github.com/confluentinc/cli/v3/pkg/cmd"
+	"github.com/confluentinc/cli/v3/pkg/errors"
+	"github.com/confluentinc/cli/v3/pkg/output"
+)
+
+func (c *peeringCommand) newPeeringListCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "Display peering connections in the current environment.",
+		Args:  cobra.NoArgs,
+		RunE:  c.list,
+	}
+
+	pcmd.AddContextFlag(cmd, c.CLICommand)
+	pcmd.AddEnvironmentFlag(cmd, c.AuthenticatedCLICommand)
+	pcmd.AddOutputFlag(cmd)
+
+	return cmd
+}
+
+func (c *peeringCommand) list(cmd *cobra.Command, _ []string) error {
+	peerings, err := c.getPeerings()
+	if err != nil {
+		return err
+	}
+
+	list := output.NewList(cmd)
+	for _, peering := range peerings {
+		if peering.Spec == nil {
+			return fmt.Errorf(errors.CorruptedNetworkResponseErrorMsg, "spec")
+		}
+		if peering.Status == nil {
+			return fmt.Errorf(errors.CorruptedNetworkResponseErrorMsg, "status")
+		}
+
+		cloud, err := getCloud(peering)
+		if err != nil {
+			return err
+		}
+
+		if output.GetFormat(cmd) == output.Human {
+			list.Add(&peeringHumanOut{
+				Id:        peering.GetId(),
+				Name:      peering.Spec.GetDisplayName(),
+				NetworkId: peering.Spec.Network.GetId(),
+				Cloud:     cloud,
+				Phase:     peering.Status.GetPhase(),
+			})
+		} else {
+			list.Add(&peeringSerializedOut{
+				Id:        peering.GetId(),
+				Name:      peering.Spec.GetDisplayName(),
+				NetworkId: peering.Spec.Network.GetId(),
+				Cloud:     cloud,
+				Phase:     peering.Status.GetPhase(),
+			})
+		}
+	}
+	return list.Print()
+}
+
+func getCloud(peering networkingv1.NetworkingV1Peering) (string, error) {
+	cloud := peering.Spec.GetCloud()
+
+	if cloud.NetworkingV1AwsPeering != nil {
+		return "AWS", nil
+	} else if cloud.NetworkingV1GcpPeering != nil {
+		return "GCP", nil
+	} else if cloud.NetworkingV1AzurePeering != nil {
+		return "Azure", nil
+	}
+
+	return "", fmt.Errorf(errors.CorruptedNetworkResponseErrorMsg, "cloud")
+}

--- a/internal/network/command_peering_list.go
+++ b/internal/network/command_peering_list.go
@@ -15,7 +15,7 @@ import (
 func (c *peeringCommand) newPeeringListCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
-		Short: "Display peering connections in the current environment.",
+		Short: "List peering connections.",
 		Args:  cobra.NoArgs,
 		RunE:  c.list,
 	}

--- a/pkg/ccloudv2/networking.go
+++ b/pkg/ccloudv2/networking.go
@@ -71,3 +71,33 @@ func (c *Client) executeListNetworks(environment, pageToken string) (networkingv
 	resp, httpResp, err := req.Execute()
 	return resp, errors.CatchCCloudV2Error(err, httpResp)
 }
+
+func (c *Client) ListPeerings(environment string) ([]networkingv1.NetworkingV1Peering, error) {
+	var list []networkingv1.NetworkingV1Peering
+
+	done := false
+	pageToken := ""
+	for !done {
+		page, err := c.executeListPeerings(environment, pageToken)
+		if err != nil {
+			return nil, err
+		}
+		list = append(list, page.GetData()...)
+
+		pageToken, done, err = extractNextPageToken(page.GetMetadata().Next)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return list, nil
+}
+
+func (c *Client) executeListPeerings(environment, pageToken string) (networkingv1.NetworkingV1PeeringList, error) {
+	req := c.NetworkingClient.PeeringsNetworkingV1Api.ListNetworkingV1Peerings(c.networkingApiContext()).Environment(environment).PageSize(ccloudV2ListPageSize)
+	if pageToken != "" {
+		req = req.PageToken(pageToken)
+	}
+
+	resp, httpResp, err := req.Execute()
+	return resp, errors.CatchCCloudV2Error(err, httpResp)
+}

--- a/test/fixtures/output/network/help.golden
+++ b/test/fixtures/output/network/help.golden
@@ -7,7 +7,7 @@ Available Commands:
   create      Create a network.
   delete      Delete one or more networks.
   describe    Describe a network.
-  list        Display networks in the current environment.
+  list        List networks.
   peering     Manage peering connections.
   update      Update an existing network.
 

--- a/test/fixtures/output/network/help.golden
+++ b/test/fixtures/output/network/help.golden
@@ -8,6 +8,7 @@ Available Commands:
   delete      Delete one or more networks.
   describe    Describe a network.
   list        Display networks in the current environment.
+  peering     Manage peering connections.
   update      Update an existing network.
 
 Global Flags:

--- a/test/fixtures/output/network/list-help.golden
+++ b/test/fixtures/output/network/list-help.golden
@@ -1,4 +1,4 @@
-Display networks in the current environment.
+List networks.
 
 Usage:
   confluent network list [flags]

--- a/test/fixtures/output/network/peering/help.golden
+++ b/test/fixtures/output/network/peering/help.golden
@@ -1,0 +1,14 @@
+Manage peering connections.
+
+Usage:
+  confluent network peering [command]
+
+Available Commands:
+  list        Display peering connections in the current environment.
+
+Global Flags:
+  -h, --help            Show help for this command.
+      --unsafe-trace    Equivalent to -vvvv, but also log HTTP requests and responses which might contain plaintext secrets.
+  -v, --verbose count   Increase verbosity (-v for warn, -vv for info, -vvv for debug, -vvvv for trace).
+
+Use "confluent network peering [command] --help" for more information about a command.

--- a/test/fixtures/output/network/peering/help.golden
+++ b/test/fixtures/output/network/peering/help.golden
@@ -4,7 +4,7 @@ Usage:
   confluent network peering [command]
 
 Available Commands:
-  list        Display peering connections in the current environment.
+  list        List peering connections.
 
 Global Flags:
   -h, --help            Show help for this command.

--- a/test/fixtures/output/network/peering/list-help.golden
+++ b/test/fixtures/output/network/peering/list-help.golden
@@ -1,4 +1,4 @@
-Display peering connections in the current environment.
+List peering connections.
 
 Usage:
   confluent network peering list [flags]

--- a/test/fixtures/output/network/peering/list-help.golden
+++ b/test/fixtures/output/network/peering/list-help.golden
@@ -1,0 +1,14 @@
+Display peering connections in the current environment.
+
+Usage:
+  confluent network peering list [flags]
+
+Flags:
+      --context string       CLI context name.
+      --environment string   Environment ID.
+  -o, --output string        Specify the output format as "human", "json", or "yaml". (default "human")
+
+Global Flags:
+  -h, --help            Show help for this command.
+      --unsafe-trace    Equivalent to -vvvv, but also log HTTP requests and responses which might contain plaintext secrets.
+  -v, --verbose count   Increase verbosity (-v for warn, -vv for info, -vvv for debug, -vvvv for trace).

--- a/test/fixtures/output/network/peering/list-json.golden
+++ b/test/fixtures/output/network/peering/list-json.golden
@@ -1,0 +1,23 @@
+[
+  {
+    "id": "peer-111111",
+    "name": "aws-peering",
+    "network_id": "n-abcde1",
+    "cloud": "AWS",
+    "phase": "READY"
+  },
+  {
+    "id": "peer-111112",
+    "name": "gcp-peering",
+    "network_id": "n-abcde1",
+    "cloud": "GCP",
+    "phase": "READY"
+  },
+  {
+    "id": "peer-111113",
+    "name": "azure-peering",
+    "network_id": "n-abcde1",
+    "cloud": "Azure",
+    "phase": "READY"
+  }
+]

--- a/test/fixtures/output/network/peering/list.golden
+++ b/test/fixtures/output/network/peering/list.golden
@@ -1,0 +1,5 @@
+      ID      |     Name      | Network ID | Cloud | Phase  
+--------------+---------------+------------+-------+--------
+  peer-111111 | aws-peering   | n-abcde1   | AWS   | READY  
+  peer-111112 | gcp-peering   | n-abcde1   | GCP   | READY  
+  peer-111113 | azure-peering | n-abcde1   | Azure | READY  

--- a/test/network_test.go
+++ b/test/network_test.go
@@ -90,3 +90,14 @@ func (s *CLITestSuite) TestNetwork_Autocomplete() {
 		s.runIntegrationTest(test)
 	}
 }
+
+func (s *CLITestSuite) TestNetworkPeeringList() {
+	tests := []CLITest{
+		{args: "network peering list", fixture: "network/peering/list.golden"},
+		{args: "network peering list --output json", fixture: "network/peering/list-json.golden"},
+	}
+	for _, test := range tests {
+		test.login = "cloud"
+		s.runIntegrationTest(test)
+	}
+}

--- a/test/test-server/ccloudv2_router.go
+++ b/test/test-server/ccloudv2_router.go
@@ -59,6 +59,7 @@ var ccloudV2Routes = []route{
 	{"/ksqldbcm/v2/clusters/{id}", handleKsqlCluster},
 	{"/networking/v1/networks", handleNetworkingNetworks},
 	{"/networking/v1/networks/{id}", handleNetworkingNetwork},
+	{"/networking/v1/peerings", handleNetworkingPeerings},
 	{"/org/v2/environments", handleOrgEnvironments},
 	{"/org/v2/environments/{id}", handleOrgEnvironment},
 	{"/org/v2/organizations", handleOrgOrganizations},


### PR DESCRIPTION
What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->
Note that this is merging into the feature branch https://github.com/confluentinc/cli/tree/traffic-8850-network-cli. We will merge commits into main from this feature branch after all of the commands for network are implemented

* Added `confluent network peering` to manage peering connections and `confluent network peering list` to display peering connections

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->
[CLI Commands Design](https://confluentinc.atlassian.net/wiki/spaces/PM/pages/2987394300/1-pager+--+Network+CLI)
[Implementation 1-Pager](https://confluentinc.atlassian.net/wiki/spaces/~712020463029eabbac401bbe1b033ce0d3a00e/pages/3136749631/Network+CLI)

Test & Review
-------------
<!--
Has it been tested? How?
Copy and paste any instructions or steps that can save the reviewer time.
-->
Added integration tests.

Performed manual tests

Open Questions / Follow-ups
---------------------------
<!--
Optional: Anything open to discussion for the reviewer, out of scope of this PR, or follow-ups.
-->