### PR TITLE
[TRAFFIC-9353][TRAFFIC-9354][TRAFFIC-9355]: Add `confluent network private-link attachment update|delete|create` commands

### DIFF
--- a/internal/network/command_peering_update.go
+++ b/internal/network/command_peering_update.go
@@ -18,7 +18,7 @@ func (c *command) newPeeringUpdateCommand() *cobra.Command {
 		RunE:              c.peeringUpdate,
 		Example: examples.BuildExampleString(
 			examples.Example{
-				Text: `Update the name of peering "peer-123456"`,
+				Text: `Update the name of peering "peer-123456".`,
 				Code: `confluent network peering update peer-123456 --name "new name"`,
 			},
 		),

--- a/internal/network/command_private_link_access_create.go
+++ b/internal/network/command_private_link_access_create.go
@@ -19,7 +19,7 @@ func (c *command) newPrivateLinkAccessCreateCommand() *cobra.Command {
 		RunE:  c.privateLinkAccessCreate,
 		Example: examples.BuildExampleString(
 			examples.Example{
-				Text: "Create an AWS Private Link access.",
+				Text: "Create an AWS PrivateLink access.",
 				Code: "confluent network private-link access create aws-private-link-access --network n-123456 --cloud aws --cloud-account 123456789012",
 			},
 			examples.Example{

--- a/internal/network/command_private_link_access_update.go
+++ b/internal/network/command_private_link_access_update.go
@@ -18,7 +18,7 @@ func (c *command) newPrivateLinkAccessUpdateCommand() *cobra.Command {
 		RunE:              c.privateLinkAccessUpdate,
 		Example: examples.BuildExampleString(
 			examples.Example{
-				Text: `Update the name of private link access "pla-123456"`,
+				Text: `Update the name of private link access "pla-123456".`,
 				Code: `confluent network private-link access update pla-123456 --name "new name"`,
 			},
 		),

--- a/internal/network/command_private_link_attachment.go
+++ b/internal/network/command_private_link_attachment.go
@@ -26,8 +26,11 @@ func (c *command) newPrivateLinkAttachmentCommand() *cobra.Command {
 		Short: "Manage private link attachments.",
 	}
 
+	cmd.AddCommand(c.newPrivateLinkAttachmentCreateCommand())
+	cmd.AddCommand(c.newPrivateLinkAttachmentDeleteCommand())
 	cmd.AddCommand(c.newPrivateLinkAttachmentDescribeCommand())
 	cmd.AddCommand(c.newPrivateLinkAttachmentListCommand())
+	cmd.AddCommand(c.newPrivateLinkAttachmentUpdateCommand())
 
 	return cmd
 }

--- a/internal/network/command_private_link_attachment_create.go
+++ b/internal/network/command_private_link_attachment_create.go
@@ -26,7 +26,7 @@ func (c *command) newPrivateLinkAttachmentCreateCommand() *cobra.Command {
 	}
 
 	pcmd.AddCloudFlag(cmd)
-	cmd.Flags().String("region", "", "Cloud service provider region where the resources to be accessed using the PrivateLink attachment are located.")
+	cmd.Flags().String("region", "", "Cloud service provider region where the resources to be accessed using the private link attachment are located.")
 	pcmd.AddContextFlag(cmd, c.CLICommand)
 	pcmd.AddEnvironmentFlag(cmd, c.AuthenticatedCLICommand)
 	pcmd.AddOutputFlag(cmd)

--- a/internal/network/command_private_link_attachment_create.go
+++ b/internal/network/command_private_link_attachment_create.go
@@ -1,0 +1,72 @@
+package network
+
+import (
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	networkingprivatelinkv1 "github.com/confluentinc/ccloud-sdk-go-v2/networking-privatelink/v1"
+
+	pcmd "github.com/confluentinc/cli/v3/pkg/cmd"
+	"github.com/confluentinc/cli/v3/pkg/examples"
+)
+
+func (c *command) newPrivateLinkAttachmentCreateCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "create <name>",
+		Short: "Create a private link attachment.",
+		Args:  cobra.ExactArgs(1),
+		RunE:  c.privateLinkAttachmentCreate,
+		Example: examples.BuildExampleString(
+			examples.Example{
+				Text: "Create an AWS PrivateLink attachment.",
+				Code: "confluent network private-link attachment create aws-private-link-attachment --cloud aws --region us-west-2",
+			},
+		),
+	}
+
+	pcmd.AddCloudFlag(cmd)
+	cmd.Flags().String("region", "", "Cloud service provider region where the resources to be accessed using the PrivateLink attachment are located.")
+	pcmd.AddContextFlag(cmd, c.CLICommand)
+	pcmd.AddEnvironmentFlag(cmd, c.AuthenticatedCLICommand)
+	pcmd.AddOutputFlag(cmd)
+
+	cobra.CheckErr(cmd.MarkFlagRequired("cloud"))
+	cobra.CheckErr(cmd.MarkFlagRequired("region"))
+
+	return cmd
+}
+
+func (c *command) privateLinkAttachmentCreate(cmd *cobra.Command, args []string) error {
+	cloud, err := cmd.Flags().GetString("cloud")
+	if err != nil {
+		return err
+	}
+	cloud = strings.ToUpper(cloud)
+
+	region, err := cmd.Flags().GetString("region")
+	if err != nil {
+		return err
+	}
+
+	environmentId, err := c.Context.EnvironmentId()
+	if err != nil {
+		return err
+	}
+
+	createPrivateLinkAttachment := networkingprivatelinkv1.NetworkingV1PrivateLinkAttachment{
+		Spec: &networkingprivatelinkv1.NetworkingV1PrivateLinkAttachmentSpec{
+			DisplayName: networkingprivatelinkv1.PtrString(args[0]),
+			Environment: &networkingprivatelinkv1.ObjectReference{Id: environmentId},
+			Cloud:       networkingprivatelinkv1.PtrString(cloud),
+			Region:      networkingprivatelinkv1.PtrString(region),
+		},
+	}
+
+	attachment, err := c.V2Client.CreatePrivateLinkAttachment(createPrivateLinkAttachment)
+	if err != nil {
+		return err
+	}
+
+	return printPrivateLinkAttachmentTable(cmd, attachment)
+}

--- a/internal/network/command_private_link_attachment_delete.go
+++ b/internal/network/command_private_link_attachment_delete.go
@@ -1,0 +1,63 @@
+package network
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	pcmd "github.com/confluentinc/cli/v3/pkg/cmd"
+	"github.com/confluentinc/cli/v3/pkg/deletion"
+	"github.com/confluentinc/cli/v3/pkg/errors"
+	"github.com/confluentinc/cli/v3/pkg/output"
+	"github.com/confluentinc/cli/v3/pkg/resource"
+	"github.com/confluentinc/cli/v3/pkg/utils"
+)
+
+func (c *command) newPrivateLinkAttachmentDeleteCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:               "delete <id-1> [id-2] ... [id-n]",
+		Short:             "Delete one or more private link attachments.",
+		Args:              cobra.MinimumNArgs(1),
+		ValidArgsFunction: pcmd.NewValidArgsFunction(c.validPrivateLinkAttachmentArgsMultiple),
+		RunE:              c.privateLinkAttachmentDelete,
+	}
+
+	pcmd.AddForceFlag(cmd)
+	pcmd.AddContextFlag(cmd, c.CLICommand)
+	pcmd.AddEnvironmentFlag(cmd, c.AuthenticatedCLICommand)
+
+	return cmd
+}
+
+func (c *command) privateLinkAttachmentDelete(cmd *cobra.Command, args []string) error {
+	environmentId, err := c.Context.EnvironmentId()
+	if err != nil {
+		return err
+	}
+
+	existenceFunc := func(id string) bool {
+		_, err := c.V2Client.GetPrivateLinkAttachment(environmentId, id)
+		return err == nil
+	}
+
+	if err := deletion.ValidateAndConfirmDeletionYesNo(cmd, args, existenceFunc, resource.PrivateLinkAttachment); err != nil {
+		return err
+	}
+
+	deleteFunc := func(id string) error {
+		if err := c.V2Client.DeletePrivateLinkAttachment(environmentId, id); err != nil {
+			return errors.Errorf(errors.DeleteResourceErrorMsg, resource.PrivateLinkAttachment, id, err)
+		}
+		return nil
+	}
+
+	deletedIds, err := deletion.DeleteWithoutMessage(args, deleteFunc)
+	deleteMsg := "Requested to delete %s %s.\n"
+	if len(deletedIds) == 1 {
+		output.Printf(deleteMsg, resource.PrivateLinkAttachment, fmt.Sprintf(`"%s"`, deletedIds[0]))
+	} else if len(deletedIds) > 1 {
+		output.Printf(deleteMsg, resource.Plural(resource.PrivateLinkAttachment), utils.ArrayToCommaDelimitedString(deletedIds, "and"))
+	}
+
+	return err
+}

--- a/internal/network/command_private_link_attachment_update.go
+++ b/internal/network/command_private_link_attachment_update.go
@@ -1,0 +1,61 @@
+package network
+
+import (
+	"github.com/spf13/cobra"
+
+	networkingprivatelinkv1 "github.com/confluentinc/ccloud-sdk-go-v2/networking-privatelink/v1"
+
+	pcmd "github.com/confluentinc/cli/v3/pkg/cmd"
+	"github.com/confluentinc/cli/v3/pkg/examples"
+)
+
+func (c *command) newPrivateLinkAttachmentUpdateCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:               "update <id>",
+		Short:             "Update an existing private link attachment.",
+		Args:              cobra.ExactArgs(1),
+		ValidArgsFunction: pcmd.NewValidArgsFunction(c.validPrivateLinkAttachmentArgs),
+		RunE:              c.privateLinkAttachmentUpdate,
+		Example: examples.BuildExampleString(
+			examples.Example{
+				Text: `Update the name of private link attachment "platt-123456"`,
+				Code: `confluent network private-link attachment update platt-123456 --name "new name"`,
+			},
+		),
+	}
+
+	cmd.Flags().String("name", "", "Name of the private link attachment.")
+	pcmd.AddContextFlag(cmd, c.CLICommand)
+	pcmd.AddEnvironmentFlag(cmd, c.AuthenticatedCLICommand)
+	pcmd.AddOutputFlag(cmd)
+
+	cobra.CheckErr(cmd.MarkFlagRequired("name"))
+
+	return cmd
+}
+
+func (c *command) privateLinkAttachmentUpdate(cmd *cobra.Command, args []string) error {
+	environmentId, err := c.Context.EnvironmentId()
+	if err != nil {
+		return err
+	}
+
+	name, err := cmd.Flags().GetString("name")
+	if err != nil {
+		return err
+	}
+
+	UpdatePrivateLinkAttachment := networkingprivatelinkv1.NetworkingV1PrivateLinkAttachmentUpdate{
+		Spec: &networkingprivatelinkv1.NetworkingV1PrivateLinkAttachmentSpecUpdate{
+			DisplayName: networkingprivatelinkv1.PtrString(name),
+			Environment: &networkingprivatelinkv1.ObjectReference{Id: environmentId},
+		},
+	}
+
+	attachment, err := c.V2Client.UpdatePrivateLinkAttachment(environmentId, args[0], UpdatePrivateLinkAttachment)
+	if err != nil {
+		return err
+	}
+
+	return printPrivateLinkAttachmentTable(cmd, attachment)
+}

--- a/internal/network/command_private_link_attachment_update.go
+++ b/internal/network/command_private_link_attachment_update.go
@@ -18,7 +18,7 @@ func (c *command) newPrivateLinkAttachmentUpdateCommand() *cobra.Command {
 		RunE:              c.privateLinkAttachmentUpdate,
 		Example: examples.BuildExampleString(
 			examples.Example{
-				Text: `Update the name of private link attachment "platt-123456"`,
+				Text: `Update the name of private link attachment "platt-123456".`,
 				Code: `confluent network private-link attachment update platt-123456 --name "new name"`,
 			},
 		),

--- a/internal/network/command_transit_gateway_attachment_update.go
+++ b/internal/network/command_transit_gateway_attachment_update.go
@@ -18,7 +18,7 @@ func (c *command) newTransitGatewayAttachmentUpdateCommand() *cobra.Command {
 		RunE:              c.transitGatewayAttachmentUpdate,
 		Example: examples.BuildExampleString(
 			examples.Example{
-				Text: `Update the name of transit gateway attachment "tgwa-123456"`,
+				Text: `Update the name of transit gateway attachment "tgwa-123456".`,
 				Code: `confluent network transit-gateway-attachment update tgwa-123456 --name "new name"`,
 			},
 		),

--- a/pkg/ccloudv2/networking_privatelink.go
+++ b/pkg/ccloudv2/networking_privatelink.go
@@ -56,3 +56,18 @@ func (c *Client) GetPrivateLinkAttachment(environment, id string) (networkingpri
 	resp, httpResp, err := c.NetworkingPrivateLinkClient.PrivateLinkAttachmentsNetworkingV1Api.GetNetworkingV1PrivateLinkAttachment(c.networkingPrivateLinkApiContext(), id).Environment(environment).Execute()
 	return resp, errors.CatchCCloudV2Error(err, httpResp)
 }
+
+func (c *Client) UpdatePrivateLinkAttachment(environment, id string, privateLinkAttachmentUpdate networkingprivatelinkv1.NetworkingV1PrivateLinkAttachmentUpdate) (networkingprivatelinkv1.NetworkingV1PrivateLinkAttachment, error) {
+	resp, httpResp, err := c.NetworkingPrivateLinkClient.PrivateLinkAttachmentsNetworkingV1Api.UpdateNetworkingV1PrivateLinkAttachment(c.networkingPrivateLinkApiContext(), id).NetworkingV1PrivateLinkAttachmentUpdate(privateLinkAttachmentUpdate).Execute()
+	return resp, errors.CatchCCloudV2Error(err, httpResp)
+}
+
+func (c *Client) DeletePrivateLinkAttachment(environment, id string) error {
+	httpResp, err := c.NetworkingPrivateLinkClient.PrivateLinkAttachmentsNetworkingV1Api.DeleteNetworkingV1PrivateLinkAttachment(c.networkingPrivateLinkApiContext(), id).Environment(environment).Execute()
+	return errors.CatchCCloudV2Error(err, httpResp)
+}
+
+func (c *Client) CreatePrivateLinkAttachment(attachment networkingprivatelinkv1.NetworkingV1PrivateLinkAttachment) (networkingprivatelinkv1.NetworkingV1PrivateLinkAttachment, error) {
+	resp, httpResp, err := c.NetworkingPrivateLinkClient.PrivateLinkAttachmentsNetworkingV1Api.CreateNetworkingV1PrivateLinkAttachment(c.networkingPrivateLinkApiContext()).NetworkingV1PrivateLinkAttachment(attachment).Execute()
+	return resp, errors.CatchCCloudV2Error(err, httpResp)
+}

--- a/pkg/resource/resource.go
+++ b/pkg/resource/resource.go
@@ -37,6 +37,7 @@ const (
 	Organization                = "organization"
 	Peering                     = "peering"
 	PrivateLinkAccess           = "private link access"
+	PrivateLinkAttachment       = "private link attachment"
 	ProviderShare               = "provider share"
 	Pipeline                    = "pipeline"
 	SchemaExporter              = "schema exporter"

--- a/test/fixtures/output/network/peering/update-help.golden
+++ b/test/fixtures/output/network/peering/update-help.golden
@@ -4,7 +4,7 @@ Usage:
   confluent network peering update <id> [flags]
 
 Examples:
-Update the name of peering "peer-123456"
+Update the name of peering "peer-123456".
 
   $ confluent network peering update peer-123456 --name "new name"
 

--- a/test/fixtures/output/network/peering/update-missing-args.golden
+++ b/test/fixtures/output/network/peering/update-missing-args.golden
@@ -3,7 +3,7 @@ Usage:
   confluent network peering update <id> [flags]
 
 Examples:
-Update the name of peering "peer-123456"
+Update the name of peering "peer-123456".
 
   $ confluent network peering update peer-123456 --name "new name"
 

--- a/test/fixtures/output/network/peering/update-missing-flags.golden
+++ b/test/fixtures/output/network/peering/update-missing-flags.golden
@@ -3,7 +3,7 @@ Usage:
   confluent network peering update <id> [flags]
 
 Examples:
-Update the name of peering "peer-123456"
+Update the name of peering "peer-123456".
 
   $ confluent network peering update peer-123456 --name "new name"
 

--- a/test/fixtures/output/network/private-link/access/create-help.golden
+++ b/test/fixtures/output/network/private-link/access/create-help.golden
@@ -4,7 +4,7 @@ Usage:
   confluent network private-link access create <name> [flags]
 
 Examples:
-Create an AWS Private Link access.
+Create an AWS PrivateLink access.
 
   $ confluent network private-link access create aws-private-link-access --network n-123456 --cloud aws --cloud-account 123456789012
 

--- a/test/fixtures/output/network/private-link/access/create-missing-flags.golden
+++ b/test/fixtures/output/network/private-link/access/create-missing-flags.golden
@@ -3,7 +3,7 @@ Usage:
   confluent network private-link access create <name> [flags]
 
 Examples:
-Create an AWS Private Link access.
+Create an AWS PrivateLink access.
 
   $ confluent network private-link access create aws-private-link-access --network n-123456 --cloud aws --cloud-account 123456789012
 

--- a/test/fixtures/output/network/private-link/access/update-help.golden
+++ b/test/fixtures/output/network/private-link/access/update-help.golden
@@ -4,7 +4,7 @@ Usage:
   confluent network private-link access update <id> [flags]
 
 Examples:
-Update the name of private link access "pla-123456"
+Update the name of private link access "pla-123456".
 
   $ confluent network private-link access update pla-123456 --name "new name"
 

--- a/test/fixtures/output/network/private-link/access/update-missing-args.golden
+++ b/test/fixtures/output/network/private-link/access/update-missing-args.golden
@@ -3,7 +3,7 @@ Usage:
   confluent network private-link access update <id> [flags]
 
 Examples:
-Update the name of private link access "pla-123456"
+Update the name of private link access "pla-123456".
 
   $ confluent network private-link access update pla-123456 --name "new name"
 

--- a/test/fixtures/output/network/private-link/access/update-missing-flags.golden
+++ b/test/fixtures/output/network/private-link/access/update-missing-flags.golden
@@ -3,7 +3,7 @@ Usage:
   confluent network private-link access update <id> [flags]
 
 Examples:
-Update the name of private link access "pla-123456"
+Update the name of private link access "pla-123456".
 
   $ confluent network private-link access update pla-123456 --name "new name"
 

--- a/test/fixtures/output/network/private-link/attachment/create-aws.golden
+++ b/test/fixtures/output/network/private-link/attachment/create-aws.golden
@@ -1,0 +1,7 @@
++--------+--------------+
+| ID     | pla-123456   |
+| Name   | aws-platt    |
+| Cloud  | AWS          |
+| Region | us-west-2    |
+| Phase  | PROVISIONING |
++--------+--------------+

--- a/test/fixtures/output/network/private-link/attachment/create-azure-fail.golden
+++ b/test/fixtures/output/network/private-link/attachment/create-azure-fail.golden
@@ -1,0 +1,1 @@
+Error: The private link attachment region 'eastus2' for the cloud provider 'azure' is not supported.: 400 Bad Request

--- a/test/fixtures/output/network/private-link/attachment/create-gcp-fail.golden
+++ b/test/fixtures/output/network/private-link/attachment/create-gcp-fail.golden
@@ -1,0 +1,1 @@
+Error: The private link attachment region 'us-central1' for the cloud provider 'gcp' is not supported.: 400 Bad Request

--- a/test/fixtures/output/network/private-link/attachment/create-help.golden
+++ b/test/fixtures/output/network/private-link/attachment/create-help.golden
@@ -10,7 +10,7 @@ Create an AWS PrivateLink attachment.
 
 Flags:
       --cloud string         REQUIRED: Specify the cloud provider as "aws", "azure", or "gcp".
-      --region string        REQUIRED: Cloud service provider region where the resources to be accessed using the PrivateLink attachment are located.
+      --region string        REQUIRED: Cloud service provider region where the resources to be accessed using the private link attachment are located.
       --context string       CLI context name.
       --environment string   Environment ID.
   -o, --output string        Specify the output format as "human", "json", or "yaml". (default "human")

--- a/test/fixtures/output/network/private-link/attachment/create-help.golden
+++ b/test/fixtures/output/network/private-link/attachment/create-help.golden
@@ -1,0 +1,21 @@
+Create a private link attachment.
+
+Usage:
+  confluent network private-link attachment create <name> [flags]
+
+Examples:
+Create an AWS PrivateLink attachment.
+
+  $ confluent network private-link attachment create aws-private-link-attachment --cloud aws --region us-west-2
+
+Flags:
+      --cloud string         REQUIRED: Specify the cloud provider as "aws", "azure", or "gcp".
+      --region string        REQUIRED: Cloud service provider region where the resources to be accessed using the PrivateLink attachment are located.
+      --context string       CLI context name.
+      --environment string   Environment ID.
+  -o, --output string        Specify the output format as "human", "json", or "yaml". (default "human")
+
+Global Flags:
+  -h, --help            Show help for this command.
+      --unsafe-trace    Equivalent to -vvvv, but also log HTTP requests and responses which might contain plaintext secrets.
+  -v, --verbose count   Increase verbosity (-v for warn, -vv for info, -vvv for debug, -vvvv for trace).

--- a/test/fixtures/output/network/private-link/attachment/create-missing-flags.golden
+++ b/test/fixtures/output/network/private-link/attachment/create-missing-flags.golden
@@ -1,0 +1,21 @@
+Error: required flag(s) "cloud", "region" not set
+Usage:
+  confluent network private-link attachment create <name> [flags]
+
+Examples:
+Create an AWS PrivateLink attachment.
+
+  $ confluent network private-link attachment create aws-private-link-attachment --cloud aws --region us-west-2
+
+Flags:
+      --cloud string         REQUIRED: Specify the cloud provider as "aws", "azure", or "gcp".
+      --region string        REQUIRED: Cloud service provider region where the resources to be accessed using the PrivateLink attachment are located.
+      --context string       CLI context name.
+      --environment string   Environment ID.
+  -o, --output string        Specify the output format as "human", "json", or "yaml". (default "human")
+
+Global Flags:
+  -h, --help            Show help for this command.
+      --unsafe-trace    Equivalent to -vvvv, but also log HTTP requests and responses which might contain plaintext secrets.
+  -v, --verbose count   Increase verbosity (-v for warn, -vv for info, -vvv for debug, -vvvv for trace).
+

--- a/test/fixtures/output/network/private-link/attachment/create-missing-flags.golden
+++ b/test/fixtures/output/network/private-link/attachment/create-missing-flags.golden
@@ -9,7 +9,7 @@ Create an AWS PrivateLink attachment.
 
 Flags:
       --cloud string         REQUIRED: Specify the cloud provider as "aws", "azure", or "gcp".
-      --region string        REQUIRED: Cloud service provider region where the resources to be accessed using the PrivateLink attachment are located.
+      --region string        REQUIRED: Cloud service provider region where the resources to be accessed using the private link attachment are located.
       --context string       CLI context name.
       --environment string   Environment ID.
   -o, --output string        Specify the output format as "human", "json", or "yaml". (default "human")

--- a/test/fixtures/output/network/private-link/attachment/delete-autocomplete.golden
+++ b/test/fixtures/output/network/private-link/attachment/delete-autocomplete.golden
@@ -1,0 +1,5 @@
+platt-111111	aws-platt-1
+platt-111112	aws-platt-2
+platt-111113	aws-platt-3
+:4
+Completion ended with directive: ShellCompDirectiveNoFileComp

--- a/test/fixtures/output/network/private-link/attachment/delete-help.golden
+++ b/test/fixtures/output/network/private-link/attachment/delete-help.golden
@@ -1,0 +1,14 @@
+Delete one or more private link attachments.
+
+Usage:
+  confluent network private-link attachment delete <id-1> [id-2] ... [id-n] [flags]
+
+Flags:
+      --force                Skip the deletion confirmation prompt.
+      --context string       CLI context name.
+      --environment string   Environment ID.
+
+Global Flags:
+  -h, --help            Show help for this command.
+      --unsafe-trace    Equivalent to -vvvv, but also log HTTP requests and responses which might contain plaintext secrets.
+  -v, --verbose count   Increase verbosity (-v for warn, -vv for info, -vvv for debug, -vvvv for trace).

--- a/test/fixtures/output/network/private-link/attachment/delete-multiple-fail.golden
+++ b/test/fixtures/output/network/private-link/attachment/delete-multiple-fail.golden
@@ -1,0 +1,4 @@
+Error: private link attachment "platt-invalid" not found
+
+Suggestions:
+    List available private link attachments with `confluent network private-link attachment list`.

--- a/test/fixtures/output/network/private-link/attachment/delete-multiple-refuse.golden
+++ b/test/fixtures/output/network/private-link/attachment/delete-multiple-refuse.golden
@@ -1,0 +1,1 @@
+Are you sure you want to delete private link attachments "platt-111111" and "platt-222222"? (y/n): 

--- a/test/fixtures/output/network/private-link/attachment/delete-multiple-success.golden
+++ b/test/fixtures/output/network/private-link/attachment/delete-multiple-success.golden
@@ -1,0 +1,1 @@
+Are you sure you want to delete private link attachments "platt-111111" and "platt-222222"? (y/n): Requested to delete private link attachments "platt-111111" and "platt-222222".

--- a/test/fixtures/output/network/private-link/attachment/delete-platt-not-exist.golden
+++ b/test/fixtures/output/network/private-link/attachment/delete-platt-not-exist.golden
@@ -1,0 +1,4 @@
+Error: private link attachment "platt-invalid" not found
+
+Suggestions:
+    List available private link attachments with `confluent network private-link attachment list`.

--- a/test/fixtures/output/network/private-link/attachment/delete-prompt.golden
+++ b/test/fixtures/output/network/private-link/attachment/delete-prompt.golden
@@ -1,0 +1,1 @@
+Are you sure you want to delete private link attachment "platt-111111"? (y/n): Requested to delete private link attachment "platt-111111".

--- a/test/fixtures/output/network/private-link/attachment/delete.golden
+++ b/test/fixtures/output/network/private-link/attachment/delete.golden
@@ -1,0 +1,1 @@
+Requested to delete private link attachment "platt-111111".

--- a/test/fixtures/output/network/private-link/attachment/help.golden
+++ b/test/fixtures/output/network/private-link/attachment/help.golden
@@ -4,8 +4,11 @@ Usage:
   confluent network private-link attachment [command]
 
 Available Commands:
+  create      Create a private link attachment.
+  delete      Delete one or more private link attachments.
   describe    Describe a private link attachment.
   list        List private link attachments.
+  update      Update an existing private link attachment.
 
 Global Flags:
   -h, --help            Show help for this command.

--- a/test/fixtures/output/network/private-link/attachment/update-autocomplete.golden
+++ b/test/fixtures/output/network/private-link/attachment/update-autocomplete.golden
@@ -1,0 +1,6 @@
+--name	Name of the private link attachment.
+platt-111111	aws-platt-1
+platt-111112	aws-platt-2
+platt-111113	aws-platt-3
+:4
+Completion ended with directive: ShellCompDirectiveNoFileComp

--- a/test/fixtures/output/network/private-link/attachment/update-help.golden
+++ b/test/fixtures/output/network/private-link/attachment/update-help.golden
@@ -4,7 +4,7 @@ Usage:
   confluent network private-link attachment update <id> [flags]
 
 Examples:
-Update the name of private link attachment "platt-123456"
+Update the name of private link attachment "platt-123456".
 
   $ confluent network private-link attachment update platt-123456 --name "new name"
 

--- a/test/fixtures/output/network/private-link/attachment/update-help.golden
+++ b/test/fixtures/output/network/private-link/attachment/update-help.golden
@@ -1,0 +1,20 @@
+Update an existing private link attachment.
+
+Usage:
+  confluent network private-link attachment update <id> [flags]
+
+Examples:
+Update the name of private link attachment "platt-123456"
+
+  $ confluent network private-link attachment update platt-123456 --name "new name"
+
+Flags:
+      --name string          REQUIRED: Name of the private link attachment.
+      --context string       CLI context name.
+      --environment string   Environment ID.
+  -o, --output string        Specify the output format as "human", "json", or "yaml". (default "human")
+
+Global Flags:
+  -h, --help            Show help for this command.
+      --unsafe-trace    Equivalent to -vvvv, but also log HTTP requests and responses which might contain plaintext secrets.
+  -v, --verbose count   Increase verbosity (-v for warn, -vv for info, -vvv for debug, -vvvv for trace).

--- a/test/fixtures/output/network/private-link/attachment/update-missing-args.golden
+++ b/test/fixtures/output/network/private-link/attachment/update-missing-args.golden
@@ -3,7 +3,7 @@ Usage:
   confluent network private-link attachment update <id> [flags]
 
 Examples:
-Update the name of private link attachment "platt-123456"
+Update the name of private link attachment "platt-123456".
 
   $ confluent network private-link attachment update platt-123456 --name "new name"
 

--- a/test/fixtures/output/network/private-link/attachment/update-missing-args.golden
+++ b/test/fixtures/output/network/private-link/attachment/update-missing-args.golden
@@ -1,0 +1,20 @@
+Error: accepts 1 arg(s), received 0
+Usage:
+  confluent network private-link attachment update <id> [flags]
+
+Examples:
+Update the name of private link attachment "platt-123456"
+
+  $ confluent network private-link attachment update platt-123456 --name "new name"
+
+Flags:
+      --name string          Name of the private link attachment.
+      --context string       CLI context name.
+      --environment string   Environment ID.
+  -o, --output string        Specify the output format as "human", "json", or "yaml". (default "human")
+
+Global Flags:
+  -h, --help            Show help for this command.
+      --unsafe-trace    Equivalent to -vvvv, but also log HTTP requests and responses which might contain plaintext secrets.
+  -v, --verbose count   Increase verbosity (-v for warn, -vv for info, -vvv for debug, -vvvv for trace).
+

--- a/test/fixtures/output/network/private-link/attachment/update-missing-flags.golden
+++ b/test/fixtures/output/network/private-link/attachment/update-missing-flags.golden
@@ -3,7 +3,7 @@ Usage:
   confluent network private-link attachment update <id> [flags]
 
 Examples:
-Update the name of private link attachment "platt-123456"
+Update the name of private link attachment "platt-123456".
 
   $ confluent network private-link attachment update platt-123456 --name "new name"
 

--- a/test/fixtures/output/network/private-link/attachment/update-missing-flags.golden
+++ b/test/fixtures/output/network/private-link/attachment/update-missing-flags.golden
@@ -1,0 +1,20 @@
+Error: required flag(s) "name" not set
+Usage:
+  confluent network private-link attachment update <id> [flags]
+
+Examples:
+Update the name of private link attachment "platt-123456"
+
+  $ confluent network private-link attachment update platt-123456 --name "new name"
+
+Flags:
+      --name string          REQUIRED: Name of the private link attachment.
+      --context string       CLI context name.
+      --environment string   Environment ID.
+  -o, --output string        Specify the output format as "human", "json", or "yaml". (default "human")
+
+Global Flags:
+  -h, --help            Show help for this command.
+      --unsafe-trace    Equivalent to -vvvv, but also log HTTP requests and responses which might contain plaintext secrets.
+  -v, --verbose count   Increase verbosity (-v for warn, -vv for info, -vvv for debug, -vvvv for trace).
+

--- a/test/fixtures/output/network/private-link/attachment/update-platt-not-exist.golden
+++ b/test/fixtures/output/network/private-link/attachment/update-platt-not-exist.golden
@@ -1,0 +1,1 @@
+Error: 404 Not Found

--- a/test/fixtures/output/network/private-link/attachment/update.golden
+++ b/test/fixtures/output/network/private-link/attachment/update.golden
@@ -1,0 +1,8 @@
++--------------------------+---------------------------------------------------------+
+| ID                       | platt-111111                                            |
+| Name                     | new-name                                                |
+| Cloud                    | AWS                                                     |
+| Region                   | us-west-2                                               |
+| AWS VPC Endpoint Service | com.amazonaws.vpce.us-west-2.vpce-svc-01234567890abcdef |
+| Phase                    | WAITING_FOR_CONNECTIONS                                 |
++--------------------------+---------------------------------------------------------+

--- a/test/fixtures/output/network/transit-gateway-attachment/update-help.golden
+++ b/test/fixtures/output/network/transit-gateway-attachment/update-help.golden
@@ -4,7 +4,7 @@ Usage:
   confluent network transit-gateway-attachment update <id> [flags]
 
 Examples:
-Update the name of transit gateway attachment "tgwa-123456"
+Update the name of transit gateway attachment "tgwa-123456".
 
   $ confluent network transit-gateway-attachment update tgwa-123456 --name "new name"
 

--- a/test/fixtures/output/network/transit-gateway-attachment/update-missing-args.golden
+++ b/test/fixtures/output/network/transit-gateway-attachment/update-missing-args.golden
@@ -3,7 +3,7 @@ Usage:
   confluent network transit-gateway-attachment update <id> [flags]
 
 Examples:
-Update the name of transit gateway attachment "tgwa-123456"
+Update the name of transit gateway attachment "tgwa-123456".
 
   $ confluent network transit-gateway-attachment update tgwa-123456 --name "new name"
 

--- a/test/fixtures/output/network/transit-gateway-attachment/update-missing-flags.golden
+++ b/test/fixtures/output/network/transit-gateway-attachment/update-missing-flags.golden
@@ -3,7 +3,7 @@ Usage:
   confluent network transit-gateway-attachment update <id> [flags]
 
 Examples:
-Update the name of transit gateway attachment "tgwa-123456"
+Update the name of transit gateway attachment "tgwa-123456".
 
   $ confluent network transit-gateway-attachment update tgwa-123456 --name "new name"
 

--- a/test/network_test.go
+++ b/test/network_test.go
@@ -396,9 +396,56 @@ func (s *CLITestSuite) TestNetworkPrivateLinkAttachmentDescribe() {
 	}
 }
 
+func (s *CLITestSuite) TestNetworkPrivateLinkAttachmentUpdate() {
+	tests := []CLITest{
+		{args: "network private-link attachment update", fixture: "network/private-link/attachment/update-missing-args.golden", exitCode: 1},
+		{args: "network private-link attachment update platt-111111", fixture: "network/private-link/attachment/update-missing-flags.golden", exitCode: 1},
+		{args: "network pl attachment update platt-111111 --name new-name", fixture: "network/private-link/attachment/update.golden"},
+		{args: "network private-link attachment update platt-111111 --name new-name", fixture: "network/private-link/attachment/update.golden"},
+		{args: "network private-link attachment update platt-invalid --name new-name", fixture: "network/private-link/attachment/update-platt-not-exist.golden", exitCode: 1},
+	}
+
+	for _, test := range tests {
+		test.login = "cloud"
+		s.runIntegrationTest(test)
+	}
+}
+
+func (s *CLITestSuite) TestNetworkPrivateLinkAttachmentDelete() {
+	tests := []CLITest{
+		{args: "network private-link attachment delete platt-111111 --force", fixture: "network/private-link/attachment/delete.golden"},
+		{args: "network private-link attachment delete platt-111111", input: "y\n", fixture: "network/private-link/attachment/delete-prompt.golden"},
+		{args: "network private-link attachment delete platt-111111 platt-222222", input: "n\n", fixture: "network/private-link/attachment/delete-multiple-refuse.golden"},
+		{args: "network private-link attachment delete platt-111111 platt-222222", input: "y\n", fixture: "network/private-link/attachment/delete-multiple-success.golden"},
+		{args: "network private-link attachment delete platt-111111 platt-invalid", fixture: "network/private-link/attachment/delete-multiple-fail.golden", exitCode: 1},
+		{args: "network private-link attachment delete platt-invalid --force", fixture: "network/private-link/attachment/delete-platt-not-exist.golden", exitCode: 1},
+	}
+
+	for _, test := range tests {
+		test.login = "cloud"
+		s.runIntegrationTest(test)
+	}
+}
+
+func (s *CLITestSuite) TestNetworkPrivateLinkAttachmentCreate() {
+	tests := []CLITest{
+		{args: "network private-link attachment create platt", fixture: "network/private-link/attachment/create-missing-flags.golden", exitCode: 1},
+		{args: "network private-link attachment create aws-platt --cloud aws --region us-west-2", fixture: "network/private-link/attachment/create-aws.golden"},
+		{args: "network private-link attachment create gcp-platt --cloud gcp --region us-central1", fixture: "network/private-link/attachment/create-gcp-fail.golden", exitCode: 1},
+		{args: "network private-link attachment create azure-platt --cloud azure --region eastus2", fixture: "network/private-link/attachment/create-azure-fail.golden", exitCode: 1},
+	}
+
+	for _, test := range tests {
+		test.login = "cloud"
+		s.runIntegrationTest(test)
+	}
+}
+
 func (s *CLITestSuite) TestNetworkPrivateLinkAttachment_Autocomplete() {
 	tests := []CLITest{
 		{args: `__complete network private-link attachment describe ""`, login: "cloud", fixture: "network/private-link/attachment/describe-autocomplete.golden"},
+		{args: `__complete network private-link attachment update ""`, login: "cloud", fixture: "network/private-link/attachment/update-autocomplete.golden"},
+		{args: `__complete network private-link attachment delete ""`, login: "cloud", fixture: "network/private-link/attachment/delete-autocomplete.golden"},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->
Note that this is merging into the feature branch https://github.com/confluentinc/cli/tree/traffic-8850-network-cli. We will merge commits into main from this feature branch after all of the commands for network are implemented

* Add `confluent network private-link attachment update`
* Add `confluent network private-link attachment delete`
* Add `confluent network private-link attachment create`

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->
[CLI Commands Design](https://confluentinc.atlassian.net/wiki/spaces/PM/pages/2987394300/1-pager+--+Network+CLI)
[Implementation 1-Pager](https://confluentinc.atlassian.net/wiki/spaces/~712020463029eabbac401bbe1b033ce0d3a00e/pages/3136749631/Network+CLI)

Test & Review
-------------
<!--
Has it been tested? How?
Copy and paste any instructions or steps that can save the reviewer time.
-->
Added integration tests.

Performed manual tests


Open Questions / Follow-ups
---------------------------
<!--
Optional: Anything open to discussion for the reviewer, out of scope of this PR, or follow-ups.
-->
Note that this "private link attachment" feature is tied to ESKU which is only available in AWS at the moment. I confirmed with our PM @kabraham13 that once we support ESKU in other clouds, the engineers who work on the API changes for that project should also be responsible for updating the CLI.
