### PR TITLE
[TRAFFIC-9330][TRAFFIC-9331] - Add `confluent network private-link access list|describe` commands

### DIFF
--- a/internal/network/command.go
+++ b/internal/network/command.go
@@ -82,6 +82,7 @@ func New(prerunner pcmd.PreRunner) *cobra.Command {
 	cmd.AddCommand(c.newDescribeCommand())
 	cmd.AddCommand(c.newListCommand())
 	cmd.AddCommand(newPeeringCommand(prerunner))
+	cmd.AddCommand(newPrivateLinkCommand(prerunner))
 	cmd.AddCommand(newTransitGatewayAttachmentCommand(prerunner))
 	cmd.AddCommand(c.newUpdateCommand())
 

--- a/internal/network/command.go
+++ b/internal/network/command.go
@@ -82,7 +82,7 @@ func New(prerunner pcmd.PreRunner) *cobra.Command {
 	cmd.AddCommand(c.newDescribeCommand())
 	cmd.AddCommand(c.newListCommand())
 	cmd.AddCommand(newPeeringCommand(prerunner))
-	cmd.AddCommand(newPrivateLinkCommand(prerunner))
+	cmd.AddCommand(c.newPrivateLinkCommand())
 	cmd.AddCommand(newTransitGatewayAttachmentCommand(prerunner))
 	cmd.AddCommand(c.newUpdateCommand())
 

--- a/internal/network/command_private_link.go
+++ b/internal/network/command_private_link.go
@@ -1,0 +1,20 @@
+package network
+
+import (
+	"github.com/spf13/cobra"
+
+	pcmd "github.com/confluentinc/cli/v3/pkg/cmd"
+)
+
+func newPrivateLinkCommand(prerunner pcmd.PreRunner) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "private-link",
+		Short:   "Manage private links.",
+		Aliases: []string{"pl"},
+		Args:    cobra.NoArgs,
+	}
+
+	cmd.AddCommand(newPrivateLinkAccessCommand(prerunner))
+
+	return cmd
+}

--- a/internal/network/command_private_link.go
+++ b/internal/network/command_private_link.go
@@ -2,18 +2,16 @@ package network
 
 import (
 	"github.com/spf13/cobra"
-
-	pcmd "github.com/confluentinc/cli/v3/pkg/cmd"
 )
 
-func newPrivateLinkCommand(prerunner pcmd.PreRunner) *cobra.Command {
+func (c *command) newPrivateLinkCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "private-link",
 		Short:   "Manage private links.",
 		Aliases: []string{"pl"},
 	}
 
-	cmd.AddCommand(newPrivateLinkAccessCommand(prerunner))
+	cmd.AddCommand(c.newPrivateLinkAccessCommand())
 
 	return cmd
 }

--- a/internal/network/command_private_link.go
+++ b/internal/network/command_private_link.go
@@ -11,7 +11,6 @@ func newPrivateLinkCommand(prerunner pcmd.PreRunner) *cobra.Command {
 		Use:     "private-link",
 		Short:   "Manage private links.",
 		Aliases: []string{"pl"},
-		Args:    cobra.NoArgs,
 	}
 
 	cmd.AddCommand(newPrivateLinkAccessCommand(prerunner))

--- a/internal/network/command_private_link_access_describe.go
+++ b/internal/network/command_private_link_access_describe.go
@@ -1,0 +1,44 @@
+package network
+
+import (
+	"github.com/spf13/cobra"
+
+	pcmd "github.com/confluentinc/cli/v3/pkg/cmd"
+	"github.com/confluentinc/cli/v3/pkg/examples"
+)
+
+func (c *privateLinkAccessCommand) newDescribeCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:               "describe <id>",
+		Short:             "Describe a private link access.",
+		Args:              cobra.ExactArgs(1),
+		ValidArgsFunction: pcmd.NewValidArgsFunction(c.validArgs),
+		RunE:              c.describe,
+		Example: examples.BuildExampleString(
+			examples.Example{
+				Text: `Describe private link access "pla-123456".`,
+				Code: "confluent network private-link access describe pla-123456",
+			},
+		),
+	}
+
+	pcmd.AddContextFlag(cmd, c.CLICommand)
+	pcmd.AddEnvironmentFlag(cmd, c.AuthenticatedCLICommand)
+	pcmd.AddOutputFlag(cmd)
+
+	return cmd
+}
+
+func (c *privateLinkAccessCommand) describe(cmd *cobra.Command, args []string) error {
+	environmentId, err := c.Context.EnvironmentId()
+	if err != nil {
+		return err
+	}
+
+	access, err := c.V2Client.GetPrivateLinkAccess(environmentId, args[0])
+	if err != nil {
+		return err
+	}
+
+	return c.printPrivateLinkAccessTable(cmd, access)
+}

--- a/internal/network/command_private_link_access_describe.go
+++ b/internal/network/command_private_link_access_describe.go
@@ -7,13 +7,13 @@ import (
 	"github.com/confluentinc/cli/v3/pkg/examples"
 )
 
-func (c *privateLinkAccessCommand) newDescribeCommand() *cobra.Command {
+func (c *command) newPrivateLinkAccessDescribeCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "describe <id>",
 		Short:             "Describe a private link access.",
 		Args:              cobra.ExactArgs(1),
-		ValidArgsFunction: pcmd.NewValidArgsFunction(c.validArgs),
-		RunE:              c.describe,
+		ValidArgsFunction: pcmd.NewValidArgsFunction(c.validPrivateLinkAccessArgs),
+		RunE:              c.describePrivateLinkAccess,
 		Example: examples.BuildExampleString(
 			examples.Example{
 				Text: `Describe private link access "pla-123456".`,
@@ -29,7 +29,7 @@ func (c *privateLinkAccessCommand) newDescribeCommand() *cobra.Command {
 	return cmd
 }
 
-func (c *privateLinkAccessCommand) describe(cmd *cobra.Command, args []string) error {
+func (c *command) describePrivateLinkAccess(cmd *cobra.Command, args []string) error {
 	environmentId, err := c.Context.EnvironmentId()
 	if err != nil {
 		return err

--- a/internal/network/command_private_link_access_list.go
+++ b/internal/network/command_private_link_access_list.go
@@ -19,12 +19,12 @@ type listPrivateLinkAccessOut struct {
 	Phase        string `human:"Phase" serialized:"phase"`
 }
 
-func (c *privateLinkAccessCommand) newListCommand() *cobra.Command {
+func (c *command) newPrivateLinkAccessListCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List private link accesses.",
 		Args:  cobra.NoArgs,
-		RunE:  c.list,
+		RunE:  c.listPrivateLinkAccesses,
 	}
 
 	pcmd.AddContextFlag(cmd, c.CLICommand)
@@ -34,7 +34,7 @@ func (c *privateLinkAccessCommand) newListCommand() *cobra.Command {
 	return cmd
 }
 
-func (c *privateLinkAccessCommand) list(cmd *cobra.Command, _ []string) error {
+func (c *command) listPrivateLinkAccesses(cmd *cobra.Command, _ []string) error {
 	accesses, err := c.getPrivateLinkAccesses()
 	if err != nil {
 		return err
@@ -49,7 +49,7 @@ func (c *privateLinkAccessCommand) list(cmd *cobra.Command, _ []string) error {
 			return fmt.Errorf(errors.CorruptedNetworkResponseErrorMsg, "status")
 		}
 
-		cloud, err := c.getCloud(access)
+		cloud, err := getPrivateLinkAccessCloud(access)
 		if err != nil {
 			return err
 		}

--- a/internal/network/command_private_link_access_list.go
+++ b/internal/network/command_private_link_access_list.go
@@ -1,0 +1,77 @@
+package network
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	pcmd "github.com/confluentinc/cli/v3/pkg/cmd"
+	"github.com/confluentinc/cli/v3/pkg/errors"
+	"github.com/confluentinc/cli/v3/pkg/output"
+)
+
+type listPrivateLinkAccessOut struct {
+	Id           string `human:"ID" serialized:"id"`
+	Name         string `human:"Name" serialized:"name"`
+	NetworkId    string `human:"Network ID" serialized:"network_id"`
+	Cloud        string `human:"Cloud" serialized:"cloud"`
+	CloudAccount string `human:"Cloud Account,omitempty" serialized:"cloud_account,omitempty"`
+	Phase        string `human:"Phase" serialized:"phase"`
+}
+
+func (c *privateLinkAccessCommand) newListCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List private link accesses.",
+		Args:  cobra.NoArgs,
+		RunE:  c.list,
+	}
+
+	pcmd.AddContextFlag(cmd, c.CLICommand)
+	pcmd.AddEnvironmentFlag(cmd, c.AuthenticatedCLICommand)
+	pcmd.AddOutputFlag(cmd)
+
+	return cmd
+}
+
+func (c *privateLinkAccessCommand) list(cmd *cobra.Command, _ []string) error {
+	accesses, err := c.getPrivateLinkAccesses()
+	if err != nil {
+		return err
+	}
+
+	list := output.NewList(cmd)
+	for _, access := range accesses {
+		if access.Spec == nil {
+			return fmt.Errorf(errors.CorruptedNetworkResponseErrorMsg, "spec")
+		}
+		if access.Status == nil {
+			return fmt.Errorf(errors.CorruptedNetworkResponseErrorMsg, "status")
+		}
+
+		cloud, err := c.getCloud(access)
+		if err != nil {
+			return err
+		}
+
+		out := &listPrivateLinkAccessOut{
+			Id:        access.GetId(),
+			Name:      access.Spec.GetDisplayName(),
+			NetworkId: access.Spec.Network.GetId(),
+			Cloud:     cloud,
+			Phase:     access.Status.GetPhase(),
+		}
+
+		switch cloud {
+		case CloudAws:
+			out.CloudAccount = access.Spec.Cloud.NetworkingV1AwsPrivateLinkAccess.GetAccount()
+		case CloudGcp:
+			out.CloudAccount = access.Spec.Cloud.NetworkingV1GcpPrivateServiceConnectAccess.GetProject()
+		case CloudAzure:
+			out.CloudAccount = access.Spec.Cloud.NetworkingV1AzurePrivateLinkAccess.GetSubscription()
+		}
+
+		list.Add(out)
+	}
+	return list.Print()
+}

--- a/internal/network/command_private_link_access_test.go
+++ b/internal/network/command_private_link_access_test.go
@@ -1,0 +1,42 @@
+package network
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+
+	networkingv1 "github.com/confluentinc/ccloud-sdk-go-v2/networking/v1"
+
+	pcmd "github.com/confluentinc/cli/v3/pkg/cmd"
+	"github.com/confluentinc/cli/v3/pkg/config"
+	dynamicconfig "github.com/confluentinc/cli/v3/pkg/dynamic-config"
+)
+
+func TesGetCloudWithAwsPrivateLinkAccess(t *testing.T) {
+	cmd := new(cobra.Command)
+	cfg := config.AuthenticatedCloudConfigMock()
+	prerunner := &pcmd.PreRun{Config: cfg}
+	c := &privateLinkAccessCommand{pcmd.NewAuthenticatedCLICommand(cmd, prerunner)}
+	c.Config = dynamicconfig.New(cfg, nil)
+
+	cloud, err := c.getCloud(networkingv1.NetworkingV1PrivateLinkAccess{
+		Id: networkingv1.PtrString("pla-123456"),
+		Spec: &networkingv1.NetworkingV1PrivateLinkAccessSpec{
+			Cloud: &networkingv1.NetworkingV1PrivateLinkAccessSpecCloudOneOf{
+				NetworkingV1AwsPrivateLinkAccess: &networkingv1.NetworkingV1AwsPrivateLinkAccess{
+					Kind:    "AwsPrivateLinkAccess",
+					Account: "012345678901",
+				},
+			},
+			DisplayName: networkingv1.PtrString("aws-pla"),
+			Environment: &networkingv1.ObjectReference{Id: "env-00000"},
+			Network:     &networkingv1.ObjectReference{Id: "n-abcde1"},
+		},
+		Status: &networkingv1.NetworkingV1PrivateLinkAccessStatus{
+			Phase: "READY",
+		},
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, CloudAws, cloud)
+}

--- a/internal/network/command_private_link_access_test.go
+++ b/internal/network/command_private_link_access_test.go
@@ -3,24 +3,13 @@ package network
 import (
 	"testing"
 
-	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 
 	networkingv1 "github.com/confluentinc/ccloud-sdk-go-v2/networking/v1"
-
-	pcmd "github.com/confluentinc/cli/v3/pkg/cmd"
-	"github.com/confluentinc/cli/v3/pkg/config"
-	dynamicconfig "github.com/confluentinc/cli/v3/pkg/dynamic-config"
 )
 
-func TesGetCloudWithAwsPrivateLinkAccess(t *testing.T) {
-	cmd := new(cobra.Command)
-	cfg := config.AuthenticatedCloudConfigMock()
-	prerunner := &pcmd.PreRun{Config: cfg}
-	c := &privateLinkAccessCommand{pcmd.NewAuthenticatedCLICommand(cmd, prerunner)}
-	c.Config = dynamicconfig.New(cfg, nil)
-
-	cloud, err := c.getCloud(networkingv1.NetworkingV1PrivateLinkAccess{
+func TestGetPrivateLinkAccessCloudWithAws(t *testing.T) {
+	cloud, err := getPrivateLinkAccessCloud(networkingv1.NetworkingV1PrivateLinkAccess{
 		Id: networkingv1.PtrString("pla-123456"),
 		Spec: &networkingv1.NetworkingV1PrivateLinkAccessSpec{
 			Cloud: &networkingv1.NetworkingV1PrivateLinkAccessSpecCloudOneOf{
@@ -39,4 +28,53 @@ func TesGetCloudWithAwsPrivateLinkAccess(t *testing.T) {
 	})
 	assert.NoError(t, err)
 	assert.Equal(t, CloudAws, cloud)
+}
+
+func TestGetPrivateLinkAccessCloudWithAzure(t *testing.T) {
+	cloud, err := getPrivateLinkAccessCloud(networkingv1.NetworkingV1PrivateLinkAccess{
+		Id: networkingv1.PtrString("pla-123456"),
+		Spec: &networkingv1.NetworkingV1PrivateLinkAccessSpec{
+			Cloud: &networkingv1.NetworkingV1PrivateLinkAccessSpecCloudOneOf{
+				NetworkingV1AzurePrivateLinkAccess: &networkingv1.NetworkingV1AzurePrivateLinkAccess{
+					Kind:         "AzurePrivateLinkAccess",
+					Subscription: "1234abcd-12ab-34cd-1234-123456abcdef",
+				},
+			},
+			DisplayName: networkingv1.PtrString("aws-pla"),
+			Environment: &networkingv1.ObjectReference{Id: "env-00000"},
+			Network:     &networkingv1.ObjectReference{Id: "n-abcde1"},
+		},
+		Status: &networkingv1.NetworkingV1PrivateLinkAccessStatus{
+			Phase: "READY",
+		},
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, CloudAzure, cloud)
+}
+
+func TestGetPrivateLinkAccessCloudWithGcp(t *testing.T) {
+	cloud, err := getPrivateLinkAccessCloud(networkingv1.NetworkingV1PrivateLinkAccess{
+		Id: networkingv1.PtrString("pla-123456"),
+		Spec: &networkingv1.NetworkingV1PrivateLinkAccessSpec{
+			Cloud: &networkingv1.NetworkingV1PrivateLinkAccessSpecCloudOneOf{
+				NetworkingV1GcpPrivateServiceConnectAccess: &networkingv1.NetworkingV1GcpPrivateServiceConnectAccess{
+					Kind:    "GcpPrivateServiceConnectAccess",
+					Project: "temp-gear-123456",
+				},
+			},
+			DisplayName: networkingv1.PtrString("aws-pla"),
+			Environment: &networkingv1.ObjectReference{Id: "env-00000"},
+			Network:     &networkingv1.ObjectReference{Id: "n-abcde1"},
+		},
+		Status: &networkingv1.NetworkingV1PrivateLinkAccessStatus{
+			Phase: "READY",
+		},
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, CloudGcp, cloud)
+}
+
+func TestGetPrivateLinkAccessCloudWithEmptyValue(t *testing.T) {
+	_, err := getPrivateLinkAccessCloud(networkingv1.NetworkingV1PrivateLinkAccess{})
+	assert.Error(t, err)
 }

--- a/pkg/ccloudv2/networking.go
+++ b/pkg/ccloudv2/networking.go
@@ -171,3 +171,38 @@ func (c *Client) CreateTransitGatewayAttachment(attachment networkingv1.Networki
 	resp, httpResp, err := c.NetworkingClient.TransitGatewayAttachmentsNetworkingV1Api.CreateNetworkingV1TransitGatewayAttachment(c.networkingApiContext()).NetworkingV1TransitGatewayAttachment(attachment).Execute()
 	return resp, errors.CatchCCloudV2Error(err, httpResp)
 }
+
+func (c *Client) ListPrivateLinkAccesses(environment string) ([]networkingv1.NetworkingV1PrivateLinkAccess, error) {
+	var list []networkingv1.NetworkingV1PrivateLinkAccess
+
+	done := false
+	pageToken := ""
+	for !done {
+		page, err := c.executeListPrivateLinkAccesses(environment, pageToken)
+		if err != nil {
+			return nil, err
+		}
+		list = append(list, page.GetData()...)
+
+		pageToken, done, err = extractNextPageToken(page.GetMetadata().Next)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return list, nil
+}
+
+func (c *Client) executeListPrivateLinkAccesses(environment, pageToken string) (networkingv1.NetworkingV1PrivateLinkAccessList, error) {
+	req := c.NetworkingClient.PrivateLinkAccessesNetworkingV1Api.ListNetworkingV1PrivateLinkAccesses(c.networkingApiContext()).Environment(environment).PageSize(ccloudV2ListPageSize)
+	if pageToken != "" {
+		req = req.PageToken(pageToken)
+	}
+
+	resp, httpResp, err := req.Execute()
+	return resp, errors.CatchCCloudV2Error(err, httpResp)
+}
+
+func (c *Client) GetPrivateLinkAccess(environment, id string) (networkingv1.NetworkingV1PrivateLinkAccess, error) {
+	resp, httpResp, err := c.NetworkingClient.PrivateLinkAccessesNetworkingV1Api.GetNetworkingV1PrivateLinkAccess(c.networkingApiContext(), id).Environment(environment).Execute()
+	return resp, errors.CatchCCloudV2Error(err, httpResp)
+}

--- a/test/fixtures/output/network/help.golden
+++ b/test/fixtures/output/network/help.golden
@@ -9,6 +9,7 @@ Available Commands:
   describe                   Describe a network.
   list                       List networks.
   peering                    Manage peerings.
+  private-link               Manage private links.
   transit-gateway-attachment Manage transit gateway attachments.
   update                     Update an existing network.
 

--- a/test/fixtures/output/network/private-link/access/describe-autocomplete.golden
+++ b/test/fixtures/output/network/private-link/access/describe-autocomplete.golden
@@ -1,0 +1,5 @@
+pla-111111	aws-pla
+pla-111112	gcp-pla
+pla-111113	azure-pla
+:4
+Completion ended with directive: ShellCompDirectiveNoFileComp

--- a/test/fixtures/output/network/private-link/access/describe-aws-json.golden
+++ b/test/fixtures/output/network/private-link/access/describe-aws-json.golden
@@ -1,0 +1,8 @@
+{
+  "id": "pla-111111",
+  "name": "aws-pla",
+  "network_id": "n-abcde1",
+  "cloud": "AWS",
+  "aws_account": "012345678901",
+  "phase": "READY"
+}

--- a/test/fixtures/output/network/private-link/access/describe-aws.golden
+++ b/test/fixtures/output/network/private-link/access/describe-aws.golden
@@ -1,0 +1,8 @@
++-------------+--------------+
+| ID          | pla-111111   |
+| Name        | aws-pla      |
+| Network ID  | n-abcde1     |
+| Cloud       | AWS          |
+| AWS Account | 012345678901 |
+| Phase       | READY        |
++-------------+--------------+

--- a/test/fixtures/output/network/private-link/access/describe-azure.golden
+++ b/test/fixtures/output/network/private-link/access/describe-azure.golden
@@ -1,0 +1,8 @@
++--------------------+--------------------------------------+
+| ID                 | pla-111113                           |
+| Name               | azure-pla                            |
+| Network ID         | n-abcde1                             |
+| Cloud              | AZURE                                |
+| Azure Subscription | 1234abcd-12ab-34cd-1234-123456abcdef |
+| Phase              | READY                                |
++--------------------+--------------------------------------+

--- a/test/fixtures/output/network/private-link/access/describe-gcp.golden
+++ b/test/fixtures/output/network/private-link/access/describe-gcp.golden
@@ -1,0 +1,8 @@
++-------------+------------------+
+| ID          | pla-111112       |
+| Name        | gcp-pla          |
+| Network ID  | n-abcde1         |
+| Cloud       | GCP              |
+| GCP Project | temp-gear-123456 |
+| Phase       | READY            |
++-------------+------------------+

--- a/test/fixtures/output/network/private-link/access/describe-help.golden
+++ b/test/fixtures/output/network/private-link/access/describe-help.golden
@@ -1,0 +1,19 @@
+Describe a private link access.
+
+Usage:
+  confluent network private-link access describe <id> [flags]
+
+Examples:
+Describe private link access "pla-123456".
+
+  $ confluent network private-link access describe pla-123456
+
+Flags:
+      --context string       CLI context name.
+      --environment string   Environment ID.
+  -o, --output string        Specify the output format as "human", "json", or "yaml". (default "human")
+
+Global Flags:
+  -h, --help            Show help for this command.
+      --unsafe-trace    Equivalent to -vvvv, but also log HTTP requests and responses which might contain plaintext secrets.
+  -v, --verbose count   Increase verbosity (-v for warn, -vv for info, -vvv for debug, -vvvv for trace).

--- a/test/fixtures/output/network/private-link/access/describe-invalid.golden
+++ b/test/fixtures/output/network/private-link/access/describe-invalid.golden
@@ -1,0 +1,1 @@
+Error: The private-link-access pla-invalid was not found.: 404 Not Found

--- a/test/fixtures/output/network/private-link/access/describe-missing-id.golden
+++ b/test/fixtures/output/network/private-link/access/describe-missing-id.golden
@@ -1,0 +1,19 @@
+Error: accepts 1 arg(s), received 0
+Usage:
+  confluent network private-link access describe <id> [flags]
+
+Examples:
+Describe private link access "pla-123456".
+
+  $ confluent network private-link access describe pla-123456
+
+Flags:
+      --context string       CLI context name.
+      --environment string   Environment ID.
+  -o, --output string        Specify the output format as "human", "json", or "yaml". (default "human")
+
+Global Flags:
+  -h, --help            Show help for this command.
+      --unsafe-trace    Equivalent to -vvvv, but also log HTTP requests and responses which might contain plaintext secrets.
+  -v, --verbose count   Increase verbosity (-v for warn, -vv for info, -vvv for debug, -vvvv for trace).
+

--- a/test/fixtures/output/network/private-link/access/help.golden
+++ b/test/fixtures/output/network/private-link/access/help.golden
@@ -1,0 +1,15 @@
+Manage private link accesses.
+
+Usage:
+  confluent network private-link access [command]
+
+Available Commands:
+  describe    Describe a private link access.
+  list        List private link accesses.
+
+Global Flags:
+  -h, --help            Show help for this command.
+      --unsafe-trace    Equivalent to -vvvv, but also log HTTP requests and responses which might contain plaintext secrets.
+  -v, --verbose count   Increase verbosity (-v for warn, -vv for info, -vvv for debug, -vvvv for trace).
+
+Use "confluent network private-link access [command] --help" for more information about a command.

--- a/test/fixtures/output/network/private-link/access/list-help.golden
+++ b/test/fixtures/output/network/private-link/access/list-help.golden
@@ -1,0 +1,14 @@
+List private link accesses.
+
+Usage:
+  confluent network private-link access list [flags]
+
+Flags:
+      --context string       CLI context name.
+      --environment string   Environment ID.
+  -o, --output string        Specify the output format as "human", "json", or "yaml". (default "human")
+
+Global Flags:
+  -h, --help            Show help for this command.
+      --unsafe-trace    Equivalent to -vvvv, but also log HTTP requests and responses which might contain plaintext secrets.
+  -v, --verbose count   Increase verbosity (-v for warn, -vv for info, -vvv for debug, -vvvv for trace).

--- a/test/fixtures/output/network/private-link/access/list-json.golden
+++ b/test/fixtures/output/network/private-link/access/list-json.golden
@@ -1,0 +1,26 @@
+[
+  {
+    "id": "pla-111111",
+    "name": "aws-pla",
+    "network_id": "n-abcde1",
+    "cloud": "AWS",
+    "cloud_account": "012345678901",
+    "phase": "READY"
+  },
+  {
+    "id": "pla-111112",
+    "name": "gcp-pla",
+    "network_id": "n-abcde1",
+    "cloud": "GCP",
+    "cloud_account": "temp-gear-123456",
+    "phase": "READY"
+  },
+  {
+    "id": "pla-111113",
+    "name": "azure-pla",
+    "network_id": "n-abcde1",
+    "cloud": "AZURE",
+    "cloud_account": "1234abcd-12ab-34cd-1234-123456abcdef",
+    "phase": "READY"
+  }
+]

--- a/test/fixtures/output/network/private-link/access/list.golden
+++ b/test/fixtures/output/network/private-link/access/list.golden
@@ -1,0 +1,5 @@
+      ID     |   Name    | Network ID | Cloud |            Cloud Account             | Phase  
+-------------+-----------+------------+-------+--------------------------------------+--------
+  pla-111111 | aws-pla   | n-abcde1   | AWS   |                         012345678901 | READY  
+  pla-111112 | gcp-pla   | n-abcde1   | GCP   | temp-gear-123456                     | READY  
+  pla-111113 | azure-pla | n-abcde1   | AZURE | 1234abcd-12ab-34cd-1234-123456abcdef | READY  

--- a/test/fixtures/output/network/private-link/help.golden
+++ b/test/fixtures/output/network/private-link/help.golden
@@ -1,0 +1,17 @@
+Manage private links.
+
+Usage:
+  confluent network private-link [command]
+
+Aliases:
+  private-link, pl
+
+Available Commands:
+  access      Manage private link accesses.
+
+Global Flags:
+  -h, --help            Show help for this command.
+      --unsafe-trace    Equivalent to -vvvv, but also log HTTP requests and responses which might contain plaintext secrets.
+  -v, --verbose count   Increase verbosity (-v for warn, -vv for info, -vvv for debug, -vvvv for trace).
+
+Use "confluent network private-link [command] --help" for more information about a command.

--- a/test/network_test.go
+++ b/test/network_test.go
@@ -269,3 +269,44 @@ func (s *CLITestSuite) TestNetworkTransitGatewayAttachment_Autocomplete() {
 		s.runIntegrationTest(test)
 	}
 }
+
+func (s *CLITestSuite) TestNetworkPrivateLinkAccessList() {
+	tests := []CLITest{
+		{args: "network pl access list", fixture: "network/private-link/access/list.golden"},
+		{args: "network private-link access list", fixture: "network/private-link/access/list.golden"},
+		{args: "network private-link access list --output json", fixture: "network/private-link/access/list-json.golden"},
+	}
+
+	for _, test := range tests {
+		test.login = "cloud"
+		s.runIntegrationTest(test)
+	}
+}
+
+func (s *CLITestSuite) TestNetworkPrivateLinkAccessDescribe() {
+	tests := []CLITest{
+		{args: "network pl access describe pla-111111", fixture: "network/private-link/access/describe-aws.golden"},
+		{args: "network private-link access describe pla-111111", fixture: "network/private-link/access/describe-aws.golden"},
+		{args: "network private-link access describe pla-111111 --output json", fixture: "network/private-link/access/describe-aws-json.golden"},
+		{args: "network private-link access describe pla-111112", fixture: "network/private-link/access/describe-gcp.golden"},
+		{args: "network private-link access describe pla-111113", fixture: "network/private-link/access/describe-azure.golden"},
+		{args: "network private-link access describe", fixture: "network/private-link/access/describe-missing-id.golden", exitCode: 1},
+		{args: "network private-link access describe pla-invalid", fixture: "network/private-link/access/describe-invalid.golden", exitCode: 1},
+	}
+
+	for _, test := range tests {
+		test.login = "cloud"
+		s.runIntegrationTest(test)
+	}
+}
+
+func (s *CLITestSuite) TestNetworkPrivateLinkAccess_Autocomplete() {
+	tests := []CLITest{
+		{args: `__complete network private-link access describe ""`, login: "cloud", fixture: "network/private-link/access/describe-autocomplete.golden"},
+	}
+
+	for _, test := range tests {
+		test.login = "cloud"
+		s.runIntegrationTest(test)
+	}
+}

--- a/test/test-server/ccloudv2_router.go
+++ b/test/test-server/ccloudv2_router.go
@@ -61,6 +61,8 @@ var ccloudV2Routes = []route{
 	{"/networking/v1/networks/{id}", handleNetworkingNetwork},
 	{"/networking/v1/peerings", handleNetworkingPeerings},
 	{"/networking/v1/peerings/{id}", handleNetworkingPeering},
+	{"/networking/v1/private-link-accesses", handleNetworkingPrivateLinkAccesses},
+	{"/networking/v1/private-link-accesses/{id}", handleNetworkingPrivateLinkAccess},
 	{"/networking/v1/transit-gateway-attachments", handleNetworkingTransitGatewayAttachments},
 	{"/networking/v1/transit-gateway-attachments/{id}", handleNetworkingTransitGatewayAttachment},
 	{"/org/v2/environments", handleOrgEnvironments},


### PR DESCRIPTION
What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->
Note that this is merging into the feature branch https://github.com/confluentinc/cli/tree/traffic-8850-network-cli. We will merge commits into main from this feature branch after all of the commands for network are implemented
* Add `confluent network private-link` and an alias "pl"
* Add `confluent network private-link access`
* Add `confluent network private-link access list`
* Add `confluent network private-link access describe <id>`


References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->
[CLI Commands Design](https://confluentinc.atlassian.net/wiki/spaces/PM/pages/2987394300/1-pager+--+Network+CLI)
[Implementation 1-Pager](https://confluentinc.atlassian.net/wiki/spaces/~712020463029eabbac401bbe1b033ce0d3a00e/pages/3136749631/Network+CLI)


Test & Review
-------------
<!--
Has it been tested? How?
Copy and paste any instructions or steps that can save the reviewer time.
-->
Added integration tests.

Performed manual tests

Open Questions / Follow-ups
---------------------------
<!--
Optional: Anything open to discussion for the reviewer, out of scope of this PR, or follow-ups.
-->
