### PR TITLE
[CLI-2802] Remove `402 Payment Required` from quota exceeded errors

### DIFF
--- a/pkg/errors/catcher.go
+++ b/pkg/errors/catcher.go
@@ -165,7 +165,7 @@ func CatchCCloudV2Error(err error, r *http.Response) error {
 	if len(resBody.Errors) > 0 {
 		detail := resBody.Errors[0].Detail
 		if ok, _ := regexp.MatchString(quotaExceededRegex, detail); ok {
-			return NewWrapErrorWithSuggestions(err, detail, QuotaExceededSuggestions)
+			return NewErrorWithSuggestions(detail, QuotaExceededSuggestions)
 		} else if detail != "" {
 			err = errors.Wrap(err, strings.TrimSuffix(detail, "\n"))
 			if resolution := strings.TrimSuffix(resBody.Errors[0].Resolution, "\n"); resolution != "" {

--- a/pkg/errors/catcher_test.go
+++ b/pkg/errors/catcher_test.go
@@ -14,7 +14,7 @@ func TestCatchClustersExceedError(t *testing.T) {
 
 	err := CatchClusterConfigurationNotValidError(New("402 Payment Required"), res)
 	require.Error(t, err)
-	require.Equal(t, err.Error(), "Your environment is currently limited to 50 kafka clusters: 402 Payment Required")
+	require.Equal(t, err.Error(), "Your environment is currently limited to 50 kafka clusters")
 }
 
 func TestCatchServiceAccountExceedError(t *testing.T) {
@@ -22,5 +22,5 @@ func TestCatchServiceAccountExceedError(t *testing.T) {
 
 	err := CatchServiceNameInUseError(New("402 Payment Required"), res, "")
 	require.Error(t, err)
-	require.Equal(t, "Your environment is currently limited to 1000 service accounts: 402 Payment Required", err.Error())
+	require.Equal(t, "Your environment is currently limited to 1000 service accounts", err.Error())
 }


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- PLACEHOLDER

New Features
- PLACEHOLDER

Bug Fixes
- PLACEHOLDER

Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
We use 402 for `quota exceeded` errors, but 402 is the standard code for `Payment Required`. This leads to a misleading error message when users reach limits.

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
Tested manually by hitting the api key per user limit.

Open Questions / Follow-ups
---------------------------
<!--
Optional: Anything open to discussion for the reviewer, out of scope of this PR, or follow-ups.
-->
