### PR TITLE
[TRAFFIC-9332][TRAFFIC-9333] - Add confluent network private-link access update|delete commands

### DIFF
--- a/internal/network/command_private_link_access.go
+++ b/internal/network/command_private_link_access.go
@@ -29,8 +29,10 @@ func (c *command) newPrivateLinkAccessCommand() *cobra.Command {
 		Args:  cobra.NoArgs,
 	}
 
+	cmd.AddCommand(c.newPrivateLinkAccessDeleteCommand())
 	cmd.AddCommand(c.newPrivateLinkAccessDescribeCommand())
 	cmd.AddCommand(c.newPrivateLinkAccessListCommand())
+	cmd.AddCommand(c.newPrivateLinkAccessUpdateCommand())
 
 	return cmd
 }

--- a/internal/network/command_private_link_access_delete.go
+++ b/internal/network/command_private_link_access_delete.go
@@ -1,0 +1,63 @@
+package network
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	pcmd "github.com/confluentinc/cli/v3/pkg/cmd"
+	"github.com/confluentinc/cli/v3/pkg/deletion"
+	"github.com/confluentinc/cli/v3/pkg/errors"
+	"github.com/confluentinc/cli/v3/pkg/output"
+	"github.com/confluentinc/cli/v3/pkg/resource"
+	"github.com/confluentinc/cli/v3/pkg/utils"
+)
+
+func (c *command) newPrivateLinkAccessDeleteCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:               "delete <id-1> [id-2] ... [id-n]",
+		Short:             "Delete one or more private link accesses.",
+		Args:              cobra.MinimumNArgs(1),
+		ValidArgsFunction: pcmd.NewValidArgsFunction(c.validPrivateLinkAccessArgsMultiple),
+		RunE:              c.privateLinkAccessDelete,
+	}
+
+	pcmd.AddForceFlag(cmd)
+	pcmd.AddContextFlag(cmd, c.CLICommand)
+	pcmd.AddEnvironmentFlag(cmd, c.AuthenticatedCLICommand)
+
+	return cmd
+}
+
+func (c *command) privateLinkAccessDelete(cmd *cobra.Command, args []string) error {
+	environmentId, err := c.Context.EnvironmentId()
+	if err != nil {
+		return err
+	}
+
+	existenceFunc := func(id string) bool {
+		_, err := c.V2Client.GetPrivateLinkAccess(environmentId, id)
+		return err == nil
+	}
+
+	if err := deletion.ValidateAndConfirmDeletionYesNo(cmd, args, existenceFunc, resource.PrivateLinkAccess); err != nil {
+		return err
+	}
+
+	deleteFunc := func(id string) error {
+		if err := c.V2Client.DeletePrivateLinkAccess(environmentId, id); err != nil {
+			return errors.Errorf(errors.DeleteResourceErrorMsg, resource.PrivateLinkAccess, id, err)
+		}
+		return nil
+	}
+
+	deletedIds, err := deletion.DeleteWithoutMessage(args, deleteFunc)
+	deleteMsg := "Requested to delete %s %s.\n"
+	if len(deletedIds) == 1 {
+		output.Printf(deleteMsg, resource.PrivateLinkAccess, fmt.Sprintf(`"%s"`, deletedIds[0]))
+	} else if len(deletedIds) > 1 {
+		output.Printf(deleteMsg, resource.Plural(resource.PrivateLinkAccess), utils.ArrayToCommaDelimitedString(deletedIds, "and"))
+	}
+
+	return err
+}

--- a/internal/network/command_private_link_access_update.go
+++ b/internal/network/command_private_link_access_update.go
@@ -1,0 +1,61 @@
+package network
+
+import (
+	"github.com/spf13/cobra"
+
+	networkingv1 "github.com/confluentinc/ccloud-sdk-go-v2/networking/v1"
+
+	pcmd "github.com/confluentinc/cli/v3/pkg/cmd"
+	"github.com/confluentinc/cli/v3/pkg/examples"
+)
+
+func (c *command) newPrivateLinkAccessUpdateCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:               "update <id>",
+		Short:             "Update an existing private link access.",
+		Args:              cobra.ExactArgs(1),
+		ValidArgsFunction: pcmd.NewValidArgsFunction(c.validPrivateLinkAccessArgs),
+		RunE:              c.privateLinkAccessUpdate,
+		Example: examples.BuildExampleString(
+			examples.Example{
+				Text: `Update the name of private link access "pla-123456"`,
+				Code: `confluent network private-link access update pla-123456 --name "new name"`,
+			},
+		),
+	}
+
+	cmd.Flags().String("name", "", "Name of the private link access.")
+	pcmd.AddContextFlag(cmd, c.CLICommand)
+	pcmd.AddEnvironmentFlag(cmd, c.AuthenticatedCLICommand)
+	pcmd.AddOutputFlag(cmd)
+
+	cobra.CheckErr(cmd.MarkFlagRequired("name"))
+
+	return cmd
+}
+
+func (c *command) privateLinkAccessUpdate(cmd *cobra.Command, args []string) error {
+	environmentId, err := c.Context.EnvironmentId()
+	if err != nil {
+		return err
+	}
+
+	name, err := cmd.Flags().GetString("name")
+	if err != nil {
+		return err
+	}
+
+	updatePrivateLinkAccess := networkingv1.NetworkingV1PrivateLinkAccessUpdate{
+		Spec: &networkingv1.NetworkingV1PrivateLinkAccessSpecUpdate{
+			DisplayName: networkingv1.PtrString(name),
+			Environment: &networkingv1.ObjectReference{Id: environmentId},
+		},
+	}
+
+	access, err := c.V2Client.UpdatePrivateLinkAccess(environmentId, args[0], updatePrivateLinkAccess)
+	if err != nil {
+		return err
+	}
+
+	return printPrivateLinkAccessTable(cmd, access)
+}

--- a/pkg/ccloudv2/networking.go
+++ b/pkg/ccloudv2/networking.go
@@ -206,3 +206,13 @@ func (c *Client) GetPrivateLinkAccess(environment, id string) (networkingv1.Netw
 	resp, httpResp, err := c.NetworkingClient.PrivateLinkAccessesNetworkingV1Api.GetNetworkingV1PrivateLinkAccess(c.networkingApiContext(), id).Environment(environment).Execute()
 	return resp, errors.CatchCCloudV2Error(err, httpResp)
 }
+
+func (c *Client) UpdatePrivateLinkAccess(environment, id string, privateLinkAccessUpdate networkingv1.NetworkingV1PrivateLinkAccessUpdate) (networkingv1.NetworkingV1PrivateLinkAccess, error) {
+	resp, httpResp, err := c.NetworkingClient.PrivateLinkAccessesNetworkingV1Api.UpdateNetworkingV1PrivateLinkAccess(c.networkingApiContext(), id).NetworkingV1PrivateLinkAccessUpdate(privateLinkAccessUpdate).Execute()
+	return resp, errors.CatchCCloudV2Error(err, httpResp)
+}
+
+func (c *Client) DeletePrivateLinkAccess(environment, id string) error {
+	httpResp, err := c.NetworkingClient.PrivateLinkAccessesNetworkingV1Api.DeleteNetworkingV1PrivateLinkAccess(c.networkingApiContext(), id).Environment(environment).Execute()
+	return errors.CatchCCloudV2Error(err, httpResp)
+}

--- a/pkg/resource/resource.go
+++ b/pkg/resource/resource.go
@@ -36,6 +36,7 @@ const (
 	Network                     = "network"
 	Organization                = "organization"
 	Peering                     = "peering"
+	PrivateLinkAccess           = "private link access"
 	ProviderShare               = "provider share"
 	Pipeline                    = "pipeline"
 	SchemaExporter              = "schema exporter"

--- a/test/fixtures/output/network/private-link/access/delete-autocomplete.golden
+++ b/test/fixtures/output/network/private-link/access/delete-autocomplete.golden
@@ -1,0 +1,5 @@
+pla-111111	aws-pla
+pla-111112	gcp-pla
+pla-111113	azure-pla
+:4
+Completion ended with directive: ShellCompDirectiveNoFileComp

--- a/test/fixtures/output/network/private-link/access/delete-help.golden
+++ b/test/fixtures/output/network/private-link/access/delete-help.golden
@@ -1,0 +1,14 @@
+Delete one or more private link accesses.
+
+Usage:
+  confluent network private-link access delete <id-1> [id-2] ... [id-n] [flags]
+
+Flags:
+      --force                Skip the deletion confirmation prompt.
+      --context string       CLI context name.
+      --environment string   Environment ID.
+
+Global Flags:
+  -h, --help            Show help for this command.
+      --unsafe-trace    Equivalent to -vvvv, but also log HTTP requests and responses which might contain plaintext secrets.
+  -v, --verbose count   Increase verbosity (-v for warn, -vv for info, -vvv for debug, -vvvv for trace).

--- a/test/fixtures/output/network/private-link/access/delete-multiple-fail.golden
+++ b/test/fixtures/output/network/private-link/access/delete-multiple-fail.golden
@@ -1,0 +1,4 @@
+Error: private link access "pla-invalid" not found
+
+Suggestions:
+    List available private link accesss with `confluent network private-link access list`.

--- a/test/fixtures/output/network/private-link/access/delete-multiple-refuse.golden
+++ b/test/fixtures/output/network/private-link/access/delete-multiple-refuse.golden
@@ -1,0 +1,1 @@
+Are you sure you want to delete private link accesss "pla-111111" and "pla-222222"? (y/n): 

--- a/test/fixtures/output/network/private-link/access/delete-multiple-success.golden
+++ b/test/fixtures/output/network/private-link/access/delete-multiple-success.golden
@@ -1,0 +1,1 @@
+Are you sure you want to delete private link accesss "pla-111111" and "pla-222222"? (y/n): Requested to delete private link accesses "pla-111111" and "pla-222222".

--- a/test/fixtures/output/network/private-link/access/delete-pla-not-exist.golden
+++ b/test/fixtures/output/network/private-link/access/delete-pla-not-exist.golden
@@ -1,0 +1,4 @@
+Error: private link access "pla-invalid" not found
+
+Suggestions:
+    List available private link accesss with `confluent network private-link access list`.

--- a/test/fixtures/output/network/private-link/access/delete-prompt.golden
+++ b/test/fixtures/output/network/private-link/access/delete-prompt.golden
@@ -1,0 +1,1 @@
+Are you sure you want to delete private link access "pla-111111"? (y/n): Requested to delete private link access "pla-111111".

--- a/test/fixtures/output/network/private-link/access/delete.golden
+++ b/test/fixtures/output/network/private-link/access/delete.golden
@@ -1,0 +1,1 @@
+Requested to delete private link access "pla-111111".

--- a/test/fixtures/output/network/private-link/access/help.golden
+++ b/test/fixtures/output/network/private-link/access/help.golden
@@ -4,8 +4,10 @@ Usage:
   confluent network private-link access [command]
 
 Available Commands:
+  delete      Delete one or more private link accesses.
   describe    Describe a private link access.
   list        List private link accesses.
+  update      Update an existing private link access.
 
 Global Flags:
   -h, --help            Show help for this command.

--- a/test/fixtures/output/network/private-link/access/update-autocomplete.golden
+++ b/test/fixtures/output/network/private-link/access/update-autocomplete.golden
@@ -1,0 +1,6 @@
+--name	Name of the private link access.
+pla-111111	aws-pla
+pla-111112	gcp-pla
+pla-111113	azure-pla
+:4
+Completion ended with directive: ShellCompDirectiveNoFileComp

--- a/test/fixtures/output/network/private-link/access/update-help.golden
+++ b/test/fixtures/output/network/private-link/access/update-help.golden
@@ -1,0 +1,20 @@
+Update an existing private link access.
+
+Usage:
+  confluent network private-link access update <id> [flags]
+
+Examples:
+Update the name of private link access "pla-123456"
+
+  $ confluent network private-link access update pla-123456 --name "new name"
+
+Flags:
+      --name string          REQUIRED: Name of the private link access.
+      --context string       CLI context name.
+      --environment string   Environment ID.
+  -o, --output string        Specify the output format as "human", "json", or "yaml". (default "human")
+
+Global Flags:
+  -h, --help            Show help for this command.
+      --unsafe-trace    Equivalent to -vvvv, but also log HTTP requests and responses which might contain plaintext secrets.
+  -v, --verbose count   Increase verbosity (-v for warn, -vv for info, -vvv for debug, -vvvv for trace).

--- a/test/fixtures/output/network/private-link/access/update-missing-args.golden
+++ b/test/fixtures/output/network/private-link/access/update-missing-args.golden
@@ -1,0 +1,20 @@
+Error: accepts 1 arg(s), received 0
+Usage:
+  confluent network private-link access update <id> [flags]
+
+Examples:
+Update the name of private link access "pla-123456"
+
+  $ confluent network private-link access update pla-123456 --name "new name"
+
+Flags:
+      --name string          Name of the private link access.
+      --context string       CLI context name.
+      --environment string   Environment ID.
+  -o, --output string        Specify the output format as "human", "json", or "yaml". (default "human")
+
+Global Flags:
+  -h, --help            Show help for this command.
+      --unsafe-trace    Equivalent to -vvvv, but also log HTTP requests and responses which might contain plaintext secrets.
+  -v, --verbose count   Increase verbosity (-v for warn, -vv for info, -vvv for debug, -vvvv for trace).
+

--- a/test/fixtures/output/network/private-link/access/update-missing-flags.golden
+++ b/test/fixtures/output/network/private-link/access/update-missing-flags.golden
@@ -1,0 +1,20 @@
+Error: required flag(s) "name" not set
+Usage:
+  confluent network private-link access update <id> [flags]
+
+Examples:
+Update the name of private link access "pla-123456"
+
+  $ confluent network private-link access update pla-123456 --name "new name"
+
+Flags:
+      --name string          REQUIRED: Name of the private link access.
+      --context string       CLI context name.
+      --environment string   Environment ID.
+  -o, --output string        Specify the output format as "human", "json", or "yaml". (default "human")
+
+Global Flags:
+  -h, --help            Show help for this command.
+      --unsafe-trace    Equivalent to -vvvv, but also log HTTP requests and responses which might contain plaintext secrets.
+  -v, --verbose count   Increase verbosity (-v for warn, -vv for info, -vvv for debug, -vvvv for trace).
+

--- a/test/fixtures/output/network/private-link/access/update-pla-not-exist.golden
+++ b/test/fixtures/output/network/private-link/access/update-pla-not-exist.golden
@@ -1,0 +1,1 @@
+Error: The private-link-access pla-invalid was not found.: 404 Not Found

--- a/test/fixtures/output/network/private-link/access/update.golden
+++ b/test/fixtures/output/network/private-link/access/update.golden
@@ -1,0 +1,8 @@
++-------------+--------------+
+| ID          | pla-111111   |
+| Name        | new-name     |
+| Network ID  | n-abcde1     |
+| Cloud       | AWS          |
+| AWS Account | 012345678901 |
+| Phase       | READY        |
++-------------+--------------+

--- a/test/network_test.go
+++ b/test/network_test.go
@@ -306,9 +306,42 @@ func (s *CLITestSuite) TestNetworkPrivateLinkAccessDescribe() {
 	}
 }
 
+func (s *CLITestSuite) TestNetworkPrivateLinkAccessUpdate() {
+	tests := []CLITest{
+		{args: "network private-link access update", fixture: "network/private-link/access/update-missing-args.golden", exitCode: 1},
+		{args: "network private-link access update pla-111111", fixture: "network/private-link/access/update-missing-flags.golden", exitCode: 1},
+		{args: "network pl access update pla-111111 --name new-name", fixture: "network/private-link/access/update.golden"},
+		{args: "network private-link access update pla-111111 --name new-name", fixture: "network/private-link/access/update.golden"},
+		{args: "network private-link access update pla-invalid --name new-name", fixture: "network/private-link/access/update-pla-not-exist.golden", exitCode: 1},
+	}
+
+	for _, test := range tests {
+		test.login = "cloud"
+		s.runIntegrationTest(test)
+	}
+}
+
+func (s *CLITestSuite) TestNetworkPrivateLinkAccessDelete() {
+	tests := []CLITest{
+		{args: "network private-link access delete pla-111111 --force", fixture: "network/private-link/access/delete.golden"},
+		{args: "network private-link access delete pla-111111", input: "y\n", fixture: "network/private-link/access/delete-prompt.golden"},
+		{args: "network private-link access delete pla-111111 pla-222222", input: "n\n", fixture: "network/private-link/access/delete-multiple-refuse.golden"},
+		{args: "network private-link access delete pla-111111 pla-222222", input: "y\n", fixture: "network/private-link/access/delete-multiple-success.golden"},
+		{args: "network private-link access delete pla-111111 pla-invalid", fixture: "network/private-link/access/delete-multiple-fail.golden", exitCode: 1},
+		{args: "network private-link access delete pla-invalid --force", fixture: "network/private-link/access/delete-pla-not-exist.golden", exitCode: 1},
+	}
+
+	for _, test := range tests {
+		test.login = "cloud"
+		s.runIntegrationTest(test)
+	}
+}
+
 func (s *CLITestSuite) TestNetworkPrivateLinkAccess_Autocomplete() {
 	tests := []CLITest{
 		{args: `__complete network private-link access describe ""`, login: "cloud", fixture: "network/private-link/access/describe-autocomplete.golden"},
+		{args: `__complete network private-link access update ""`, login: "cloud", fixture: "network/private-link/access/update-autocomplete.golden"},
+		{args: `__complete network private-link access delete ""`, login: "cloud", fixture: "network/private-link/access/delete-autocomplete.golden"},
 	}
 
 	for _, test := range tests {

--- a/test/test-server/networking_handlers.go
+++ b/test/test-server/networking_handlers.go
@@ -100,6 +100,10 @@ func handleNetworkingPrivateLinkAccess(t *testing.T) http.HandlerFunc {
 		switch r.Method {
 		case http.MethodGet:
 			handleNetworkingPrivateLinkAccessGet(t, id)(w, r)
+		case http.MethodPatch:
+			handleNetworkingPrivateLinkAccessUpdate(t, id)(w, r)
+		case http.MethodDelete:
+			handleNetworkingPrivateLinkAccessDelete(t, id)(w, r)
 		}
 	}
 }
@@ -753,5 +757,37 @@ func handleNetworkingPrivateLinkAccessList(t *testing.T) http.HandlerFunc {
 
 		err := json.NewEncoder(w).Encode(peeringList)
 		require.NoError(t, err)
+	}
+}
+
+func handleNetworkingPrivateLinkAccessUpdate(t *testing.T, id string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		switch id {
+		case "pla-invalid":
+			w.WriteHeader(http.StatusNotFound)
+			err := writeErrorJson(w, "The private-link-access pla-invalid was not found.")
+			require.NoError(t, err)
+		case "pla-111111":
+			body := &networkingv1.NetworkingV1Network{}
+			err := json.NewDecoder(r.Body).Decode(body)
+			require.NoError(t, err)
+
+			attachment := getPrivateLinkAccess("pla-111111", body.Spec.GetDisplayName(), "AWS")
+			err = json.NewEncoder(w).Encode(attachment)
+			require.NoError(t, err)
+		}
+	}
+}
+
+func handleNetworkingPrivateLinkAccessDelete(t *testing.T, id string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		switch id {
+		case "pla-invalid":
+			w.WriteHeader(http.StatusNotFound)
+			err := writeErrorJson(w, "The private-link-access pla-invalid was not found.")
+			require.NoError(t, err)
+		case "pla-111111", "pla-222222":
+			w.WriteHeader(http.StatusNoContent)
+		}
 	}
 }


### PR DESCRIPTION
What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->
Note that this is merging into the feature branch https://github.com/confluentinc/cli/tree/traffic-8850-network-cli. We will merge commits into main from this feature branch after all of the commands for network are implemented
* Add `confluent network private-link access update` 
* Add `confluent network private-link access delete`

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->
[CLI Commands Design](https://confluentinc.atlassian.net/wiki/spaces/PM/pages/2987394300/1-pager+--+Network+CLI)
[Implementation 1-Pager](https://confluentinc.atlassian.net/wiki/spaces/~712020463029eabbac401bbe1b033ce0d3a00e/pages/3136749631/Network+CLI)

Test & Review
-------------
<!--
Has it been tested? How?
Copy and paste any instructions or steps that can save the reviewer time.
-->
Added integration tests.

Performed manual tests

Open Questions / Follow-ups
---------------------------
<!--
Optional: Anything open to discussion for the reviewer, out of scope of this PR, or follow-ups.
-->
