### PR TITLE
Feat/KFS-1166 default and initialvalues

### DIFF
--- a/pkg/flink/internal/store/.snapshots/TestProcessResetStatement-should_return_all_keys_and_values_including_default_and_initial_values_before_reseting
+++ b/pkg/flink/internal/store/.snapshots/TestProcessResetStatement-should_return_all_keys_and_values_including_default_and_initial_values_before_reseting
@@ -52,7 +52,7 @@
         },
         (types.AtomicStatementResultField) {
           Type: (types.StatementResultFieldType) (len=7) "VARCHAR",
-          Value: (string) (len=19) "GMT+02:00 (default)"
+          Value: (string) (len=10) "London/GMT"
         }
       }
     }

--- a/pkg/flink/internal/store/.snapshots/TestProcessResetStatement-should_return_all_keys_and_values_including_default_and_initial_values_before_reseting
+++ b/pkg/flink/internal/store/.snapshots/TestProcessResetStatement-should_return_all_keys_and_values_including_default_and_initial_values_before_reseting
@@ -3,7 +3,7 @@
     (string) (len=3) "Key",
     (string) (len=5) "Value"
   },
-  Rows: ([]types.StatementResultRow) (len=3) {
+  Rows: ([]types.StatementResultRow) (len=4) {
     (types.StatementResultRow) {
       Operation: (types.StatementResultOperation) +I,
       Fields: ([]types.StatementResultField) (len=2) {
@@ -13,7 +13,7 @@
         },
         (types.AtomicStatementResultField) {
           Type: (types.StatementResultFieldType) (len=7) "VARCHAR",
-          Value: (string) (len=17) "<unset> (default)"
+          Value: (string) (len=16) "sa-123 (default)"
         }
       }
     },
@@ -26,7 +26,20 @@
         },
         (types.AtomicStatementResultField) {
           Type: (types.StatementResultFieldType) (len=7) "VARCHAR",
-          Value: (string) (len=7) "env-123"
+          Value: (string) (len=7) "envName"
+        }
+      }
+    },
+    (types.StatementResultRow) {
+      Operation: (types.StatementResultOperation) +I,
+      Fields: ([]types.StatementResultField) (len=2) {
+        (types.AtomicStatementResultField) {
+          Type: (types.StatementResultFieldType) (len=7) "VARCHAR",
+          Value: (string) (len=20) "sql.current-database"
+        },
+        (types.AtomicStatementResultField) {
+          Type: (types.StatementResultFieldType) (len=7) "VARCHAR",
+          Value: (string) (len=8) "database"
         }
       }
     },
@@ -39,7 +52,7 @@
         },
         (types.AtomicStatementResultField) {
           Type: (types.StatementResultFieldType) (len=7) "VARCHAR",
-          Value: (string) (len=10) "London/GMT"
+          Value: (string) (len=19) "GMT+02:00 (default)"
         }
       }
     }

--- a/pkg/flink/internal/store/.snapshots/TestProcessSetStatement-should_return_all_keys_and_values_from_config_if_configKey_is_empty_after_updates
+++ b/pkg/flink/internal/store/.snapshots/TestProcessSetStatement-should_return_all_keys_and_values_from_config_if_configKey_is_empty_after_updates
@@ -3,7 +3,7 @@
     (string) (len=3) "Key",
     (string) (len=5) "Value"
   },
-  Rows: ([]types.StatementResultRow) (len=5) {
+  Rows: ([]types.StatementResultRow) (len=4) {
     (types.StatementResultRow) {
       Operation: (types.StatementResultOperation) +I,
       Fields: ([]types.StatementResultField) (len=2) {
@@ -39,20 +39,7 @@
         },
         (types.AtomicStatementResultField) {
           Type: (types.StatementResultFieldType) (len=7) "VARCHAR",
-          Value: (string) (len=17) "<unset> (default)"
-        }
-      }
-    },
-    (types.StatementResultRow) {
-      Operation: (types.StatementResultOperation) +I,
-      Fields: ([]types.StatementResultField) (len=2) {
-        (types.AtomicStatementResultField) {
-          Type: (types.StatementResultFieldType) (len=7) "VARCHAR",
-          Value: (string) (len=20) "sql.current-database"
-        },
-        (types.AtomicStatementResultField) {
-          Type: (types.StatementResultFieldType) (len=7) "VARCHAR",
-          Value: (string) (len=17) "<unset> (default)"
+          Value: (string) (len=7) "env-123"
         }
       }
     },

--- a/pkg/flink/internal/store/.snapshots/TestUserPropertiesTestSuite-TestToSortedSlice-with_initial_values
+++ b/pkg/flink/internal/store/.snapshots/TestUserPropertiesTestSuite-TestToSortedSlice-with_initial_values
@@ -1,0 +1,14 @@
+([][]string) (len=3) {
+  ([]string) (len=2) {
+    (string) (len=11) "default-key",
+    (string) (len=23) "default-value (default)"
+  },
+  ([]string) (len=2) {
+    (string) (len=13) "initial.key.1",
+    (string) (len=6) "value1"
+  },
+  ([]string) (len=2) {
+    (string) (len=13) "initial.key.2",
+    (string) (len=6) "value2"
+  }
+}

--- a/pkg/flink/internal/store/store.go
+++ b/pkg/flink/internal/store/store.go
@@ -251,7 +251,7 @@ func extractPageToken(nextUrl string) (string, error) {
 
 func NewStore(client ccloudv2.GatewayClientInterface, exitApplication func(), appOptions *types.ApplicationOptions, tokenRefreshFunc func() error) types.StoreInterface {
 	return &Store{
-		Properties:       NewUserProperties(getDefaultProperties(appOptions)),
+		Properties:       NewUserProperties(getDefaultProperties(appOptions), getInitialProperties(appOptions)),
 		client:           client,
 		exitApplication:  exitApplication,
 		appOptions:       appOptions,
@@ -261,10 +261,21 @@ func NewStore(client ccloudv2.GatewayClientInterface, exitApplication func(), ap
 
 func getDefaultProperties(appOptions *types.ApplicationOptions) map[string]string {
 	properties := map[string]string{
-		config.ConfigKeyCatalog:       appOptions.GetEnvironmentName(),
-		config.ConfigKeyDatabase:      appOptions.GetDatabase(),
 		config.ConfigKeyServiceAcount: appOptions.GetServiceAccountId(),
 		config.ConfigKeyLocalTimeZone: getLocalTimezone(),
+	}
+
+	return properties
+}
+
+func getInitialProperties(appOptions *types.ApplicationOptions) map[string]string {
+	properties := map[string]string{}
+
+	if appOptions.GetEnvironmentName() != "" {
+		properties[config.ConfigKeyCatalog] = appOptions.GetEnvironmentName()
+	}
+	if appOptions.GetDatabase() != "" {
+		properties[config.ConfigKeyDatabase] = appOptions.GetDatabase()
 	}
 
 	return properties

--- a/pkg/flink/internal/store/store_test.go
+++ b/pkg/flink/internal/store/store_test.go
@@ -985,7 +985,7 @@ func TestTimeout(t *testing.T) {
 
 	// Iterate over test cases and run the function for each input, comparing output to expected value
 	for _, tc := range testCases {
-		store := Store{Properties: NewUserProperties(tc.properties)}
+		store := Store{Properties: NewUserProperties(tc.properties, map[string]string{})}
 		result := store.getTimeout()
 		require.Equal(t, tc.expected, result, tc.name)
 	}
@@ -1000,7 +1000,7 @@ func (s *StoreTestSuite) TestProcessStatementWithIdentityPool() {
 		IdentityPoolId: "identityPoolId",
 	}
 	store := Store{
-		Properties:       NewUserProperties(map[string]string{"TestProp": "TestVal"}),
+		Properties:       NewUserProperties(map[string]string{"TestProp": "TestVal"}, map[string]string{}),
 		client:           client,
 		appOptions:       appOptions,
 		tokenRefreshFunc: tokenRefreshFunc,
@@ -1032,7 +1032,7 @@ func (s *StoreTestSuite) TestProcessStatementWithServiceAccount() {
 	}
 	serviceAccountId := "sa-123"
 	store := Store{
-		Properties:       NewUserProperties(map[string]string{"client.service-account": serviceAccountId, "TestProp": "TestVal"}),
+		Properties:       NewUserProperties(map[string]string{"client.service-account": serviceAccountId, "TestProp": "TestVal"}, map[string]string{}),
 		client:           client,
 		appOptions:       appOptions,
 		tokenRefreshFunc: tokenRefreshFunc,
@@ -1065,7 +1065,7 @@ func (s *StoreTestSuite) TestProcessStatementWithNeitherIdentityPoolNorServiceAc
 		ComputePoolId: "computePoolId",
 	}
 	store := Store{
-		Properties:       NewUserProperties(map[string]string{"TestProp": "TestVal"}),
+		Properties:       NewUserProperties(map[string]string{"TestProp": "TestVal"}, map[string]string{}),
 		client:           client,
 		appOptions:       appOptions,
 		tokenRefreshFunc: tokenRefreshFunc,
@@ -1097,7 +1097,7 @@ func (s *StoreTestSuite) TestProcessStatementFailsOnError() {
 		IdentityPoolId: "identityPoolId",
 	}
 	store := Store{
-		Properties:       NewUserProperties(map[string]string{"TestProp": "TestVal"}),
+		Properties:       NewUserProperties(map[string]string{"TestProp": "TestVal"}, map[string]string{}),
 		client:           client,
 		appOptions:       appOptions,
 		tokenRefreshFunc: tokenRefreshFunc,
@@ -1131,7 +1131,7 @@ func (s *StoreTestSuite) TestWaitPendingStatement() {
 		EnvironmentId: "envId",
 	}
 	store := Store{
-		Properties:       NewUserProperties(map[string]string{"TestProp": "TestVal"}),
+		Properties:       NewUserProperties(map[string]string{"TestProp": "TestVal"}, map[string]string{}),
 		client:           client,
 		appOptions:       appOptions,
 		tokenRefreshFunc: tokenRefreshFunc,
@@ -1161,7 +1161,7 @@ func (s *StoreTestSuite) TestWaitPendingStatement() {
 func (s *StoreTestSuite) TestWaitPendingStatementNoWaitForCompletedStatement() {
 	client := mock.NewMockGatewayClientInterface(gomock.NewController(s.T()))
 	store := Store{
-		Properties: NewUserProperties(map[string]string{"TestProp": "TestVal"}),
+		Properties: NewUserProperties(map[string]string{"TestProp": "TestVal"}, map[string]string{}),
 		client:     client,
 	}
 
@@ -1177,7 +1177,7 @@ func (s *StoreTestSuite) TestWaitPendingStatementNoWaitForCompletedStatement() {
 func (s *StoreTestSuite) TestWaitPendingStatementNoWaitForRunningStatement() {
 	client := mock.NewMockGatewayClientInterface(gomock.NewController(s.T()))
 	store := Store{
-		Properties: NewUserProperties(map[string]string{"TestProp": "TestVal"}),
+		Properties: NewUserProperties(map[string]string{"TestProp": "TestVal"}, map[string]string{}),
 		client:     client,
 	}
 
@@ -1195,7 +1195,7 @@ func (s *StoreTestSuite) TestWaitPendingStatementFailsOnWaitError() {
 		EnvironmentId: "envId",
 	}
 	store := Store{
-		Properties:       NewUserProperties(map[string]string{"TestProp": "TestVal"}),
+		Properties:       NewUserProperties(map[string]string{"TestProp": "TestVal"}, map[string]string{}),
 		client:           client,
 		appOptions:       appOptions,
 		tokenRefreshFunc: tokenRefreshFunc,
@@ -1233,7 +1233,7 @@ func (s *StoreTestSuite) TestWaitPendingStatementFailsOnNonCompletedOrRunningSta
 		EnvironmentId: "envId",
 	}
 	store := Store{
-		Properties:       NewUserProperties(map[string]string{"TestProp": "TestVal"}),
+		Properties:       NewUserProperties(map[string]string{"TestProp": "TestVal"}, map[string]string{}),
 		client:           client,
 		appOptions:       appOptions,
 		tokenRefreshFunc: tokenRefreshFunc,

--- a/pkg/flink/internal/store/store_utils_test.go
+++ b/pkg/flink/internal/store/store_utils_test.go
@@ -130,6 +130,8 @@ func TestProcessResetStatement(t *testing.T) {
 		ServiceAccountId: "sa-123",
 	}
 	s := NewStore(client, nil, &appOptions, tokenRefreshFunc).(*Store)
+	s.Properties.Set(config.ConfigKeyLocalTimeZone, "London/GMT")
+
 	defaultSetOutput := createStatementResults([]string{"Key", "Value"}, [][]string{
 		{config.ConfigKeyLocalTimeZone, fmt.Sprintf("%s (default)", getLocalTimezone())},
 		{config.ConfigKeyServiceAcount, fmt.Sprintf("%s (default)", appOptions.ServiceAccountId)},

--- a/pkg/flink/internal/store/store_utils_test.go
+++ b/pkg/flink/internal/store/store_utils_test.go
@@ -82,7 +82,7 @@ func TestRemoveWhiteSpaces(t *testing.T) {
 func TestProcessSetStatement(t *testing.T) {
 	// Create a new store
 	client := ccloudv2.NewFlinkGatewayClient("url", "userAgent", false, "authToken")
-	s := NewStore(client, nil, &types.ApplicationOptions{}, tokenRefreshFunc).(*Store)
+	s := NewStore(client, nil, &types.ApplicationOptions{EnvironmentName: "env-123"}, tokenRefreshFunc).(*Store)
 	// This is just a string, so really doesn't matter
 	s.Properties.Set(config.ConfigKeyLocalTimeZone, "London/GMT")
 
@@ -131,10 +131,18 @@ func TestProcessResetStatement(t *testing.T) {
 	}
 	s := NewStore(client, nil, &appOptions, tokenRefreshFunc).(*Store)
 	defaultSetOutput := createStatementResults([]string{"Key", "Value"}, [][]string{
-		{config.ConfigKeyCatalog, fmt.Sprintf("%s (default)", appOptions.EnvironmentName)},
-		{config.ConfigKeyDatabase, fmt.Sprintf("%s (default)", appOptions.Database)},
 		{config.ConfigKeyLocalTimeZone, fmt.Sprintf("%s (default)", getLocalTimezone())},
 		{config.ConfigKeyServiceAcount, fmt.Sprintf("%s (default)", appOptions.ServiceAccountId)},
+	})
+
+	t.Run("should return all keys and values including default and initial values before reseting", func(t *testing.T) {
+		result, err := s.processSetStatement("set")
+		assert.Nil(t, err)
+		assert.EqualValues(t, types.COMPLETED, result.Status)
+
+		assert.Equal(t, 2, len(result.StatementResults.Headers))
+		assert.Equal(t, len(s.Properties.GetProperties()), len(result.StatementResults.Rows))
+		cupaloy.SnapshotT(t, result.StatementResults)
 	})
 
 	t.Run("should return an error message if statement is invalid", func(t *testing.T) {

--- a/pkg/flink/internal/store/user_properties.go
+++ b/pkg/flink/internal/store/user_properties.go
@@ -17,10 +17,11 @@ type UserProperties struct {
 	properties        map[string]string
 }
 
-func NewUserProperties(defaultProperties map[string]string) UserProperties {
+// add initial props
+func NewUserProperties(defaultProperties map[string]string, initialProperties map[string]string) UserProperties {
 	userProperties := UserProperties{
 		defaultProperties: defaultProperties,
-		properties:        map[string]string{},
+		properties:        initialProperties,
 	}
 	userProperties.addDefaultProperties()
 	return userProperties

--- a/pkg/flink/internal/store/user_properties_test.go
+++ b/pkg/flink/internal/store/user_properties_test.go
@@ -26,7 +26,7 @@ func TestUserPropertiesTestSuite(t *testing.T) {
 func (s *UserPropertiesTestSuite) SetupTest() {
 	s.defaultKey = "default-key"
 	s.defaultValue = "default-value"
-	s.userProperties = NewUserProperties(map[string]string{s.defaultKey: s.defaultValue})
+	s.userProperties = NewUserProperties(map[string]string{s.defaultKey: s.defaultValue}, map[string]string{})
 	require.Equal(s.T(), s.defaultValue, s.userProperties.Get(s.defaultKey))
 }
 
@@ -154,8 +154,17 @@ func (s *UserPropertiesTestSuite) TestToSortedSlice() {
 		userPropertiesWithEmptyDefault := NewUserProperties(map[string]string{
 			s.defaultKey:                 s.defaultValue,
 			"default-key-with-empty-val": "",
-		})
+		}, map[string]string{})
 		cupaloy.SnapshotT(t, userPropertiesWithEmptyDefault.ToSortedSlice(true))
+	})
+	s.T().Run("with initial values", func(t *testing.T) {
+		userPropertiesWithInitialValues := NewUserProperties(map[string]string{
+			s.defaultKey: s.defaultValue,
+		}, map[string]string{
+			"initial.key.1": "value1",
+			"initial.key.2": "value2",
+		})
+		cupaloy.SnapshotT(t, userPropertiesWithInitialValues.ToSortedSlice(true))
 	})
 }
 


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->
----------
We now have default and initial values. Initial values can be as all props set to nit. Default will always have a default value. Catalog and database are now initial values, thus can be reseted if necessary.
References
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
<!--
Has it been tested? How?
Copy and paste any instructions or steps that can save the reviewer time.
-->
unit tests, snapshot tests

Open Questions / Follow-ups
---------------------------
<!--
Optional: Anything open to discussion for the reviewer, out of scope of this PR, or follow-ups.
-->
