### PR TITLE
Refactor network commands

### DIFF
--- a/internal/network/command.go
+++ b/internal/network/command.go
@@ -90,9 +90,6 @@ func New(prerunner pcmd.PreRunner) *cobra.Command {
 }
 
 func printTable(cmd *cobra.Command, network networkingv1.NetworkingV1Network) error {
-	table := output.NewTable(cmd)
-	describeFields := []string{"Id", "EnvironmentId", "Name", "Cloud", "Region", "Cidr", "Zones", "DnsResolution", "Phase", "SupportedConnectionTypes", "ActiveConnectionTypes"}
-
 	if network.Spec == nil {
 		return fmt.Errorf(errors.CorruptedNetworkResponseErrorMsg, "spec")
 	}
@@ -134,6 +131,8 @@ func printTable(cmd *cobra.Command, network networkingv1.NetworkingV1Network) er
 		ActiveConnectionTypes:    activeConnectionTypes,
 	}
 
+	describeFields := []string{"Id", "EnvironmentId", "Name", "Cloud", "Region", "Cidr", "Zones", "DnsResolution", "Phase", "SupportedConnectionTypes", "ActiveConnectionTypes"}
+
 	if phase == "READY" {
 		if network.Status.Cloud == nil {
 			return fmt.Errorf(errors.CorruptedNetworkResponseErrorMsg, "cloud")
@@ -160,6 +159,8 @@ func printTable(cmd *cobra.Command, network networkingv1.NetworkingV1Network) er
 			describeFields = append(describeFields, "AzureVNet", "AzureSubscription")
 		}
 	}
+
+	table := output.NewTable(cmd)
 
 	if output.GetFormat(cmd) == output.Human {
 		table.Add(human)

--- a/internal/network/command.go
+++ b/internal/network/command.go
@@ -83,7 +83,7 @@ func New(prerunner pcmd.PreRunner) *cobra.Command {
 	cmd.AddCommand(c.newListCommand())
 	cmd.AddCommand(c.newPeeringCommand())
 	cmd.AddCommand(c.newPrivateLinkCommand())
-	cmd.AddCommand(newTransitGatewayAttachmentCommand(prerunner))
+	cmd.AddCommand(c.newTransitGatewayAttachmentCommand())
 	cmd.AddCommand(c.newUpdateCommand())
 
 	return cmd

--- a/internal/network/command.go
+++ b/internal/network/command.go
@@ -81,7 +81,7 @@ func New(prerunner pcmd.PreRunner) *cobra.Command {
 	cmd.AddCommand(c.newDeleteCommand())
 	cmd.AddCommand(c.newDescribeCommand())
 	cmd.AddCommand(c.newListCommand())
-	cmd.AddCommand(newPeeringCommand(prerunner))
+	cmd.AddCommand(c.newPeeringCommand())
 	cmd.AddCommand(c.newPrivateLinkCommand())
 	cmd.AddCommand(newTransitGatewayAttachmentCommand(prerunner))
 	cmd.AddCommand(c.newUpdateCommand())

--- a/internal/network/command_peering_create.go
+++ b/internal/network/command_peering_create.go
@@ -11,12 +11,12 @@ import (
 	"github.com/confluentinc/cli/v3/pkg/examples"
 )
 
-func (c *peeringCommand) newCreateCommand() *cobra.Command {
+func (c *command) newPeeringCreateCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create <name>",
 		Short: "Create a peering.",
 		Args:  cobra.ExactArgs(1),
-		RunE:  c.create,
+		RunE:  c.createPeering,
 		Example: examples.BuildExampleString(
 			examples.Example{
 				Text: "Create an AWS VPC peering.",
@@ -52,7 +52,7 @@ func (c *peeringCommand) newCreateCommand() *cobra.Command {
 	return cmd
 }
 
-func (c *peeringCommand) create(cmd *cobra.Command, args []string) error {
+func (c *command) createPeering(cmd *cobra.Command, args []string) error {
 	name := args[0]
 
 	cloud, err := cmd.Flags().GetString("cloud")
@@ -120,7 +120,7 @@ func (c *peeringCommand) create(cmd *cobra.Command, args []string) error {
 	return printPeeringTable(cmd, peering)
 }
 
-func (c *peeringCommand) createAwsPeeringRequest(cmd *cobra.Command, networkRegion string) (*networkingv1.NetworkingV1AwsPeering, error) {
+func (c *command) createAwsPeeringRequest(cmd *cobra.Command, networkRegion string) (*networkingv1.NetworkingV1AwsPeering, error) {
 	account, err := cmd.Flags().GetString("cloud-account")
 	if err != nil {
 		return nil, err
@@ -155,7 +155,7 @@ func (c *peeringCommand) createAwsPeeringRequest(cmd *cobra.Command, networkRegi
 	return awsPeering, nil
 }
 
-func (c *peeringCommand) createGcpPeeringRequest(cmd *cobra.Command) (*networkingv1.NetworkingV1GcpPeering, error) {
+func (c *command) createGcpPeeringRequest(cmd *cobra.Command) (*networkingv1.NetworkingV1GcpPeering, error) {
 	project, err := cmd.Flags().GetString("cloud-account")
 	if err != nil {
 		return nil, err
@@ -181,7 +181,7 @@ func (c *peeringCommand) createGcpPeeringRequest(cmd *cobra.Command) (*networkin
 	return gcpPeering, nil
 }
 
-func (c *peeringCommand) createAzurePeeringRequest(cmd *cobra.Command, networkRegion string) (*networkingv1.NetworkingV1AzurePeering, error) {
+func (c *command) createAzurePeeringRequest(cmd *cobra.Command, networkRegion string) (*networkingv1.NetworkingV1AzurePeering, error) {
 	tenant, err := cmd.Flags().GetString("cloud-account")
 	if err != nil {
 		return nil, err

--- a/internal/network/command_peering_create.go
+++ b/internal/network/command_peering_create.go
@@ -16,7 +16,7 @@ func (c *command) newPeeringCreateCommand() *cobra.Command {
 		Use:   "create <name>",
 		Short: "Create a peering.",
 		Args:  cobra.ExactArgs(1),
-		RunE:  c.createPeering,
+		RunE:  c.peeringCreate,
 		Example: examples.BuildExampleString(
 			examples.Example{
 				Text: "Create an AWS VPC peering.",
@@ -52,7 +52,7 @@ func (c *command) newPeeringCreateCommand() *cobra.Command {
 	return cmd
 }
 
-func (c *command) createPeering(cmd *cobra.Command, args []string) error {
+func (c *command) peeringCreate(cmd *cobra.Command, args []string) error {
 	name := args[0]
 
 	cloud, err := cmd.Flags().GetString("cloud")

--- a/internal/network/command_peering_create.go
+++ b/internal/network/command_peering_create.go
@@ -87,7 +87,7 @@ func (c *command) createPeering(cmd *cobra.Command, args []string) error {
 
 	switch cloud {
 	case CloudAws:
-		awsPeering, err := c.createAwsPeeringRequest(cmd, region)
+		awsPeering, err := createAwsPeeringRequest(cmd, region)
 		if err != nil {
 			return err
 		}
@@ -95,7 +95,7 @@ func (c *command) createPeering(cmd *cobra.Command, args []string) error {
 			NetworkingV1AwsPeering: awsPeering,
 		}
 	case CloudGcp:
-		gcpPeering, err := c.createGcpPeeringRequest(cmd)
+		gcpPeering, err := createGcpPeeringRequest(cmd)
 		if err != nil {
 			return err
 		}
@@ -103,7 +103,7 @@ func (c *command) createPeering(cmd *cobra.Command, args []string) error {
 			NetworkingV1GcpPeering: gcpPeering,
 		}
 	case CloudAzure:
-		azurePeering, err := c.createAzurePeeringRequest(cmd, region)
+		azurePeering, err := createAzurePeeringRequest(cmd, region)
 		if err != nil {
 			return err
 		}
@@ -120,7 +120,7 @@ func (c *command) createPeering(cmd *cobra.Command, args []string) error {
 	return printPeeringTable(cmd, peering)
 }
 
-func (c *command) createAwsPeeringRequest(cmd *cobra.Command, networkRegion string) (*networkingv1.NetworkingV1AwsPeering, error) {
+func createAwsPeeringRequest(cmd *cobra.Command, networkRegion string) (*networkingv1.NetworkingV1AwsPeering, error) {
 	account, err := cmd.Flags().GetString("cloud-account")
 	if err != nil {
 		return nil, err
@@ -155,7 +155,7 @@ func (c *command) createAwsPeeringRequest(cmd *cobra.Command, networkRegion stri
 	return awsPeering, nil
 }
 
-func (c *command) createGcpPeeringRequest(cmd *cobra.Command) (*networkingv1.NetworkingV1GcpPeering, error) {
+func createGcpPeeringRequest(cmd *cobra.Command) (*networkingv1.NetworkingV1GcpPeering, error) {
 	project, err := cmd.Flags().GetString("cloud-account")
 	if err != nil {
 		return nil, err
@@ -181,7 +181,7 @@ func (c *command) createGcpPeeringRequest(cmd *cobra.Command) (*networkingv1.Net
 	return gcpPeering, nil
 }
 
-func (c *command) createAzurePeeringRequest(cmd *cobra.Command, networkRegion string) (*networkingv1.NetworkingV1AzurePeering, error) {
+func createAzurePeeringRequest(cmd *cobra.Command, networkRegion string) (*networkingv1.NetworkingV1AzurePeering, error) {
 	tenant, err := cmd.Flags().GetString("cloud-account")
 	if err != nil {
 		return nil, err

--- a/internal/network/command_peering_delete.go
+++ b/internal/network/command_peering_delete.go
@@ -13,13 +13,13 @@ import (
 	"github.com/confluentinc/cli/v3/pkg/utils"
 )
 
-func (c *peeringCommand) newDeleteCommand() *cobra.Command {
+func (c *command) newPeeringDeleteCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "delete <id-1> [id-2] ... [id-n]",
 		Short:             "Delete one or more peerings.",
 		Args:              cobra.MinimumNArgs(1),
-		ValidArgsFunction: pcmd.NewValidArgsFunction(c.validArgsMultiple),
-		RunE:              c.delete,
+		ValidArgsFunction: pcmd.NewValidArgsFunction(c.validPeeringArgsMultiple),
+		RunE:              c.deletePeering,
 	}
 
 	pcmd.AddForceFlag(cmd)
@@ -29,7 +29,7 @@ func (c *peeringCommand) newDeleteCommand() *cobra.Command {
 	return cmd
 }
 
-func (c *peeringCommand) delete(cmd *cobra.Command, args []string) error {
+func (c *command) deletePeering(cmd *cobra.Command, args []string) error {
 	environmentId, err := c.Context.EnvironmentId()
 	if err != nil {
 		return err

--- a/internal/network/command_peering_delete.go
+++ b/internal/network/command_peering_delete.go
@@ -19,7 +19,7 @@ func (c *command) newPeeringDeleteCommand() *cobra.Command {
 		Short:             "Delete one or more peerings.",
 		Args:              cobra.MinimumNArgs(1),
 		ValidArgsFunction: pcmd.NewValidArgsFunction(c.validPeeringArgsMultiple),
-		RunE:              c.deletePeering,
+		RunE:              c.peeringDelete,
 	}
 
 	pcmd.AddForceFlag(cmd)
@@ -29,7 +29,7 @@ func (c *command) newPeeringDeleteCommand() *cobra.Command {
 	return cmd
 }
 
-func (c *command) deletePeering(cmd *cobra.Command, args []string) error {
+func (c *command) peeringDelete(cmd *cobra.Command, args []string) error {
 	environmentId, err := c.Context.EnvironmentId()
 	if err != nil {
 		return err

--- a/internal/network/command_peering_describe.go
+++ b/internal/network/command_peering_describe.go
@@ -13,7 +13,7 @@ func (c *command) newPeeringDescribeCommand() *cobra.Command {
 		Short:             "Describe a peering.",
 		Args:              cobra.ExactArgs(1),
 		ValidArgsFunction: pcmd.NewValidArgsFunction(c.validPeeringArgs),
-		RunE:              c.describePeering,
+		RunE:              c.peeringDescribe,
 		Example: examples.BuildExampleString(
 			examples.Example{
 				Text: `Describe peering "peer-123456".`,
@@ -29,7 +29,7 @@ func (c *command) newPeeringDescribeCommand() *cobra.Command {
 	return cmd
 }
 
-func (c *command) describePeering(cmd *cobra.Command, args []string) error {
+func (c *command) peeringDescribe(cmd *cobra.Command, args []string) error {
 	environmentId, err := c.Context.EnvironmentId()
 	if err != nil {
 		return err

--- a/internal/network/command_peering_describe.go
+++ b/internal/network/command_peering_describe.go
@@ -7,13 +7,13 @@ import (
 	"github.com/confluentinc/cli/v3/pkg/examples"
 )
 
-func (c *peeringCommand) newDescribeCommand() *cobra.Command {
+func (c *command) newPeeringDescribeCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "describe <id>",
 		Short:             "Describe a peering.",
 		Args:              cobra.ExactArgs(1),
-		ValidArgsFunction: pcmd.NewValidArgsFunction(c.validArgs),
-		RunE:              c.describe,
+		ValidArgsFunction: pcmd.NewValidArgsFunction(c.validPeeringArgs),
+		RunE:              c.describePeering,
 		Example: examples.BuildExampleString(
 			examples.Example{
 				Text: `Describe peering "peer-123456".`,
@@ -29,7 +29,7 @@ func (c *peeringCommand) newDescribeCommand() *cobra.Command {
 	return cmd
 }
 
-func (c *peeringCommand) describe(cmd *cobra.Command, args []string) error {
+func (c *command) describePeering(cmd *cobra.Command, args []string) error {
 	environmentId, err := c.Context.EnvironmentId()
 	if err != nil {
 		return err

--- a/internal/network/command_peering_list.go
+++ b/internal/network/command_peering_list.go
@@ -26,7 +26,7 @@ func (c *command) newPeeringListCommand() *cobra.Command {
 		Use:   "list",
 		Short: "List peerings.",
 		Args:  cobra.NoArgs,
-		RunE:  c.listPeering,
+		RunE:  c.peeringList,
 	}
 
 	pcmd.AddContextFlag(cmd, c.CLICommand)
@@ -36,7 +36,7 @@ func (c *command) newPeeringListCommand() *cobra.Command {
 	return cmd
 }
 
-func (c *command) listPeering(cmd *cobra.Command, _ []string) error {
+func (c *command) peeringList(cmd *cobra.Command, _ []string) error {
 	peerings, err := c.getPeerings()
 	if err != nil {
 		return err

--- a/internal/network/command_peering_list.go
+++ b/internal/network/command_peering_list.go
@@ -21,12 +21,12 @@ type listPeeringOut struct {
 	Phase          string `human:"Phase" serialized:"phase"`
 }
 
-func (c *peeringCommand) newListCommand() *cobra.Command {
+func (c *command) newPeeringListCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List peerings.",
 		Args:  cobra.NoArgs,
-		RunE:  c.list,
+		RunE:  c.listPeering,
 	}
 
 	pcmd.AddContextFlag(cmd, c.CLICommand)
@@ -36,7 +36,7 @@ func (c *peeringCommand) newListCommand() *cobra.Command {
 	return cmd
 }
 
-func (c *peeringCommand) list(cmd *cobra.Command, _ []string) error {
+func (c *command) listPeering(cmd *cobra.Command, _ []string) error {
 	peerings, err := c.getPeerings()
 	if err != nil {
 		return err
@@ -51,7 +51,7 @@ func (c *peeringCommand) list(cmd *cobra.Command, _ []string) error {
 			return fmt.Errorf(errors.CorruptedNetworkResponseErrorMsg, "status")
 		}
 
-		cloud, err := getCloud(peering)
+		cloud, err := getPeeringCloud(peering)
 		if err != nil {
 			return err
 		}

--- a/internal/network/command_peering_update.go
+++ b/internal/network/command_peering_update.go
@@ -9,13 +9,13 @@ import (
 	"github.com/confluentinc/cli/v3/pkg/examples"
 )
 
-func (c *peeringCommand) newUpdateCommand() *cobra.Command {
+func (c *command) newPeeringUpdateCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "update <id>",
 		Short:             "Update an existing peering.",
 		Args:              cobra.ExactArgs(1),
-		ValidArgsFunction: pcmd.NewValidArgsFunction(c.validArgs),
-		RunE:              c.update,
+		ValidArgsFunction: pcmd.NewValidArgsFunction(c.validPeeringArgs),
+		RunE:              c.updatePeering,
 		Example: examples.BuildExampleString(
 			examples.Example{
 				Text: `Update the name of peering "peer-123456"`,
@@ -34,7 +34,7 @@ func (c *peeringCommand) newUpdateCommand() *cobra.Command {
 	return cmd
 }
 
-func (c *peeringCommand) update(cmd *cobra.Command, args []string) error {
+func (c *command) updatePeering(cmd *cobra.Command, args []string) error {
 	environmentId, err := c.Context.EnvironmentId()
 	if err != nil {
 		return err

--- a/internal/network/command_peering_update.go
+++ b/internal/network/command_peering_update.go
@@ -15,7 +15,7 @@ func (c *command) newPeeringUpdateCommand() *cobra.Command {
 		Short:             "Update an existing peering.",
 		Args:              cobra.ExactArgs(1),
 		ValidArgsFunction: pcmd.NewValidArgsFunction(c.validPeeringArgs),
-		RunE:              c.updatePeering,
+		RunE:              c.peeringUpdate,
 		Example: examples.BuildExampleString(
 			examples.Example{
 				Text: `Update the name of peering "peer-123456"`,
@@ -34,7 +34,7 @@ func (c *command) newPeeringUpdateCommand() *cobra.Command {
 	return cmd
 }
 
-func (c *command) updatePeering(cmd *cobra.Command, args []string) error {
+func (c *command) peeringUpdate(cmd *cobra.Command, args []string) error {
 	environmentId, err := c.Context.EnvironmentId()
 	if err != nil {
 		return err

--- a/internal/network/command_private_link_access.go
+++ b/internal/network/command_private_link_access.go
@@ -86,7 +86,7 @@ func getPrivateLinkAccessCloud(access networkingv1.NetworkingV1PrivateLinkAccess
 	return "", fmt.Errorf(errors.CorruptedNetworkResponseErrorMsg, "cloud")
 }
 
-func (c *command) printPrivateLinkAccessTable(cmd *cobra.Command, access networkingv1.NetworkingV1PrivateLinkAccess) error {
+func printPrivateLinkAccessTable(cmd *cobra.Command, access networkingv1.NetworkingV1PrivateLinkAccess) error {
 	if access.Spec == nil {
 		return fmt.Errorf(errors.CorruptedNetworkResponseErrorMsg, "spec")
 	}

--- a/internal/network/command_private_link_access_describe.go
+++ b/internal/network/command_private_link_access_describe.go
@@ -40,5 +40,5 @@ func (c *command) describePrivateLinkAccess(cmd *cobra.Command, args []string) e
 		return err
 	}
 
-	return c.printPrivateLinkAccessTable(cmd, access)
+	return printPrivateLinkAccessTable(cmd, access)
 }

--- a/internal/network/command_private_link_access_describe.go
+++ b/internal/network/command_private_link_access_describe.go
@@ -13,7 +13,7 @@ func (c *command) newPrivateLinkAccessDescribeCommand() *cobra.Command {
 		Short:             "Describe a private link access.",
 		Args:              cobra.ExactArgs(1),
 		ValidArgsFunction: pcmd.NewValidArgsFunction(c.validPrivateLinkAccessArgs),
-		RunE:              c.describePrivateLinkAccess,
+		RunE:              c.privateLinkAccessDescribe,
 		Example: examples.BuildExampleString(
 			examples.Example{
 				Text: `Describe private link access "pla-123456".`,
@@ -29,7 +29,7 @@ func (c *command) newPrivateLinkAccessDescribeCommand() *cobra.Command {
 	return cmd
 }
 
-func (c *command) describePrivateLinkAccess(cmd *cobra.Command, args []string) error {
+func (c *command) privateLinkAccessDescribe(cmd *cobra.Command, args []string) error {
 	environmentId, err := c.Context.EnvironmentId()
 	if err != nil {
 		return err

--- a/internal/network/command_private_link_access_list.go
+++ b/internal/network/command_private_link_access_list.go
@@ -24,7 +24,7 @@ func (c *command) newPrivateLinkAccessListCommand() *cobra.Command {
 		Use:   "list",
 		Short: "List private link accesses.",
 		Args:  cobra.NoArgs,
-		RunE:  c.listPrivateLinkAccesses,
+		RunE:  c.privateLinkAccessList,
 	}
 
 	pcmd.AddContextFlag(cmd, c.CLICommand)
@@ -34,7 +34,7 @@ func (c *command) newPrivateLinkAccessListCommand() *cobra.Command {
 	return cmd
 }
 
-func (c *command) listPrivateLinkAccesses(cmd *cobra.Command, _ []string) error {
+func (c *command) privateLinkAccessList(cmd *cobra.Command, _ []string) error {
 	accesses, err := c.getPrivateLinkAccesses()
 	if err != nil {
 		return err

--- a/internal/network/command_transit_gateway_attachment.go
+++ b/internal/network/command_transit_gateway_attachment.go
@@ -8,14 +8,9 @@ import (
 
 	networkingv1 "github.com/confluentinc/ccloud-sdk-go-v2/networking/v1"
 
-	pcmd "github.com/confluentinc/cli/v3/pkg/cmd"
 	"github.com/confluentinc/cli/v3/pkg/errors"
 	"github.com/confluentinc/cli/v3/pkg/output"
 )
-
-type transitGatewayAttachmentCommand struct {
-	*pcmd.AuthenticatedCLICommand
-}
 
 type transitGatewayAttachmentHumanOut struct {
 	Id                            string `human:"ID"`
@@ -39,7 +34,7 @@ type transitGatewayAttachmentSerializedOut struct {
 	Phase                         string   `serialized:"phase"`
 }
 
-func newTransitGatewayAttachmentCommand(prerunner pcmd.PreRunner) *cobra.Command {
+func (c *command) newTransitGatewayAttachmentCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "transit-gateway-attachment",
 		Aliases: []string{"tgwa"},
@@ -47,18 +42,16 @@ func newTransitGatewayAttachmentCommand(prerunner pcmd.PreRunner) *cobra.Command
 		Args:    cobra.NoArgs,
 	}
 
-	c := &transitGatewayAttachmentCommand{pcmd.NewAuthenticatedCLICommand(cmd, prerunner)}
-
-	cmd.AddCommand(c.newCreateCommand())
-	cmd.AddCommand(c.newDeleteCommand())
-	cmd.AddCommand(c.newDescribeCommand())
-	cmd.AddCommand(c.newListCommand())
-	cmd.AddCommand(c.newUpdateCommand())
+	cmd.AddCommand(c.newTransitGatewayAttachmentCreateCommand())
+	cmd.AddCommand(c.newTransitGatewayAttachmentDeleteCommand())
+	cmd.AddCommand(c.newTransitGatewayAttachmentDescribeCommand())
+	cmd.AddCommand(c.newTransitGatewayAttachmentListCommand())
+	cmd.AddCommand(c.newTransitGatewayAttachmentUpdateCommand())
 
 	return cmd
 }
 
-func (c *transitGatewayAttachmentCommand) getTransitGatewayAttachments() ([]networkingv1.NetworkingV1TransitGatewayAttachment, error) {
+func (c *command) getTransitGatewayAttachments() ([]networkingv1.NetworkingV1TransitGatewayAttachment, error) {
 	environmentId, err := c.Context.EnvironmentId()
 	if err != nil {
 		return nil, err
@@ -67,14 +60,14 @@ func (c *transitGatewayAttachmentCommand) getTransitGatewayAttachments() ([]netw
 	return c.V2Client.ListTransitGatewayAttachments(environmentId)
 }
 
-func (c *transitGatewayAttachmentCommand) validArgs(cmd *cobra.Command, args []string) []string {
+func (c *command) validTransitGatewayAttachmentArgs(cmd *cobra.Command, args []string) []string {
 	if len(args) > 0 {
 		return nil
 	}
-	return c.validArgsMultiple(cmd, args)
+	return c.validTransitGatewayAttachmentArgsMultiple(cmd, args)
 }
 
-func (c *transitGatewayAttachmentCommand) validArgsMultiple(cmd *cobra.Command, args []string) []string {
+func (c *command) validTransitGatewayAttachmentArgsMultiple(cmd *cobra.Command, args []string) []string {
 	if err := c.PersistentPreRunE(cmd, args); err != nil {
 		return nil
 	}
@@ -82,7 +75,7 @@ func (c *transitGatewayAttachmentCommand) validArgsMultiple(cmd *cobra.Command, 
 	return c.autocompleteTransitGatewayAttachments()
 }
 
-func (c *transitGatewayAttachmentCommand) autocompleteTransitGatewayAttachments() []string {
+func (c *command) autocompleteTransitGatewayAttachments() []string {
 	attachments, err := c.getTransitGatewayAttachments()
 	if err != nil {
 		return nil
@@ -96,14 +89,14 @@ func (c *transitGatewayAttachmentCommand) autocompleteTransitGatewayAttachments(
 }
 
 func printTransitGatewayAttachmentTable(cmd *cobra.Command, attachment networkingv1.NetworkingV1TransitGatewayAttachment) error {
-	table := output.NewTable(cmd)
-
 	if attachment.Spec == nil {
 		return fmt.Errorf(errors.CorruptedNetworkResponseErrorMsg, "spec")
 	}
 	if attachment.Status == nil {
 		return fmt.Errorf(errors.CorruptedNetworkResponseErrorMsg, "status")
 	}
+
+	table := output.NewTable(cmd)
 
 	if output.GetFormat(cmd) == output.Human {
 		table.Add(&transitGatewayAttachmentHumanOut{

--- a/internal/network/command_transit_gateway_attachment_create.go
+++ b/internal/network/command_transit_gateway_attachment_create.go
@@ -14,7 +14,7 @@ func (c *command) newTransitGatewayAttachmentCreateCommand() *cobra.Command {
 		Use:   "create <name>",
 		Short: "Create a transit gateway attachment.",
 		Args:  cobra.ExactArgs(1),
-		RunE:  c.createTransitGatewayAttachment,
+		RunE:  c.transitGatewayAttachmentCreate,
 		Example: examples.BuildExampleString(
 			examples.Example{
 				Text: "Create a transit gateway attachment in AWS.",
@@ -39,7 +39,7 @@ func (c *command) newTransitGatewayAttachmentCreateCommand() *cobra.Command {
 	return cmd
 }
 
-func (c *command) createTransitGatewayAttachment(cmd *cobra.Command, args []string) error {
+func (c *command) transitGatewayAttachmentCreate(cmd *cobra.Command, args []string) error {
 	name := args[0]
 
 	network, err := cmd.Flags().GetString("network")

--- a/internal/network/command_transit_gateway_attachment_create.go
+++ b/internal/network/command_transit_gateway_attachment_create.go
@@ -9,12 +9,12 @@ import (
 	"github.com/confluentinc/cli/v3/pkg/examples"
 )
 
-func (c *transitGatewayAttachmentCommand) newCreateCommand() *cobra.Command {
+func (c *command) newTransitGatewayAttachmentCreateCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create <name>",
 		Short: "Create a transit gateway attachment.",
 		Args:  cobra.ExactArgs(1),
-		RunE:  c.create,
+		RunE:  c.createTransitGatewayAttachment,
 		Example: examples.BuildExampleString(
 			examples.Example{
 				Text: "Create a transit gateway attachment in AWS.",
@@ -39,7 +39,7 @@ func (c *transitGatewayAttachmentCommand) newCreateCommand() *cobra.Command {
 	return cmd
 }
 
-func (c *transitGatewayAttachmentCommand) create(cmd *cobra.Command, args []string) error {
+func (c *command) createTransitGatewayAttachment(cmd *cobra.Command, args []string) error {
 	name := args[0]
 
 	network, err := cmd.Flags().GetString("network")

--- a/internal/network/command_transit_gateway_attachment_delete.go
+++ b/internal/network/command_transit_gateway_attachment_delete.go
@@ -19,7 +19,7 @@ func (c *command) newTransitGatewayAttachmentDeleteCommand() *cobra.Command {
 		Short:             "Delete one or more transit gateway attachments.",
 		Args:              cobra.MinimumNArgs(1),
 		ValidArgsFunction: pcmd.NewValidArgsFunction(c.validTransitGatewayAttachmentArgsMultiple),
-		RunE:              c.deleteTransitGatewayAttachment,
+		RunE:              c.transitGatewayAttachmentDelete,
 	}
 
 	pcmd.AddForceFlag(cmd)
@@ -29,7 +29,7 @@ func (c *command) newTransitGatewayAttachmentDeleteCommand() *cobra.Command {
 	return cmd
 }
 
-func (c *command) deleteTransitGatewayAttachment(cmd *cobra.Command, args []string) error {
+func (c *command) transitGatewayAttachmentDelete(cmd *cobra.Command, args []string) error {
 	environmentId, err := c.Context.EnvironmentId()
 	if err != nil {
 		return err

--- a/internal/network/command_transit_gateway_attachment_delete.go
+++ b/internal/network/command_transit_gateway_attachment_delete.go
@@ -13,13 +13,13 @@ import (
 	"github.com/confluentinc/cli/v3/pkg/utils"
 )
 
-func (c *transitGatewayAttachmentCommand) newDeleteCommand() *cobra.Command {
+func (c *command) newTransitGatewayAttachmentDeleteCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "delete <id-1> [id-2] ... [id-n]",
 		Short:             "Delete one or more transit gateway attachments.",
 		Args:              cobra.MinimumNArgs(1),
-		ValidArgsFunction: pcmd.NewValidArgsFunction(c.validArgsMultiple),
-		RunE:              c.delete,
+		ValidArgsFunction: pcmd.NewValidArgsFunction(c.validTransitGatewayAttachmentArgsMultiple),
+		RunE:              c.deleteTransitGatewayAttachment,
 	}
 
 	pcmd.AddForceFlag(cmd)
@@ -29,7 +29,7 @@ func (c *transitGatewayAttachmentCommand) newDeleteCommand() *cobra.Command {
 	return cmd
 }
 
-func (c *transitGatewayAttachmentCommand) delete(cmd *cobra.Command, args []string) error {
+func (c *command) deleteTransitGatewayAttachment(cmd *cobra.Command, args []string) error {
 	environmentId, err := c.Context.EnvironmentId()
 	if err != nil {
 		return err

--- a/internal/network/command_transit_gateway_attachment_describe.go
+++ b/internal/network/command_transit_gateway_attachment_describe.go
@@ -7,13 +7,13 @@ import (
 	"github.com/confluentinc/cli/v3/pkg/examples"
 )
 
-func (c *transitGatewayAttachmentCommand) newDescribeCommand() *cobra.Command {
+func (c *command) newTransitGatewayAttachmentDescribeCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "describe <id>",
 		Short:             "Describe a transit gateway attachment.",
-		ValidArgsFunction: pcmd.NewValidArgsFunction(c.validArgs),
+		ValidArgsFunction: pcmd.NewValidArgsFunction(c.validTransitGatewayAttachmentArgs),
 		Args:              cobra.ExactArgs(1),
-		RunE:              c.describe,
+		RunE:              c.describeTransitGatewayAttachment,
 		Example: examples.BuildExampleString(
 			examples.Example{
 				Text: `Describe transit gateway attachment "tgwa-123456".`,
@@ -29,7 +29,7 @@ func (c *transitGatewayAttachmentCommand) newDescribeCommand() *cobra.Command {
 	return cmd
 }
 
-func (c *transitGatewayAttachmentCommand) describe(cmd *cobra.Command, args []string) error {
+func (c *command) describeTransitGatewayAttachment(cmd *cobra.Command, args []string) error {
 	environmentId, err := c.Context.EnvironmentId()
 	if err != nil {
 		return err

--- a/internal/network/command_transit_gateway_attachment_describe.go
+++ b/internal/network/command_transit_gateway_attachment_describe.go
@@ -13,7 +13,7 @@ func (c *command) newTransitGatewayAttachmentDescribeCommand() *cobra.Command {
 		Short:             "Describe a transit gateway attachment.",
 		ValidArgsFunction: pcmd.NewValidArgsFunction(c.validTransitGatewayAttachmentArgs),
 		Args:              cobra.ExactArgs(1),
-		RunE:              c.describeTransitGatewayAttachment,
+		RunE:              c.transitGatewayAttachmentDescribe,
 		Example: examples.BuildExampleString(
 			examples.Example{
 				Text: `Describe transit gateway attachment "tgwa-123456".`,
@@ -29,7 +29,7 @@ func (c *command) newTransitGatewayAttachmentDescribeCommand() *cobra.Command {
 	return cmd
 }
 
-func (c *command) describeTransitGatewayAttachment(cmd *cobra.Command, args []string) error {
+func (c *command) transitGatewayAttachmentDescribe(cmd *cobra.Command, args []string) error {
 	environmentId, err := c.Context.EnvironmentId()
 	if err != nil {
 		return err

--- a/internal/network/command_transit_gateway_attachment_list.go
+++ b/internal/network/command_transit_gateway_attachment_list.go
@@ -11,12 +11,12 @@ import (
 	"github.com/confluentinc/cli/v3/pkg/output"
 )
 
-func (c *transitGatewayAttachmentCommand) newListCommand() *cobra.Command {
+func (c *command) newTransitGatewayAttachmentListCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List transit gateway attachments.",
 		Args:  cobra.NoArgs,
-		RunE:  c.list,
+		RunE:  c.listTransitGatewayAttachment,
 	}
 
 	pcmd.AddContextFlag(cmd, c.CLICommand)
@@ -26,7 +26,7 @@ func (c *transitGatewayAttachmentCommand) newListCommand() *cobra.Command {
 	return cmd
 }
 
-func (c *transitGatewayAttachmentCommand) list(cmd *cobra.Command, _ []string) error {
+func (c *command) listTransitGatewayAttachment(cmd *cobra.Command, _ []string) error {
 	attachments, err := c.getTransitGatewayAttachments()
 	if err != nil {
 		return err

--- a/internal/network/command_transit_gateway_attachment_list.go
+++ b/internal/network/command_transit_gateway_attachment_list.go
@@ -16,7 +16,7 @@ func (c *command) newTransitGatewayAttachmentListCommand() *cobra.Command {
 		Use:   "list",
 		Short: "List transit gateway attachments.",
 		Args:  cobra.NoArgs,
-		RunE:  c.listTransitGatewayAttachment,
+		RunE:  c.transitGatewayAttachmentList,
 	}
 
 	pcmd.AddContextFlag(cmd, c.CLICommand)
@@ -26,7 +26,7 @@ func (c *command) newTransitGatewayAttachmentListCommand() *cobra.Command {
 	return cmd
 }
 
-func (c *command) listTransitGatewayAttachment(cmd *cobra.Command, _ []string) error {
+func (c *command) transitGatewayAttachmentList(cmd *cobra.Command, _ []string) error {
 	attachments, err := c.getTransitGatewayAttachments()
 	if err != nil {
 		return err

--- a/internal/network/command_transit_gateway_attachment_update.go
+++ b/internal/network/command_transit_gateway_attachment_update.go
@@ -9,13 +9,13 @@ import (
 	"github.com/confluentinc/cli/v3/pkg/examples"
 )
 
-func (c *transitGatewayAttachmentCommand) newUpdateCommand() *cobra.Command {
+func (c *command) newTransitGatewayAttachmentUpdateCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "update <id>",
 		Short:             "Update an existing transit gateway attachment.",
 		Args:              cobra.ExactArgs(1),
-		ValidArgsFunction: pcmd.NewValidArgsFunction(c.validArgs),
-		RunE:              c.update,
+		ValidArgsFunction: pcmd.NewValidArgsFunction(c.validTransitGatewayAttachmentArgs),
+		RunE:              c.updateTransitGatewayAttachment,
 		Example: examples.BuildExampleString(
 			examples.Example{
 				Text: `Update the name of transit gateway attachment "tgwa-123456"`,
@@ -34,7 +34,7 @@ func (c *transitGatewayAttachmentCommand) newUpdateCommand() *cobra.Command {
 	return cmd
 }
 
-func (c *transitGatewayAttachmentCommand) update(cmd *cobra.Command, args []string) error {
+func (c *command) updateTransitGatewayAttachment(cmd *cobra.Command, args []string) error {
 	environmentId, err := c.Context.EnvironmentId()
 	if err != nil {
 		return err

--- a/internal/network/command_transit_gateway_attachment_update.go
+++ b/internal/network/command_transit_gateway_attachment_update.go
@@ -15,7 +15,7 @@ func (c *command) newTransitGatewayAttachmentUpdateCommand() *cobra.Command {
 		Short:             "Update an existing transit gateway attachment.",
 		Args:              cobra.ExactArgs(1),
 		ValidArgsFunction: pcmd.NewValidArgsFunction(c.validTransitGatewayAttachmentArgs),
-		RunE:              c.updateTransitGatewayAttachment,
+		RunE:              c.transitGatewayAttachmentUpdate,
 		Example: examples.BuildExampleString(
 			examples.Example{
 				Text: `Update the name of transit gateway attachment "tgwa-123456"`,
@@ -34,7 +34,7 @@ func (c *command) newTransitGatewayAttachmentUpdateCommand() *cobra.Command {
 	return cmd
 }
 
-func (c *command) updateTransitGatewayAttachment(cmd *cobra.Command, args []string) error {
+func (c *command) transitGatewayAttachmentUpdate(cmd *cobra.Command, args []string) error {
 	environmentId, err := c.Context.EnvironmentId()
 	if err != nil {
 		return err

--- a/test/fixtures/output/network/delete-autocomplete.golden
+++ b/test/fixtures/output/network/delete-autocomplete.golden
@@ -1,0 +1,5 @@
+n-abcde1	prod-aws-us-east1
+n-abcde2	prod-gcp-us-central1
+n-abcde3	prod-azure-eastus2
+:4
+Completion ended with directive: ShellCompDirectiveNoFileComp

--- a/test/fixtures/output/network/peering/delete-autocomplete.golden
+++ b/test/fixtures/output/network/peering/delete-autocomplete.golden
@@ -1,0 +1,5 @@
+peer-111111	aws-peering
+peer-111112	gcp-peering
+peer-111113	azure-peering
+:4
+Completion ended with directive: ShellCompDirectiveNoFileComp

--- a/test/fixtures/output/network/peering/update-autocomplete.golden
+++ b/test/fixtures/output/network/peering/update-autocomplete.golden
@@ -1,0 +1,6 @@
+--name	Name of the peering.
+peer-111111	aws-peering
+peer-111112	gcp-peering
+peer-111113	azure-peering
+:4
+Completion ended with directive: ShellCompDirectiveNoFileComp

--- a/test/fixtures/output/network/transit-gateway-attachment/delete-autocomplete.golden
+++ b/test/fixtures/output/network/transit-gateway-attachment/delete-autocomplete.golden
@@ -1,0 +1,5 @@
+tgwa-111111	aws-tgwa1
+tgwa-222222	aws-tgwa2
+tgwa-333333	aws-tgwa3
+:4
+Completion ended with directive: ShellCompDirectiveNoFileComp

--- a/test/fixtures/output/network/transit-gateway-attachment/update-autocomplete.golden
+++ b/test/fixtures/output/network/transit-gateway-attachment/update-autocomplete.golden
@@ -1,0 +1,6 @@
+--name	Name of the transit gateway attachment.
+tgwa-111111	aws-tgwa1
+tgwa-222222	aws-tgwa2
+tgwa-333333	aws-tgwa3
+:4
+Completion ended with directive: ShellCompDirectiveNoFileComp

--- a/test/fixtures/output/network/update-autocomplete.golden
+++ b/test/fixtures/output/network/update-autocomplete.golden
@@ -1,0 +1,6 @@
+--name	Name of the network.
+n-abcde1	prod-aws-us-east1
+n-abcde2	prod-gcp-us-central1
+n-abcde3	prod-azure-eastus2
+:4
+Completion ended with directive: ShellCompDirectiveNoFileComp

--- a/test/network_test.go
+++ b/test/network_test.go
@@ -174,6 +174,8 @@ func (s *CLITestSuite) TestNetworkPeeringCreate() {
 func (s *CLITestSuite) TestNetworkPeering_Autocomplete() {
 	tests := []CLITest{
 		{args: `__complete network peering describe ""`, login: "cloud", fixture: "network/peering/describe-autocomplete.golden"},
+		{args: `__complete network peering update ""`, login: "cloud", fixture: "network/peering/update-autocomplete.golden"},
+		{args: `__complete network peering delete ""`, login: "cloud", fixture: "network/peering/delete-autocomplete.golden"},
 		{args: `__complete network peering create aws-peering --network ""`, login: "cloud", fixture: "network/peering/create-autocomplete.golden"},
 	}
 

--- a/test/network_test.go
+++ b/test/network_test.go
@@ -84,6 +84,8 @@ func (s *CLITestSuite) TestNetworkCreate() {
 func (s *CLITestSuite) TestNetwork_Autocomplete() {
 	tests := []CLITest{
 		{args: `__complete network describe ""`, login: "cloud", fixture: "network/describe-autocomplete.golden"},
+		{args: `__complete network update ""`, login: "cloud", fixture: "network/update-autocomplete.golden"},
+		{args: `__complete network delete ""`, login: "cloud", fixture: "network/delete-autocomplete.golden"},
 		{args: `__complete network create new-network --connection-types ""`, login: "cloud", fixture: "network/create-autocomplete-connection-types.golden"},
 		{args: `__complete network create new-network --dns-resolution ""`, login: "cloud", fixture: "network/create-autocomplete-dns-resolution.golden"},
 	}

--- a/test/network_test.go
+++ b/test/network_test.go
@@ -263,6 +263,8 @@ func (s *CLITestSuite) TestNetworkTransitGatewayAttachmentCreate() {
 func (s *CLITestSuite) TestNetworkTransitGatewayAttachment_Autocomplete() {
 	tests := []CLITest{
 		{args: `__complete network transit-gateway-attachment describe ""`, login: "cloud", fixture: "network/transit-gateway-attachment/describe-autocomplete.golden"},
+		{args: `__complete network transit-gateway-attachment update ""`, login: "cloud", fixture: "network/transit-gateway-attachment/update-autocomplete.golden"},
+		{args: `__complete network transit-gateway-attachment delete ""`, login: "cloud", fixture: "network/transit-gateway-attachment/delete-autocomplete.golden"},
 		{args: `__complete network transit-gateway-attachment create tgwa --network ""`, login: "cloud", fixture: "network/transit-gateway-attachment/create-autocomplete.golden"},
 	}
 


### PR DESCRIPTION
What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->
Note that this is merging into the feature branch https://github.com/confluentinc/cli/tree/traffic-8850-network-cli
* Update `peering`, `transit-gateway-attachment` subcommands to use the `command` struct from the parent command, as discussed in https://github.com/confluentinc/cli/pull/2251#discussion_r1322058537.
* Move variable declaration closer to where it's used, as discussed in https://github.com/confluentinc/cli/pull/2251#discussion_r1322060160.
* Add autocomplete test cases for `update` and `delete`, this is to ensure that these commands are using the correct `ValidXXXArgs` functions.

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
<!--
Has it been tested? How?
Copy and paste any instructions or steps that can save the reviewer time.
-->
```
make build
make lint
make test
```


Open Questions / Follow-ups
---------------------------
<!--
Optional: Anything open to discussion for the reviewer, out of scope of this PR, or follow-ups.
-->
