### PR TITLE
Increased timeout for sling client for s3 upload

### DIFF
--- a/internal/connect/command_custom_plugin_update.go
+++ b/internal/connect/command_custom_plugin_update.go
@@ -58,10 +58,10 @@ func (c *customPluginCommand) update(cmd *cobra.Command, args []string) error {
 		}
 	}
 	if cmd.Flags().Changed("sensitive-properties") {
-		if sensitiveProperties, err := cmd.Flags().GetString("sensitive-properties"); err != nil {
+		if sensitiveProperties, err := cmd.Flags().GetStringSlice("sensitive-properties"); err != nil {
 			return err
 		} else {
-			updateCustomPluginRequest.SetDisplayName(sensitiveProperties)
+			updateCustomPluginRequest.SetSensitiveConfigProperties(sensitiveProperties)
 		}
 	}
 

--- a/internal/connect/utils.go
+++ b/internal/connect/utils.go
@@ -5,8 +5,10 @@ import (
 	"encoding/json"
 	"io"
 	"mime/multipart"
+	"net/http"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/dghubble/sling"
 	"github.com/spf13/cobra"
@@ -111,7 +113,10 @@ func uploadFile(url, filePath string, formFields map[string]any) error {
 		return err
 	}
 
-	_, err = sling.New().Base(url).Set("Content-Type", writer.FormDataContentType()).Post("").Body(&buffer).ReceiveSuccess(nil)
+	client := &http.Client{
+		Timeout: 20 * time.Minute,
+	}
+	_, err = sling.New().Client(client).Base(url).Set("Content-Type", writer.FormDataContentType()).Post("").Body(&buffer).ReceiveSuccess(nil)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Release Notes
-------------


Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   yes: ok 

What
----
Depending on the internet connection of the user some file upload to s3 for custom connector plugins would time out. Increased the timeout to 20 minutes to support that.

Test & Review
-------------
Tested manually using the binary

