### PR TITLE
[TRAFFIC-9334] - Add `confluent network private-link access create` command

### DIFF
--- a/internal/network/command_private_link_access.go
+++ b/internal/network/command_private_link_access.go
@@ -29,6 +29,7 @@ func (c *command) newPrivateLinkAccessCommand() *cobra.Command {
 		Args:  cobra.NoArgs,
 	}
 
+	cmd.AddCommand(c.newPrivateLinkAccessCreateCommand())
 	cmd.AddCommand(c.newPrivateLinkAccessDeleteCommand())
 	cmd.AddCommand(c.newPrivateLinkAccessDescribeCommand())
 	cmd.AddCommand(c.newPrivateLinkAccessListCommand())

--- a/internal/network/command_private_link_access_create.go
+++ b/internal/network/command_private_link_access_create.go
@@ -35,7 +35,7 @@ func (c *command) newPrivateLinkAccessCreateCommand() *cobra.Command {
 
 	addNetworkFlag(cmd, c.AuthenticatedCLICommand)
 	pcmd.AddCloudFlag(cmd)
-	cmd.Flags().String("cloud-account", "", "AWS account ID for the account containing the VPCs you want to connect from using AWS PrivateLink, or GCP project ID for the account containing the VPCs that you want to connect from using Private Service Connect, or Azure subscription ID for the account containing the VNets you want to connect from using Azure Private Link.")
+	cmd.Flags().String("cloud-account", "", "AWS account ID for the account containing the VPCs you want to connect from using AWS PrivateLink. GCP project ID for the account containing the VPCs that you want to connect from using Private Service Connect. Azure subscription ID for the account containing the VNets you want to connect from using Azure Private Link.")
 	pcmd.AddContextFlag(cmd, c.CLICommand)
 	pcmd.AddEnvironmentFlag(cmd, c.AuthenticatedCLICommand)
 	pcmd.AddOutputFlag(cmd)

--- a/internal/network/command_private_link_access_create.go
+++ b/internal/network/command_private_link_access_create.go
@@ -1,0 +1,112 @@
+package network
+
+import (
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	networkingv1 "github.com/confluentinc/ccloud-sdk-go-v2/networking/v1"
+
+	pcmd "github.com/confluentinc/cli/v3/pkg/cmd"
+	"github.com/confluentinc/cli/v3/pkg/examples"
+)
+
+func (c *command) newPrivateLinkAccessCreateCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "create <name>",
+		Short: "Create a private link access.",
+		Args:  cobra.ExactArgs(1),
+		RunE:  c.privateLinkAccessCreate,
+		Example: examples.BuildExampleString(
+			examples.Example{
+				Text: "Create an AWS Private Link access.",
+				Code: "confluent network private-link access create aws-private-link-access --network n-123456 --cloud aws --cloud-account 123456789012",
+			},
+			examples.Example{
+				Text: "Create a GCP Private Service Connect access.",
+				Code: "confluent network private-link access create gcp-private-link-access --network n-123456 --cloud gcp --cloud-account temp-123456",
+			},
+			examples.Example{
+				Text: "Create an Azure Private Link access.",
+				Code: "confluent network private-link access create azure-private-link-access --network n-123456 --cloud azure --cloud-account 1234abcd-12ab-34cd-1234-123456abcdef",
+			},
+		),
+	}
+
+	addNetworkFlag(cmd, c.AuthenticatedCLICommand)
+	pcmd.AddCloudFlag(cmd)
+	cmd.Flags().String("cloud-account", "", "AWS account ID for the account containing the VPCs you want to connect from using AWS PrivateLink, or GCP project ID for the account containing the VPCs that you want to connect from using Private Service Connect, or Azure subscription ID for the account containing the VNets you want to connect from using Azure Private Link.")
+	pcmd.AddContextFlag(cmd, c.CLICommand)
+	pcmd.AddEnvironmentFlag(cmd, c.AuthenticatedCLICommand)
+	pcmd.AddOutputFlag(cmd)
+
+	cobra.CheckErr(cmd.MarkFlagRequired("network"))
+	cobra.CheckErr(cmd.MarkFlagRequired("cloud"))
+	cobra.CheckErr(cmd.MarkFlagRequired("cloud-account"))
+
+	return cmd
+}
+
+func (c *command) privateLinkAccessCreate(cmd *cobra.Command, args []string) error {
+	name := args[0]
+
+	cloud, err := cmd.Flags().GetString("cloud")
+	if err != nil {
+		return err
+	}
+	cloud = strings.ToUpper(cloud)
+
+	network, err := cmd.Flags().GetString("network")
+	if err != nil {
+		return err
+	}
+
+	environmentId, err := c.Context.EnvironmentId()
+	if err != nil {
+		return err
+	}
+
+	cloudAccount, err := cmd.Flags().GetString("cloud-account")
+	if err != nil {
+		return err
+	}
+
+	createPrivateLinkAccess := networkingv1.NetworkingV1PrivateLinkAccess{
+		Spec: &networkingv1.NetworkingV1PrivateLinkAccessSpec{
+			DisplayName: networkingv1.PtrString(name),
+			Environment: &networkingv1.ObjectReference{Id: environmentId},
+			Network:     &networkingv1.ObjectReference{Id: network},
+		},
+	}
+
+	switch cloud {
+	case CloudAws:
+		createPrivateLinkAccess.Spec.Cloud = &networkingv1.NetworkingV1PrivateLinkAccessSpecCloudOneOf{
+			NetworkingV1AwsPrivateLinkAccess: &networkingv1.NetworkingV1AwsPrivateLinkAccess{
+				Kind:    "AwsPrivateLinkAccess",
+				Account: cloudAccount,
+			},
+		}
+	case CloudAzure:
+		createPrivateLinkAccess.Spec.Cloud = &networkingv1.NetworkingV1PrivateLinkAccessSpecCloudOneOf{
+			NetworkingV1AzurePrivateLinkAccess: &networkingv1.NetworkingV1AzurePrivateLinkAccess{
+				Kind:         "AzurePrivateLinkAccess",
+				Subscription: cloudAccount,
+			},
+		}
+	case CloudGcp:
+		createPrivateLinkAccess.Spec.Cloud = &networkingv1.NetworkingV1PrivateLinkAccessSpecCloudOneOf{
+			NetworkingV1GcpPrivateServiceConnectAccess: &networkingv1.NetworkingV1GcpPrivateServiceConnectAccess{
+				Kind:    "GcpPrivateServiceConnectAccess",
+				Project: cloudAccount,
+			},
+		}
+	}
+
+	access, err := c.V2Client.CreatePrivateLinkAccess(createPrivateLinkAccess)
+	if err != nil {
+		return err
+	}
+
+	return printPrivateLinkAccessTable(cmd, access)
+}

--- a/pkg/ccloudv2/networking.go
+++ b/pkg/ccloudv2/networking.go
@@ -216,3 +216,8 @@ func (c *Client) DeletePrivateLinkAccess(environment, id string) error {
 	httpResp, err := c.NetworkingClient.PrivateLinkAccessesNetworkingV1Api.DeleteNetworkingV1PrivateLinkAccess(c.networkingApiContext(), id).Environment(environment).Execute()
 	return errors.CatchCCloudV2Error(err, httpResp)
 }
+
+func (c *Client) CreatePrivateLinkAccess(access networkingv1.NetworkingV1PrivateLinkAccess) (networkingv1.NetworkingV1PrivateLinkAccess, error) {
+	resp, httpResp, err := c.NetworkingClient.PrivateLinkAccessesNetworkingV1Api.CreateNetworkingV1PrivateLinkAccess(c.networkingApiContext()).NetworkingV1PrivateLinkAccess(access).Execute()
+	return resp, errors.CatchCCloudV2Error(err, httpResp)
+}

--- a/test/fixtures/output/network/private-link/access/create-autocomplete.golden
+++ b/test/fixtures/output/network/private-link/access/create-autocomplete.golden
@@ -1,0 +1,5 @@
+n-abcde1	prod-aws-us-east1
+n-abcde2	prod-gcp-us-central1
+n-abcde3	prod-azure-eastus2
+:4
+Completion ended with directive: ShellCompDirectiveNoFileComp

--- a/test/fixtures/output/network/private-link/access/create-aws.golden
+++ b/test/fixtures/output/network/private-link/access/create-aws.golden
@@ -1,0 +1,8 @@
++-------------+--------------+
+| ID          | pla-123456   |
+| Name        | aws-pla      |
+| Network ID  | n-abcde1     |
+| Cloud       | AWS          |
+| AWS Account | 012345678901 |
+| Phase       | PROVISIONING |
++-------------+--------------+

--- a/test/fixtures/output/network/private-link/access/create-azure.golden
+++ b/test/fixtures/output/network/private-link/access/create-azure.golden
@@ -1,0 +1,8 @@
++--------------------+--------------------------------------+
+| ID                 | pla-123456                           |
+| Name               | azure-pla                            |
+| Network ID         | n-abcde1                             |
+| Cloud              | AZURE                                |
+| Azure Subscription | 1234abcd-12ab-34cd-1234-123456abcdef |
+| Phase              | PROVISIONING                         |
++--------------------+--------------------------------------+

--- a/test/fixtures/output/network/private-link/access/create-duplicate.golden
+++ b/test/fixtures/output/network/private-link/access/create-duplicate.golden
@@ -1,0 +1,1 @@
+Error: The provided network n-azure resides in AZURE which differs from AWS, the cloud specified for this resource.: 400 Bad Request

--- a/test/fixtures/output/network/private-link/access/create-gcp.golden
+++ b/test/fixtures/output/network/private-link/access/create-gcp.golden
@@ -1,0 +1,8 @@
++-------------+--------------+
+| ID          | pla-123456   |
+| Name        | gcp-pla      |
+| Network ID  | n-abcde1     |
+| Cloud       | GCP          |
+| GCP Project | temp-123456  |
+| Phase       | PROVISIONING |
++-------------+--------------+

--- a/test/fixtures/output/network/private-link/access/create-help.golden
+++ b/test/fixtures/output/network/private-link/access/create-help.golden
@@ -1,0 +1,30 @@
+Create a private link access.
+
+Usage:
+  confluent network private-link access create <name> [flags]
+
+Examples:
+Create an AWS Private Link access.
+
+  $ confluent network private-link access create aws-private-link-access --network n-123456 --cloud aws --cloud-account 123456789012
+
+Create a GCP Private Service Connect access.
+
+  $ confluent network private-link access create gcp-private-link-access --network n-123456 --cloud gcp --cloud-account temp-123456
+
+Create an Azure Private Link access.
+
+  $ confluent network private-link access create azure-private-link-access --network n-123456 --cloud azure --cloud-account 1234abcd-12ab-34cd-1234-123456abcdef
+
+Flags:
+      --network string         REQUIRED: Network ID.
+      --cloud string           REQUIRED: Specify the cloud provider as "aws", "azure", or "gcp".
+      --cloud-account string   REQUIRED: AWS account ID for the account containing the VPCs you want to connect from using AWS PrivateLink, or GCP project ID for the account containing the VPCs that you want to connect from using Private Service Connect, or Azure subscription ID for the account containing the VNets you want to connect from using Azure Private Link.
+      --context string         CLI context name.
+      --environment string     Environment ID.
+  -o, --output string          Specify the output format as "human", "json", or "yaml". (default "human")
+
+Global Flags:
+  -h, --help            Show help for this command.
+      --unsafe-trace    Equivalent to -vvvv, but also log HTTP requests and responses which might contain plaintext secrets.
+  -v, --verbose count   Increase verbosity (-v for warn, -vv for info, -vvv for debug, -vvvv for trace).

--- a/test/fixtures/output/network/private-link/access/create-help.golden
+++ b/test/fixtures/output/network/private-link/access/create-help.golden
@@ -19,7 +19,7 @@ Create an Azure Private Link access.
 Flags:
       --network string         REQUIRED: Network ID.
       --cloud string           REQUIRED: Specify the cloud provider as "aws", "azure", or "gcp".
-      --cloud-account string   REQUIRED: AWS account ID for the account containing the VPCs you want to connect from using AWS PrivateLink, or GCP project ID for the account containing the VPCs that you want to connect from using Private Service Connect, or Azure subscription ID for the account containing the VNets you want to connect from using Azure Private Link.
+      --cloud-account string   REQUIRED: AWS account ID for the account containing the VPCs you want to connect from using AWS PrivateLink. GCP project ID for the account containing the VPCs that you want to connect from using Private Service Connect. Azure subscription ID for the account containing the VNets you want to connect from using Azure Private Link.
       --context string         CLI context name.
       --environment string     Environment ID.
   -o, --output string          Specify the output format as "human", "json", or "yaml". (default "human")

--- a/test/fixtures/output/network/private-link/access/create-missing-flags.golden
+++ b/test/fixtures/output/network/private-link/access/create-missing-flags.golden
@@ -1,0 +1,30 @@
+Error: required flag(s) "cloud", "cloud-account" not set
+Usage:
+  confluent network private-link access create <name> [flags]
+
+Examples:
+Create an AWS Private Link access.
+
+  $ confluent network private-link access create aws-private-link-access --network n-123456 --cloud aws --cloud-account 123456789012
+
+Create a GCP Private Service Connect access.
+
+  $ confluent network private-link access create gcp-private-link-access --network n-123456 --cloud gcp --cloud-account temp-123456
+
+Create an Azure Private Link access.
+
+  $ confluent network private-link access create azure-private-link-access --network n-123456 --cloud azure --cloud-account 1234abcd-12ab-34cd-1234-123456abcdef
+
+Flags:
+      --network string         REQUIRED: Network ID.
+      --cloud string           REQUIRED: Specify the cloud provider as "aws", "azure", or "gcp".
+      --cloud-account string   REQUIRED: AWS account ID for the account containing the VPCs you want to connect from using AWS PrivateLink, or GCP project ID for the account containing the VPCs that you want to connect from using Private Service Connect, or Azure subscription ID for the account containing the VNets you want to connect from using Azure Private Link.
+      --context string         CLI context name.
+      --environment string     Environment ID.
+  -o, --output string          Specify the output format as "human", "json", or "yaml". (default "human")
+
+Global Flags:
+  -h, --help            Show help for this command.
+      --unsafe-trace    Equivalent to -vvvv, but also log HTTP requests and responses which might contain plaintext secrets.
+  -v, --verbose count   Increase verbosity (-v for warn, -vv for info, -vvv for debug, -vvvv for trace).
+

--- a/test/fixtures/output/network/private-link/access/create-missing-flags.golden
+++ b/test/fixtures/output/network/private-link/access/create-missing-flags.golden
@@ -18,7 +18,7 @@ Create an Azure Private Link access.
 Flags:
       --network string         REQUIRED: Network ID.
       --cloud string           REQUIRED: Specify the cloud provider as "aws", "azure", or "gcp".
-      --cloud-account string   REQUIRED: AWS account ID for the account containing the VPCs you want to connect from using AWS PrivateLink, or GCP project ID for the account containing the VPCs that you want to connect from using Private Service Connect, or Azure subscription ID for the account containing the VNets you want to connect from using Azure Private Link.
+      --cloud-account string   REQUIRED: AWS account ID for the account containing the VPCs you want to connect from using AWS PrivateLink. GCP project ID for the account containing the VPCs that you want to connect from using Private Service Connect. Azure subscription ID for the account containing the VNets you want to connect from using Azure Private Link.
       --context string         CLI context name.
       --environment string     Environment ID.
   -o, --output string          Specify the output format as "human", "json", or "yaml". (default "human")

--- a/test/fixtures/output/network/private-link/access/create-wrong-network-cloud.golden
+++ b/test/fixtures/output/network/private-link/access/create-wrong-network-cloud.golden
@@ -1,0 +1,1 @@
+Error: Private link already exists.: 409 Conflict

--- a/test/fixtures/output/network/private-link/access/help.golden
+++ b/test/fixtures/output/network/private-link/access/help.golden
@@ -4,6 +4,7 @@ Usage:
   confluent network private-link access [command]
 
 Available Commands:
+  create      Create a private link access.
   delete      Delete one or more private link accesses.
   describe    Describe a private link access.
   list        List private link accesses.

--- a/test/network_test.go
+++ b/test/network_test.go
@@ -337,11 +337,28 @@ func (s *CLITestSuite) TestNetworkPrivateLinkAccessDelete() {
 	}
 }
 
+func (s *CLITestSuite) TestNetworkPrivateLinkAccessCreate() {
+	tests := []CLITest{
+		{args: "network private-link access create pla --network n-abcde1", fixture: "network/private-link/access/create-missing-flags.golden", exitCode: 1},
+		{args: "network private-link access create aws-pla --network n-abcde1 --cloud aws --cloud-account 012345678901", fixture: "network/private-link/access/create-aws.golden"},
+		{args: "network private-link access create gcp-pla --network n-abcde1 --cloud gcp --cloud-account temp-123456", fixture: "network/private-link/access/create-gcp.golden"},
+		{args: "network private-link access create azure-pla --network n-abcde1 --cloud azure --cloud-account 1234abcd-12ab-34cd-1234-123456abcdef", fixture: "network/private-link/access/create-azure.golden"},
+		{args: "network private-link access create aws-pla --network n-azure --cloud aws --cloud-account 012345678901", fixture: "network/private-link/access/create-duplicate.golden", exitCode: 1},
+		{args: "network private-link access create aws-pla --network n-duplicate --cloud aws --cloud-account 012345678901", fixture: "network/private-link/access/create-wrong-network-cloud.golden", exitCode: 1},
+	}
+
+	for _, test := range tests {
+		test.login = "cloud"
+		s.runIntegrationTest(test)
+	}
+}
+
 func (s *CLITestSuite) TestNetworkPrivateLinkAccess_Autocomplete() {
 	tests := []CLITest{
 		{args: `__complete network private-link access describe ""`, login: "cloud", fixture: "network/private-link/access/describe-autocomplete.golden"},
 		{args: `__complete network private-link access update ""`, login: "cloud", fixture: "network/private-link/access/update-autocomplete.golden"},
 		{args: `__complete network private-link access delete ""`, login: "cloud", fixture: "network/private-link/access/delete-autocomplete.golden"},
+		{args: `__complete network private-link access create pla --network ""`, login: "cloud", fixture: "network/private-link/access/create-autocomplete.golden"},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->
Note that this is merging into the feature branch https://github.com/confluentinc/cli/tree/traffic-8850-network-cli. We will merge commits into main from this feature branch after all of the commands for network are implemented
* Add `confluent network private-link access create` 


References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->
[CLI Commands Design](https://confluentinc.atlassian.net/wiki/spaces/PM/pages/2987394300/1-pager+--+Network+CLI)
[Implementation 1-Pager](https://confluentinc.atlassian.net/wiki/spaces/~712020463029eabbac401bbe1b033ce0d3a00e/pages/3136749631/Network+CLI)


Test & Review
-------------
<!--
Has it been tested? How?
Copy and paste any instructions or steps that can save the reviewer time.
-->
Added integration tests.

Performed manual tests
* create aws pl access
* create gcp psc access
* create azure pl access

Open Questions / Follow-ups
---------------------------
<!--
Optional: Anything open to discussion for the reviewer, out of scope of this PR, or follow-ups.
-->
