### PR TITLE
[confluent-local-2] fix local kafka produce with key panic

### DIFF
--- a/internal/local/command_kafka_topic_produce.go
+++ b/internal/local/command_kafka_topic_produce.go
@@ -70,7 +70,7 @@ func (c *command) kafkaTopicProduce(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	return kafka.ProduceToTopic(cmd, []byte{}, []byte{}, topicName, nil, serializationProvider, producer)
+	return kafka.ProduceToTopic(cmd, []byte{}, []byte{}, topicName, serializationProvider, serializationProvider, producer)
 }
 
 func newOnPremProducer(cmd *cobra.Command, bootstrap string) (*ckafka.Producer, error) {


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- PLACEHOLDER

New Features
- PLACEHOLDER

Bug Fixes
- Fix a bug causing panic when running `confluent local kafka topic produce <topic> --parse-key`

Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->
looks like earlier value schema serializer introduced a bug here. key was missing serializer. local kafka doesn't support sr yet so using the same `string` serializer for both key and value.

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
<!--
Has it been tested? How?
Copy and paste any instructions or steps that can save the reviewer time.
-->

Open Questions / Follow-ups
---------------------------
<!--
Optional: Anything open to discussion for the reviewer, out of scope of this PR, or follow-ups.
-->
