### PR TITLE
[TRAFFIC-9320] [TRAFFIC-9321] - Add `confluent network peering update|delete` command

### DIFF
--- a/internal/network/command_peering.go
+++ b/internal/network/command_peering.go
@@ -52,7 +52,7 @@ type peeringSerializedOut struct {
 func newPeeringCommand(prerunner pcmd.PreRunner) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "peering",
-		Short: "Manage peering connections.",
+		Short: "Manage peerings.",
 		Args:  cobra.NoArgs,
 	}
 

--- a/internal/network/command_peering.go
+++ b/internal/network/command_peering.go
@@ -58,6 +58,7 @@ func newPeeringCommand(prerunner pcmd.PreRunner) *cobra.Command {
 
 	c := &peeringCommand{AuthenticatedCLICommand: pcmd.NewAuthenticatedCLICommand(cmd, prerunner)}
 
+	cmd.AddCommand(c.newDeleteCommand())
 	cmd.AddCommand(c.newDescribeCommand())
 	cmd.AddCommand(c.newListCommand())
 	cmd.AddCommand(c.newUpdateCommand())

--- a/internal/network/command_peering.go
+++ b/internal/network/command_peering.go
@@ -60,6 +60,7 @@ func newPeeringCommand(prerunner pcmd.PreRunner) *cobra.Command {
 
 	cmd.AddCommand(c.newDescribeCommand())
 	cmd.AddCommand(c.newListCommand())
+	cmd.AddCommand(c.newUpdateCommand())
 
 	return cmd
 }

--- a/internal/network/command_peering_delete.go
+++ b/internal/network/command_peering_delete.go
@@ -1,0 +1,63 @@
+package network
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	pcmd "github.com/confluentinc/cli/v3/pkg/cmd"
+	"github.com/confluentinc/cli/v3/pkg/deletion"
+	"github.com/confluentinc/cli/v3/pkg/errors"
+	"github.com/confluentinc/cli/v3/pkg/output"
+	"github.com/confluentinc/cli/v3/pkg/resource"
+	"github.com/confluentinc/cli/v3/pkg/utils"
+)
+
+func (c *peeringCommand) newDeleteCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:               "delete <id-1> [id-2] ... [id-n]",
+		Short:             "Delete one or more peering connections.",
+		Args:              cobra.MinimumNArgs(1),
+		ValidArgsFunction: pcmd.NewValidArgsFunction(c.validArgsMultiple),
+		RunE:              c.delete,
+	}
+
+	pcmd.AddForceFlag(cmd)
+	pcmd.AddContextFlag(cmd, c.CLICommand)
+	pcmd.AddEnvironmentFlag(cmd, c.AuthenticatedCLICommand)
+
+	return cmd
+}
+
+func (c *peeringCommand) delete(cmd *cobra.Command, args []string) error {
+	environmentId, err := c.Context.EnvironmentId()
+	if err != nil {
+		return err
+	}
+
+	existenceFunc := func(id string) bool {
+		_, err := c.V2Client.GetPeering(environmentId, id)
+		return err == nil
+	}
+
+	if err := deletion.ValidateAndConfirmDeletionYesNo(cmd, args, existenceFunc, resource.Peering); err != nil {
+		return err
+	}
+
+	deleteFunc := func(id string) error {
+		if err := c.V2Client.DeletePeering(environmentId, id); err != nil {
+			return errors.Errorf(errors.DeleteResourceErrorMsg, resource.Peering, id, err)
+		}
+		return nil
+	}
+
+	deletedIds, err := deletion.DeleteWithoutMessage(args, deleteFunc)
+	deleteMsg := "Requested to delete %s %s.\n"
+	if len(deletedIds) == 1 {
+		output.Printf(deleteMsg, resource.Peering, fmt.Sprintf(`"%s"`, deletedIds[0]))
+	} else if len(deletedIds) > 1 {
+		output.Printf(deleteMsg, resource.Plural(resource.Peering), utils.ArrayToCommaDelimitedString(deletedIds, "and"))
+	}
+
+	return err
+}

--- a/internal/network/command_peering_delete.go
+++ b/internal/network/command_peering_delete.go
@@ -16,7 +16,7 @@ import (
 func (c *peeringCommand) newDeleteCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "delete <id-1> [id-2] ... [id-n]",
-		Short:             "Delete one or more peering connections.",
+		Short:             "Delete one or more peerings.",
 		Args:              cobra.MinimumNArgs(1),
 		ValidArgsFunction: pcmd.NewValidArgsFunction(c.validArgsMultiple),
 		RunE:              c.delete,

--- a/internal/network/command_peering_describe.go
+++ b/internal/network/command_peering_describe.go
@@ -10,13 +10,13 @@ import (
 func (c *peeringCommand) newDescribeCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "describe <id>",
-		Short:             "Describe a peering connection.",
+		Short:             "Describe a peering.",
 		Args:              cobra.ExactArgs(1),
 		ValidArgsFunction: pcmd.NewValidArgsFunction(c.validArgs),
 		RunE:              c.describe,
 		Example: examples.BuildExampleString(
 			examples.Example{
-				Text: `Describe peering connection "peer-111111".`,
+				Text: `Describe peering "peer-111111".`,
 				Code: "confluent network peering describe peer-111111",
 			},
 		),

--- a/internal/network/command_peering_list.go
+++ b/internal/network/command_peering_list.go
@@ -24,7 +24,7 @@ type listPeeringOut struct {
 func (c *peeringCommand) newListCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
-		Short: "List peering connections.",
+		Short: "List peerings.",
 		Args:  cobra.NoArgs,
 		RunE:  c.list,
 	}

--- a/internal/network/command_peering_update.go
+++ b/internal/network/command_peering_update.go
@@ -1,0 +1,61 @@
+package network
+
+import (
+	"github.com/spf13/cobra"
+
+	networkingv1 "github.com/confluentinc/ccloud-sdk-go-v2/networking/v1"
+
+	pcmd "github.com/confluentinc/cli/v3/pkg/cmd"
+	"github.com/confluentinc/cli/v3/pkg/examples"
+)
+
+func (c *peeringCommand) newUpdateCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:               "update <id>",
+		Short:             "Update an existing peering connection.",
+		Args:              cobra.ExactArgs(1),
+		ValidArgsFunction: pcmd.NewValidArgsFunction(c.validArgs),
+		RunE:              c.update,
+		Example: examples.BuildExampleString(
+			examples.Example{
+				Text: `Update the name of peering "peer-111111"`,
+				Code: `confluent network peering update peer-111111 --name "new name"`,
+			},
+		),
+	}
+
+	cmd.Flags().String("name", "", "Name of the peering.")
+	pcmd.AddContextFlag(cmd, c.CLICommand)
+	pcmd.AddEnvironmentFlag(cmd, c.AuthenticatedCLICommand)
+	pcmd.AddOutputFlag(cmd)
+
+	cobra.CheckErr(cmd.MarkFlagRequired("name"))
+
+	return cmd
+}
+
+func (c *peeringCommand) update(cmd *cobra.Command, args []string) error {
+	environmentId, err := c.Context.EnvironmentId()
+	if err != nil {
+		return err
+	}
+
+	name, err := cmd.Flags().GetString("name")
+	if err != nil {
+		return err
+	}
+
+	updatePeering := networkingv1.NetworkingV1PeeringUpdate{
+		Spec: &networkingv1.NetworkingV1PeeringSpecUpdate{
+			DisplayName: networkingv1.PtrString(name),
+			Environment: &networkingv1.ObjectReference{Id: environmentId},
+		},
+	}
+
+	peering, err := c.V2Client.UpdatePeering(environmentId, args[0], updatePeering)
+	if err != nil {
+		return err
+	}
+
+	return printPeeringTable(cmd, peering)
+}

--- a/internal/network/command_peering_update.go
+++ b/internal/network/command_peering_update.go
@@ -12,7 +12,7 @@ import (
 func (c *peeringCommand) newUpdateCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "update <id>",
-		Short:             "Update an existing peering connection.",
+		Short:             "Update an existing peering.",
 		Args:              cobra.ExactArgs(1),
 		ValidArgsFunction: pcmd.NewValidArgsFunction(c.validArgs),
 		RunE:              c.update,

--- a/pkg/ccloudv2/networking.go
+++ b/pkg/ccloudv2/networking.go
@@ -111,3 +111,8 @@ func (c *Client) UpdatePeering(environment, id string, peeringUpdate networkingv
 	resp, httpResp, err := c.NetworkingClient.PeeringsNetworkingV1Api.UpdateNetworkingV1Peering(c.networkingApiContext(), id).NetworkingV1PeeringUpdate(peeringUpdate).Execute()
 	return resp, errors.CatchCCloudV2Error(err, httpResp)
 }
+
+func (c *Client) DeletePeering(environment, id string) error {
+	httpResp, err := c.NetworkingClient.PeeringsNetworkingV1Api.DeleteNetworkingV1Peering(c.networkingApiContext(), id).Environment(environment).Execute()
+	return errors.CatchCCloudV2Error(err, httpResp)
+}

--- a/pkg/ccloudv2/networking.go
+++ b/pkg/ccloudv2/networking.go
@@ -106,3 +106,8 @@ func (c *Client) GetPeering(environment, id string) (networkingv1.NetworkingV1Pe
 	resp, httpResp, err := c.NetworkingClient.PeeringsNetworkingV1Api.GetNetworkingV1Peering(c.networkingApiContext(), id).Environment(environment).Execute()
 	return resp, errors.CatchCCloudV2Error(err, httpResp)
 }
+
+func (c *Client) UpdatePeering(environment, id string, peeringUpdate networkingv1.NetworkingV1PeeringUpdate) (networkingv1.NetworkingV1Peering, error) {
+	resp, httpResp, err := c.NetworkingClient.PeeringsNetworkingV1Api.UpdateNetworkingV1Peering(c.networkingApiContext(), id).NetworkingV1PeeringUpdate(peeringUpdate).Execute()
+	return resp, errors.CatchCCloudV2Error(err, httpResp)
+}

--- a/pkg/resource/resource.go
+++ b/pkg/resource/resource.go
@@ -35,6 +35,7 @@ const (
 	MirrorTopic                 = "mirror topic"
 	Network                     = "network"
 	Organization                = "organization"
+	Peering                     = "peering"
 	ProviderShare               = "provider share"
 	Pipeline                    = "pipeline"
 	SchemaExporter              = "schema exporter"
@@ -162,7 +163,7 @@ func Plural(resource string) string {
 	}
 
 	// Singular words ending w/ these suffixes generally add an extra -es syllable in their plural forms
-	var pluralExtraSyllableSuffix = types.NewSet("s", "x", "z", "ch", "sh")
+	pluralExtraSyllableSuffix := types.NewSet("s", "x", "z", "ch", "sh")
 
 	for suffix := range pluralExtraSyllableSuffix {
 		if strings.HasSuffix(resource, suffix) {

--- a/pkg/resource/resource.go
+++ b/pkg/resource/resource.go
@@ -163,7 +163,7 @@ func Plural(resource string) string {
 	}
 
 	// Singular words ending w/ these suffixes generally add an extra -es syllable in their plural forms
-	pluralExtraSyllableSuffix := types.NewSet("s", "x", "z", "ch", "sh")
+	var pluralExtraSyllableSuffix = types.NewSet("s", "x", "z", "ch", "sh")
 
 	for suffix := range pluralExtraSyllableSuffix {
 		if strings.HasSuffix(resource, suffix) {

--- a/test/fixtures/output/network/help.golden
+++ b/test/fixtures/output/network/help.golden
@@ -8,7 +8,7 @@ Available Commands:
   delete      Delete one or more networks.
   describe    Describe a network.
   list        List networks.
-  peering     Manage peering connections.
+  peering     Manage peerings.
   update      Update an existing network.
 
 Global Flags:

--- a/test/fixtures/output/network/peering/delete-help.golden
+++ b/test/fixtures/output/network/peering/delete-help.golden
@@ -1,0 +1,14 @@
+Delete one or more peering connections.
+
+Usage:
+  confluent network peering delete <id-1> [id-2] ... [id-n] [flags]
+
+Flags:
+      --force                Skip the deletion confirmation prompt.
+      --context string       CLI context name.
+      --environment string   Environment ID.
+
+Global Flags:
+  -h, --help            Show help for this command.
+      --unsafe-trace    Equivalent to -vvvv, but also log HTTP requests and responses which might contain plaintext secrets.
+  -v, --verbose count   Increase verbosity (-v for warn, -vv for info, -vvv for debug, -vvvv for trace).

--- a/test/fixtures/output/network/peering/delete-help.golden
+++ b/test/fixtures/output/network/peering/delete-help.golden
@@ -1,4 +1,4 @@
-Delete one or more peering connections.
+Delete one or more peerings.
 
 Usage:
   confluent network peering delete <id-1> [id-2] ... [id-n] [flags]

--- a/test/fixtures/output/network/peering/delete-multiple-fail.golden
+++ b/test/fixtures/output/network/peering/delete-multiple-fail.golden
@@ -1,0 +1,4 @@
+Error: peering "peer-invalid" not found
+
+Suggestions:
+    List available peerings with `confluent network peering list`.

--- a/test/fixtures/output/network/peering/delete-multiple-refuse.golden
+++ b/test/fixtures/output/network/peering/delete-multiple-refuse.golden
@@ -1,0 +1,1 @@
+Are you sure you want to delete peerings "peer-111111" and "peer-111112"? (y/n): 

--- a/test/fixtures/output/network/peering/delete-multiple-success.golden
+++ b/test/fixtures/output/network/peering/delete-multiple-success.golden
@@ -1,0 +1,1 @@
+Are you sure you want to delete peerings "peer-111111" and "peer-111112"? (y/n): Requested to delete peerings "peer-111111" and "peer-111112".

--- a/test/fixtures/output/network/peering/delete-peering-not-exist.golden
+++ b/test/fixtures/output/network/peering/delete-peering-not-exist.golden
@@ -1,0 +1,4 @@
+Error: peering "peer-invalid" not found
+
+Suggestions:
+    List available peerings with `confluent network peering list`.

--- a/test/fixtures/output/network/peering/delete-prompt.golden
+++ b/test/fixtures/output/network/peering/delete-prompt.golden
@@ -1,0 +1,1 @@
+Are you sure you want to delete peering "peer-111111"? (y/n): Requested to delete peering "peer-111111".

--- a/test/fixtures/output/network/peering/delete.golden
+++ b/test/fixtures/output/network/peering/delete.golden
@@ -1,0 +1,1 @@
+Requested to delete peering "peer-111111".

--- a/test/fixtures/output/network/peering/describe-help.golden
+++ b/test/fixtures/output/network/peering/describe-help.golden
@@ -1,10 +1,10 @@
-Describe a peering connection.
+Describe a peering.
 
 Usage:
   confluent network peering describe <id> [flags]
 
 Examples:
-Describe peering connection "peer-111111".
+Describe peering "peer-111111".
 
   $ confluent network peering describe peer-111111
 

--- a/test/fixtures/output/network/peering/describe-missing-id.golden
+++ b/test/fixtures/output/network/peering/describe-missing-id.golden
@@ -3,7 +3,7 @@ Usage:
   confluent network peering describe <id> [flags]
 
 Examples:
-Describe peering connection "peer-111111".
+Describe peering "peer-111111".
 
   $ confluent network peering describe peer-111111
 

--- a/test/fixtures/output/network/peering/help.golden
+++ b/test/fixtures/output/network/peering/help.golden
@@ -6,6 +6,7 @@ Usage:
 Available Commands:
   describe    Describe a peering connection.
   list        List peering connections.
+  update      Update an existing peering connection.
 
 Global Flags:
   -h, --help            Show help for this command.

--- a/test/fixtures/output/network/peering/help.golden
+++ b/test/fixtures/output/network/peering/help.golden
@@ -1,13 +1,13 @@
-Manage peering connections.
+Manage peerings.
 
 Usage:
   confluent network peering [command]
 
 Available Commands:
-  delete      Delete one or more peering connections.
-  describe    Describe a peering connection.
-  list        List peering connections.
-  update      Update an existing peering connection.
+  delete      Delete one or more peerings.
+  describe    Describe a peering.
+  list        List peerings.
+  update      Update an existing peering.
 
 Global Flags:
   -h, --help            Show help for this command.

--- a/test/fixtures/output/network/peering/help.golden
+++ b/test/fixtures/output/network/peering/help.golden
@@ -4,6 +4,7 @@ Usage:
   confluent network peering [command]
 
 Available Commands:
+  delete      Delete one or more peering connections.
   describe    Describe a peering connection.
   list        List peering connections.
   update      Update an existing peering connection.

--- a/test/fixtures/output/network/peering/list-help.golden
+++ b/test/fixtures/output/network/peering/list-help.golden
@@ -1,4 +1,4 @@
-List peering connections.
+List peerings.
 
 Usage:
   confluent network peering list [flags]

--- a/test/fixtures/output/network/peering/update-help.golden
+++ b/test/fixtures/output/network/peering/update-help.golden
@@ -1,4 +1,4 @@
-Update an existing peering connection.
+Update an existing peering.
 
 Usage:
   confluent network peering update <id> [flags]

--- a/test/fixtures/output/network/peering/update-help.golden
+++ b/test/fixtures/output/network/peering/update-help.golden
@@ -1,0 +1,20 @@
+Update an existing peering connection.
+
+Usage:
+  confluent network peering update <id> [flags]
+
+Examples:
+Update the name of peering "peer-111111"
+
+  $ confluent network peering update peer-111111 --name "new name"
+
+Flags:
+      --name string          REQUIRED: Name of the peering.
+      --context string       CLI context name.
+      --environment string   Environment ID.
+  -o, --output string        Specify the output format as "human", "json", or "yaml". (default "human")
+
+Global Flags:
+  -h, --help            Show help for this command.
+      --unsafe-trace    Equivalent to -vvvv, but also log HTTP requests and responses which might contain plaintext secrets.
+  -v, --verbose count   Increase verbosity (-v for warn, -vv for info, -vvv for debug, -vvvv for trace).

--- a/test/fixtures/output/network/peering/update-missing-args.golden
+++ b/test/fixtures/output/network/peering/update-missing-args.golden
@@ -1,0 +1,20 @@
+Error: accepts 1 arg(s), received 0
+Usage:
+  confluent network peering update <id> [flags]
+
+Examples:
+Update the name of peering "peer-111111"
+
+  $ confluent network peering update peer-111111 --name "new name"
+
+Flags:
+      --name string          Name of the peering.
+      --context string       CLI context name.
+      --environment string   Environment ID.
+  -o, --output string        Specify the output format as "human", "json", or "yaml". (default "human")
+
+Global Flags:
+  -h, --help            Show help for this command.
+      --unsafe-trace    Equivalent to -vvvv, but also log HTTP requests and responses which might contain plaintext secrets.
+  -v, --verbose count   Increase verbosity (-v for warn, -vv for info, -vvv for debug, -vvvv for trace).
+

--- a/test/fixtures/output/network/peering/update-missing-flags.golden
+++ b/test/fixtures/output/network/peering/update-missing-flags.golden
@@ -1,0 +1,20 @@
+Error: required flag(s) "name" not set
+Usage:
+  confluent network peering update <id> [flags]
+
+Examples:
+Update the name of peering "peer-111111"
+
+  $ confluent network peering update peer-111111 --name "new name"
+
+Flags:
+      --name string          REQUIRED: Name of the peering.
+      --context string       CLI context name.
+      --environment string   Environment ID.
+  -o, --output string        Specify the output format as "human", "json", or "yaml". (default "human")
+
+Global Flags:
+  -h, --help            Show help for this command.
+      --unsafe-trace    Equivalent to -vvvv, but also log HTTP requests and responses which might contain plaintext secrets.
+  -v, --verbose count   Increase verbosity (-v for warn, -vv for info, -vvv for debug, -vvvv for trace).
+

--- a/test/fixtures/output/network/peering/update-peering-not-exist.golden
+++ b/test/fixtures/output/network/peering/update-peering-not-exist.golden
@@ -1,0 +1,1 @@
+Error: The peering peer-invalid was not found.: 404 Not Found

--- a/test/fixtures/output/network/peering/update.golden
+++ b/test/fixtures/output/network/peering/update.golden
@@ -1,0 +1,11 @@
++---------------+-----------------------+
+| ID            | peer-111111           |
+| Name          | new-peering-name      |
+| Network ID    | n-abcde1              |
+| Cloud         | AWS                   |
+| Phase         | READY                 |
+| Custom Region | us-east-1             |
+| AWS VPC       | vpc-00000000000000000 |
+| AWS Account   | 000000000000          |
+| AWS Routes    | 10.108.16.0/21        |
++---------------+-----------------------+

--- a/test/network_test.go
+++ b/test/network_test.go
@@ -136,6 +136,22 @@ func (s *CLITestSuite) TestNetworkPeeringUpdate() {
 	}
 }
 
+func (s *CLITestSuite) TestNetworkPeeringDelete() {
+	tests := []CLITest{
+		{args: "network peering delete peer-111111 --force", fixture: "network/peering/delete.golden"},
+		{args: "network peering delete peer-111111", input: "y\n", fixture: "network/peering/delete-prompt.golden"},
+		{args: "network peering delete peer-111111 peer-invalid", fixture: "network/peering/delete-multiple-fail.golden", exitCode: 1},
+		{args: "network peering delete peer-111111 peer-111112", input: "n\n", fixture: "network/peering/delete-multiple-refuse.golden"},
+		{args: "network peering delete peer-111111 peer-111112", input: "y\n", fixture: "network/peering/delete-multiple-success.golden"},
+		{args: "network peering delete peer-invalid --force", fixture: "network/peering/delete-peering-not-exist.golden", exitCode: 1},
+	}
+
+	for _, test := range tests {
+		test.login = "cloud"
+		s.runIntegrationTest(test)
+	}
+}
+
 func (s *CLITestSuite) TestNetworkPeering_Autocomplete() {
 	tests := []CLITest{
 		{args: `__complete network peering describe ""`, login: "cloud", fixture: "network/peering/describe-autocomplete.golden"},

--- a/test/network_test.go
+++ b/test/network_test.go
@@ -13,6 +13,7 @@ func (s *CLITestSuite) TestNetworkDescribe() {
 		{args: "network describe", fixture: "network/describe-missing-id.golden", exitCode: 1},
 		{args: "network describe n-invalid", fixture: "network/describe-invalid.golden", exitCode: 1},
 	}
+
 	for _, test := range tests {
 		test.login = "cloud"
 		s.runIntegrationTest(test)
@@ -29,6 +30,7 @@ func (s *CLITestSuite) TestNetworkDelete() {
 		{args: "network delete n-dependency --force", fixture: "network/delete-network-with-dependency.golden", exitCode: 1},
 		{args: "network delete n-invalid --force", fixture: "network/delete-network-not-exist.golden", exitCode: 1},
 	}
+
 	for _, test := range tests {
 		test.login = "cloud"
 		s.runIntegrationTest(test)
@@ -85,6 +87,7 @@ func (s *CLITestSuite) TestNetwork_Autocomplete() {
 		{args: `__complete network create new-network --connection-types ""`, login: "cloud", fixture: "network/create-autocomplete-connection-types.golden"},
 		{args: `__complete network create new-network --dns-resolution ""`, login: "cloud", fixture: "network/create-autocomplete-dns-resolution.golden"},
 	}
+
 	for _, test := range tests {
 		test.login = "cloud"
 		s.runIntegrationTest(test)
@@ -96,6 +99,7 @@ func (s *CLITestSuite) TestNetworkPeeringList() {
 		{args: "network peering list", fixture: "network/peering/list.golden"},
 		{args: "network peering list --output json", fixture: "network/peering/list-json.golden"},
 	}
+
 	for _, test := range tests {
 		test.login = "cloud"
 		s.runIntegrationTest(test)
@@ -111,6 +115,21 @@ func (s *CLITestSuite) TestNetworkPeeringDescribe() {
 		{args: "network peering describe", fixture: "network/peering/describe-missing-id.golden", exitCode: 1},
 		{args: "network peering describe peer-invalid", fixture: "network/peering/describe-invalid.golden", exitCode: 1},
 	}
+
+	for _, test := range tests {
+		test.login = "cloud"
+		s.runIntegrationTest(test)
+	}
+}
+
+func (s *CLITestSuite) TestNetworkPeeringUpdate() {
+	tests := []CLITest{
+		{args: "network peering update", fixture: "network/peering/update-missing-args.golden", exitCode: 1},
+		{args: "network peering update peer-111111", fixture: "network/peering/update-missing-flags.golden", exitCode: 1},
+		{args: "network peering update peer-111111 --name new-peering-name", fixture: "network/peering/update.golden"},
+		{args: "network peering update peer-invalid --name new-peering-name", fixture: "network/peering/update-peering-not-exist.golden", exitCode: 1},
+	}
+
 	for _, test := range tests {
 		test.login = "cloud"
 		s.runIntegrationTest(test)
@@ -121,6 +140,7 @@ func (s *CLITestSuite) TestNetworkPeering_Autocomplete() {
 	tests := []CLITest{
 		{args: `__complete network peering describe ""`, login: "cloud", fixture: "network/peering/describe-autocomplete.golden"},
 	}
+
 	for _, test := range tests {
 		test.login = "cloud"
 		s.runIntegrationTest(test)

--- a/test/test-server/networking_handlers.go
+++ b/test/test-server/networking_handlers.go
@@ -46,6 +46,8 @@ func handleNetworkingPeering(t *testing.T) http.HandlerFunc {
 		switch r.Method {
 		case http.MethodGet:
 			handleNetworkingPeeringGet(t, id)(w, r)
+		case http.MethodPatch:
+			handleNetworkingPeeringUpdate(t, id)(w, r)
 		}
 	}
 }
@@ -397,6 +399,25 @@ func handleNetworkingPeeringGet(t *testing.T, id string) http.HandlerFunc {
 		case "peer-111113":
 			peering := getPeering("peer-111113", "azure-peering", "AZURE")
 			err := json.NewEncoder(w).Encode(peering)
+			require.NoError(t, err)
+		}
+	}
+}
+
+func handleNetworkingPeeringUpdate(t *testing.T, id string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		switch id {
+		case "peer-invalid":
+			w.WriteHeader(http.StatusNotFound)
+			err := writeErrorJson(w, "The peering peer-invalid was not found.")
+			require.NoError(t, err)
+		case "peer-111111":
+			body := &networkingv1.NetworkingV1Network{}
+			err := json.NewDecoder(r.Body).Decode(body)
+			require.NoError(t, err)
+
+			peering := getPeering("peer-111111", body.Spec.GetDisplayName(), "AWS")
+			err = json.NewEncoder(w).Encode(peering)
 			require.NoError(t, err)
 		}
 	}

--- a/test/test-server/networking_handlers.go
+++ b/test/test-server/networking_handlers.go
@@ -48,6 +48,8 @@ func handleNetworkingPeering(t *testing.T) http.HandlerFunc {
 			handleNetworkingPeeringGet(t, id)(w, r)
 		case http.MethodPatch:
 			handleNetworkingPeeringUpdate(t, id)(w, r)
+		case http.MethodDelete:
+			handleNetworkingPeeringDelete(t, id)(w, r)
 		}
 	}
 }
@@ -419,6 +421,19 @@ func handleNetworkingPeeringUpdate(t *testing.T, id string) http.HandlerFunc {
 			peering := getPeering("peer-111111", body.Spec.GetDisplayName(), "AWS")
 			err = json.NewEncoder(w).Encode(peering)
 			require.NoError(t, err)
+		}
+	}
+}
+
+func handleNetworkingPeeringDelete(t *testing.T, id string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		switch id {
+		case "peer-invalid":
+			w.WriteHeader(http.StatusNotFound)
+			err := writeErrorJson(w, "The network peer-invalid was not found.")
+			require.NoError(t, err)
+		case "peer-111111", "peer-111112":
+			w.WriteHeader(http.StatusNoContent)
 		}
 	}
 }


### PR DESCRIPTION
What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->
Note that this is merging into the feature branch https://github.com/confluentinc/cli/tree/traffic-8850-network-cli. We will merge commits into main from this feature branch after all of the commands for network are implemented
* Add `confluent network peering update` to update the display name of a peering connection.
* Add `confluent network peering delete` to delete a peering connection.

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->
[CLI Commands Design](https://confluentinc.atlassian.net/wiki/spaces/PM/pages/2987394300/1-pager+--+Network+CLI)
[Implementation 1-Pager](https://confluentinc.atlassian.net/wiki/spaces/~712020463029eabbac401bbe1b033ce0d3a00e/pages/3136749631/Network+CLI)

Test & Review
-------------
<!--
Has it been tested? How?
Copy and paste any instructions or steps that can save the reviewer time.
-->
Added integration tests.

Performed manual tests

Open Questions / Follow-ups
---------------------------
<!--
Optional: Anything open to discussion for the reviewer, out of scope of this PR, or follow-ups.
-->
