### PR TITLE
Remove `--force` and add `--output` to `confluent kafka link describe`

### DIFF
--- a/internal/kafka/command_link_describe.go
+++ b/internal/kafka/command_link_describe.go
@@ -29,10 +29,10 @@ func (c *linkCommand) newDescribeCommand() *cobra.Command {
 		RunE:              c.describe,
 	}
 
-	pcmd.AddForceFlag(cmd)
 	pcmd.AddClusterFlag(cmd, c.AuthenticatedCLICommand)
 	pcmd.AddContextFlag(cmd, c.CLICommand)
 	pcmd.AddEnvironmentFlag(cmd, c.AuthenticatedCLICommand)
+	pcmd.AddOutputFlag(cmd)
 
 	return cmd
 }

--- a/test/fixtures/output/kafka/link/describe-help.golden
+++ b/test/fixtures/output/kafka/link/describe-help.golden
@@ -4,10 +4,10 @@ Usage:
   confluent kafka link describe <link> [flags]
 
 Flags:
-      --force                Skip the deletion confirmation prompt.
       --cluster string       Kafka cluster ID.
       --context string       CLI context name.
       --environment string   Environment ID.
+  -o, --output string        Specify the output format as "human", "json", or "yaml". (default "human")
 
 Global Flags:
   -h, --help            Show help for this command.

--- a/test/fixtures/output/kafka/link/describe-json.golden
+++ b/test/fixtures/output/kafka/link/describe-json.golden
@@ -1,0 +1,7 @@
+{
+  "link_name": "link-1",
+  "source_cluster_id": "lkc-describe-topic",
+  "destination_cluster_id": "",
+  "remote_cluster_id": "",
+  "state": "AVAILABLE"
+}

--- a/test/kafka_test.go
+++ b/test/kafka_test.go
@@ -142,6 +142,7 @@ func (s *CLITestSuite) TestKafka() {
 		{args: "kafka link delete link-1 link-2", input: "y\n", fixture: "kafka/link/delete-link-multiple.golden", useKafka: "lkc-describe-topic"},
 		{args: "kafka link delete link-1 link-2 link-dne", fixture: "kafka/link/delete-link-multiple-fail.golden", useKafka: "lkc-describe-topic", exitCode: 1},
 		{args: "kafka link describe link-1 --cluster lkc-describe-topic", fixture: "kafka/link/describe.golden", useKafka: "lkc-describe-topic"},
+		{args: "kafka link describe link-1 --cluster lkc-describe-topic -o json", fixture: "kafka/link/describe-json.golden", useKafka: "lkc-describe-topic"},
 		{args: "kafka link describe link-4 --cluster lkc-describe-topic", fixture: "kafka/link/describe-bidirectional-link.golden", useKafka: "lkc-describe-topic"},
 		{args: "kafka link describe link-3 --cluster lkc-describe-topic", fixture: "kafka/link/describe-error.golden", useKafka: "lkc-describe-topic"},
 		{args: "kafka link configuration list --cluster lkc-describe-topic link-1", fixture: "kafka/link/configuration-list-plain.golden", useKafka: "lkc-describe-topic"},


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- PLACEHOLDER

New Features
- PLACEHOLDER

Bug Fixes
- Add the missing `--output` flag to `confluent kafka link describe` and remove the unused `--force` flag

Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
I think this qualifies more as a bug fix than a breaking change, because the `--force` flag was never intended to be available for this command. Since `--output` is also missing, this was just a copy paste error.

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
Added a new integration test for the output flag.

Open Questions / Follow-ups
---------------------------
<!--
Optional: Anything open to discussion for the reviewer, out of scope of this PR, or follow-ups.
-->
