### PR TITLE
Fix cipher: message authentication failed after renaming context

### DIFF
--- a/internal/context/command_update.go
+++ b/internal/context/command_update.go
@@ -49,6 +49,14 @@ func (c *command) update(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf(errors.ContextAlreadyExistsErrorMsg, name)
 		}
 
+		if err := ctx.Config.ContextStates[ctx.Name].DecryptContextStateAuthToken(ctx.Name); err != nil {
+			return err
+		}
+
+		if err := ctx.Config.ContextStates[ctx.Name].DecryptContextStateAuthRefreshToken(ctx.Name); err != nil {
+			return err
+		}
+
 		delete(ctx.Config.Contexts, ctx.Name)
 		delete(ctx.Config.ContextStates, ctx.Name)
 


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- PLACEHOLDER

New Features
- PLACEHOLDER

Bug Fixes
- Fix a bug when running CLI after running `confluent context update --name`

Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->
context tokens are encrypted using ctx name as part of additional info. when it's renamed, tokens should be decrypted first and then be encrypted again (this is done in 'save'), or a inconsistent ctx name will lead to decrypting failures.

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
<!--
Has it been tested? How?
Copy and paste any instructions or steps that can save the reviewer time.
-->
```
mhe@C02DV0KVMD6T cli % confluent context update login-mhe@confluent.io-https://confluent.cloud --name xtc
decrypting auth token of context: login-mhe@confluent.io-https://confluent.cloud
decrypting refresh auth token of context: login-mhe@confluent.io-https://confluent.cloud
hey, encrypting here! the name i use is: xtc
+------------+---------------------------+
| Name       | xtc                       |
| Platform   | confluent.cloud           |
| Credential | username-mhe@confluent.io |
+------------+---------------------------+
mhe@C02DV0KVMD6T cli % confluent iam user list
decrypting auth token of context: xtc
decrypting refresh auth token of context: xtc
     ID    |     Name     |         Email          | Authentication Method  
-----------+--------------+------------------------+------------------------
  u-e02dw5 | Muwei He     | mhe@confluent.io       | Username/Password      
  u-j5pzoq | Muwei Cinder | mhe+apple@confluent.io | Username/Password 
```

Open Questions / Follow-ups
---------------------------
<!--
Optional: Anything open to discussion for the reviewer, out of scope of this PR, or follow-ups.
-->
