### PR TITLE
Remove Link prefix validation

### DIFF
--- a/pkg/resource/resource.go
+++ b/pkg/resource/resource.go
@@ -46,7 +46,6 @@ const (
 )
 
 const (
-	ClusterLinkPrefix           = "link"
 	EnvironmentPrefix           = "env"
 	IdentityPoolPrefix          = "pool"
 	IdentityProviderPrefix      = "op"
@@ -58,7 +57,6 @@ const (
 )
 
 var prefixToResource = map[string]string{
-	ClusterLinkPrefix:           ClusterLink,
 	EnvironmentPrefix:           Environment,
 	IdentityPoolPrefix:          IdentityPool,
 	IdentityProviderPrefix:      IdentityProvider,
@@ -70,7 +68,6 @@ var prefixToResource = map[string]string{
 }
 
 var resourceToPrefix = map[string]string{
-	ClusterLink:           ClusterLinkPrefix,
 	Environment:           EnvironmentPrefix,
 	IdentityPool:          IdentityPoolPrefix,
 	IdentityProvider:      IdentityProviderPrefix,

--- a/test/fixtures/output/kafka/link/delete-link-no-prefix.golden
+++ b/test/fixtures/output/kafka/link/delete-link-no-prefix.golden
@@ -1,0 +1,2 @@
+Are you sure you want to delete cluster link "myLink_1"?
+To confirm, type "myLink_1". To cancel, press Ctrl-C: Deleted cluster link "myLink_1".

--- a/test/kafka_test.go
+++ b/test/kafka_test.go
@@ -137,6 +137,7 @@ func (s *CLITestSuite) TestKafka() {
 		{args: "kafka link list --cluster lkc-describe-topic -o json", fixture: "kafka/link/list-link-json.golden", useKafka: "lkc-describe-topic"},
 		{args: "kafka link list --cluster lkc-describe-topic -o yaml", fixture: "kafka/link/list-link-yaml.golden", useKafka: "lkc-describe-topic"},
 		{args: "kafka link delete link-1", input: "link-1\n", fixture: "kafka/link/delete-link.golden", useKafka: "lkc-describe-topic"},
+		{args: "kafka link delete myLink_1", input: "myLink_1\n", fixture: "kafka/link/delete-link-no-prefix.golden", useKafka: "lkc-describe-topic"},
 		{args: "kafka link delete link-1 link-2", input: "n\n", fixture: "kafka/link/delete-link-multiple-refuse.golden", useKafka: "lkc-describe-topic"},
 		{args: "kafka link delete link-1 link-2", input: "y\n", fixture: "kafka/link/delete-link-multiple.golden", useKafka: "lkc-describe-topic"},
 		{args: "kafka link delete link-1 link-2 link-dne", fixture: "kafka/link/delete-link-multiple-fail.golden", useKafka: "lkc-describe-topic", exitCode: 1},

--- a/test/test-server/kafka_rest_router.go
+++ b/test/test-server/kafka_rest_router.go
@@ -663,7 +663,7 @@ func handleKafkaRestLink(t *testing.T) http.HandlerFunc {
 		link := mux.Vars(r)["link"]
 		switch r.Method {
 		case http.MethodGet:
-			if link == "link-1" {
+			if link == "link-1" || link == "myLink_1" {
 				switch cluster {
 				case "cluster-1":
 					err := json.NewEncoder(w).Encode(cpkafkarestv3.ListLinksResponseData{


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- PLACEHOLDER

New Features
- PLACEHOLDER

Bug Fixes
- Resolve an issue in `confluent kafka link delete` preventing users from deleting certain cluster links

Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
Cluster links do not have a set prefix, so `ClusterLinkPrefix` causes the prefix validation to fail when deleting cluster links unless the link name happens to starts with `link-`.

This PR removes this variable from the resource/prefix maps, so that prefix validation will do nothing (as intended for resources with no prefix) when deleting cluster links.

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
Added a new integration test case with a link that doesn't start with this prefix.

Open Questions / Follow-ups
---------------------------
<!--
Optional: Anything open to discussion for the reviewer, out of scope of this PR, or follow-ups.
-->
