### PR TITLE
Feat/kfs 1170 pass statement name

### DIFF
--- a/pkg/flink/config/local_statements.go
+++ b/pkg/flink/config/local_statements.go
@@ -19,4 +19,5 @@ const (
 	ConfigKeyLocalTimeZone  = "sql.local-time-zone"
 	ConfigKeyResultsTimeout = "client.results-timeout"
 	ConfigKeyServiceAccount = "client.service-account"
+	ConfigKeyStatementName  = "client.statement-name"
 )

--- a/pkg/flink/internal/store/store.go
+++ b/pkg/flink/internal/store/store.go
@@ -78,7 +78,8 @@ func (s *Store) ProcessStatement(statement string) (*types.ProcessedStatement, *
 		return result, sErr
 	}
 
-	statementName := uuid.New().String()[:18]
+	statementName := s.Properties.GetOrDefault(config.ConfigKeyStatementName, uuid.New().String()[:18])
+	defer s.Properties.Delete(config.ConfigKeyStatementName)
 
 	// Process remote statements
 	computePoolId := s.appOptions.GetComputePoolId()

--- a/pkg/flink/internal/store/store_test.go
+++ b/pkg/flink/internal/store/store_test.go
@@ -1005,7 +1005,7 @@ func (s *StoreTestSuite) TestProcessStatementWithServiceAccount() {
 	}
 	serviceAccountId := "sa-123"
 	store := Store{
-		Properties:       NewUserProperties(map[string]string{"client.service-account": serviceAccountId, "TestProp": "TestVal"}, map[string]string{}),
+		Properties:       NewUserProperties(map[string]string{flinkconfig.ConfigKeyServiceAccount: serviceAccountId, "TestProp": "TestVal"}, map[string]string{}),
 		client:           client,
 		appOptions:       appOptions,
 		tokenRefreshFunc: tokenRefreshFunc,
@@ -1095,7 +1095,7 @@ func (s *StoreTestSuite) TestProcessStatementFailsOnError() {
 		ComputePoolId: "computePoolId",
 	}
 	store := Store{
-		Properties:       NewUserProperties(map[string]string{"client.service-account": serviceAccountId, "TestProp": "TestVal"}, map[string]string{}),
+		Properties:       NewUserProperties(map[string]string{flinkconfig.ConfigKeyServiceAccount: serviceAccountId, "TestProp": "TestVal"}, map[string]string{}),
 		client:           client,
 		appOptions:       appOptions,
 		tokenRefreshFunc: tokenRefreshFunc,
@@ -1126,6 +1126,48 @@ func (s *StoreTestSuite) TestProcessStatementFailsOnError() {
 	processedStatement, err := store.ProcessStatement(statement)
 	require.Nil(s.T(), processedStatement)
 	require.Equal(s.T(), expectedError, err)
+}
+
+func (s *StoreTestSuite) TestProcessStatementUsesUserProvidedStatementName() {
+	client := mock.NewMockGatewayClientInterface(gomock.NewController(s.T()))
+	appOptions := &types.ApplicationOptions{
+		OrgResourceId: "orgId",
+		EnvironmentId: "envId",
+		ComputePoolId: "computePoolId",
+	}
+	serviceAccountId := "sa-123"
+	statementName := "test-statement"
+	store := Store{
+		Properties:       NewUserProperties(map[string]string{flinkconfig.ConfigKeyServiceAccount: serviceAccountId}, map[string]string{flinkconfig.ConfigKeyStatementName: statementName}),
+		client:           client,
+		appOptions:       appOptions,
+		tokenRefreshFunc: tokenRefreshFunc,
+	}
+
+	statement := "SELECT * FROM table"
+	statusDetailMessage := "Test status detail message"
+
+	statementObj := flinkgatewayv1beta1.SqlV1beta1Statement{
+		Name: &statementName,
+		Status: &flinkgatewayv1beta1.SqlV1beta1StatementStatus{
+			Phase:  "PENDING",
+			Detail: &statusDetailMessage,
+		},
+		Spec: &flinkgatewayv1beta1.SqlV1beta1StatementSpec{
+			Properties:    &map[string]string{}, // only sql properties are passed to the gateway
+			ComputePoolId: &appOptions.ComputePoolId,
+			Statement:     &statement,
+		},
+	}
+
+	client.EXPECT().CreateStatement(SqlV1beta1StatementMatcher{statementObj}, serviceAccountId, appOptions.EnvironmentId, appOptions.OrgResourceId).
+		Return(statementObj, nil)
+
+	processedStatement, err := store.ProcessStatement(statement)
+	require.Nil(s.T(), err)
+	require.Equal(s.T(), types.NewProcessedStatement(statementObj), processedStatement)
+	// statement name should be cleared after submission
+	require.False(s.T(), store.Properties.HasKey(flinkconfig.ConfigKeyStatementName))
 }
 
 func (s *StoreTestSuite) TestWaitPendingStatement() {
@@ -1607,15 +1649,18 @@ type SqlV1beta1StatementMatcher struct {
 	Expected flinkgatewayv1beta1.SqlV1beta1Statement
 }
 
-// statementName is set inside the process function, we can only computePoolId, properties and statement
 func (p SqlV1beta1StatementMatcher) Matches(x interface{}) bool {
 	actual, ok := x.(flinkgatewayv1beta1.SqlV1beta1Statement)
 	if !ok {
 		return false
 	}
-	return *actual.Spec.ComputePoolId == *p.Expected.Spec.ComputePoolId &&
+	statementMatches := *actual.Spec.ComputePoolId == *p.Expected.Spec.ComputePoolId &&
 		reflect.DeepEqual(actual.Spec.Properties, p.Expected.Spec.Properties) &&
 		*actual.Spec.Statement == *p.Expected.Spec.Statement
+	if p.Expected.Name == nil {
+		return statementMatches
+	}
+	return statementMatches && *actual.Name == *p.Expected.Name
 }
 
 func (p SqlV1beta1StatementMatcher) String() string {

--- a/pkg/flink/internal/store/store_utils.go
+++ b/pkg/flink/internal/store/store_utils.go
@@ -64,6 +64,12 @@ func (s *Store) processSetStatement(statement string) (*types.ProcessedStatement
 			Suggestion: `please set a catalog with "USE CATALOG catalog-name" and a database with "USE db-name"`,
 		}
 	}
+	if configKey == config.ConfigKeyStatementName && strings.TrimSpace(configVal) == "" {
+		return nil, &types.StatementError{
+			Message:    "cannot set an empty statement name",
+			Suggestion: `please provide a non-empty statement name with "SET 'client.statement-name'='non-empty-name'"`,
+		}
+	}
 	s.Properties.Set(configKey, configVal)
 
 	return &types.ProcessedStatement{

--- a/pkg/flink/internal/store/store_utils_test.go
+++ b/pkg/flink/internal/store/store_utils_test.go
@@ -120,13 +120,27 @@ func TestProcessSetStatement(t *testing.T) {
 	})
 
 	t.Run("should fail if user wants to set the catalog", func(t *testing.T) {
-		_, err := s.processSetStatement("set" + config.ConfigKeyCatalog)
-		assert.NotNil(t, err)
+		_, err := s.processSetStatement(fmt.Sprintf("set '%s'='%s'", config.ConfigKeyCatalog, "catalog-name"))
+		assert.Equal(t, &types.StatementError{
+			Message:    "cannot set a catalog or a database with SET command",
+			Suggestion: `please set a catalog with "USE CATALOG catalog-name" and a database with "USE db-name"`,
+		}, err)
 	})
 
 	t.Run("should fail if user wants to set the database", func(t *testing.T) {
-		_, err := s.processSetStatement("set" + config.ConfigKeyDatabase)
-		assert.NotNil(t, err)
+		_, err := s.processSetStatement(fmt.Sprintf("set '%s'='%s'", config.ConfigKeyDatabase, "db-name"))
+		assert.Equal(t, &types.StatementError{
+			Message:    "cannot set a catalog or a database with SET command",
+			Suggestion: `please set a catalog with "USE CATALOG catalog-name" and a database with "USE db-name"`,
+		}, err)
+	})
+
+	t.Run("should fail if user wants to set an empty statement name", func(t *testing.T) {
+		_, err := s.processSetStatement(fmt.Sprintf("set '%s'='%s'", config.ConfigKeyStatementName, ""))
+		assert.Equal(t, &types.StatementError{
+			Message:    "cannot set an empty statement name",
+			Suggestion: `please provide a non-empty statement name with "SET 'client.statement-name'='non-empty-name'"`,
+		}, err)
 	})
 }
 


### PR DESCRIPTION

Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->
Users can now specify names for their statements by setting the `client.statement-name` property. The property will clear itself after submission. 

Also added some basic validation to not allow setting empty statement names.