### PR TITLE
Switch remaining `confluent kafka mirror` commands to using the cloud version of the kafkarest sdk

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -190,3 +190,5 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
+
+replace github.com/confluentinc/ccloud-sdk-go-v2/kafkarest => github.com/confluentinc/ccloud-sdk-go-v2-internal/kafkarest v0.0.12

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/confluentinc/ccloud-sdk-go-v2/iam v0.10.0
 	github.com/confluentinc/ccloud-sdk-go-v2/identity-provider v0.2.0
 	github.com/confluentinc/ccloud-sdk-go-v2/kafka-quotas v0.4.0
-	github.com/confluentinc/ccloud-sdk-go-v2/kafkarest v0.14.0
+	github.com/confluentinc/ccloud-sdk-go-v2/kafkarest v0.15.0
 	github.com/confluentinc/ccloud-sdk-go-v2/ksql v0.2.0
 	github.com/confluentinc/ccloud-sdk-go-v2/mds v0.4.0
 	github.com/confluentinc/ccloud-sdk-go-v2/metrics v0.2.0
@@ -190,5 +190,3 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
-
-replace github.com/confluentinc/ccloud-sdk-go-v2/kafkarest => github.com/confluentinc/ccloud-sdk-go-v2-internal/kafkarest v0.0.12

--- a/go.sum
+++ b/go.sum
@@ -108,8 +108,6 @@ github.com/cncf/xds/go v0.0.0-20211001041855-01bcc9b48dfe/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/confluentinc/ccloud-sdk-go-v1-public v0.0.0-20230427001341-5f8d2cce5ad9 h1:SPb0hN0B/XCUvaeaxferqVb9X5xFGaMKBAlP3HVW+MQ=
 github.com/confluentinc/ccloud-sdk-go-v1-public v0.0.0-20230427001341-5f8d2cce5ad9/go.mod h1:Ja+ScdwUPpLwPDi/jI4FU2hI4Ncu3o4A4nxo05ehXHQ=
-github.com/confluentinc/ccloud-sdk-go-v2-internal/kafkarest v0.0.12 h1:i2quX3BHb3iNEBgSY8PfpdY8jq1+s63v4HkufyEm6Vw=
-github.com/confluentinc/ccloud-sdk-go-v2-internal/kafkarest v0.0.12/go.mod h1:KBB4DTvDkiyw+1Di+sAEiWy/pvSllTl3kPGBwQy/Eq4=
 github.com/confluentinc/ccloud-sdk-go-v2/apikeys v0.4.0 h1:8fWyLwMuy8ec0MVF5Avd54UvbIxhDFhZzanHBVwgxdw=
 github.com/confluentinc/ccloud-sdk-go-v2/apikeys v0.4.0/go.mod h1:wNa9Qg2e2v/+PQsUyKh+qB22hhLkPR6Ahy6rP+1jmGI=
 github.com/confluentinc/ccloud-sdk-go-v2/billing v0.3.0 h1:a2EaPzwLEYkgil7rlsqRUlt994PMGubtdgRrF8Kbo10=
@@ -134,6 +132,8 @@ github.com/confluentinc/ccloud-sdk-go-v2/identity-provider v0.2.0 h1:9TT8UCFRc5z
 github.com/confluentinc/ccloud-sdk-go-v2/identity-provider v0.2.0/go.mod h1:JLmrXfnT2PzcuXHD8a6c2cW1c9LKK7aMsdZjjqxYPEk=
 github.com/confluentinc/ccloud-sdk-go-v2/kafka-quotas v0.4.0 h1:T9e7lNj/VjxE89+tcpX2RS2NE4rWNWbJjxcO2yehEqM=
 github.com/confluentinc/ccloud-sdk-go-v2/kafka-quotas v0.4.0/go.mod h1:7gqwWFIyj2MAGpL/kf6SGXm/pi2Z6qpMJIjKlgEEhhg=
+github.com/confluentinc/ccloud-sdk-go-v2/kafkarest v0.15.0 h1:NZv/gTgZEyzL3Di21oxIpFr8MVwhOe/iIpPTEZp1qZs=
+github.com/confluentinc/ccloud-sdk-go-v2/kafkarest v0.15.0/go.mod h1:1hTwJlTy/3WPjA6I4tFf3X8RjXRHe0RQhRYfR+gHaqc=
 github.com/confluentinc/ccloud-sdk-go-v2/ksql v0.2.0 h1:g6OHa1iW3HO3N/YiTAL9Q6Y7rdjMBAjOPYK37akTt0M=
 github.com/confluentinc/ccloud-sdk-go-v2/ksql v0.2.0/go.mod h1:0LAvd4VqlaRwKU4yvDEkVCtV43yNezt56+hBe9Lmg7Q=
 github.com/confluentinc/ccloud-sdk-go-v2/mds v0.4.0 h1:jIXXhGi+Xn+XYFCErnMvd035QijbYXla1Bo8W7V7lFM=

--- a/go.sum
+++ b/go.sum
@@ -108,6 +108,8 @@ github.com/cncf/xds/go v0.0.0-20211001041855-01bcc9b48dfe/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/confluentinc/ccloud-sdk-go-v1-public v0.0.0-20230427001341-5f8d2cce5ad9 h1:SPb0hN0B/XCUvaeaxferqVb9X5xFGaMKBAlP3HVW+MQ=
 github.com/confluentinc/ccloud-sdk-go-v1-public v0.0.0-20230427001341-5f8d2cce5ad9/go.mod h1:Ja+ScdwUPpLwPDi/jI4FU2hI4Ncu3o4A4nxo05ehXHQ=
+github.com/confluentinc/ccloud-sdk-go-v2-internal/kafkarest v0.0.12 h1:i2quX3BHb3iNEBgSY8PfpdY8jq1+s63v4HkufyEm6Vw=
+github.com/confluentinc/ccloud-sdk-go-v2-internal/kafkarest v0.0.12/go.mod h1:KBB4DTvDkiyw+1Di+sAEiWy/pvSllTl3kPGBwQy/Eq4=
 github.com/confluentinc/ccloud-sdk-go-v2/apikeys v0.4.0 h1:8fWyLwMuy8ec0MVF5Avd54UvbIxhDFhZzanHBVwgxdw=
 github.com/confluentinc/ccloud-sdk-go-v2/apikeys v0.4.0/go.mod h1:wNa9Qg2e2v/+PQsUyKh+qB22hhLkPR6Ahy6rP+1jmGI=
 github.com/confluentinc/ccloud-sdk-go-v2/billing v0.3.0 h1:a2EaPzwLEYkgil7rlsqRUlt994PMGubtdgRrF8Kbo10=
@@ -132,16 +134,12 @@ github.com/confluentinc/ccloud-sdk-go-v2/identity-provider v0.2.0 h1:9TT8UCFRc5z
 github.com/confluentinc/ccloud-sdk-go-v2/identity-provider v0.2.0/go.mod h1:JLmrXfnT2PzcuXHD8a6c2cW1c9LKK7aMsdZjjqxYPEk=
 github.com/confluentinc/ccloud-sdk-go-v2/kafka-quotas v0.4.0 h1:T9e7lNj/VjxE89+tcpX2RS2NE4rWNWbJjxcO2yehEqM=
 github.com/confluentinc/ccloud-sdk-go-v2/kafka-quotas v0.4.0/go.mod h1:7gqwWFIyj2MAGpL/kf6SGXm/pi2Z6qpMJIjKlgEEhhg=
-github.com/confluentinc/ccloud-sdk-go-v2/kafkarest v0.14.0 h1:PBtG7eLIbaYngsPe42nO8bFbYdG9Q41RctCap/PkiLg=
-github.com/confluentinc/ccloud-sdk-go-v2/kafkarest v0.14.0/go.mod h1:1hTwJlTy/3WPjA6I4tFf3X8RjXRHe0RQhRYfR+gHaqc=
 github.com/confluentinc/ccloud-sdk-go-v2/ksql v0.2.0 h1:g6OHa1iW3HO3N/YiTAL9Q6Y7rdjMBAjOPYK37akTt0M=
 github.com/confluentinc/ccloud-sdk-go-v2/ksql v0.2.0/go.mod h1:0LAvd4VqlaRwKU4yvDEkVCtV43yNezt56+hBe9Lmg7Q=
 github.com/confluentinc/ccloud-sdk-go-v2/mds v0.4.0 h1:jIXXhGi+Xn+XYFCErnMvd035QijbYXla1Bo8W7V7lFM=
 github.com/confluentinc/ccloud-sdk-go-v2/mds v0.4.0/go.mod h1:ufn9In8kDsyJ7Nru2ygpAaWdGw7DSDTOTtDhQVSmZjs=
 github.com/confluentinc/ccloud-sdk-go-v2/metrics v0.2.0 h1:TWwZHdfo2XNKrnGOuxXx4LF8WgahqqDC47Ap51L4thM=
 github.com/confluentinc/ccloud-sdk-go-v2/metrics v0.2.0/go.mod h1:odGsHChrn2l+jaOvx4Gib5//U4a3Id79wstQVkNh8v0=
-github.com/confluentinc/ccloud-sdk-go-v2/org v0.6.0 h1:kHITtUyof5/kALFCHLH7wSMlYmEZX0jKlh8Hich0Q8I=
-github.com/confluentinc/ccloud-sdk-go-v2/org v0.6.0/go.mod h1:40AGTF6TnYiBLR25utDlAdBKEYB3gt0wldxokJLz5r0=
 github.com/confluentinc/ccloud-sdk-go-v2/org v0.7.0 h1:+yjQZhFXd06wcW+oxhg2OGrYkN8QvYrOlOGrnw4PLUc=
 github.com/confluentinc/ccloud-sdk-go-v2/org v0.7.0/go.mod h1:40AGTF6TnYiBLR25utDlAdBKEYB3gt0wldxokJLz5r0=
 github.com/confluentinc/ccloud-sdk-go-v2/service-quota v0.2.0 h1:xVSmwdycExze1E2Jta99CaFuMOlL6k6KExOOSY1hSFg=

--- a/internal/kafka/command_mirror.go
+++ b/internal/kafka/command_mirror.go
@@ -1,10 +1,7 @@
 package kafka
 
 import (
-	"github.com/antihax/optional"
 	"github.com/spf13/cobra"
-
-	"github.com/confluentinc/kafka-rest-sdk-go/kafkarestv3"
 
 	pcmd "github.com/confluentinc/cli/v3/pkg/cmd"
 )
@@ -82,15 +79,14 @@ func (c *mirrorCommand) autocompleteMirrorTopics(cmd *cobra.Command) []string {
 		return nil
 	}
 
-	opts := &kafkarestv3.ListKafkaMirrorTopicsUnderLinkOpts{MirrorStatus: optional.EmptyInterface()}
-	listMirrorTopicsResponseDataList, _, err := kafkaREST.Client.ClusterLinkingV3Api.ListKafkaMirrorTopicsUnderLink(kafkaREST.Context, kafkaREST.GetClusterId(), linkName, opts)
+	mirrors, err := kafkaREST.CloudClient.ListKafkaMirrorTopicsUnderLink(linkName, nil)
 	if err != nil {
 		return nil
 	}
 
-	suggestions := make([]string, len(listMirrorTopicsResponseDataList.Data))
-	for i, mirrorTopic := range listMirrorTopicsResponseDataList.Data {
-		suggestions[i] = mirrorTopic.MirrorTopicName
+	suggestions := make([]string, len(mirrors.GetData()))
+	for i, mirror := range mirrors.GetData() {
+		suggestions[i] = mirror.GetMirrorTopicName()
 	}
 	return suggestions
 }

--- a/internal/kafka/command_mirror_describe.go
+++ b/internal/kafka/command_mirror_describe.go
@@ -5,7 +5,6 @@ import (
 
 	pcmd "github.com/confluentinc/cli/v3/pkg/cmd"
 	"github.com/confluentinc/cli/v3/pkg/examples"
-	"github.com/confluentinc/cli/v3/pkg/kafkarest"
 	"github.com/confluentinc/cli/v3/pkg/output"
 )
 
@@ -48,22 +47,22 @@ func (c *mirrorCommand) describe(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	mirror, httpResp, err := kafkaREST.Client.ClusterLinkingV3Api.ReadKafkaMirrorTopic(kafkaREST.Context, kafkaREST.GetClusterId(), linkName, mirrorTopicName)
+	mirror, err := kafkaREST.CloudClient.ReadKafkaMirrorTopic(linkName, mirrorTopicName)
 	if err != nil {
-		return kafkarest.NewError(kafkaREST.CloudClient.GetUrl(), err, httpResp)
+		return err
 	}
 
 	list := output.NewList(cmd)
-	for _, partitionLag := range mirror.MirrorLags {
+	for _, partitionLag := range mirror.GetMirrorLags().Items {
 		list.Add(&mirrorOut{
-			LinkName:              mirror.LinkName,
-			MirrorTopicName:       mirror.MirrorTopicName,
-			SourceTopicName:       mirror.SourceTopicName,
-			MirrorStatus:          string(mirror.MirrorStatus),
-			StatusTimeMs:          mirror.StateTimeMs,
-			Partition:             partitionLag.Partition,
-			PartitionMirrorLag:    partitionLag.Lag,
-			LastSourceFetchOffset: partitionLag.LastSourceFetchOffset,
+			LinkName:              mirror.GetLinkName(),
+			MirrorTopicName:       mirror.GetMirrorTopicName(),
+			SourceTopicName:       mirror.GetSourceTopicName(),
+			MirrorStatus:          string(mirror.GetMirrorStatus()),
+			StatusTimeMs:          mirror.GetStateTimeMs(),
+			Partition:             partitionLag.GetPartition(),
+			PartitionMirrorLag:    partitionLag.GetLag(),
+			LastSourceFetchOffset: partitionLag.GetLastSourceFetchOffset(),
 		})
 	}
 	list.Filter([]string{"LinkName", "MirrorTopicName", "Partition", "PartitionMirrorLag", "SourceTopicName", "MirrorStatus", "StatusTimeMs", "LastSourceFetchOffset"})

--- a/internal/kafka/command_mirror_list.go
+++ b/internal/kafka/command_mirror_list.go
@@ -2,16 +2,14 @@ package kafka
 
 import (
 	"fmt"
-	"net/http"
+	"strings"
 
-	"github.com/antihax/optional"
 	"github.com/spf13/cobra"
 
-	"github.com/confluentinc/kafka-rest-sdk-go/kafkarestv3"
+	kafkarestv3 "github.com/confluentinc/ccloud-sdk-go-v2/kafkarest/v3"
 
 	pcmd "github.com/confluentinc/cli/v3/pkg/cmd"
 	"github.com/confluentinc/cli/v3/pkg/examples"
-	"github.com/confluentinc/cli/v3/pkg/kafkarest"
 	"github.com/confluentinc/cli/v3/pkg/output"
 	"github.com/confluentinc/cli/v3/pkg/utils"
 )
@@ -62,41 +60,43 @@ func (c *mirrorCommand) list(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	mirrorStatusOpt := optional.EmptyInterface()
+	var mirrorTopicStatus *kafkarestv3.MirrorTopicStatus
 	if mirrorStatus != "" {
-		mirrorStatusOpt = optional.NewInterface(kafkarestv3.MirrorTopicStatus(mirrorStatus))
+		mirrorTopicStatus, err = kafkarestv3.NewMirrorTopicStatusFromValue(strings.ToUpper(mirrorStatus))
+		if err != nil {
+			return err
+		}
 	}
 
-	var listMirrorTopicsResponseDataList kafkarestv3.ListMirrorTopicsResponseDataList
-	var httpResp *http.Response
-
+	var mirrors kafkarestv3.ListMirrorTopicsResponseDataList
 	if linkName == "" {
-		opts := &kafkarestv3.ListKafkaMirrorTopicsOpts{MirrorStatus: mirrorStatusOpt}
-		listMirrorTopicsResponseDataList, httpResp, err = kafkaREST.Client.ClusterLinkingV3Api.ListKafkaMirrorTopics(kafkaREST.Context, kafkaREST.GetClusterId(), opts)
+		mirrors, err = kafkaREST.CloudClient.ListKafkaMirrorTopics(mirrorTopicStatus)
+		if err != nil {
+			return err
+		}
 	} else {
-		opts := &kafkarestv3.ListKafkaMirrorTopicsUnderLinkOpts{MirrorStatus: mirrorStatusOpt}
-		listMirrorTopicsResponseDataList, httpResp, err = kafkaREST.Client.ClusterLinkingV3Api.ListKafkaMirrorTopicsUnderLink(kafkaREST.Context, kafkaREST.GetClusterId(), linkName, opts)
-	}
-	if err != nil {
-		return kafkarest.NewError(kafkaREST.CloudClient.GetUrl(), err, httpResp)
+		mirrors, err = kafkaREST.CloudClient.ListKafkaMirrorTopicsUnderLink(linkName, mirrorTopicStatus)
+		if err != nil {
+			return err
+		}
 	}
 
 	list := output.NewList(cmd)
-	for _, mirror := range listMirrorTopicsResponseDataList.Data {
+	for _, mirror := range mirrors.GetData() {
 		var maxLag int64 = 0
-		for _, mirrorLag := range mirror.MirrorLags {
-			if mirrorLag.Lag > maxLag {
-				maxLag = mirrorLag.Lag
+		for _, mirrorLag := range mirror.GetMirrorLags().Items {
+			if lag := mirrorLag.GetLag(); lag > maxLag {
+				maxLag = lag
 			}
 		}
 
 		list.Add(&mirrorOut{
-			LinkName:                 mirror.LinkName,
-			MirrorTopicName:          mirror.MirrorTopicName,
-			SourceTopicName:          mirror.SourceTopicName,
-			MirrorStatus:             string(mirror.MirrorStatus),
-			StatusTimeMs:             mirror.StateTimeMs,
-			NumPartition:             mirror.NumPartitions,
+			LinkName:                 mirror.GetLinkName(),
+			MirrorTopicName:          mirror.GetMirrorTopicName(),
+			SourceTopicName:          mirror.GetSourceTopicName(),
+			MirrorStatus:             string(mirror.GetMirrorStatus()),
+			StatusTimeMs:             mirror.GetStateTimeMs(),
+			NumPartition:             mirror.GetNumPartitions(),
 			MaxPerPartitionMirrorLag: maxLag,
 		})
 	}

--- a/test/fixtures/output/kafka/mirror/describe-autocomplete.golden
+++ b/test/fixtures/output/kafka/mirror/describe-autocomplete.golden
@@ -1,4 +1,7 @@
 dest-topic-1
 dest-topic-2
+dest-topic-3
+dest-topic-4
+dest-topic-5
 :4
 Completion ended with directive: ShellCompDirectiveNoFileComp

--- a/test/fixtures/output/kafka/mirror/list-mirror-json.golden
+++ b/test/fixtures/output/kafka/mirror/list-mirror-json.golden
@@ -16,5 +16,32 @@
     "status_time_ms": 222222222,
     "num_partition": 2,
     "max_per_partition_mirror_lag": 0
+  },
+  {
+    "link_name": "link-3",
+    "mirror_topic_name": "dest-topic-3",
+    "source_topic_name": "src-topic-3",
+    "mirror_status": "LINK_FAILED",
+    "status_time_ms": 222222222,
+    "num_partition": 2,
+    "max_per_partition_mirror_lag": 0
+  },
+  {
+    "link_name": "link-4",
+    "mirror_topic_name": "dest-topic-4",
+    "source_topic_name": "src-topic-4",
+    "mirror_status": "LINK_PAUSED",
+    "status_time_ms": 222222222,
+    "num_partition": 2,
+    "max_per_partition_mirror_lag": 0
+  },
+  {
+    "link_name": "link-5",
+    "mirror_topic_name": "dest-topic-5",
+    "source_topic_name": "src-topic-5",
+    "mirror_status": "SOURCE_UNAVAILABLE",
+    "status_time_ms": 222222222,
+    "num_partition": 2,
+    "max_per_partition_mirror_lag": 0
   }
 ]

--- a/test/fixtures/output/kafka/mirror/list-mirror-yaml.golden
+++ b/test/fixtures/output/kafka/mirror/list-mirror-yaml.golden
@@ -12,3 +12,24 @@
   status_time_ms: 222222222
   num_partition: 2
   max_per_partition_mirror_lag: 0
+- link_name: link-3
+  mirror_topic_name: dest-topic-3
+  source_topic_name: src-topic-3
+  mirror_status: LINK_FAILED
+  status_time_ms: 222222222
+  num_partition: 2
+  max_per_partition_mirror_lag: 0
+- link_name: link-4
+  mirror_topic_name: dest-topic-4
+  source_topic_name: src-topic-4
+  mirror_status: LINK_PAUSED
+  status_time_ms: 222222222
+  num_partition: 2
+  max_per_partition_mirror_lag: 0
+- link_name: link-5
+  mirror_topic_name: dest-topic-5
+  source_topic_name: src-topic-5
+  mirror_status: SOURCE_UNAVAILABLE
+  status_time_ms: 222222222
+  num_partition: 2
+  max_per_partition_mirror_lag: 0

--- a/test/fixtures/output/kafka/mirror/list-mirror.golden
+++ b/test/fixtures/output/kafka/mirror/list-mirror.golden
@@ -1,4 +1,7 @@
-  Link Name | Mirror Topic Name | Source Topic Name | Mirror Status | Status Time (ms) | Num Partition | Max Per Partition Mirror Lag  
-------------+-------------------+-------------------+---------------+------------------+---------------+-------------------------------
-  link-1    | dest-topic-1      | src-topic-1       | ACTIVE        |        111111111 |             3 |                       571428  
-  link-2    | dest-topic-2      | src-topic-2       | STOPPED       |        222222222 |             2 |                            0  
+  Link Name | Mirror Topic Name | Source Topic Name |   Mirror Status    | Status Time (ms) | Num Partition | Max Per Partition Mirror Lag  
+------------+-------------------+-------------------+--------------------+------------------+---------------+-------------------------------
+  link-1    | dest-topic-1      | src-topic-1       | ACTIVE             |        111111111 |             3 |                       571428  
+  link-2    | dest-topic-2      | src-topic-2       | STOPPED            |        222222222 |             2 |                            0  
+  link-3    | dest-topic-3      | src-topic-3       | LINK_FAILED        |        222222222 |             2 |                            0  
+  link-4    | dest-topic-4      | src-topic-4       | LINK_PAUSED        |        222222222 |             2 |                            0  
+  link-5    | dest-topic-5      | src-topic-5       | SOURCE_UNAVAILABLE |        222222222 |             2 |                            0  

--- a/test/test-server/kafka_rest_router.go
+++ b/test/test-server/kafka_rest_router.go
@@ -914,6 +914,72 @@ func handleKafkaRestMirrors(t *testing.T) http.HandlerFunc {
 					MirrorStatus: cckafkarestv3.STOPPED,
 					StateTimeMs:  222222222,
 				},
+				{
+					LinkName:        "link-3",
+					MirrorTopicName: "dest-topic-3",
+					SourceTopicName: "src-topic-3",
+					NumPartitions:   2,
+					MirrorLags: cckafkarestv3.MirrorLags{
+						Items: []cckafkarestv3.MirrorLag{
+							{
+								Partition:             0,
+								Lag:                   0,
+								LastSourceFetchOffset: 0,
+							},
+							{
+								Partition:             1,
+								Lag:                   0,
+								LastSourceFetchOffset: 0,
+							},
+						},
+					},
+					MirrorStatus: cckafkarestv3.LINK_FAILED,
+					StateTimeMs:  222222222,
+				},
+				{
+					LinkName:        "link-4",
+					MirrorTopicName: "dest-topic-4",
+					SourceTopicName: "src-topic-4",
+					NumPartitions:   2,
+					MirrorLags: cckafkarestv3.MirrorLags{
+						Items: []cckafkarestv3.MirrorLag{
+							{
+								Partition:             0,
+								Lag:                   0,
+								LastSourceFetchOffset: 0,
+							},
+							{
+								Partition:             1,
+								Lag:                   0,
+								LastSourceFetchOffset: 0,
+							},
+						},
+					},
+					MirrorStatus: cckafkarestv3.LINK_PAUSED,
+					StateTimeMs:  222222222,
+				},
+				{
+					LinkName:        "link-5",
+					MirrorTopicName: "dest-topic-5",
+					SourceTopicName: "src-topic-5",
+					NumPartitions:   2,
+					MirrorLags: cckafkarestv3.MirrorLags{
+						Items: []cckafkarestv3.MirrorLag{
+							{
+								Partition:             0,
+								Lag:                   0,
+								LastSourceFetchOffset: 0,
+							},
+							{
+								Partition:             1,
+								Lag:                   0,
+								LastSourceFetchOffset: 0,
+							},
+						},
+					},
+					MirrorStatus: cckafkarestv3.SOURCE_UNAVAILABLE,
+					StateTimeMs:  222222222,
+				},
 			}})
 			require.NoError(t, err)
 		}


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- PLACEHOLDER

New Features
- PLACEHOLDER

Bug Fixes
- PLACEHOLDER

Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
Switch `mirror describe | list` back to using the proper SDK, which has been updated to include the previously missing `LINK_PAUSED`, `LINK_FAILED`, and `SOURCE_UNAVAILABLE` statuses.

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
Updated the list test to include the three missing statuses.

Open Questions / Follow-ups
---------------------------
<!--
Optional: Anything open to discussion for the reviewer, out of scope of this PR, or follow-ups.
-->
