### PR TITLE
[CLI-2797] Fix panic in `kafka topic consume`

### DIFF
--- a/internal/kafka/command_topic_consume.go
+++ b/internal/kafka/command_topic_consume.go
@@ -170,7 +170,7 @@ func (c *command) consume(cmd *cobra.Command, args []string) error {
 	}
 
 	var srClient *schemaregistry.Client
-	if slices.Contains(serdes.SchemaBasedFormats, valueFormat) {
+	if slices.Contains(serdes.SchemaBasedFormats, valueFormat) || slices.Contains(serdes.SchemaBasedFormats, keyFormat) {
 		// Only initialize client and context when schema is specified.
 		srClient, err = c.GetSchemaRegistryClient(cmd)
 		if err != nil {


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- PLACEHOLDER

New Features
- PLACEHOLDER

Bug Fixes
- Fix a panic that occurs when using `confluent kafka topic consume --key-format` with a schema based key format

Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
The SR client was previously only initialized if the user provided a schema based value format. This PR initializes the SR client if they provide a schema based value format or key format.

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
Manual testing:
```
confluent kafka topic produce avro-test --key-format avro --key-schema ~/schemas/schema-avro-test-value-v1.avsc --parse-key --value-format string --delimiter ";"
Successfully registered schema with ID "100003".
Starting Kafka Producer. Use Ctrl-C or Ctrl-D to exit.
{"my_field1":1, "my_field2":1.0, "my_field3":""};hello
```
Without fix:
```
confluent kafka topic consume avro-test --key-format avro --print-key --value-format string --delimiter ";" -b
Starting Kafka Consumer. Use Ctrl-C to exit.
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x10106b5b3]
```
With fix:
```
confluent kafka topic consume avro-test --key-format avro --print-key --value-format string --delimiter ";" -b
Starting Kafka Consumer. Use Ctrl-C to exit.
{"my_field2":1,"my_field3":"","my_field1":1};hello
```
Open Questions / Follow-ups
---------------------------
<!--
Optional: Anything open to discussion for the reviewer, out of scope of this PR, or follow-ups.
-->
