### PR TITLE
[CLI-2679] Update group mapping prefix

### DIFF
--- a/internal/iam/command_groupmapping_delete.go
+++ b/internal/iam/command_groupmapping_delete.go
@@ -18,8 +18,8 @@ func (c *groupMappingCommand) newDeleteCommand() *cobra.Command {
 		RunE:              c.delete,
 		Example: examples.BuildExampleString(
 			examples.Example{
-				Text: `Delete group mapping "pool-12345":`,
-				Code: "confluent iam group-mapping delete pool-12345",
+				Text: `Delete group mapping "group-123456":`,
+				Code: "confluent iam group-mapping delete group-123456",
 			},
 		),
 	}

--- a/internal/iam/command_groupmapping_update.go
+++ b/internal/iam/command_groupmapping_update.go
@@ -19,8 +19,8 @@ func (c *groupMappingCommand) newUpdateCommand() *cobra.Command {
 		RunE:              c.update,
 		Example: examples.BuildExampleString(
 			examples.Example{
-				Text: `Update the description of group mapping "pool-123456".`,
-				Code: `confluent iam group-mapping update pool-123456 --description "updated description"`,
+				Text: `Update the description of group mapping "group-123456".`,
+				Code: `confluent iam group-mapping update group-123456 --description "updated description"`,
 			},
 		),
 	}

--- a/test/fixtures/output/iam/group-mapping/delete-help.golden
+++ b/test/fixtures/output/iam/group-mapping/delete-help.golden
@@ -4,9 +4,9 @@ Usage:
   confluent iam group-mapping delete <id-1> [id-2] ... [id-n] [flags]
 
 Examples:
-Delete group mapping "pool-12345":
+Delete group mapping "group-123456":
 
-  $ confluent iam group-mapping delete pool-12345
+  $ confluent iam group-mapping delete group-123456
 
 Flags:
       --context string   CLI context name.

--- a/test/fixtures/output/iam/group-mapping/update-help.golden
+++ b/test/fixtures/output/iam/group-mapping/update-help.golden
@@ -4,9 +4,9 @@ Usage:
   confluent iam group-mapping update <id> [flags]
 
 Examples:
-Update the description of group mapping "pool-123456".
+Update the description of group mapping "group-123456".
 
-  $ confluent iam group-mapping update pool-123456 --description "updated description"
+  $ confluent iam group-mapping update group-123456 --description "updated description"
 
 Flags:
       --name string          Name of the group mapping.


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
Update `iam group-mapping` examples to use the "group-" prefix instead of the "pool-" prefix.

References
----------
https://confluentinc.atlassian.net/browse/CLI-2679