### PR TITLE
[TRAFFIC-9351][TRAFFIC-9352]: Add `confluent network private-link attachment list|describe` commands

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/confluentinc/ccloud-sdk-go-v2/mds v0.4.0
 	github.com/confluentinc/ccloud-sdk-go-v2/metrics v0.2.0
 	github.com/confluentinc/ccloud-sdk-go-v2/networking v0.8.0
+	github.com/confluentinc/ccloud-sdk-go-v2/networking-privatelink v0.1.0
 	github.com/confluentinc/ccloud-sdk-go-v2/org v0.7.0
 	github.com/confluentinc/ccloud-sdk-go-v2/service-quota v0.2.0
 	github.com/confluentinc/ccloud-sdk-go-v2/srcm v0.5.0

--- a/go.sum
+++ b/go.sum
@@ -142,8 +142,8 @@ github.com/confluentinc/ccloud-sdk-go-v2/metrics v0.2.0 h1:TWwZHdfo2XNKrnGOuxXx4
 github.com/confluentinc/ccloud-sdk-go-v2/metrics v0.2.0/go.mod h1:odGsHChrn2l+jaOvx4Gib5//U4a3Id79wstQVkNh8v0=
 github.com/confluentinc/ccloud-sdk-go-v2/networking v0.8.0 h1:/QkBQMSVgVKuQwgsV44KaNKMuB8a1MF8gjjcuF9pB8g=
 github.com/confluentinc/ccloud-sdk-go-v2/networking v0.8.0/go.mod h1:jL9lLHYwFKzCJE5Fh62UdRqJCMJ9T/xg5QOdnQRYIUg=
-github.com/confluentinc/ccloud-sdk-go-v2/org v0.6.0 h1:kHITtUyof5/kALFCHLH7wSMlYmEZX0jKlh8Hich0Q8I=
-github.com/confluentinc/ccloud-sdk-go-v2/org v0.6.0/go.mod h1:40AGTF6TnYiBLR25utDlAdBKEYB3gt0wldxokJLz5r0=
+github.com/confluentinc/ccloud-sdk-go-v2/networking-privatelink v0.1.0 h1:CA+3m6Rddo6tw0qnTkK487myHFVfsLYQO3aSTKy8w5o=
+github.com/confluentinc/ccloud-sdk-go-v2/networking-privatelink v0.1.0/go.mod h1:uj/ybBJPQbmuuBdSoznMiMGEwW3z/g0Uko8uKWg36I8=
 github.com/confluentinc/ccloud-sdk-go-v2/org v0.7.0 h1:+yjQZhFXd06wcW+oxhg2OGrYkN8QvYrOlOGrnw4PLUc=
 github.com/confluentinc/ccloud-sdk-go-v2/org v0.7.0/go.mod h1:40AGTF6TnYiBLR25utDlAdBKEYB3gt0wldxokJLz5r0=
 github.com/confluentinc/ccloud-sdk-go-v2/service-quota v0.2.0 h1:xVSmwdycExze1E2Jta99CaFuMOlL6k6KExOOSY1hSFg=

--- a/internal/network/command_private_link.go
+++ b/internal/network/command_private_link.go
@@ -12,6 +12,7 @@ func (c *command) newPrivateLinkCommand() *cobra.Command {
 	}
 
 	cmd.AddCommand(c.newPrivateLinkAccessCommand())
+	cmd.AddCommand(c.newPrivateLinkAttachmentCommand())
 
 	return cmd
 }

--- a/internal/network/command_private_link_attachment.go
+++ b/internal/network/command_private_link_attachment.go
@@ -79,12 +79,15 @@ func printPrivateLinkAttachmentTable(cmd *cobra.Command, attachment networkingpr
 	}
 
 	out := &privateLinkAttachmentOut{
-		Id:                    attachment.GetId(),
-		Name:                  attachment.Spec.GetDisplayName(),
-		Cloud:                 attachment.Spec.GetCloud(),
-		Region:                attachment.Spec.GetRegion(),
-		AwsVpcEndpointService: attachment.Status.Cloud.NetworkingV1AwsPrivateLinkAttachmentStatus.VpcEndpointService.GetVpcEndpointServiceName(),
-		Phase:                 attachment.Status.GetPhase(),
+		Id:     attachment.GetId(),
+		Name:   attachment.Spec.GetDisplayName(),
+		Cloud:  attachment.Spec.GetCloud(),
+		Region: attachment.Spec.GetRegion(),
+		Phase:  attachment.Status.GetPhase(),
+	}
+
+	if attachment.Status.GetPhase() == "WAITING_FOR_CONNECTIONS" {
+		out.AwsVpcEndpointService = attachment.Status.Cloud.NetworkingV1AwsPrivateLinkAttachmentStatus.VpcEndpointService.GetVpcEndpointServiceName()
 	}
 
 	table := output.NewTable(cmd)

--- a/internal/network/command_private_link_attachment.go
+++ b/internal/network/command_private_link_attachment.go
@@ -86,7 +86,7 @@ func printPrivateLinkAttachmentTable(cmd *cobra.Command, attachment networkingpr
 		Phase:  attachment.Status.GetPhase(),
 	}
 
-	if attachment.Status.GetPhase() == "WAITING_FOR_CONNECTIONS" {
+	if attachment.Status.Cloud != nil && attachment.Status.Cloud.NetworkingV1AwsPrivateLinkAttachmentStatus != nil {
 		out.AwsVpcEndpointService = attachment.Status.Cloud.NetworkingV1AwsPrivateLinkAttachmentStatus.VpcEndpointService.GetVpcEndpointServiceName()
 	}
 

--- a/internal/network/command_private_link_attachment.go
+++ b/internal/network/command_private_link_attachment.go
@@ -1,0 +1,94 @@
+package network
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	networkingprivatelinkv1 "github.com/confluentinc/ccloud-sdk-go-v2/networking-privatelink/v1"
+
+	"github.com/confluentinc/cli/v3/pkg/errors"
+	"github.com/confluentinc/cli/v3/pkg/output"
+)
+
+type privateLinkAttachmentOut struct {
+	Id                    string `human:"ID" serialized:"id"`
+	Name                  string `human:"Name" serialized:"name"`
+	Cloud                 string `human:"Cloud" serialized:"cloud"`
+	Region                string `human:"Region" serialized:"region"`
+	AwsVpcEndpointService string `human:"AWS VPC Endpoint Service,omitempty" serialized:"aws_vpc_endpoint_service,omitempty"`
+	Phase                 string `human:"Phase" serialized:"phase"`
+}
+
+func (c *command) newPrivateLinkAttachmentCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "attachment",
+		Short: "Manage private link attachments.",
+		Args:  cobra.NoArgs,
+	}
+
+	cmd.AddCommand(c.newPrivateLinkAttachmentDescribeCommand())
+	cmd.AddCommand(c.newPrivateLinkAttachmentListCommand())
+
+	return cmd
+}
+
+func (c *command) getPrivateLinkAttachments() ([]networkingprivatelinkv1.NetworkingV1PrivateLinkAttachment, error) {
+	environmentId, err := c.Context.EnvironmentId()
+	if err != nil {
+		return nil, err
+	}
+
+	return c.V2Client.ListPrivateLinkAttachments(environmentId)
+}
+
+func (c *command) validPrivateLinkAttachmentArgs(cmd *cobra.Command, args []string) []string {
+	if len(args) > 0 {
+		return nil
+	}
+	return c.validPrivateLinkAttachmentArgsMultiple(cmd, args)
+}
+
+func (c *command) validPrivateLinkAttachmentArgsMultiple(cmd *cobra.Command, args []string) []string {
+	if err := c.PersistentPreRunE(cmd, args); err != nil {
+		return nil
+	}
+
+	return c.autocompletePrivateLinkAttachments()
+}
+
+func (c *command) autocompletePrivateLinkAttachments() []string {
+	attachments, err := c.getPrivateLinkAttachments()
+	if err != nil {
+		return nil
+	}
+
+	suggestions := make([]string, len(attachments))
+	for i, attachment := range attachments {
+		suggestions[i] = fmt.Sprintf("%s\t%s", attachment.GetId(), attachment.Spec.GetDisplayName())
+	}
+	return suggestions
+}
+
+func printPrivateLinkAttachmentTable(cmd *cobra.Command, attachment networkingprivatelinkv1.NetworkingV1PrivateLinkAttachment) error {
+	if attachment.Spec == nil {
+		return fmt.Errorf(errors.CorruptedNetworkResponseErrorMsg, "spec")
+	}
+	if attachment.Status == nil {
+		return fmt.Errorf(errors.CorruptedNetworkResponseErrorMsg, "status")
+	}
+
+	out := &privateLinkAttachmentOut{
+		Id:                    attachment.GetId(),
+		Name:                  attachment.Spec.GetDisplayName(),
+		Cloud:                 attachment.Spec.GetCloud(),
+		Region:                attachment.Spec.GetRegion(),
+		AwsVpcEndpointService: attachment.Status.Cloud.NetworkingV1AwsPrivateLinkAttachmentStatus.VpcEndpointService.GetVpcEndpointServiceName(),
+		Phase:                 attachment.Status.GetPhase(),
+	}
+
+	table := output.NewTable(cmd)
+	table.Add(out)
+
+	return table.Print()
+}

--- a/internal/network/command_private_link_attachment.go
+++ b/internal/network/command_private_link_attachment.go
@@ -24,7 +24,6 @@ func (c *command) newPrivateLinkAttachmentCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "attachment",
 		Short: "Manage private link attachments.",
-		Args:  cobra.NoArgs,
 	}
 
 	cmd.AddCommand(c.newPrivateLinkAttachmentDescribeCommand())

--- a/internal/network/command_private_link_attachment_describe.go
+++ b/internal/network/command_private_link_attachment_describe.go
@@ -1,0 +1,44 @@
+package network
+
+import (
+	"github.com/spf13/cobra"
+
+	pcmd "github.com/confluentinc/cli/v3/pkg/cmd"
+	"github.com/confluentinc/cli/v3/pkg/examples"
+)
+
+func (c *command) newPrivateLinkAttachmentDescribeCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:               "describe <id>",
+		Short:             "Describe a private link attachment.",
+		Args:              cobra.ExactArgs(1),
+		ValidArgsFunction: pcmd.NewValidArgsFunction(c.validPrivateLinkAttachmentArgs),
+		RunE:              c.privateLinkAttachmentDescribe,
+		Example: examples.BuildExampleString(
+			examples.Example{
+				Text: `Describe private link attachment "platt-123456".`,
+				Code: "confluent network private-link attachment describe platt-123456",
+			},
+		),
+	}
+
+	pcmd.AddContextFlag(cmd, c.CLICommand)
+	pcmd.AddEnvironmentFlag(cmd, c.AuthenticatedCLICommand)
+	pcmd.AddOutputFlag(cmd)
+
+	return cmd
+}
+
+func (c *command) privateLinkAttachmentDescribe(cmd *cobra.Command, args []string) error {
+	environmentId, err := c.Context.EnvironmentId()
+	if err != nil {
+		return err
+	}
+
+	attachment, err := c.V2Client.GetPrivateLinkAttachment(environmentId, args[0])
+	if err != nil {
+		return err
+	}
+
+	return printPrivateLinkAttachmentTable(cmd, attachment)
+}

--- a/internal/network/command_private_link_attachment_list.go
+++ b/internal/network/command_private_link_attachment_list.go
@@ -1,0 +1,56 @@
+package network
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	pcmd "github.com/confluentinc/cli/v3/pkg/cmd"
+	"github.com/confluentinc/cli/v3/pkg/errors"
+	"github.com/confluentinc/cli/v3/pkg/output"
+)
+
+func (c *command) newPrivateLinkAttachmentListCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List private link attachments.",
+		Args:  cobra.NoArgs,
+		RunE:  c.privateLinkAttachmentList,
+	}
+
+	pcmd.AddContextFlag(cmd, c.CLICommand)
+	pcmd.AddEnvironmentFlag(cmd, c.AuthenticatedCLICommand)
+	pcmd.AddOutputFlag(cmd)
+
+	return cmd
+}
+
+func (c *command) privateLinkAttachmentList(cmd *cobra.Command, _ []string) error {
+	attachments, err := c.getPrivateLinkAttachments()
+	if err != nil {
+		return err
+	}
+
+	list := output.NewList(cmd)
+	for _, attachment := range attachments {
+		if attachment.Spec == nil {
+			return fmt.Errorf(errors.CorruptedNetworkResponseErrorMsg, "spec")
+		}
+		if attachment.Status == nil {
+			return fmt.Errorf(errors.CorruptedNetworkResponseErrorMsg, "status")
+		}
+
+		out := &privateLinkAttachmentOut{
+			Id:                    attachment.GetId(),
+			Name:                  attachment.Spec.GetDisplayName(),
+			Cloud:                 attachment.Spec.GetCloud(),
+			Region:                attachment.Spec.GetRegion(),
+			AwsVpcEndpointService: attachment.Status.Cloud.NetworkingV1AwsPrivateLinkAttachmentStatus.VpcEndpointService.GetVpcEndpointServiceName(),
+			Phase:                 attachment.Status.GetPhase(),
+		}
+
+		list.Add(out)
+	}
+
+	return list.Print()
+}

--- a/internal/network/command_private_link_attachment_list.go
+++ b/internal/network/command_private_link_attachment_list.go
@@ -48,7 +48,7 @@ func (c *command) privateLinkAttachmentList(cmd *cobra.Command, _ []string) erro
 			Phase:  attachment.Status.GetPhase(),
 		}
 
-		if attachment.Status.GetPhase() == "WAITING_FOR_CONNECTIONS" {
+		if attachment.Status.Cloud != nil && attachment.Status.Cloud.NetworkingV1AwsPrivateLinkAttachmentStatus != nil {
 			out.AwsVpcEndpointService = attachment.Status.Cloud.NetworkingV1AwsPrivateLinkAttachmentStatus.VpcEndpointService.GetVpcEndpointServiceName()
 		}
 

--- a/internal/network/command_private_link_attachment_list.go
+++ b/internal/network/command_private_link_attachment_list.go
@@ -41,12 +41,15 @@ func (c *command) privateLinkAttachmentList(cmd *cobra.Command, _ []string) erro
 		}
 
 		out := &privateLinkAttachmentOut{
-			Id:                    attachment.GetId(),
-			Name:                  attachment.Spec.GetDisplayName(),
-			Cloud:                 attachment.Spec.GetCloud(),
-			Region:                attachment.Spec.GetRegion(),
-			AwsVpcEndpointService: attachment.Status.Cloud.NetworkingV1AwsPrivateLinkAttachmentStatus.VpcEndpointService.GetVpcEndpointServiceName(),
-			Phase:                 attachment.Status.GetPhase(),
+			Id:     attachment.GetId(),
+			Name:   attachment.Spec.GetDisplayName(),
+			Cloud:  attachment.Spec.GetCloud(),
+			Region: attachment.Spec.GetRegion(),
+			Phase:  attachment.Status.GetPhase(),
+		}
+
+		if attachment.Status.GetPhase() == "WAITING_FOR_CONNECTIONS" {
+			out.AwsVpcEndpointService = attachment.Status.Cloud.NetworkingV1AwsPrivateLinkAttachmentStatus.VpcEndpointService.GetVpcEndpointServiceName()
 		}
 
 		list.Add(out)

--- a/pkg/ccloudv2/client.go
+++ b/pkg/ccloudv2/client.go
@@ -14,6 +14,7 @@ import (
 	kafkaquotasv1 "github.com/confluentinc/ccloud-sdk-go-v2/kafka-quotas/v1"
 	ksqlv2 "github.com/confluentinc/ccloud-sdk-go-v2/ksql/v2"
 	mdsv2 "github.com/confluentinc/ccloud-sdk-go-v2/mds/v2"
+	networkingprivatelinkv1 "github.com/confluentinc/ccloud-sdk-go-v2/networking-privatelink/v1"
 	networkingv1 "github.com/confluentinc/ccloud-sdk-go-v2/networking/v1"
 	orgv2 "github.com/confluentinc/ccloud-sdk-go-v2/org/v2"
 	servicequotav1 "github.com/confluentinc/ccloud-sdk-go-v2/service-quota/v1"
@@ -28,25 +29,26 @@ import (
 type Client struct {
 	AuthToken string
 
-	ApiKeysClient          *apikeysv2.APIClient
-	BillingClient          *billingv1.APIClient
-	ByokClient             *byokv1.APIClient
-	CdxClient              *cdxv1.APIClient
-	CliClient              *cliv1.APIClient
-	CmkClient              *cmkv2.APIClient
-	ConnectClient          *connectv1.APIClient
-	FlinkClient            *flinkv2.APIClient
-	IamClient              *iamv2.APIClient
-	IdentityProviderClient *identityproviderv2.APIClient
-	KsqlClient             *ksqlv2.APIClient
-	KafkaQuotasClient      *kafkaquotasv1.APIClient
-	MdsClient              *mdsv2.APIClient
-	NetworkingClient       *networkingv1.APIClient
-	OrgClient              *orgv2.APIClient
-	SchemaRegistryClient   *srcmv2.APIClient
-	SsoClient              *ssov2.APIClient
-	StreamDesignerClient   *streamdesignerv1.APIClient
-	ServiceQuotaClient     *servicequotav1.APIClient
+	ApiKeysClient               *apikeysv2.APIClient
+	BillingClient               *billingv1.APIClient
+	ByokClient                  *byokv1.APIClient
+	CdxClient                   *cdxv1.APIClient
+	CliClient                   *cliv1.APIClient
+	CmkClient                   *cmkv2.APIClient
+	ConnectClient               *connectv1.APIClient
+	FlinkClient                 *flinkv2.APIClient
+	IamClient                   *iamv2.APIClient
+	IdentityProviderClient      *identityproviderv2.APIClient
+	KsqlClient                  *ksqlv2.APIClient
+	KafkaQuotasClient           *kafkaquotasv1.APIClient
+	MdsClient                   *mdsv2.APIClient
+	NetworkingPrivateLinkClient *networkingprivatelinkv1.APIClient
+	NetworkingClient            *networkingv1.APIClient
+	OrgClient                   *orgv2.APIClient
+	SchemaRegistryClient        *srcmv2.APIClient
+	SsoClient                   *ssov2.APIClient
+	StreamDesignerClient        *streamdesignerv1.APIClient
+	ServiceQuotaClient          *servicequotav1.APIClient
 }
 
 func NewClient(baseUrl string, isTest bool, authToken, userAgent string, unsafeTrace bool) *Client {
@@ -58,24 +60,25 @@ func NewClient(baseUrl string, isTest bool, authToken, userAgent string, unsafeT
 	return &Client{
 		AuthToken: authToken,
 
-		ApiKeysClient:          newApiKeysClient(url, userAgent, unsafeTrace),
-		BillingClient:          newBillingClient(url, userAgent, unsafeTrace),
-		ByokClient:             newByokV1Client(url, userAgent, unsafeTrace),
-		CdxClient:              newCdxClient(url, userAgent, unsafeTrace),
-		CliClient:              newCliClient(url, userAgent, unsafeTrace),
-		CmkClient:              newCmkClient(url, userAgent, unsafeTrace),
-		ConnectClient:          newConnectClient(url, userAgent, unsafeTrace),
-		FlinkClient:            newFlinkClient(url, userAgent, unsafeTrace),
-		IamClient:              newIamClient(url, userAgent, unsafeTrace),
-		IdentityProviderClient: newIdentityProviderClient(url, userAgent, unsafeTrace),
-		KsqlClient:             newKsqlClient(url, userAgent, unsafeTrace),
-		KafkaQuotasClient:      newKafkaQuotasClient(url, userAgent, unsafeTrace),
-		MdsClient:              newMdsClient(url, userAgent, unsafeTrace),
-		NetworkingClient:       newNetowrkingClient(url, userAgent, unsafeTrace),
-		OrgClient:              newOrgClient(url, userAgent, unsafeTrace),
-		SchemaRegistryClient:   newSchemaRegistryClient(url, userAgent, unsafeTrace),
-		SsoClient:              newSsoClient(url, userAgent, unsafeTrace),
-		StreamDesignerClient:   newStreamDesignerClient(url, userAgent, unsafeTrace),
-		ServiceQuotaClient:     newServiceQuotaClient(url, userAgent, unsafeTrace),
+		ApiKeysClient:               newApiKeysClient(url, userAgent, unsafeTrace),
+		BillingClient:               newBillingClient(url, userAgent, unsafeTrace),
+		ByokClient:                  newByokV1Client(url, userAgent, unsafeTrace),
+		CdxClient:                   newCdxClient(url, userAgent, unsafeTrace),
+		CliClient:                   newCliClient(url, userAgent, unsafeTrace),
+		CmkClient:                   newCmkClient(url, userAgent, unsafeTrace),
+		ConnectClient:               newConnectClient(url, userAgent, unsafeTrace),
+		FlinkClient:                 newFlinkClient(url, userAgent, unsafeTrace),
+		IamClient:                   newIamClient(url, userAgent, unsafeTrace),
+		IdentityProviderClient:      newIdentityProviderClient(url, userAgent, unsafeTrace),
+		KsqlClient:                  newKsqlClient(url, userAgent, unsafeTrace),
+		KafkaQuotasClient:           newKafkaQuotasClient(url, userAgent, unsafeTrace),
+		MdsClient:                   newMdsClient(url, userAgent, unsafeTrace),
+		NetworkingPrivateLinkClient: newNetworkingPrivateLinkClient(url, userAgent, unsafeTrace),
+		NetworkingClient:            newNetworkingClient(url, userAgent, unsafeTrace),
+		OrgClient:                   newOrgClient(url, userAgent, unsafeTrace),
+		SchemaRegistryClient:        newSchemaRegistryClient(url, userAgent, unsafeTrace),
+		SsoClient:                   newSsoClient(url, userAgent, unsafeTrace),
+		StreamDesignerClient:        newStreamDesignerClient(url, userAgent, unsafeTrace),
+		ServiceQuotaClient:          newServiceQuotaClient(url, userAgent, unsafeTrace),
 	}
 }

--- a/pkg/ccloudv2/client.go
+++ b/pkg/ccloudv2/client.go
@@ -42,8 +42,8 @@ type Client struct {
 	KsqlClient                  *ksqlv2.APIClient
 	KafkaQuotasClient           *kafkaquotasv1.APIClient
 	MdsClient                   *mdsv2.APIClient
-	NetworkingPrivateLinkClient *networkingprivatelinkv1.APIClient
 	NetworkingClient            *networkingv1.APIClient
+	NetworkingPrivateLinkClient *networkingprivatelinkv1.APIClient
 	OrgClient                   *orgv2.APIClient
 	SchemaRegistryClient        *srcmv2.APIClient
 	SsoClient                   *ssov2.APIClient
@@ -73,8 +73,8 @@ func NewClient(baseUrl string, isTest bool, authToken, userAgent string, unsafeT
 		KsqlClient:                  newKsqlClient(url, userAgent, unsafeTrace),
 		KafkaQuotasClient:           newKafkaQuotasClient(url, userAgent, unsafeTrace),
 		MdsClient:                   newMdsClient(url, userAgent, unsafeTrace),
-		NetworkingPrivateLinkClient: newNetworkingPrivateLinkClient(url, userAgent, unsafeTrace),
 		NetworkingClient:            newNetworkingClient(url, userAgent, unsafeTrace),
+		NetworkingPrivateLinkClient: newNetworkingPrivateLinkClient(url, userAgent, unsafeTrace),
 		OrgClient:                   newOrgClient(url, userAgent, unsafeTrace),
 		SchemaRegistryClient:        newSchemaRegistryClient(url, userAgent, unsafeTrace),
 		SsoClient:                   newSsoClient(url, userAgent, unsafeTrace),

--- a/pkg/ccloudv2/networking.go
+++ b/pkg/ccloudv2/networking.go
@@ -8,7 +8,7 @@ import (
 	"github.com/confluentinc/cli/v3/pkg/errors"
 )
 
-func newNetowrkingClient(url, userAgent string, unsafeTrace bool) *networkingv1.APIClient {
+func newNetworkingClient(url, userAgent string, unsafeTrace bool) *networkingv1.APIClient {
 	cfg := networkingv1.NewConfiguration()
 	cfg.Debug = unsafeTrace
 	cfg.HTTPClient = NewRetryableHttpClient(unsafeTrace)

--- a/pkg/ccloudv2/networking_privatelink.go
+++ b/pkg/ccloudv2/networking_privatelink.go
@@ -1,0 +1,58 @@
+package ccloudv2
+
+import (
+	"context"
+
+	networkingprivatelinkv1 "github.com/confluentinc/ccloud-sdk-go-v2/networking-privatelink/v1"
+
+	"github.com/confluentinc/cli/v3/pkg/errors"
+)
+
+func newNetworkingPrivateLinkClient(url, userAgent string, unsafeTrace bool) *networkingprivatelinkv1.APIClient {
+	cfg := networkingprivatelinkv1.NewConfiguration()
+	cfg.Debug = unsafeTrace
+	cfg.HTTPClient = NewRetryableHttpClient(unsafeTrace)
+	cfg.Servers = networkingprivatelinkv1.ServerConfigurations{{URL: url}}
+	cfg.UserAgent = userAgent
+
+	return networkingprivatelinkv1.NewAPIClient(cfg)
+}
+
+func (c *Client) networkingPrivateLinkApiContext() context.Context {
+	return context.WithValue(context.Background(), networkingprivatelinkv1.ContextAccessToken, c.AuthToken)
+}
+
+func (c *Client) ListPrivateLinkAttachments(environment string) ([]networkingprivatelinkv1.NetworkingV1PrivateLinkAttachment, error) {
+	var list []networkingprivatelinkv1.NetworkingV1PrivateLinkAttachment
+
+	done := false
+	pageToken := ""
+	for !done {
+		page, err := c.executeListPrivateLinkAttachments(environment, pageToken)
+		if err != nil {
+			return nil, err
+		}
+		list = append(list, page.GetData()...)
+
+		pageToken, done, err = extractNextPageToken(page.GetMetadata().Next)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return list, nil
+}
+
+func (c *Client) executeListPrivateLinkAttachments(environment, pageToken string) (networkingprivatelinkv1.NetworkingV1PrivateLinkAttachmentList, error) {
+	req := c.NetworkingPrivateLinkClient.PrivateLinkAttachmentsNetworkingV1Api.ListNetworkingV1PrivateLinkAttachments(c.networkingPrivateLinkApiContext()).Environment(environment).PageSize(ccloudV2ListPageSize)
+	if pageToken != "" {
+		req = req.PageToken(pageToken)
+	}
+
+	resp, httpResp, err := req.Execute()
+	return resp, errors.CatchCCloudV2Error(err, httpResp)
+}
+
+func (c *Client) GetPrivateLinkAttachment(environment, id string) (networkingprivatelinkv1.NetworkingV1PrivateLinkAttachment, error) {
+	resp, httpResp, err := c.NetworkingPrivateLinkClient.PrivateLinkAttachmentsNetworkingV1Api.GetNetworkingV1PrivateLinkAttachment(c.networkingPrivateLinkApiContext(), id).Environment(environment).Execute()
+	return resp, errors.CatchCCloudV2Error(err, httpResp)
+}

--- a/test/fixtures/output/network/private-link/attachment/describe-autocomplete.golden
+++ b/test/fixtures/output/network/private-link/attachment/describe-autocomplete.golden
@@ -1,0 +1,5 @@
+platt-111111	aws-platt-1
+platt-111112	aws-platt-2
+platt-111113	aws-platt-3
+:4
+Completion ended with directive: ShellCompDirectiveNoFileComp

--- a/test/fixtures/output/network/private-link/attachment/describe-aws-json.golden
+++ b/test/fixtures/output/network/private-link/attachment/describe-aws-json.golden
@@ -1,0 +1,8 @@
+{
+  "id": "platt-111111",
+  "name": "aws-platt",
+  "cloud": "AWS",
+  "region": "us-west-2",
+  "aws_vpc_endpoint_service": "com.amazonaws.vpce.us-west-2.vpce-svc-01234567890abcdef",
+  "phase": "WAITING_FOR_CONNECTIONS"
+}

--- a/test/fixtures/output/network/private-link/attachment/describe-aws-provisioning.golden
+++ b/test/fixtures/output/network/private-link/attachment/describe-aws-provisioning.golden
@@ -1,0 +1,7 @@
++--------+--------------+
+| ID     | platt-111112 |
+| Name   | aws-platt    |
+| Cloud  | AWS          |
+| Region | us-west-2    |
+| Phase  | PROVISIONING |
++--------+--------------+

--- a/test/fixtures/output/network/private-link/attachment/describe-aws.golden
+++ b/test/fixtures/output/network/private-link/attachment/describe-aws.golden
@@ -1,0 +1,8 @@
++--------------------------+---------------------------------------------------------+
+| ID                       | platt-111111                                            |
+| Name                     | aws-platt                                               |
+| Cloud                    | AWS                                                     |
+| Region                   | us-west-2                                               |
+| AWS VPC Endpoint Service | com.amazonaws.vpce.us-west-2.vpce-svc-01234567890abcdef |
+| Phase                    | WAITING_FOR_CONNECTIONS                                 |
++--------------------------+---------------------------------------------------------+

--- a/test/fixtures/output/network/private-link/attachment/describe-help.golden
+++ b/test/fixtures/output/network/private-link/attachment/describe-help.golden
@@ -1,0 +1,19 @@
+Describe a private link attachment.
+
+Usage:
+  confluent network private-link attachment describe <id> [flags]
+
+Examples:
+Describe private link attachment "platt-123456".
+
+  $ confluent network private-link attachment describe platt-123456
+
+Flags:
+      --context string       CLI context name.
+      --environment string   Environment ID.
+  -o, --output string        Specify the output format as "human", "json", or "yaml". (default "human")
+
+Global Flags:
+  -h, --help            Show help for this command.
+      --unsafe-trace    Equivalent to -vvvv, but also log HTTP requests and responses which might contain plaintext secrets.
+  -v, --verbose count   Increase verbosity (-v for warn, -vv for info, -vvv for debug, -vvvv for trace).

--- a/test/fixtures/output/network/private-link/attachment/describe-invalid.golden
+++ b/test/fixtures/output/network/private-link/attachment/describe-invalid.golden
@@ -1,0 +1,1 @@
+Error: 404 Not Found

--- a/test/fixtures/output/network/private-link/attachment/describe-missing-id.golden
+++ b/test/fixtures/output/network/private-link/attachment/describe-missing-id.golden
@@ -1,0 +1,19 @@
+Error: accepts 1 arg(s), received 0
+Usage:
+  confluent network private-link attachment describe <id> [flags]
+
+Examples:
+Describe private link attachment "platt-123456".
+
+  $ confluent network private-link attachment describe platt-123456
+
+Flags:
+      --context string       CLI context name.
+      --environment string   Environment ID.
+  -o, --output string        Specify the output format as "human", "json", or "yaml". (default "human")
+
+Global Flags:
+  -h, --help            Show help for this command.
+      --unsafe-trace    Equivalent to -vvvv, but also log HTTP requests and responses which might contain plaintext secrets.
+  -v, --verbose count   Increase verbosity (-v for warn, -vv for info, -vvv for debug, -vvvv for trace).
+

--- a/test/fixtures/output/network/private-link/attachment/help.golden
+++ b/test/fixtures/output/network/private-link/attachment/help.golden
@@ -1,18 +1,15 @@
-Manage private links.
+Manage private link attachments.
 
 Usage:
-  confluent network private-link [command]
-
-Aliases:
-  private-link, pl
+  confluent network private-link attachment [command]
 
 Available Commands:
-  access      Manage private link accesses.
-  attachment  Manage private link attachments.
+  describe    Describe a private link attachment.
+  list        List private link attachments.
 
 Global Flags:
   -h, --help            Show help for this command.
       --unsafe-trace    Equivalent to -vvvv, but also log HTTP requests and responses which might contain plaintext secrets.
   -v, --verbose count   Increase verbosity (-v for warn, -vv for info, -vvv for debug, -vvvv for trace).
 
-Use "confluent network private-link [command] --help" for more information about a command.
+Use "confluent network private-link attachment [command] --help" for more information about a command.

--- a/test/fixtures/output/network/private-link/attachment/list-help.golden
+++ b/test/fixtures/output/network/private-link/attachment/list-help.golden
@@ -1,18 +1,14 @@
-Manage private links.
+List private link attachments.
 
 Usage:
-  confluent network private-link [command]
+  confluent network private-link attachment list [flags]
 
-Aliases:
-  private-link, pl
-
-Available Commands:
-  access      Manage private link accesses.
-  attachment  Manage private link attachments.
+Flags:
+      --context string       CLI context name.
+      --environment string   Environment ID.
+  -o, --output string        Specify the output format as "human", "json", or "yaml". (default "human")
 
 Global Flags:
   -h, --help            Show help for this command.
       --unsafe-trace    Equivalent to -vvvv, but also log HTTP requests and responses which might contain plaintext secrets.
   -v, --verbose count   Increase verbosity (-v for warn, -vv for info, -vvv for debug, -vvvv for trace).
-
-Use "confluent network private-link [command] --help" for more information about a command.

--- a/test/fixtures/output/network/private-link/attachment/list-json.golden
+++ b/test/fixtures/output/network/private-link/attachment/list-json.golden
@@ -4,8 +4,7 @@
     "name": "aws-platt-1",
     "cloud": "AWS",
     "region": "us-west-2",
-    "aws_vpc_endpoint_service": "com.amazonaws.vpce.us-west-2.vpce-svc-01234567890abcdef",
-    "phase": "WAITING_FOR_CONNECTIONS"
+    "phase": "PROVISIONING"
   },
   {
     "id": "platt-111112",

--- a/test/fixtures/output/network/private-link/attachment/list-json.golden
+++ b/test/fixtures/output/network/private-link/attachment/list-json.golden
@@ -1,0 +1,26 @@
+[
+  {
+    "id": "platt-111111",
+    "name": "aws-platt-1",
+    "cloud": "AWS",
+    "region": "us-west-2",
+    "aws_vpc_endpoint_service": "com.amazonaws.vpce.us-west-2.vpce-svc-01234567890abcdef",
+    "phase": "WAITING_FOR_CONNECTIONS"
+  },
+  {
+    "id": "platt-111112",
+    "name": "aws-platt-2",
+    "cloud": "AWS",
+    "region": "us-west-2",
+    "aws_vpc_endpoint_service": "com.amazonaws.vpce.us-west-2.vpce-svc-01234567890abcdef",
+    "phase": "WAITING_FOR_CONNECTIONS"
+  },
+  {
+    "id": "platt-111113",
+    "name": "aws-platt-3",
+    "cloud": "AWS",
+    "region": "us-west-2",
+    "aws_vpc_endpoint_service": "com.amazonaws.vpce.us-west-2.vpce-svc-01234567890abcdef",
+    "phase": "WAITING_FOR_CONNECTIONS"
+  }
+]

--- a/test/fixtures/output/network/private-link/attachment/list.golden
+++ b/test/fixtures/output/network/private-link/attachment/list.golden
@@ -1,5 +1,5 @@
        ID      |    Name     | Cloud |  Region   |                AWS VPC Endpoint Service                 |          Phase           
 ---------------+-------------+-------+-----------+---------------------------------------------------------+--------------------------
-  platt-111111 | aws-platt-1 | AWS   | us-west-2 | com.amazonaws.vpce.us-west-2.vpce-svc-01234567890abcdef | WAITING_FOR_CONNECTIONS  
+  platt-111111 | aws-platt-1 | AWS   | us-west-2 |                                                         | PROVISIONING             
   platt-111112 | aws-platt-2 | AWS   | us-west-2 | com.amazonaws.vpce.us-west-2.vpce-svc-01234567890abcdef | WAITING_FOR_CONNECTIONS  
   platt-111113 | aws-platt-3 | AWS   | us-west-2 | com.amazonaws.vpce.us-west-2.vpce-svc-01234567890abcdef | WAITING_FOR_CONNECTIONS  

--- a/test/fixtures/output/network/private-link/attachment/list.golden
+++ b/test/fixtures/output/network/private-link/attachment/list.golden
@@ -1,0 +1,5 @@
+       ID      |    Name     | Cloud |  Region   |                AWS VPC Endpoint Service                 |          Phase           
+---------------+-------------+-------+-----------+---------------------------------------------------------+--------------------------
+  platt-111111 | aws-platt-1 | AWS   | us-west-2 | com.amazonaws.vpce.us-west-2.vpce-svc-01234567890abcdef | WAITING_FOR_CONNECTIONS  
+  platt-111112 | aws-platt-2 | AWS   | us-west-2 | com.amazonaws.vpce.us-west-2.vpce-svc-01234567890abcdef | WAITING_FOR_CONNECTIONS  
+  platt-111113 | aws-platt-3 | AWS   | us-west-2 | com.amazonaws.vpce.us-west-2.vpce-svc-01234567890abcdef | WAITING_FOR_CONNECTIONS  

--- a/test/network_test.go
+++ b/test/network_test.go
@@ -384,6 +384,7 @@ func (s *CLITestSuite) TestNetworkPrivateLinkAttachmentDescribe() {
 	tests := []CLITest{
 		{args: "network pl attachment describe platt-111111", fixture: "network/private-link/attachment/describe-aws.golden"},
 		{args: "network private-link attachment describe platt-111111", fixture: "network/private-link/attachment/describe-aws.golden"},
+		{args: "network private-link attachment describe platt-111112", fixture: "network/private-link/attachment/describe-aws-provisioning.golden"},
 		{args: "network private-link attachment describe platt-111111 --output json", fixture: "network/private-link/attachment/describe-aws-json.golden"},
 		{args: "network private-link attachment describe", fixture: "network/private-link/attachment/describe-missing-id.golden", exitCode: 1},
 		{args: "network private-link attachment describe platt-invalid", fixture: "network/private-link/attachment/describe-invalid.golden", exitCode: 1},

--- a/test/network_test.go
+++ b/test/network_test.go
@@ -366,3 +366,42 @@ func (s *CLITestSuite) TestNetworkPrivateLinkAccess_Autocomplete() {
 		s.runIntegrationTest(test)
 	}
 }
+
+func (s *CLITestSuite) TestNetworkPrivateLinkAttachmentList() {
+	tests := []CLITest{
+		{args: "network pl attachment list", fixture: "network/private-link/attachment/list.golden"},
+		{args: "network private-link attachment list", fixture: "network/private-link/attachment/list.golden"},
+		{args: "network private-link attachment list --output json", fixture: "network/private-link/attachment/list-json.golden"},
+	}
+
+	for _, test := range tests {
+		test.login = "cloud"
+		s.runIntegrationTest(test)
+	}
+}
+
+func (s *CLITestSuite) TestNetworkPrivateLinkAttachmentDescribe() {
+	tests := []CLITest{
+		{args: "network pl attachment describe platt-111111", fixture: "network/private-link/attachment/describe-aws.golden"},
+		{args: "network private-link attachment describe platt-111111", fixture: "network/private-link/attachment/describe-aws.golden"},
+		{args: "network private-link attachment describe platt-111111 --output json", fixture: "network/private-link/attachment/describe-aws-json.golden"},
+		{args: "network private-link attachment describe", fixture: "network/private-link/attachment/describe-missing-id.golden", exitCode: 1},
+		{args: "network private-link attachment describe platt-invalid", fixture: "network/private-link/attachment/describe-invalid.golden", exitCode: 1},
+	}
+
+	for _, test := range tests {
+		test.login = "cloud"
+		s.runIntegrationTest(test)
+	}
+}
+
+func (s *CLITestSuite) TestNetworkPrivateLinkAttachment_Autocomplete() {
+	tests := []CLITest{
+		{args: `__complete network private-link attachment describe ""`, login: "cloud", fixture: "network/private-link/attachment/describe-autocomplete.golden"},
+	}
+
+	for _, test := range tests {
+		test.login = "cloud"
+		s.runIntegrationTest(test)
+	}
+}

--- a/test/test-server/ccloudv2_router.go
+++ b/test/test-server/ccloudv2_router.go
@@ -63,6 +63,8 @@ var ccloudV2Routes = []route{
 	{"/networking/v1/peerings/{id}", handleNetworkingPeering},
 	{"/networking/v1/private-link-accesses", handleNetworkingPrivateLinkAccesses},
 	{"/networking/v1/private-link-accesses/{id}", handleNetworkingPrivateLinkAccess},
+	{"/networking/v1/private-link-attachments", handleNetworkingPrivateLinkAttachments},
+	{"/networking/v1/private-link-attachments/{id}", handleNetworkingPrivateLinkAttachment},
 	{"/networking/v1/transit-gateway-attachments", handleNetworkingTransitGatewayAttachments},
 	{"/networking/v1/transit-gateway-attachments/{id}", handleNetworkingTransitGatewayAttachment},
 	{"/org/v2/environments", handleOrgEnvironments},


### PR DESCRIPTION
What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->
Note that this is merging into the feature branch https://github.com/confluentinc/cli/tree/traffic-8850-network-cli. We will merge commits into main from this feature branch after all of the commands for network are implemented

* Add `confluent network private-link attachment`
* Add `confluent network private-link attachment list`
* Add `confluent network private-link attachment describe <id>`

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->
[CLI Commands Design](https://confluentinc.atlassian.net/wiki/spaces/PM/pages/2987394300/1-pager+--+Network+CLI)
[Implementation 1-Pager](https://confluentinc.atlassian.net/wiki/spaces/~712020463029eabbac401bbe1b033ce0d3a00e/pages/3136749631/Network+CLI)

Test & Review
-------------
<!--
Has it been tested? How?
Copy and paste any instructions or steps that can save the reviewer time.
-->
Added integration tests.

Performed manual tests

Open Questions / Follow-ups
---------------------------
<!--
Optional: Anything open to discussion for the reviewer, out of scope of this PR, or follow-ups.
-->

Note that this "private link attachment" feature is tied to ESKU which is only available in AWS at the moment. I confirmed with our PM @kabraham13 that once we support ESKU in other clouds, the engineers who work on the API changes for that project should also be responsible for updating the CLI.
