### PR TITLE
feat: require catalog to be set before setting a database

### DIFF
--- a/pkg/flink/internal/store/store_utils.go
+++ b/pkg/flink/internal/store/store_utils.go
@@ -105,6 +105,14 @@ func (s *Store) processUseStatement(statement string) (*types.ProcessedStatement
 		return nil, &types.StatementError{Message: err.Error()}
 	}
 
+	// require catalog to be set before running USE <database>
+	if configKey == config.ConfigKeyDatabase && !s.Properties.HasKey(config.ConfigKeyCatalog) {
+		return nil, &types.StatementError{
+			Message:    "no catalog was set",
+			Suggestion: `please set a catalog first with "USE CATALOG 'catalog-name'" before setting a database`,
+		}
+	}
+
 	s.Properties.Set(configKey, configVal)
 
 	return &types.ProcessedStatement{

--- a/pkg/flink/internal/store/store_utils_test.go
+++ b/pkg/flink/internal/store/store_utils_test.go
@@ -223,6 +223,18 @@ func TestProcessUseStatement(t *testing.T) {
 		_, err := s.processUseStatement("use db1 catalog metadata")
 		require.Error(t, err)
 	})
+
+	t.Run("use database should fail if no catalog was set", func(t *testing.T) {
+		// delete the catalog
+		catalogName := s.Properties.Get(config.ConfigKeyCatalog)
+		s.Properties.Delete(config.ConfigKeyCatalog)
+
+		_, err := s.processUseStatement("use db1")
+		require.Error(t, err)
+
+		// restore previous props state
+		s.Properties.Set(config.ConfigKeyCatalog, catalogName)
+	})
 }
 
 func TestStartsWithValidSQL(t *testing.T) {


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->
Previously you could set a database without having set a catalog first. This will no longer work, when setting a database, the user has to provide a catalog first.

