### PR TITLE
CLI-2675 check java version before starting confluent local services

### DIFF
--- a/internal/local/command_service.go
+++ b/internal/local/command_service.go
@@ -252,6 +252,10 @@ func (c *command) runServiceVersionCommand(cmd *cobra.Command, _ []string) error
 }
 
 func (c *command) startService(service, configFile string) error {
+	if err := c.checkJavaVersion(service); err != nil {
+		return err
+	}
+
 	isUp, err := c.isRunning(service)
 	if err != nil {
 		return err
@@ -260,7 +264,7 @@ func (c *command) startService(service, configFile string) error {
 		return c.printStatus(service)
 	}
 
-	if err := c.checkService(service); err != nil {
+	if err := c.checkOSVersion(); err != nil {
 		return err
 	}
 
@@ -279,18 +283,6 @@ func (c *command) startService(service, configFile string) error {
 	}
 
 	return c.printStatus(service)
-}
-
-func (c *command) checkService(service string) error {
-	if err := c.checkOSVersion(); err != nil {
-		return err
-	}
-
-	if err := c.checkJavaVersion(service); err != nil {
-		return err
-	}
-
-	return nil
 }
 
 func (c *command) configService(service, configFile string) error {


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- PLACEHOLDER

New Features
- Verify Java version at the beginning when running `confluent local services start`

Bug Fixes
- PLACEHOLDER

Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->
https://confluentinc.atlassian.net/browse/CLI-2675
Check java version is valid before starting the services, so user doesn't need to wait until service is up.

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
<!--
Has it been tested? How?
Copy and paste any instructions or steps that can save the reviewer time.
-->

Open Questions / Follow-ups
---------------------------
<!--
Optional: Anything open to discussion for the reviewer, out of scope of this PR, or follow-ups.
-->
