### PR TITLE
Resolve integer deserialization issue in `topic consume`

### DIFF
--- a/internal/kafka/command_topic_produce.go
+++ b/internal/kafka/command_topic_produce.go
@@ -89,6 +89,20 @@ func (c *command) produce(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	keyFormat, err := cmd.Flags().GetString("key-format")
+	if err != nil {
+		return err
+	}
+
+	parseKey, err := cmd.Flags().GetBool("parse-key")
+	if err != nil {
+		return err
+	}
+
+	if keyFormat != "string" && !parseKey {
+		return errors.New("`--parse-key` must be set when the key format is not \"string\"")
+	}
+
 	configFile, err := cmd.Flags().GetString("config-file")
 	if err != nil {
 		return err

--- a/internal/kafka/command_topic_produce.go
+++ b/internal/kafka/command_topic_produce.go
@@ -89,18 +89,13 @@ func (c *command) produce(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	keyFormat, err := cmd.Flags().GetString("key-format")
-	if err != nil {
-		return err
-	}
-
 	parseKey, err := cmd.Flags().GetBool("parse-key")
 	if err != nil {
 		return err
 	}
 
-	if keyFormat != "string" && !parseKey {
-		return errors.New("`--parse-key` must be set when the key format is not \"string\"")
+	if cmd.Flags().Changed("key-format") && !parseKey {
+		return errors.New("`--parse-key` must be set when `key-format` is set")
 	}
 
 	configFile, err := cmd.Flags().GetString("config-file")

--- a/internal/kafka/command_topic_produce_onprem.go
+++ b/internal/kafka/command_topic_produce_onprem.go
@@ -105,18 +105,13 @@ func (c *command) produceOnPrem(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	keyFormat, err := cmd.Flags().GetString("key-format")
-	if err != nil {
-		return err
-	}
-
 	parseKey, err := cmd.Flags().GetBool("parse-key")
 	if err != nil {
 		return err
 	}
 
-	if keyFormat != "string" && !parseKey {
-		return errors.New("`--parse-key` must be set when the key format is not \"string\"")
+	if cmd.Flags().Changed("key-format") && !parseKey {
+		return errors.New("`--parse-key` must be set when `key-format` is set")
 	}
 
 	keySchema, err := cmd.Flags().GetString("key-schema")

--- a/internal/kafka/command_topic_produce_onprem.go
+++ b/internal/kafka/command_topic_produce_onprem.go
@@ -105,6 +105,20 @@ func (c *command) produceOnPrem(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	keyFormat, err := cmd.Flags().GetString("key-format")
+	if err != nil {
+		return err
+	}
+
+	parseKey, err := cmd.Flags().GetBool("parse-key")
+	if err != nil {
+		return err
+	}
+
+	if keyFormat != "string" && !parseKey {
+		return errors.New("`--parse-key` must be set when the key format is not \"string\"")
+	}
+
 	keySchema, err := cmd.Flags().GetString("key-schema")
 	if err != nil {
 		return err

--- a/pkg/serdes/integer_deserialization_provider.go
+++ b/pkg/serdes/integer_deserialization_provider.go
@@ -12,5 +12,9 @@ func (s *IntegerDeserializationProvider) LoadSchema(_ string, _ map[string]strin
 }
 
 func (s *IntegerDeserializationProvider) Deserialize(data []byte) (string, error) {
+	if len(data) == 0 {
+		return "", nil
+	}
+
 	return fmt.Sprintf("%d", binary.LittleEndian.Uint32(data)), nil
 }

--- a/pkg/serdes/integer_deserialization_provider.go
+++ b/pkg/serdes/integer_deserialization_provider.go
@@ -12,5 +12,5 @@ func (s *IntegerDeserializationProvider) LoadSchema(_ string, _ map[string]strin
 }
 
 func (s *IntegerDeserializationProvider) Deserialize(data []byte) (string, error) {
-	return fmt.Sprintf("%d", binary.BigEndian.Uint32(data)), nil
+	return fmt.Sprintf("%d", binary.LittleEndian.Uint32(data)), nil
 }


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- PLACEHOLDER

New Features
- PLACEHOLDER

Bug Fixes
- Fix an issue causing `confluent kafka topic consume` to deserialize integers to incorrect values when using `--key-format integer` or `value-format integer`
- Resolve a panic that could occur in `confluent kafka topic consume` when using `--key-format integer` and `--print-key`
- `--parse-key` must now be specified when using `confluent kafka topic produce --key-format`

Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
Integers were being serialized with Little Endian but deserialized with Big Endian, resulting in wrong values.

While investigating I also discovered that you can end up with a panic if you consume any messages without an integer key after specifying `confluent kafka topic consume <topic-name> --key-format integer --print-key -b`, so this PR does two things to address this:
- Require that users use `--parse-key` if they provide `--key-format`
- Deserialize empty keys to the empty string for integers

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
manual testing

Open Questions / Follow-ups
---------------------------
<!--
Optional: Anything open to discussion for the reviewer, out of scope of this PR, or follow-ups.
-->
