### PR TITLE
[TRAFFIC-9319] - Add `confluent network peering describe` command

### DIFF
--- a/internal/network/command.go
+++ b/internal/network/command.go
@@ -61,6 +61,10 @@ type command struct {
 var (
 	ConnectionTypes = []string{"privatelink", "peering", "transitgateway"}
 	DnsResolutions  = []string{"private", "chased-private"}
+
+	CloudAws   = "AWS"
+	CloudAzure = "AZURE"
+	CloudGcp   = "GCP"
 )
 
 func New(prerunner pcmd.PreRunner) *cobra.Command {
@@ -133,19 +137,19 @@ func printTable(cmd *cobra.Command, network networkingv1.NetworkingV1Network) er
 		}
 
 		switch cloud {
-		case "AWS":
+		case CloudAws:
 			human.AwsVpc = network.Status.Cloud.NetworkingV1AwsNetwork.GetVpc()
 			human.AwsAccount = network.Status.Cloud.NetworkingV1AwsNetwork.GetAccount()
 			serialized.AwsVpc = network.Status.Cloud.NetworkingV1AwsNetwork.GetVpc()
 			serialized.AwsAccount = network.Status.Cloud.NetworkingV1AwsNetwork.GetAccount()
 			describeFields = append(describeFields, "AwsVpc", "AwsAccount")
-		case "GCP":
+		case CloudGcp:
 			human.GcpVpcNetwork = network.Status.Cloud.NetworkingV1GcpNetwork.GetVpcNetwork()
 			human.GcpProject = network.Status.Cloud.NetworkingV1GcpNetwork.GetProject()
 			serialized.GcpVpcNetwork = network.Status.Cloud.NetworkingV1GcpNetwork.GetVpcNetwork()
 			serialized.GcpProject = network.Status.Cloud.NetworkingV1GcpNetwork.GetProject()
 			describeFields = append(describeFields, "GcpVpcNetwork", "GcpProject")
-		case "AZURE":
+		case CloudAzure:
 			human.AzureVNet = network.Status.Cloud.NetworkingV1AzureNetwork.GetVnet()
 			human.AzureSubscription = network.Status.Cloud.NetworkingV1AzureNetwork.GetSubscription()
 			serialized.AzureVNet = network.Status.Cloud.NetworkingV1AzureNetwork.GetVnet()

--- a/internal/network/command_peering_describe.go
+++ b/internal/network/command_peering_describe.go
@@ -1,0 +1,44 @@
+package network
+
+import (
+	"github.com/spf13/cobra"
+
+	pcmd "github.com/confluentinc/cli/v3/pkg/cmd"
+	"github.com/confluentinc/cli/v3/pkg/examples"
+)
+
+func (c *peeringCommand) newDescribeCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:               "describe <id>",
+		Short:             "Describe a peering connection.",
+		Args:              cobra.ExactArgs(1),
+		ValidArgsFunction: pcmd.NewValidArgsFunction(c.validArgs),
+		RunE:              c.describe,
+		Example: examples.BuildExampleString(
+			examples.Example{
+				Text: `Describe peering connection "peer-111111".`,
+				Code: "confluent network peering describe peer-111111",
+			},
+		),
+	}
+
+	pcmd.AddContextFlag(cmd, c.CLICommand)
+	pcmd.AddEnvironmentFlag(cmd, c.AuthenticatedCLICommand)
+	pcmd.AddOutputFlag(cmd)
+
+	return cmd
+}
+
+func (c *peeringCommand) describe(cmd *cobra.Command, args []string) error {
+	environmentId, err := c.Context.EnvironmentId()
+	if err != nil {
+		return err
+	}
+
+	peering, err := c.V2Client.GetPeering(environmentId, args[0])
+	if err != nil {
+		return err
+	}
+
+	return printPeeringTable(cmd, peering)
+}

--- a/internal/network/command_peering_list.go
+++ b/internal/network/command_peering_list.go
@@ -73,11 +73,11 @@ func getCloud(peering networkingv1.NetworkingV1Peering) (string, error) {
 	cloud := peering.Spec.GetCloud()
 
 	if cloud.NetworkingV1AwsPeering != nil {
-		return "AWS", nil
+		return CloudAws, nil
 	} else if cloud.NetworkingV1GcpPeering != nil {
-		return "GCP", nil
+		return CloudGcp, nil
 	} else if cloud.NetworkingV1AzurePeering != nil {
-		return "Azure", nil
+		return CloudAzure, nil
 	}
 
 	return "", fmt.Errorf(errors.CorruptedNetworkResponseErrorMsg, "cloud")

--- a/internal/network/command_peering_list.go
+++ b/internal/network/command_peering_list.go
@@ -5,14 +5,12 @@ import (
 
 	"github.com/spf13/cobra"
 
-	networkingv1 "github.com/confluentinc/ccloud-sdk-go-v2/networking/v1"
-
 	pcmd "github.com/confluentinc/cli/v3/pkg/cmd"
 	"github.com/confluentinc/cli/v3/pkg/errors"
 	"github.com/confluentinc/cli/v3/pkg/output"
 )
 
-func (c *peeringCommand) newPeeringListCommand() *cobra.Command {
+func (c *peeringCommand) newListCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List peering connections.",
@@ -67,18 +65,4 @@ func (c *peeringCommand) list(cmd *cobra.Command, _ []string) error {
 	}
 	list.Filter([]string{"Id", "Name", "NetworkId", "Cloud", "Phase"})
 	return list.Print()
-}
-
-func getCloud(peering networkingv1.NetworkingV1Peering) (string, error) {
-	cloud := peering.Spec.GetCloud()
-
-	if cloud.NetworkingV1AwsPeering != nil {
-		return CloudAws, nil
-	} else if cloud.NetworkingV1GcpPeering != nil {
-		return CloudGcp, nil
-	} else if cloud.NetworkingV1AzurePeering != nil {
-		return CloudAzure, nil
-	}
-
-	return "", fmt.Errorf(errors.CorruptedNetworkResponseErrorMsg, "cloud")
 }

--- a/internal/network/command_peering_list.go
+++ b/internal/network/command_peering_list.go
@@ -10,26 +10,15 @@ import (
 	"github.com/confluentinc/cli/v3/pkg/output"
 )
 
-type listPeeringHumanOut struct {
-	Id             string `human:"ID"`
-	Name           string `human:"Name"`
-	NetworkId      string `human:"Network ID"`
-	Cloud          string `human:"Cloud"`
-	CustomRegion   string `human:"Custom Region,omitempty"`
-	VirtualNetwork string `human:"Virtual Nework, omitempty"`
-	CloudAccount   string `human:"Cloud Account, omitempty"`
-	Phase          string `human:"Phase"`
-}
-
-type listPeeringSerializedOut struct {
-	Id             string `serialized:"id"`
-	Name           string `serialized:"name"`
-	NetworkId      string `serialized:"network_id"`
-	Cloud          string `serialized:"cloud"`
-	CustomRegion   string `serialized:"custom_region,omitempty"`
-	VirtualNetwork string `serialized:"virtual_network, omitempty"`
-	CloudAccount   string `serialized:"cloud_account, omitempty"`
-	Phase          string `serialized:"phase"`
+type listPeeringOut struct {
+	Id             string `human:"ID" serialized:"id"`
+	Name           string `human:"Name" serialized:"name"`
+	NetworkId      string `human:"Network ID" serialized:"network_id"`
+	Cloud          string `human:"Cloud" serialized:"cloud"`
+	CustomRegion   string `human:"Custom Region,omitempty" serialized:"custom_region,omitempty"`
+	VirtualNetwork string `human:"Virtual Nework,omitempty" serialized:"virtual_network,omitempty"`
+	CloudAccount   string `human:"Cloud Account,omitempty" serialized:"cloud_account,omitempty"`
+	Phase          string `human:"Phase" serialized:"phase"`
 }
 
 func (c *peeringCommand) newListCommand() *cobra.Command {
@@ -67,49 +56,28 @@ func (c *peeringCommand) list(cmd *cobra.Command, _ []string) error {
 			return err
 		}
 
-		human := &listPeeringHumanOut{
+		out := &listPeeringOut{
 			Id:        peering.GetId(),
 			Name:      peering.Spec.GetDisplayName(),
 			NetworkId: peering.Spec.Network.GetId(),
 			Cloud:     cloud,
 			Phase:     peering.Status.GetPhase(),
 		}
-
-		serialized := &listPeeringSerializedOut{
-			Id:        peering.GetId(),
-			Name:      peering.Spec.GetDisplayName(),
-			NetworkId: peering.Spec.Network.GetId(),
-			Cloud:     cloud,
-			Phase:     peering.Status.GetPhase(),
-		}
-
 		switch cloud {
 		case CloudAws:
-			human.CustomRegion = peering.Spec.Cloud.NetworkingV1AwsPeering.GetCustomerRegion()
-			human.VirtualNetwork = peering.Spec.Cloud.NetworkingV1AwsPeering.GetVpc()
-			human.CloudAccount = peering.Spec.Cloud.NetworkingV1AwsPeering.GetAccount()
-			serialized.CustomRegion = peering.Spec.Cloud.NetworkingV1AwsPeering.GetCustomerRegion()
-			serialized.VirtualNetwork = peering.Spec.Cloud.NetworkingV1AwsPeering.GetVpc()
-			serialized.CloudAccount = peering.Spec.Cloud.NetworkingV1AwsPeering.GetAccount()
+			out.CustomRegion = peering.Spec.Cloud.NetworkingV1AwsPeering.GetCustomerRegion()
+			out.VirtualNetwork = peering.Spec.Cloud.NetworkingV1AwsPeering.GetVpc()
+			out.CloudAccount = peering.Spec.Cloud.NetworkingV1AwsPeering.GetAccount()
 		case CloudGcp:
-			human.VirtualNetwork = peering.Spec.Cloud.NetworkingV1GcpPeering.GetVpcNetwork()
-			human.CloudAccount = peering.Spec.Cloud.NetworkingV1GcpPeering.GetProject()
-			serialized.VirtualNetwork = peering.Spec.Cloud.NetworkingV1GcpPeering.GetVpcNetwork()
-			serialized.CloudAccount = peering.Spec.Cloud.NetworkingV1GcpPeering.GetProject()
+			out.VirtualNetwork = peering.Spec.Cloud.NetworkingV1GcpPeering.GetVpcNetwork()
+			out.CloudAccount = peering.Spec.Cloud.NetworkingV1GcpPeering.GetProject()
 		case CloudAzure:
-			human.CustomRegion = peering.Spec.Cloud.NetworkingV1AzurePeering.GetCustomerRegion()
-			human.VirtualNetwork = peering.Spec.Cloud.NetworkingV1AzurePeering.GetVnet()
-			human.CloudAccount = peering.Spec.Cloud.NetworkingV1AzurePeering.GetTenant()
-			serialized.CustomRegion = peering.Spec.Cloud.NetworkingV1AzurePeering.GetCustomerRegion()
-			serialized.VirtualNetwork = peering.Spec.Cloud.NetworkingV1AzurePeering.GetVnet()
-			serialized.CloudAccount = peering.Spec.Cloud.NetworkingV1AzurePeering.GetTenant()
+			out.CustomRegion = peering.Spec.Cloud.NetworkingV1AzurePeering.GetCustomerRegion()
+			out.VirtualNetwork = peering.Spec.Cloud.NetworkingV1AzurePeering.GetVnet()
+			out.CloudAccount = peering.Spec.Cloud.NetworkingV1AzurePeering.GetTenant()
 		}
 
-		if output.GetFormat(cmd) == output.Human {
-			list.Add(human)
-		} else {
-			list.Add(serialized)
-		}
+		list.Add(out)
 	}
 	return list.Print()
 }

--- a/internal/network/command_peering_list.go
+++ b/internal/network/command_peering_list.go
@@ -16,7 +16,7 @@ type listPeeringHumanOut struct {
 	NetworkId      string `human:"Network ID"`
 	Cloud          string `human:"Cloud"`
 	CustomRegion   string `human:"Custom Region,omitempty"`
-	VirtualNetwork string `human:"Virtual Netwrok, omitempty"`
+	VirtualNetwork string `human:"Virtual Nework, omitempty"`
 	CloudAccount   string `human:"Cloud Account, omitempty"`
 	Phase          string `human:"Phase"`
 }

--- a/pkg/ccloudv2/networking.go
+++ b/pkg/ccloudv2/networking.go
@@ -101,3 +101,8 @@ func (c *Client) executeListPeerings(environment, pageToken string) (networkingv
 	resp, httpResp, err := req.Execute()
 	return resp, errors.CatchCCloudV2Error(err, httpResp)
 }
+
+func (c *Client) GetPeering(environment, id string) (networkingv1.NetworkingV1Peering, error) {
+	resp, httpResp, err := c.NetworkingClient.PeeringsNetworkingV1Api.GetNetworkingV1Peering(c.networkingApiContext(), id).Environment(environment).Execute()
+	return resp, errors.CatchCCloudV2Error(err, httpResp)
+}

--- a/test/fixtures/output/network/peering/describe-autocomplete.golden
+++ b/test/fixtures/output/network/peering/describe-autocomplete.golden
@@ -1,0 +1,5 @@
+peer-111111	aws-peering
+peer-111112	gcp-peering
+peer-111113	azure-peering
+:4
+Completion ended with directive: ShellCompDirectiveNoFileComp

--- a/test/fixtures/output/network/peering/describe-aws-json.golden
+++ b/test/fixtures/output/network/peering/describe-aws-json.golden
@@ -1,0 +1,11 @@
+{
+  "id": "peer-111111",
+  "name": "aws-peering",
+  "network_id": "n-abcde1",
+  "cloud": "AWS",
+  "phase": "READY",
+  "custom_region": "us-east-1",
+  "aws_vpc": "vpc-00000000000000000",
+  "aws_account": "000000000000",
+  "aws_routes": ["10.108.16.0/21"]
+}

--- a/test/fixtures/output/network/peering/describe-aws.golden
+++ b/test/fixtures/output/network/peering/describe-aws.golden
@@ -1,0 +1,11 @@
++---------------+-----------------------+
+| ID            | peer-111111           |
+| Name          | aws-peering           |
+| Network ID    | n-abcde1              |
+| Cloud         | AWS                   |
+| Phase         | READY                 |
+| Custom Region | us-east-1             |
+| AWS VPC       | vpc-00000000000000000 |
+| AWS Account   | 000000000000          |
+| AWS Routes    | 10.108.16.0/21        |
++---------------+-----------------------+

--- a/test/fixtures/output/network/peering/describe-azure.golden
+++ b/test/fixtures/output/network/peering/describe-azure.golden
@@ -1,0 +1,10 @@
++---------------+----------------------------------------------------------------------------------------------+
+| ID            | peer-111113                                                                                  |
+| Name          | azure-peering                                                                                |
+| Network ID    | n-abcde1                                                                                     |
+| Cloud         | AZURE                                                                                        |
+| Phase         | READY                                                                                        |
+| Custom Region | centralus                                                                                    |
+| Azure VNet    | /subscriptions/s-1/resourceGroups/group-1/providers/Microsoft.Network/virtualNetworks/vnet-1 |
+| Azure Tenant  | t-1                                                                                          |
++---------------+----------------------------------------------------------------------------------------------+

--- a/test/fixtures/output/network/peering/describe-gcp.golden
+++ b/test/fixtures/output/network/peering/describe-gcp.golden
@@ -1,0 +1,9 @@
++-----------------+-------------+
+| ID              | peer-111112 |
+| Name            | gcp-peering |
+| Network ID      | n-abcde1    |
+| Cloud           | GCP         |
+| Phase           | READY       |
+| GCP Project     | p-1         |
+| GCP VPC Network | v-1         |
++-----------------+-------------+

--- a/test/fixtures/output/network/peering/describe-help.golden
+++ b/test/fixtures/output/network/peering/describe-help.golden
@@ -1,0 +1,19 @@
+Describe a peering connection.
+
+Usage:
+  confluent network peering describe <id> [flags]
+
+Examples:
+Describe peering connection "peer-111111".
+
+  $ confluent network peering describe peer-111111
+
+Flags:
+      --context string       CLI context name.
+      --environment string   Environment ID.
+  -o, --output string        Specify the output format as "human", "json", or "yaml". (default "human")
+
+Global Flags:
+  -h, --help            Show help for this command.
+      --unsafe-trace    Equivalent to -vvvv, but also log HTTP requests and responses which might contain plaintext secrets.
+  -v, --verbose count   Increase verbosity (-v for warn, -vv for info, -vvv for debug, -vvvv for trace).

--- a/test/fixtures/output/network/peering/describe-invalid.golden
+++ b/test/fixtures/output/network/peering/describe-invalid.golden
@@ -1,0 +1,1 @@
+Error: The peering peer-invalid was not found.: 404 Not Found

--- a/test/fixtures/output/network/peering/describe-missing-id.golden
+++ b/test/fixtures/output/network/peering/describe-missing-id.golden
@@ -1,0 +1,19 @@
+Error: accepts 1 arg(s), received 0
+Usage:
+  confluent network peering describe <id> [flags]
+
+Examples:
+Describe peering connection "peer-111111".
+
+  $ confluent network peering describe peer-111111
+
+Flags:
+      --context string       CLI context name.
+      --environment string   Environment ID.
+  -o, --output string        Specify the output format as "human", "json", or "yaml". (default "human")
+
+Global Flags:
+  -h, --help            Show help for this command.
+      --unsafe-trace    Equivalent to -vvvv, but also log HTTP requests and responses which might contain plaintext secrets.
+  -v, --verbose count   Increase verbosity (-v for warn, -vv for info, -vvv for debug, -vvvv for trace).
+

--- a/test/fixtures/output/network/peering/help.golden
+++ b/test/fixtures/output/network/peering/help.golden
@@ -4,6 +4,7 @@ Usage:
   confluent network peering [command]
 
 Available Commands:
+  describe    Describe a peering connection.
   list        List peering connections.
 
 Global Flags:

--- a/test/fixtures/output/network/peering/list-json.golden
+++ b/test/fixtures/output/network/peering/list-json.golden
@@ -4,6 +4,9 @@
     "name": "aws-peering",
     "network_id": "n-abcde1",
     "cloud": "AWS",
+    "custom_region": "us-east-1",
+    "virtual_network": "vpc-00000000000000000",
+    "cloud_account": "000000000000",
     "phase": "READY"
   },
   {
@@ -11,6 +14,8 @@
     "name": "gcp-peering",
     "network_id": "n-abcde1",
     "cloud": "GCP",
+    "virtual_network": "v-1",
+    "cloud_account": "p-1",
     "phase": "READY"
   },
   {
@@ -18,6 +23,9 @@
     "name": "azure-peering",
     "network_id": "n-abcde1",
     "cloud": "AZURE",
+    "custom_region": "centralus",
+    "virtual_network": "/subscriptions/s-1/resourceGroups/group-1/providers/Microsoft.Network/virtualNetworks/vnet-1",
+    "cloud_account": "t-1",
     "phase": "READY"
   }
 ]

--- a/test/fixtures/output/network/peering/list-json.golden
+++ b/test/fixtures/output/network/peering/list-json.golden
@@ -17,7 +17,7 @@
     "id": "peer-111113",
     "name": "azure-peering",
     "network_id": "n-abcde1",
-    "cloud": "Azure",
+    "cloud": "AZURE",
     "phase": "READY"
   }
 ]

--- a/test/fixtures/output/network/peering/list.golden
+++ b/test/fixtures/output/network/peering/list.golden
@@ -1,5 +1,5 @@
-      ID      |     Name      | Network ID | Cloud | Phase  
---------------+---------------+------------+-------+--------
-  peer-111111 | aws-peering   | n-abcde1   | AWS   | READY  
-  peer-111112 | gcp-peering   | n-abcde1   | GCP   | READY  
-  peer-111113 | azure-peering | n-abcde1   | AZURE | READY  
+      ID      |     Name      | Network ID | Cloud | Custom Region |                                       Virtual Netwrok                                        | Cloud Account | Phase  
+--------------+---------------+------------+-------+---------------+----------------------------------------------------------------------------------------------+---------------+--------
+  peer-111111 | aws-peering   | n-abcde1   | AWS   | us-east-1     | vpc-00000000000000000                                                                        |  000000000000 | READY  
+  peer-111112 | gcp-peering   | n-abcde1   | GCP   |               | v-1                                                                                          | p-1           | READY  
+  peer-111113 | azure-peering | n-abcde1   | AZURE | centralus     | /subscriptions/s-1/resourceGroups/group-1/providers/Microsoft.Network/virtualNetworks/vnet-1 | t-1           | READY  

--- a/test/fixtures/output/network/peering/list.golden
+++ b/test/fixtures/output/network/peering/list.golden
@@ -2,4 +2,4 @@
 --------------+---------------+------------+-------+--------
   peer-111111 | aws-peering   | n-abcde1   | AWS   | READY  
   peer-111112 | gcp-peering   | n-abcde1   | GCP   | READY  
-  peer-111113 | azure-peering | n-abcde1   | Azure | READY  
+  peer-111113 | azure-peering | n-abcde1   | AZURE | READY  

--- a/test/fixtures/output/network/peering/list.golden
+++ b/test/fixtures/output/network/peering/list.golden
@@ -1,4 +1,4 @@
-      ID      |     Name      | Network ID | Cloud | Custom Region |                                       Virtual Netwrok                                        | Cloud Account | Phase  
+      ID      |     Name      | Network ID | Cloud | Custom Region |                                        Virtual Nework                                        | Cloud Account | Phase  
 --------------+---------------+------------+-------+---------------+----------------------------------------------------------------------------------------------+---------------+--------
   peer-111111 | aws-peering   | n-abcde1   | AWS   | us-east-1     | vpc-00000000000000000                                                                        |  000000000000 | READY  
   peer-111112 | gcp-peering   | n-abcde1   | GCP   |               | v-1                                                                                          | p-1           | READY  

--- a/test/network_test.go
+++ b/test/network_test.go
@@ -116,3 +116,13 @@ func (s *CLITestSuite) TestNetworkPeeringDescribe() {
 		s.runIntegrationTest(test)
 	}
 }
+
+func (s *CLITestSuite) TestNetworkPeering_Autocomplete() {
+	tests := []CLITest{
+		{args: `__complete network peering describe ""`, login: "cloud", fixture: "network/peering/describe-autocomplete.golden"},
+	}
+	for _, test := range tests {
+		test.login = "cloud"
+		s.runIntegrationTest(test)
+	}
+}

--- a/test/network_test.go
+++ b/test/network_test.go
@@ -101,3 +101,18 @@ func (s *CLITestSuite) TestNetworkPeeringList() {
 		s.runIntegrationTest(test)
 	}
 }
+
+func (s *CLITestSuite) TestNetworkPeeringDescribe() {
+	tests := []CLITest{
+		{args: "network peering describe peer-111111", fixture: "network/peering/describe-aws.golden"},
+		{args: "network peering describe peer-111111 --output json", fixture: "network/peering/describe-aws-json.golden"},
+		{args: "network peering describe peer-111112", fixture: "network/peering/describe-gcp.golden"},
+		{args: "network peering describe peer-111113", fixture: "network/peering/describe-azure.golden"},
+		{args: "network peering describe", fixture: "network/peering/describe-missing-id.golden", exitCode: 1},
+		{args: "network peering describe peer-invalid", fixture: "network/peering/describe-invalid.golden", exitCode: 1},
+	}
+	for _, test := range tests {
+		test.login = "cloud"
+		s.runIntegrationTest(test)
+	}
+}

--- a/test/test-server/ccloudv2_router.go
+++ b/test/test-server/ccloudv2_router.go
@@ -60,6 +60,7 @@ var ccloudV2Routes = []route{
 	{"/networking/v1/networks", handleNetworkingNetworks},
 	{"/networking/v1/networks/{id}", handleNetworkingNetwork},
 	{"/networking/v1/peerings", handleNetworkingPeerings},
+	{"/networking/v1/peerings/{id}", handleNetworkingPeering},
 	{"/org/v2/environments", handleOrgEnvironments},
 	{"/org/v2/environments/{id}", handleOrgEnvironment},
 	{"/org/v2/organizations", handleOrgOrganizations},

--- a/test/test-server/networking_handlers.go
+++ b/test/test-server/networking_handlers.go
@@ -39,6 +39,17 @@ func handleNetworkingNetworks(t *testing.T) http.HandlerFunc {
 	}
 }
 
+// Handler for "/networking/v1/peerings/{id}"
+func handleNetworkingPeering(t *testing.T) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		id := mux.Vars(r)["id"]
+		switch r.Method {
+		case http.MethodGet:
+			handleNetworkingPeeringGet(t, id)(w, r)
+		}
+	}
+}
+
 // Handler for "/networking/v1/peerings"
 func handleNetworkingPeerings(t *testing.T) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
@@ -366,4 +377,27 @@ func getPeering(id, name, cloud string) networkingv1.NetworkingV1Peering {
 		}
 	}
 	return peering
+}
+
+func handleNetworkingPeeringGet(t *testing.T, id string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		switch id {
+		case "peer-invalid":
+			w.WriteHeader(http.StatusNotFound)
+			err := writeErrorJson(w, "The peering peer-invalid was not found.")
+			require.NoError(t, err)
+		case "peer-111111":
+			peering := getPeering("peer-111111", "aws-peering", "AWS")
+			err := json.NewEncoder(w).Encode(peering)
+			require.NoError(t, err)
+		case "peer-111112":
+			peering := getPeering("peer-111112", "gcp-peering", "GCP")
+			err := json.NewEncoder(w).Encode(peering)
+			require.NoError(t, err)
+		case "peer-111113":
+			peering := getPeering("peer-111113", "azure-peering", "AZURE")
+			err := json.NewEncoder(w).Encode(peering)
+			require.NoError(t, err)
+		}
+	}
 }

--- a/test/test-server/networking_handlers.go
+++ b/test/test-server/networking_handlers.go
@@ -301,7 +301,7 @@ func handleNetworkingPeeringList(t *testing.T) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		awsPeering := getPeering("peer-111111", "aws-peering", "AWS")
 		gcpPeering := getPeering("peer-111112", "gcp-peering", "GCP")
-		azurePeering := getPeering("peer-111113", "azure-peering", "Azure")
+		azurePeering := getPeering("peer-111113", "azure-peering", "AZURE")
 
 		pageToken := r.URL.Query().Get("page_token")
 		var peeringList networkingv1.NetworkingV1PeeringList
@@ -357,7 +357,7 @@ func getPeering(id, name, cloud string) networkingv1.NetworkingV1Peering {
 			Project:    "p-1",
 			VpcNetwork: "v-1",
 		}
-	case "Azure":
+	case "AZURE":
 		peering.Spec.Cloud.NetworkingV1AzurePeering = &networkingv1.NetworkingV1AzurePeering{
 			Kind:           "AzurePeering",
 			Tenant:         "t-1",


### PR DESCRIPTION
What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->
Note that this is merging into the feature branch https://github.com/confluentinc/cli/tree/traffic-8850-network-cli. We will merge commits into main from this feature branch after all of the commands for network are implemented

* Added string constants `CloudAws`, `CloudGcp`, and `CloudAzure` to the `network` package as discussed in https://github.com/confluentinc/cli/pull/2227#discussion_r1310548820
* Updated output for `confluent network peering list`. I discussed with @kabraham13 regarding the `list` output that we could display `aws.account`, `gcp.project`, `azure.tenant` in the `Cloud Account` column, and `aws.vpc`, `gcp.vpc_network`, `azure.vnet` in the `Virtual Network` column. 
* Added `confluent network peering describe` to describe a peering connection
* Added autocompletion logic for peering commands

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->
[CLI Commands Design](https://confluentinc.atlassian.net/wiki/spaces/PM/pages/2987394300/1-pager+--+Network+CLI)
[Implementation 1-Pager](https://confluentinc.atlassian.net/wiki/spaces/~712020463029eabbac401bbe1b033ce0d3a00e/pages/3136749631/Network+CLI)

Test & Review
-------------
<!--
Has it been tested? How?
Copy and paste any instructions or steps that can save the reviewer time.
-->
Added integration tests.

Performed manual tests

Open Questions / Follow-ups
---------------------------
<!--
Optional: Anything open to discussion for the reviewer, out of scope of this PR, or follow-ups.
-->
