### PR TITLE
[TRAFFIC-9325][TRAFFIC-9326] - Add confluent network transit-gateway-attachment update|delete commands 

### DIFF
--- a/internal/network/command_peering_describe.go
+++ b/internal/network/command_peering_describe.go
@@ -16,8 +16,8 @@ func (c *peeringCommand) newDescribeCommand() *cobra.Command {
 		RunE:              c.describe,
 		Example: examples.BuildExampleString(
 			examples.Example{
-				Text: `Describe peering "peer-111111".`,
-				Code: "confluent network peering describe peer-111111",
+				Text: `Describe peering "peer-123456".`,
+				Code: "confluent network peering describe peer-123456",
 			},
 		),
 	}

--- a/internal/network/command_peering_update.go
+++ b/internal/network/command_peering_update.go
@@ -18,8 +18,8 @@ func (c *peeringCommand) newUpdateCommand() *cobra.Command {
 		RunE:              c.update,
 		Example: examples.BuildExampleString(
 			examples.Example{
-				Text: `Update the name of peering "peer-111111"`,
-				Code: `confluent network peering update peer-111111 --name "new name"`,
+				Text: `Update the name of peering "peer-123456"`,
+				Code: `confluent network peering update peer-123456 --name "new name"`,
 			},
 		),
 	}

--- a/internal/network/command_transit_gateway_attachment.go
+++ b/internal/network/command_transit_gateway_attachment.go
@@ -49,8 +49,10 @@ func newTransitGatewayAttachmentCommand(prerunner pcmd.PreRunner) *cobra.Command
 
 	c := &transitGatewayAttachmentCommand{pcmd.NewAuthenticatedCLICommand(cmd, prerunner)}
 
+	cmd.AddCommand(c.newDeleteCommand())
 	cmd.AddCommand(c.newDescribeCommand())
 	cmd.AddCommand(c.newListCommand())
+	cmd.AddCommand(c.newUpdateCommand())
 
 	return cmd
 }

--- a/internal/network/command_transit_gateway_attachment.go
+++ b/internal/network/command_transit_gateway_attachment.go
@@ -18,25 +18,25 @@ type transitGatewayAttachmentCommand struct {
 }
 
 type transitGatewayAttachmentHumanOut struct {
-	Id                         string `human:"ID"`
-	Name                       string `human:"Name"`
-	NetworkId                  string `human:"Network ID"`
-	RamShareArn                string `human:"RAM Share ARN"`
-	TransitGatewayId           string `human:"Transit Gateway ID"`
-	Routes                     string `human:"Routes"`
-	TransitGatewayAttachmentId string `human:"Transit Gateway Attachment ID,omitempty"`
-	Phase                      string `human:"Phase"`
+	Id                            string `human:"ID"`
+	Name                          string `human:"Name"`
+	NetworkId                     string `human:"Network ID"`
+	AwsRamShareArn                string `human:"AWS RAM Share ARN"`
+	AwsTransitGatewayId           string `human:"AWS Transit Gateway ID"`
+	Routes                        string `human:"Routes"`
+	AwsTransitGatewayAttachmentId string `human:"AWS Transit Gateway Attachment ID,omitempty"`
+	Phase                         string `human:"Phase"`
 }
 
 type transitGatewayAttachmentSerializedOut struct {
-	Id                         string   `serialized:"id"`
-	Name                       string   `serialized:"name"`
-	NetworkId                  string   `serialized:"network_id"`
-	RamShareArn                string   `serialized:"ram_share_arn"`
-	TransitGatewayId           string   `serialized:"transit_gateway_id"`
-	Routes                     []string `serialized:"routes"`
-	TransitGatewayAttachmentId string   `serialized:"transit_gateway_attachment_id,omitempty"`
-	Phase                      string   `serialized:"phase"`
+	Id                            string   `serialized:"id"`
+	Name                          string   `serialized:"name"`
+	NetworkId                     string   `serialized:"network_id"`
+	AwsRamShareArn                string   `serialized:"aws_ram_share_arn"`
+	AwsTransitGatewayId           string   `serialized:"aws_transit_gateway_id"`
+	Routes                        []string `serialized:"routes"`
+	AwsTransitGatewayAttachmentId string   `serialized:"aws_transit_gateway_attachment_id,omitempty"`
+	Phase                         string   `serialized:"phase"`
 }
 
 func newTransitGatewayAttachmentCommand(prerunner pcmd.PreRunner) *cobra.Command {
@@ -106,27 +106,27 @@ func printTransitGatewayAttachmentTable(cmd *cobra.Command, attachment networkin
 
 	if output.GetFormat(cmd) == output.Human {
 		table.Add(&transitGatewayAttachmentHumanOut{
-			Id:                         attachment.GetId(),
-			Name:                       attachment.Spec.GetDisplayName(),
-			NetworkId:                  attachment.Spec.Network.GetId(),
-			RamShareArn:                attachment.Spec.Cloud.NetworkingV1AwsTransitGatewayAttachment.GetRamShareArn(),
-			TransitGatewayId:           attachment.Spec.Cloud.NetworkingV1AwsTransitGatewayAttachment.GetTransitGatewayId(),
-			Routes:                     strings.Join(attachment.Spec.Cloud.NetworkingV1AwsTransitGatewayAttachment.GetRoutes(), ", "),
-			TransitGatewayAttachmentId: attachment.Status.Cloud.NetworkingV1AwsTransitGatewayAttachmentStatus.GetTransitGatewayAttachmentId(),
-			Phase:                      attachment.Status.GetPhase(),
+			Id:                            attachment.GetId(),
+			Name:                          attachment.Spec.GetDisplayName(),
+			NetworkId:                     attachment.Spec.Network.GetId(),
+			AwsRamShareArn:                attachment.Spec.Cloud.NetworkingV1AwsTransitGatewayAttachment.GetRamShareArn(),
+			AwsTransitGatewayId:           attachment.Spec.Cloud.NetworkingV1AwsTransitGatewayAttachment.GetTransitGatewayId(),
+			Routes:                        strings.Join(attachment.Spec.Cloud.NetworkingV1AwsTransitGatewayAttachment.GetRoutes(), ", "),
+			AwsTransitGatewayAttachmentId: attachment.Status.Cloud.NetworkingV1AwsTransitGatewayAttachmentStatus.GetTransitGatewayAttachmentId(),
+			Phase:                         attachment.Status.GetPhase(),
 		})
 	} else {
 		table.Add(&transitGatewayAttachmentSerializedOut{
-			Id:                         attachment.GetId(),
-			Name:                       attachment.Spec.GetDisplayName(),
-			NetworkId:                  attachment.Spec.Network.GetId(),
-			RamShareArn:                attachment.Spec.Cloud.NetworkingV1AwsTransitGatewayAttachment.GetRamShareArn(),
-			TransitGatewayId:           attachment.Spec.Cloud.NetworkingV1AwsTransitGatewayAttachment.GetTransitGatewayId(),
-			Routes:                     attachment.Spec.Cloud.NetworkingV1AwsTransitGatewayAttachment.GetRoutes(),
-			TransitGatewayAttachmentId: attachment.Status.Cloud.NetworkingV1AwsTransitGatewayAttachmentStatus.GetTransitGatewayAttachmentId(),
-			Phase:                      attachment.Status.GetPhase(),
+			Id:                            attachment.GetId(),
+			Name:                          attachment.Spec.GetDisplayName(),
+			NetworkId:                     attachment.Spec.Network.GetId(),
+			AwsRamShareArn:                attachment.Spec.Cloud.NetworkingV1AwsTransitGatewayAttachment.GetRamShareArn(),
+			AwsTransitGatewayId:           attachment.Spec.Cloud.NetworkingV1AwsTransitGatewayAttachment.GetTransitGatewayId(),
+			Routes:                        attachment.Spec.Cloud.NetworkingV1AwsTransitGatewayAttachment.GetRoutes(),
+			AwsTransitGatewayAttachmentId: attachment.Status.Cloud.NetworkingV1AwsTransitGatewayAttachmentStatus.GetTransitGatewayAttachmentId(),
+			Phase:                         attachment.Status.GetPhase(),
 		})
 	}
 
-	return table.Print()
+	return table.PrintWithAutoWrap(false)
 }

--- a/internal/network/command_transit_gateway_attachment_delete.go
+++ b/internal/network/command_transit_gateway_attachment_delete.go
@@ -1,0 +1,63 @@
+package network
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	pcmd "github.com/confluentinc/cli/v3/pkg/cmd"
+	"github.com/confluentinc/cli/v3/pkg/deletion"
+	"github.com/confluentinc/cli/v3/pkg/errors"
+	"github.com/confluentinc/cli/v3/pkg/output"
+	"github.com/confluentinc/cli/v3/pkg/resource"
+	"github.com/confluentinc/cli/v3/pkg/utils"
+)
+
+func (c *transitGatewayAttachmentCommand) newDeleteCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:               "delete <id-1> [id-2] ... [id-n]",
+		Short:             "Delete one or more transit gateway attachments.",
+		Args:              cobra.MinimumNArgs(1),
+		ValidArgsFunction: pcmd.NewValidArgsFunction(c.validArgsMultiple),
+		RunE:              c.delete,
+	}
+
+	pcmd.AddForceFlag(cmd)
+	pcmd.AddContextFlag(cmd, c.CLICommand)
+	pcmd.AddEnvironmentFlag(cmd, c.AuthenticatedCLICommand)
+
+	return cmd
+}
+
+func (c *transitGatewayAttachmentCommand) delete(cmd *cobra.Command, args []string) error {
+	environmentId, err := c.Context.EnvironmentId()
+	if err != nil {
+		return err
+	}
+
+	existenceFunc := func(id string) bool {
+		_, err := c.V2Client.GetTransitGatewayAttachment(environmentId, id)
+		return err == nil
+	}
+
+	if err := deletion.ValidateAndConfirmDeletionYesNo(cmd, args, existenceFunc, resource.TransitGatewayAttachment); err != nil {
+		return err
+	}
+
+	deleteFunc := func(id string) error {
+		if err := c.V2Client.DeleteTransitGatewayAttachment(environmentId, id); err != nil {
+			return errors.Errorf(errors.DeleteResourceErrorMsg, resource.TransitGatewayAttachment, id, err)
+		}
+		return nil
+	}
+
+	deletedIds, err := deletion.DeleteWithoutMessage(args, deleteFunc)
+	deleteMsg := "Requested to delete %s %s.\n"
+	if len(deletedIds) == 1 {
+		output.Printf(deleteMsg, resource.TransitGatewayAttachment, fmt.Sprintf(`"%s"`, deletedIds[0]))
+	} else if len(deletedIds) > 1 {
+		output.Printf(deleteMsg, resource.Plural(resource.TransitGatewayAttachment), utils.ArrayToCommaDelimitedString(deletedIds, "and"))
+	}
+
+	return err
+}

--- a/internal/network/command_transit_gateway_attachment_list.go
+++ b/internal/network/command_transit_gateway_attachment_list.go
@@ -43,25 +43,25 @@ func (c *transitGatewayAttachmentCommand) list(cmd *cobra.Command, _ []string) e
 
 		if output.GetFormat(cmd) == output.Human {
 			list.Add(&transitGatewayAttachmentHumanOut{
-				Id:                         attachment.GetId(),
-				Name:                       attachment.Spec.GetDisplayName(),
-				NetworkId:                  attachment.Spec.Network.GetId(),
-				RamShareArn:                attachment.Spec.Cloud.NetworkingV1AwsTransitGatewayAttachment.GetRamShareArn(),
-				TransitGatewayId:           attachment.Spec.Cloud.NetworkingV1AwsTransitGatewayAttachment.GetTransitGatewayId(),
-				Routes:                     strings.Join(attachment.Spec.Cloud.NetworkingV1AwsTransitGatewayAttachment.GetRoutes(), ", "),
-				TransitGatewayAttachmentId: attachment.Status.Cloud.NetworkingV1AwsTransitGatewayAttachmentStatus.GetTransitGatewayAttachmentId(),
-				Phase:                      attachment.Status.GetPhase(),
+				Id:                            attachment.GetId(),
+				Name:                          attachment.Spec.GetDisplayName(),
+				NetworkId:                     attachment.Spec.Network.GetId(),
+				AwsRamShareArn:                attachment.Spec.Cloud.NetworkingV1AwsTransitGatewayAttachment.GetRamShareArn(),
+				AwsTransitGatewayId:           attachment.Spec.Cloud.NetworkingV1AwsTransitGatewayAttachment.GetTransitGatewayId(),
+				Routes:                        strings.Join(attachment.Spec.Cloud.NetworkingV1AwsTransitGatewayAttachment.GetRoutes(), ", "),
+				AwsTransitGatewayAttachmentId: attachment.Status.Cloud.NetworkingV1AwsTransitGatewayAttachmentStatus.GetTransitGatewayAttachmentId(),
+				Phase:                         attachment.Status.GetPhase(),
 			})
 		} else {
 			list.Add(&transitGatewayAttachmentSerializedOut{
-				Id:                         attachment.GetId(),
-				Name:                       attachment.Spec.GetDisplayName(),
-				NetworkId:                  attachment.Spec.Network.GetId(),
-				RamShareArn:                attachment.Spec.Cloud.NetworkingV1AwsTransitGatewayAttachment.GetRamShareArn(),
-				TransitGatewayId:           attachment.Spec.Cloud.NetworkingV1AwsTransitGatewayAttachment.GetTransitGatewayId(),
-				Routes:                     attachment.Spec.Cloud.NetworkingV1AwsTransitGatewayAttachment.GetRoutes(),
-				TransitGatewayAttachmentId: attachment.Status.Cloud.NetworkingV1AwsTransitGatewayAttachmentStatus.GetTransitGatewayAttachmentId(),
-				Phase:                      attachment.Status.GetPhase(),
+				Id:                            attachment.GetId(),
+				Name:                          attachment.Spec.GetDisplayName(),
+				NetworkId:                     attachment.Spec.Network.GetId(),
+				AwsRamShareArn:                attachment.Spec.Cloud.NetworkingV1AwsTransitGatewayAttachment.GetRamShareArn(),
+				AwsTransitGatewayId:           attachment.Spec.Cloud.NetworkingV1AwsTransitGatewayAttachment.GetTransitGatewayId(),
+				Routes:                        attachment.Spec.Cloud.NetworkingV1AwsTransitGatewayAttachment.GetRoutes(),
+				AwsTransitGatewayAttachmentId: attachment.Status.Cloud.NetworkingV1AwsTransitGatewayAttachmentStatus.GetTransitGatewayAttachmentId(),
+				Phase:                         attachment.Status.GetPhase(),
 			})
 		}
 	}

--- a/internal/network/command_transit_gateway_attachment_update.go
+++ b/internal/network/command_transit_gateway_attachment_update.go
@@ -18,8 +18,8 @@ func (c *transitGatewayAttachmentCommand) newUpdateCommand() *cobra.Command {
 		RunE:              c.update,
 		Example: examples.BuildExampleString(
 			examples.Example{
-				Text: `Update the name of transit gateway attachment "tgwa-111111"`,
-				Code: `confluent network transit-gateway-attachment update tgwa-111111 --name "new name"`,
+				Text: `Update the name of transit gateway attachment "tgwa-123456"`,
+				Code: `confluent network transit-gateway-attachment update tgwa-123456 --name "new name"`,
 			},
 		),
 	}

--- a/internal/network/command_transit_gateway_attachment_update.go
+++ b/internal/network/command_transit_gateway_attachment_update.go
@@ -1,0 +1,61 @@
+package network
+
+import (
+	"github.com/spf13/cobra"
+
+	networkingv1 "github.com/confluentinc/ccloud-sdk-go-v2/networking/v1"
+
+	pcmd "github.com/confluentinc/cli/v3/pkg/cmd"
+	"github.com/confluentinc/cli/v3/pkg/examples"
+)
+
+func (c *transitGatewayAttachmentCommand) newUpdateCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:               "update <id>",
+		Short:             "Update an existing transit gateway attachment.",
+		Args:              cobra.ExactArgs(1),
+		ValidArgsFunction: pcmd.NewValidArgsFunction(c.validArgs),
+		RunE:              c.update,
+		Example: examples.BuildExampleString(
+			examples.Example{
+				Text: `Update the name of transit gateway attachment "tgwa-111111"`,
+				Code: `confluent network transit-gateway-attachment update tgwa-111111 --name "new name"`,
+			},
+		),
+	}
+
+	cmd.Flags().String("name", "", "Name of the transit gateway attachment.")
+	pcmd.AddContextFlag(cmd, c.CLICommand)
+	pcmd.AddEnvironmentFlag(cmd, c.AuthenticatedCLICommand)
+	pcmd.AddOutputFlag(cmd)
+
+	cobra.CheckErr(cmd.MarkFlagRequired("name"))
+
+	return cmd
+}
+
+func (c *transitGatewayAttachmentCommand) update(cmd *cobra.Command, args []string) error {
+	environmentId, err := c.Context.EnvironmentId()
+	if err != nil {
+		return err
+	}
+
+	name, err := cmd.Flags().GetString("name")
+	if err != nil {
+		return err
+	}
+
+	updateTransitGatewayAttachment := networkingv1.NetworkingV1TransitGatewayAttachmentUpdate{
+		Spec: &networkingv1.NetworkingV1TransitGatewayAttachmentSpecUpdate{
+			DisplayName: networkingv1.PtrString(name),
+			Environment: &networkingv1.ObjectReference{Id: environmentId},
+		},
+	}
+
+	attachment, err := c.V2Client.UpdateTransitGatewayAttachment(environmentId, args[0], updateTransitGatewayAttachment)
+	if err != nil {
+		return err
+	}
+
+	return printTransitGatewayAttachmentTable(cmd, attachment)
+}

--- a/pkg/ccloudv2/networking.go
+++ b/pkg/ccloudv2/networking.go
@@ -156,3 +156,13 @@ func (c *Client) GetTransitGatewayAttachment(environment, id string) (networking
 	resp, httpResp, err := c.NetworkingClient.TransitGatewayAttachmentsNetworkingV1Api.GetNetworkingV1TransitGatewayAttachment(c.networkingApiContext(), id).Environment(environment).Execute()
 	return resp, errors.CatchCCloudV2Error(err, httpResp)
 }
+
+func (c *Client) UpdateTransitGatewayAttachment(environment, id string, transitGatewayAttachmentUpdate networkingv1.NetworkingV1TransitGatewayAttachmentUpdate) (networkingv1.NetworkingV1TransitGatewayAttachment, error) {
+	resp, httpResp, err := c.NetworkingClient.TransitGatewayAttachmentsNetworkingV1Api.UpdateNetworkingV1TransitGatewayAttachment(c.networkingApiContext(), id).NetworkingV1TransitGatewayAttachmentUpdate(transitGatewayAttachmentUpdate).Execute()
+	return resp, errors.CatchCCloudV2Error(err, httpResp)
+}
+
+func (c *Client) DeleteTransitGatewayAttachment(environment, id string) error {
+	httpResp, err := c.NetworkingClient.TransitGatewayAttachmentsNetworkingV1Api.DeleteNetworkingV1TransitGatewayAttachment(c.networkingApiContext(), id).Environment(environment).Execute()
+	return errors.CatchCCloudV2Error(err, httpResp)
+}

--- a/pkg/resource/resource.go
+++ b/pkg/resource/resource.go
@@ -44,6 +44,7 @@ const (
 	ServiceAccount              = "service account"
 	SsoGroupMapping             = "SSO group mapping"
 	Topic                       = "topic"
+	TransitGatewayAttachment    = "transit gateway attachment"
 	User                        = "user"
 )
 

--- a/test/fixtures/output/network/peering/describe-help.golden
+++ b/test/fixtures/output/network/peering/describe-help.golden
@@ -4,9 +4,9 @@ Usage:
   confluent network peering describe <id> [flags]
 
 Examples:
-Describe peering "peer-111111".
+Describe peering "peer-123456".
 
-  $ confluent network peering describe peer-111111
+  $ confluent network peering describe peer-123456
 
 Flags:
       --context string       CLI context name.

--- a/test/fixtures/output/network/peering/describe-missing-id.golden
+++ b/test/fixtures/output/network/peering/describe-missing-id.golden
@@ -3,9 +3,9 @@ Usage:
   confluent network peering describe <id> [flags]
 
 Examples:
-Describe peering "peer-111111".
+Describe peering "peer-123456".
 
-  $ confluent network peering describe peer-111111
+  $ confluent network peering describe peer-123456
 
 Flags:
       --context string       CLI context name.

--- a/test/fixtures/output/network/peering/update-help.golden
+++ b/test/fixtures/output/network/peering/update-help.golden
@@ -4,9 +4,9 @@ Usage:
   confluent network peering update <id> [flags]
 
 Examples:
-Update the name of peering "peer-111111"
+Update the name of peering "peer-123456"
 
-  $ confluent network peering update peer-111111 --name "new name"
+  $ confluent network peering update peer-123456 --name "new name"
 
 Flags:
       --name string          REQUIRED: Name of the peering.

--- a/test/fixtures/output/network/peering/update-missing-args.golden
+++ b/test/fixtures/output/network/peering/update-missing-args.golden
@@ -3,9 +3,9 @@ Usage:
   confluent network peering update <id> [flags]
 
 Examples:
-Update the name of peering "peer-111111"
+Update the name of peering "peer-123456"
 
-  $ confluent network peering update peer-111111 --name "new name"
+  $ confluent network peering update peer-123456 --name "new name"
 
 Flags:
       --name string          Name of the peering.

--- a/test/fixtures/output/network/peering/update-missing-flags.golden
+++ b/test/fixtures/output/network/peering/update-missing-flags.golden
@@ -3,9 +3,9 @@ Usage:
   confluent network peering update <id> [flags]
 
 Examples:
-Update the name of peering "peer-111111"
+Update the name of peering "peer-123456"
 
-  $ confluent network peering update peer-111111 --name "new name"
+  $ confluent network peering update peer-123456 --name "new name"
 
 Flags:
       --name string          REQUIRED: Name of the peering.

--- a/test/fixtures/output/network/transit-gateway-attachment/delete-help.golden
+++ b/test/fixtures/output/network/transit-gateway-attachment/delete-help.golden
@@ -1,0 +1,14 @@
+Delete one or more transit gateway attachments.
+
+Usage:
+  confluent network transit-gateway-attachment delete <id-1> [id-2] ... [id-n] [flags]
+
+Flags:
+      --force                Skip the deletion confirmation prompt.
+      --context string       CLI context name.
+      --environment string   Environment ID.
+
+Global Flags:
+  -h, --help            Show help for this command.
+      --unsafe-trace    Equivalent to -vvvv, but also log HTTP requests and responses which might contain plaintext secrets.
+  -v, --verbose count   Increase verbosity (-v for warn, -vv for info, -vvv for debug, -vvvv for trace).

--- a/test/fixtures/output/network/transit-gateway-attachment/delete-multiple-fail.golden
+++ b/test/fixtures/output/network/transit-gateway-attachment/delete-multiple-fail.golden
@@ -1,0 +1,4 @@
+Error: transit gateway attachment "tgwa-invalid" not found
+
+Suggestions:
+    List available transit gateway attachments with `confluent network transit-gateway-attachment list`.

--- a/test/fixtures/output/network/transit-gateway-attachment/delete-multiple-refuse.golden
+++ b/test/fixtures/output/network/transit-gateway-attachment/delete-multiple-refuse.golden
@@ -1,0 +1,1 @@
+Are you sure you want to delete transit gateway attachments "tgwa-111111" and "tgwa-222222"? (y/n): 

--- a/test/fixtures/output/network/transit-gateway-attachment/delete-multiple-success.golden
+++ b/test/fixtures/output/network/transit-gateway-attachment/delete-multiple-success.golden
@@ -1,0 +1,1 @@
+Are you sure you want to delete transit gateway attachments "tgwa-111111" and "tgwa-222222"? (y/n): Requested to delete transit gateway attachments "tgwa-111111" and "tgwa-222222".

--- a/test/fixtures/output/network/transit-gateway-attachment/delete-prompt.golden
+++ b/test/fixtures/output/network/transit-gateway-attachment/delete-prompt.golden
@@ -1,0 +1,1 @@
+Are you sure you want to delete transit gateway attachment "tgwa-111111"? (y/n): Requested to delete transit gateway attachment "tgwa-111111".

--- a/test/fixtures/output/network/transit-gateway-attachment/delete-tgwa-not-exist.golden
+++ b/test/fixtures/output/network/transit-gateway-attachment/delete-tgwa-not-exist.golden
@@ -1,0 +1,4 @@
+Error: transit gateway attachment "tgwa-invalid" not found
+
+Suggestions:
+    List available transit gateway attachments with `confluent network transit-gateway-attachment list`.

--- a/test/fixtures/output/network/transit-gateway-attachment/delete.golden
+++ b/test/fixtures/output/network/transit-gateway-attachment/delete.golden
@@ -1,0 +1,1 @@
+Requested to delete transit gateway attachment "tgwa-111111".

--- a/test/fixtures/output/network/transit-gateway-attachment/describe-json.golden
+++ b/test/fixtures/output/network/transit-gateway-attachment/describe-json.golden
@@ -2,9 +2,9 @@
   "id": "tgwa-111111",
   "name": "aws-tgwa1",
   "network_id": "n-abcde1",
-  "ram_share_arn": "arn:aws:ram:us-east-1:000000000000:resource-share/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxx",
-  "transit_gateway_id": "tgw-00000000000000000",
+  "aws_ram_share_arn": "arn:aws:ram:us-east-1:000000000000:resource-share/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxx",
+  "aws_transit_gateway_id": "tgw-00000000000000000",
   "routes": ["10.0.0.0/16"],
-  "transit_gateway_attachment_id": "tgw-attach-00000000000000000",
+  "aws_transit_gateway_attachment_id": "tgw-attach-00000000000000000",
   "phase": "READY"
 }

--- a/test/fixtures/output/network/transit-gateway-attachment/describe.golden
+++ b/test/fixtures/output/network/transit-gateway-attachment/describe.golden
@@ -1,10 +1,10 @@
-+-------------------------------+---------------------------------------------------------------------------------------+
-| ID                            | tgwa-111111                                                                           |
-| Name                          | aws-tgwa1                                                                             |
-| Network ID                    | n-abcde1                                                                              |
-| RAM Share ARN                 | arn:aws:ram:us-east-1:000000000000:resource-share/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxx |
-| Transit Gateway ID            | tgw-00000000000000000                                                                 |
-| Routes                        | 10.0.0.0/16                                                                           |
-| Transit Gateway Attachment ID | tgw-attach-00000000000000000                                                          |
-| Phase                         | READY                                                                                 |
-+-------------------------------+---------------------------------------------------------------------------------------+
++-----------------------------------+---------------------------------------------------------------------------------------+
+| ID                                | tgwa-111111                                                                           |
+| Name                              | aws-tgwa1                                                                             |
+| Network ID                        | n-abcde1                                                                              |
+| AWS RAM Share ARN                 | arn:aws:ram:us-east-1:000000000000:resource-share/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxx |
+| AWS Transit Gateway ID            | tgw-00000000000000000                                                                 |
+| Routes                            | 10.0.0.0/16                                                                           |
+| AWS Transit Gateway Attachment ID | tgw-attach-00000000000000000                                                          |
+| Phase                             | READY                                                                                 |
++-----------------------------------+---------------------------------------------------------------------------------------+

--- a/test/fixtures/output/network/transit-gateway-attachment/help.golden
+++ b/test/fixtures/output/network/transit-gateway-attachment/help.golden
@@ -7,8 +7,10 @@ Aliases:
   transit-gateway-attachment, tgwa
 
 Available Commands:
+  delete      Delete one or more transit gateway attachments.
   describe    Describe a transit gateway attachment.
   list        List transit gateway attachments.
+  update      Update an existing transit gateway attachment.
 
 Global Flags:
   -h, --help            Show help for this command.

--- a/test/fixtures/output/network/transit-gateway-attachment/list-json.golden
+++ b/test/fixtures/output/network/transit-gateway-attachment/list-json.golden
@@ -3,30 +3,30 @@
     "id": "tgwa-111111",
     "name": "aws-tgwa1",
     "network_id": "n-abcde1",
-    "ram_share_arn": "arn:aws:ram:us-east-1:000000000000:resource-share/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxx",
-    "transit_gateway_id": "tgw-00000000000000000",
+    "aws_ram_share_arn": "arn:aws:ram:us-east-1:000000000000:resource-share/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxx",
+    "aws_transit_gateway_id": "tgw-00000000000000000",
     "routes": ["10.0.0.0/16"],
-    "transit_gateway_attachment_id": "tgw-attach-00000000000000000",
+    "aws_transit_gateway_attachment_id": "tgw-attach-00000000000000000",
     "phase": "READY"
   },
   {
     "id": "tgwa-222222",
     "name": "aws-tgwa2",
     "network_id": "n-abcde1",
-    "ram_share_arn": "arn:aws:ram:us-east-1:000000000000:resource-share/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxx",
-    "transit_gateway_id": "tgw-00000000000000000",
+    "aws_ram_share_arn": "arn:aws:ram:us-east-1:000000000000:resource-share/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxx",
+    "aws_transit_gateway_id": "tgw-00000000000000000",
     "routes": ["10.0.0.0/16"],
-    "transit_gateway_attachment_id": "tgw-attach-00000000000000000",
+    "aws_transit_gateway_attachment_id": "tgw-attach-00000000000000000",
     "phase": "READY"
   },
   {
     "id": "tgwa-333333",
     "name": "aws-tgwa3",
     "network_id": "n-abcde1",
-    "ram_share_arn": "arn:aws:ram:us-east-1:000000000000:resource-share/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxx",
-    "transit_gateway_id": "tgw-00000000000000000",
+    "aws_ram_share_arn": "arn:aws:ram:us-east-1:000000000000:resource-share/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxx",
+    "aws_transit_gateway_id": "tgw-00000000000000000",
     "routes": ["10.0.0.0/16"],
-    "transit_gateway_attachment_id": "tgw-attach-00000000000000000",
+    "aws_transit_gateway_attachment_id": "tgw-attach-00000000000000000",
     "phase": "READY"
   }
 ]

--- a/test/fixtures/output/network/transit-gateway-attachment/list.golden
+++ b/test/fixtures/output/network/transit-gateway-attachment/list.golden
@@ -1,5 +1,6 @@
-      ID      |   Name    | Network ID |                                     RAM Share ARN                                     |  Transit Gateway ID   |   Routes    | Transit Gateway Attachment ID | Phase  
---------------+-----------+------------+---------------------------------------------------------------------------------------+-----------------------+-------------+-------------------------------+--------
-  tgwa-111111 | aws-tgwa1 | n-abcde1   | arn:aws:ram:us-east-1:000000000000:resource-share/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxx | tgw-00000000000000000 | 10.0.0.0/16 | tgw-attach-00000000000000000  | READY  
-  tgwa-222222 | aws-tgwa2 | n-abcde1   | arn:aws:ram:us-east-1:000000000000:resource-share/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxx | tgw-00000000000000000 | 10.0.0.0/16 | tgw-attach-00000000000000000  | READY  
-  tgwa-333333 | aws-tgwa3 | n-abcde1   | arn:aws:ram:us-east-1:000000000000:resource-share/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxx | tgw-00000000000000000 | 10.0.0.0/16 | tgw-attach-00000000000000000  | READY  
+      ID      |   Name    | Network ID |                                   AWS RAM Share ARN                                   | AWS Transit Gateway ID |   Routes    | AWS Transit Gateway Attachment | Phase  
+              |           |            |                                                                                       |                        |             |               ID               |        
+--------------+-----------+------------+---------------------------------------------------------------------------------------+------------------------+-------------+--------------------------------+--------
+  tgwa-111111 | aws-tgwa1 | n-abcde1   | arn:aws:ram:us-east-1:000000000000:resource-share/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxx | tgw-00000000000000000  | 10.0.0.0/16 | tgw-attach-00000000000000000   | READY  
+  tgwa-222222 | aws-tgwa2 | n-abcde1   | arn:aws:ram:us-east-1:000000000000:resource-share/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxx | tgw-00000000000000000  | 10.0.0.0/16 | tgw-attach-00000000000000000   | READY  
+  tgwa-333333 | aws-tgwa3 | n-abcde1   | arn:aws:ram:us-east-1:000000000000:resource-share/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxx | tgw-00000000000000000  | 10.0.0.0/16 | tgw-attach-00000000000000000   | READY  

--- a/test/fixtures/output/network/transit-gateway-attachment/update-help.golden
+++ b/test/fixtures/output/network/transit-gateway-attachment/update-help.golden
@@ -4,9 +4,9 @@ Usage:
   confluent network transit-gateway-attachment update <id> [flags]
 
 Examples:
-Update the name of transit gateway attachment "tgwa-111111"
+Update the name of transit gateway attachment "tgwa-123456"
 
-  $ confluent network transit-gateway-attachment update tgwa-111111 --name "new name"
+  $ confluent network transit-gateway-attachment update tgwa-123456 --name "new name"
 
 Flags:
       --name string          REQUIRED: Name of the transit gateway attachment.

--- a/test/fixtures/output/network/transit-gateway-attachment/update-help.golden
+++ b/test/fixtures/output/network/transit-gateway-attachment/update-help.golden
@@ -1,0 +1,20 @@
+Update an existing transit gateway attachment.
+
+Usage:
+  confluent network transit-gateway-attachment update <id> [flags]
+
+Examples:
+Update the name of transit gateway attachment "tgwa-111111"
+
+  $ confluent network transit-gateway-attachment update tgwa-111111 --name "new name"
+
+Flags:
+      --name string          REQUIRED: Name of the transit gateway attachment.
+      --context string       CLI context name.
+      --environment string   Environment ID.
+  -o, --output string        Specify the output format as "human", "json", or "yaml". (default "human")
+
+Global Flags:
+  -h, --help            Show help for this command.
+      --unsafe-trace    Equivalent to -vvvv, but also log HTTP requests and responses which might contain plaintext secrets.
+  -v, --verbose count   Increase verbosity (-v for warn, -vv for info, -vvv for debug, -vvvv for trace).

--- a/test/fixtures/output/network/transit-gateway-attachment/update-missing-args.golden
+++ b/test/fixtures/output/network/transit-gateway-attachment/update-missing-args.golden
@@ -3,9 +3,9 @@ Usage:
   confluent network transit-gateway-attachment update <id> [flags]
 
 Examples:
-Update the name of transit gateway attachment "tgwa-111111"
+Update the name of transit gateway attachment "tgwa-123456"
 
-  $ confluent network transit-gateway-attachment update tgwa-111111 --name "new name"
+  $ confluent network transit-gateway-attachment update tgwa-123456 --name "new name"
 
 Flags:
       --name string          Name of the transit gateway attachment.

--- a/test/fixtures/output/network/transit-gateway-attachment/update-missing-args.golden
+++ b/test/fixtures/output/network/transit-gateway-attachment/update-missing-args.golden
@@ -1,0 +1,20 @@
+Error: accepts 1 arg(s), received 0
+Usage:
+  confluent network transit-gateway-attachment update <id> [flags]
+
+Examples:
+Update the name of transit gateway attachment "tgwa-111111"
+
+  $ confluent network transit-gateway-attachment update tgwa-111111 --name "new name"
+
+Flags:
+      --name string          Name of the transit gateway attachment.
+      --context string       CLI context name.
+      --environment string   Environment ID.
+  -o, --output string        Specify the output format as "human", "json", or "yaml". (default "human")
+
+Global Flags:
+  -h, --help            Show help for this command.
+      --unsafe-trace    Equivalent to -vvvv, but also log HTTP requests and responses which might contain plaintext secrets.
+  -v, --verbose count   Increase verbosity (-v for warn, -vv for info, -vvv for debug, -vvvv for trace).
+

--- a/test/fixtures/output/network/transit-gateway-attachment/update-missing-flags.golden
+++ b/test/fixtures/output/network/transit-gateway-attachment/update-missing-flags.golden
@@ -1,0 +1,20 @@
+Error: required flag(s) "name" not set
+Usage:
+  confluent network transit-gateway-attachment update <id> [flags]
+
+Examples:
+Update the name of transit gateway attachment "tgwa-111111"
+
+  $ confluent network transit-gateway-attachment update tgwa-111111 --name "new name"
+
+Flags:
+      --name string          REQUIRED: Name of the transit gateway attachment.
+      --context string       CLI context name.
+      --environment string   Environment ID.
+  -o, --output string        Specify the output format as "human", "json", or "yaml". (default "human")
+
+Global Flags:
+  -h, --help            Show help for this command.
+      --unsafe-trace    Equivalent to -vvvv, but also log HTTP requests and responses which might contain plaintext secrets.
+  -v, --verbose count   Increase verbosity (-v for warn, -vv for info, -vvv for debug, -vvvv for trace).
+

--- a/test/fixtures/output/network/transit-gateway-attachment/update-missing-flags.golden
+++ b/test/fixtures/output/network/transit-gateway-attachment/update-missing-flags.golden
@@ -3,9 +3,9 @@ Usage:
   confluent network transit-gateway-attachment update <id> [flags]
 
 Examples:
-Update the name of transit gateway attachment "tgwa-111111"
+Update the name of transit gateway attachment "tgwa-123456"
 
-  $ confluent network transit-gateway-attachment update tgwa-111111 --name "new name"
+  $ confluent network transit-gateway-attachment update tgwa-123456 --name "new name"
 
 Flags:
       --name string          REQUIRED: Name of the transit gateway attachment.

--- a/test/fixtures/output/network/transit-gateway-attachment/update-tgwa-not-exist.golden
+++ b/test/fixtures/output/network/transit-gateway-attachment/update-tgwa-not-exist.golden
@@ -1,0 +1,1 @@
+Error: 404 Not Found

--- a/test/fixtures/output/network/transit-gateway-attachment/update.golden
+++ b/test/fixtures/output/network/transit-gateway-attachment/update.golden
@@ -1,10 +1,10 @@
-+-------------------------------+---------------------------------------------------------------------------------------+
-| ID                            | tgwa-111111                                                                           |
-| Name                          | new-name                                                                              |
-| Network ID                    | n-abcde1                                                                              |
-| RAM Share ARN                 | arn:aws:ram:us-east-1:000000000000:resource-share/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxx |
-| Transit Gateway ID            | tgw-00000000000000000                                                                 |
-| Routes                        | 10.0.0.0/16                                                                           |
-| Transit Gateway Attachment ID | tgw-attach-00000000000000000                                                          |
-| Phase                         | READY                                                                                 |
-+-------------------------------+---------------------------------------------------------------------------------------+
++-----------------------------------+---------------------------------------------------------------------------------------+
+| ID                                | tgwa-111111                                                                           |
+| Name                              | new-name                                                                              |
+| Network ID                        | n-abcde1                                                                              |
+| AWS RAM Share ARN                 | arn:aws:ram:us-east-1:000000000000:resource-share/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxx |
+| AWS Transit Gateway ID            | tgw-00000000000000000                                                                 |
+| Routes                            | 10.0.0.0/16                                                                           |
+| AWS Transit Gateway Attachment ID | tgw-attach-00000000000000000                                                          |
+| Phase                             | READY                                                                                 |
++-----------------------------------+---------------------------------------------------------------------------------------+

--- a/test/fixtures/output/network/transit-gateway-attachment/update.golden
+++ b/test/fixtures/output/network/transit-gateway-attachment/update.golden
@@ -1,0 +1,10 @@
++-------------------------------+---------------------------------------------------------------------------------------+
+| ID                            | tgwa-111111                                                                           |
+| Name                          | new-name                                                                              |
+| Network ID                    | n-abcde1                                                                              |
+| RAM Share ARN                 | arn:aws:ram:us-east-1:000000000000:resource-share/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxx |
+| Transit Gateway ID            | tgw-00000000000000000                                                                 |
+| Routes                        | 10.0.0.0/16                                                                           |
+| Transit Gateway Attachment ID | tgw-attach-00000000000000000                                                          |
+| Phase                         | READY                                                                                 |
++-------------------------------+---------------------------------------------------------------------------------------+

--- a/test/network_test.go
+++ b/test/network_test.go
@@ -211,6 +211,37 @@ func (s *CLITestSuite) TestNetworkTransitGatewayAttachmentDescribe() {
 	}
 }
 
+func (s *CLITestSuite) TestNetworkTransitGatewayAttachmentUpdate() {
+	tests := []CLITest{
+		{args: "network transit-gateway-attachment update", fixture: "network/transit-gateway-attachment/update-missing-args.golden", exitCode: 1},
+		{args: "network transit-gateway-attachment update tgwa-111111", fixture: "network/transit-gateway-attachment/update-missing-flags.golden", exitCode: 1},
+		{args: "network tgwa update tgwa-111111 --name new-name", fixture: "network/transit-gateway-attachment/update.golden"},
+		{args: "network transit-gateway-attachment update tgwa-111111 --name new-name", fixture: "network/transit-gateway-attachment/update.golden"},
+		{args: "network transit-gateway-attachment update tgwa-invalid --name new-name", fixture: "network/transit-gateway-attachment/update-tgwa-not-exist.golden", exitCode: 1},
+	}
+
+	for _, test := range tests {
+		test.login = "cloud"
+		s.runIntegrationTest(test)
+	}
+}
+
+func (s *CLITestSuite) TestNetworkTransitGatewayAttachmentDelete() {
+	tests := []CLITest{
+		{args: "network transit-gateway-attachment delete tgwa-111111 --force", fixture: "network/transit-gateway-attachment/delete.golden"},
+		{args: "network transit-gateway-attachment delete tgwa-111111", input: "y\n", fixture: "network/transit-gateway-attachment/delete-prompt.golden"},
+		{args: "network transit-gateway-attachment delete tgwa-111111 tgwa-222222", input: "n\n", fixture: "network/transit-gateway-attachment/delete-multiple-refuse.golden"},
+		{args: "network transit-gateway-attachment delete tgwa-111111 tgwa-222222", input: "y\n", fixture: "network/transit-gateway-attachment/delete-multiple-success.golden"},
+		{args: "network transit-gateway-attachment delete tgwa-111111 tgwa-invalid", fixture: "network/transit-gateway-attachment/delete-multiple-fail.golden", exitCode: 1},
+		{args: "network transit-gateway-attachment delete tgwa-invalid --force", fixture: "network/transit-gateway-attachment/delete-tgwa-not-exist.golden", exitCode: 1},
+	}
+
+	for _, test := range tests {
+		test.login = "cloud"
+		s.runIntegrationTest(test)
+	}
+}
+
 func (s *CLITestSuite) TestNetworkTransitGatewayAttachment_Autocomplete() {
 	tests := []CLITest{
 		{args: `__complete network transit-gateway-attachment describe ""`, login: "cloud", fixture: "network/transit-gateway-attachment/describe-autocomplete.golden"},

--- a/test/test-server/networking_handlers.go
+++ b/test/test-server/networking_handlers.go
@@ -73,6 +73,10 @@ func handleNetworkingTransitGatewayAttachment(t *testing.T) http.HandlerFunc {
 		switch r.Method {
 		case http.MethodGet:
 			handleNetworkingTransitGatewayAttachmentGet(t, id)(w, r)
+		case http.MethodPatch:
+			handleNetworkingTransitGatewayAttachmentUpdate(t, id)(w, r)
+		case http.MethodDelete:
+			handleNetworkingTransitGatewayAttachmentDelete(t, id)(w, r)
 		}
 	}
 }
@@ -558,4 +562,34 @@ func getTransitGatewayAttachment(id, name string) networkingv1.NetworkingV1Trans
 		},
 	}
 	return attachment
+}
+
+func handleNetworkingTransitGatewayAttachmentUpdate(t *testing.T, id string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		switch id {
+		case "tgwa-invalid":
+			w.WriteHeader(http.StatusNotFound)
+			return
+		case "tgwa-111111":
+			body := &networkingv1.NetworkingV1Network{}
+			err := json.NewDecoder(r.Body).Decode(body)
+			require.NoError(t, err)
+
+			attachment := getTransitGatewayAttachment("tgwa-111111", body.Spec.GetDisplayName())
+			err = json.NewEncoder(w).Encode(attachment)
+			require.NoError(t, err)
+		}
+	}
+}
+
+func handleNetworkingTransitGatewayAttachmentDelete(_ *testing.T, id string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		switch id {
+		case "tgw-invalid":
+			w.WriteHeader(http.StatusNotFound)
+			return
+		case "tgwa-111111", "tgwa-222222":
+			w.WriteHeader(http.StatusNoContent)
+		}
+	}
 }


### PR DESCRIPTION
What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->
Note that this is merging into the feature branch https://github.com/confluentinc/cli/tree/traffic-8850-network-cli. We will merge commits into main from this feature branch after all of the commands for network are implemented
* Add `confluent network transit-gateway-attachment update`
* Add `confluent network transit-gateway-attachment delete`

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->
[CLI Commands Design](https://confluentinc.atlassian.net/wiki/spaces/PM/pages/2987394300/1-pager+--+Network+CLI)
[Implementation 1-Pager](https://confluentinc.atlassian.net/wiki/spaces/~712020463029eabbac401bbe1b033ce0d3a00e/pages/3136749631/Network+CLI)

Test & Review
-------------
<!--
Has it been tested? How?
Copy and paste any instructions or steps that can save the reviewer time.
-->
Added integration tests.

Performed manual tests

Open Questions / Follow-ups
---------------------------
<!--
Optional: Anything open to discussion for the reviewer, out of scope of this PR, or follow-ups.
-->
