### PR TITLE
Fix/kfs 1190 fix user identity warning

### DIFF
--- a/pkg/flink/internal/controller/.snapshots/TestStatementControllerTestSuite-TestExecuteStatementPrintsNoWarningForLocalStatements
+++ b/pkg/flink/internal/controller/.snapshots/TestStatementControllerTestSuite-TestExecuteStatementPrintsNoWarningForLocalStatements
@@ -1,0 +1,4 @@
+Statement successfully submitted.
+Statement phase is COMPLETED.
+status detail message.
+

--- a/pkg/flink/internal/controller/.snapshots/TestStatementControllerTestSuite-TestExecuteStatementPrintsNoWarningForStatementsOtherThanInsertOrStatementSet
+++ b/pkg/flink/internal/controller/.snapshots/TestStatementControllerTestSuite-TestExecuteStatementPrintsNoWarningForStatementsOtherThanInsertOrStatementSet
@@ -1,0 +1,6 @@
+Statement name: test-statement
+Statement successfully submitted.
+Waiting for statement to be ready. Statement phase is PENDING.
+Statement phase is COMPLETED.
+status detail message.
+

--- a/pkg/flink/internal/controller/statement_controller.go
+++ b/pkg/flink/internal/controller/statement_controller.go
@@ -74,8 +74,21 @@ func (c *StatementController) shouldDisplayUserIdentityWarning(processedStatemen
 	if processedStatement.IsLocalStatement {
 		return false
 	}
+	// the warning is only needed for INSERT INTO and STATEMENT SET statements
+	if !c.isInsertOrStatementSetStatement(processedStatement) {
+		return false
+	}
 	principal := strings.ToLower(strings.TrimSpace(processedStatement.Principal))
 	return strings.HasPrefix(principal, "u-")
+}
+
+func (c *StatementController) isInsertOrStatementSetStatement(processedStatement *types.ProcessedStatement) bool {
+	// transform statement to uppercase and remove duplicated white spaces
+	statement := strings.ToUpper(strings.Join(strings.Fields(processedStatement.Statement), " "))
+	if strings.HasPrefix(statement, "INSERT") || strings.HasPrefix(statement, "EXECUTE STATEMENT SET") {
+		return true
+	}
+	return false
 }
 
 func (c *StatementController) waitForStatementToBeReadyOrError(processedStatement types.ProcessedStatement) (*types.ProcessedStatement, *types.StatementError) {

--- a/pkg/flink/internal/controller/statement_controller.go
+++ b/pkg/flink/internal/controller/statement_controller.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"context"
 	"net/http"
+	"strings"
 	"time"
 
 	fColor "github.com/fatih/color"
@@ -41,7 +42,7 @@ func (c *StatementController) ExecuteStatement(statementToExecute string) (*type
 	c.createdStatementName = processedStatement.StatementName
 	processedStatement.PrintStatusMessage()
 
-	if !processedStatement.IsLocalStatement && processedStatement.Principal == "" {
+	if c.shouldDisplayUserIdentityWarning(processedStatement) {
 		utils.OutputWarnf("[WARN] To ensure that your statements run continuously, switch to using a service account instead of your user identity by running `SET '%s'='sa-123';`. Otherwise, statements will stop running after 4 hours.",
 			config.ConfigKeyServiceAccount)
 	}
@@ -67,6 +68,14 @@ func (c *StatementController) handleStatementError(err types.StatementError) {
 	if err.StatusCode == http.StatusUnauthorized {
 		c.applicationController.ExitApplication()
 	}
+}
+
+func (c *StatementController) shouldDisplayUserIdentityWarning(processedStatement *types.ProcessedStatement) bool {
+	if processedStatement.IsLocalStatement {
+		return false
+	}
+	principal := strings.ToLower(strings.TrimSpace(processedStatement.Principal))
+	return strings.HasPrefix(principal, "u-")
 }
 
 func (c *StatementController) waitForStatementToBeReadyOrError(processedStatement types.ProcessedStatement) (*types.ProcessedStatement, *types.StatementError) {

--- a/pkg/flink/internal/controller/statement_controller.go
+++ b/pkg/flink/internal/controller/statement_controller.go
@@ -41,7 +41,7 @@ func (c *StatementController) ExecuteStatement(statementToExecute string) (*type
 	c.createdStatementName = processedStatement.StatementName
 	processedStatement.PrintStatusMessage()
 
-	if !processedStatement.IsLocalStatement && processedStatement.ServiceAccount == "" {
+	if !processedStatement.IsLocalStatement && processedStatement.Principal == "" {
 		utils.OutputWarnf("[WARN] To ensure that your statements run continuously, switch to using a service account instead of your user identity by running `SET '%s'='sa-123';`. Otherwise, statements will stop running after 4 hours.",
 			config.ConfigKeyServiceAccount)
 	}

--- a/pkg/flink/internal/controller/statement_controller_test.go
+++ b/pkg/flink/internal/controller/statement_controller_test.go
@@ -138,10 +138,10 @@ func (s *StatementControllerTestSuite) TestExecuteStatementCancelsAndDeletesStat
 func (s *StatementControllerTestSuite) TestExecuteStatementPrintsUserInfo() {
 	statementToExecute := "select 1;"
 	processedStatement := types.ProcessedStatement{
-		StatementName:  "test-statement",
-		StatusDetail:   "status detail message",
-		Status:         types.PENDING,
-		ServiceAccount: "sa-123",
+		StatementName: "test-statement",
+		StatusDetail:  "status detail message",
+		Status:        types.PENDING,
+		Principal:     "sa-123",
 	}
 	completedStatement := processedStatement
 	completedStatement.Status = types.COMPLETED
@@ -180,7 +180,7 @@ func (s *StatementControllerTestSuite) TestExecuteStatementPrintsWarningWhenNoSe
 
 func (s *StatementControllerTestSuite) TestExecuteStatementWaitsForCompletedState() {
 	statementToExecute := "select 1;"
-	processedStatement := types.ProcessedStatement{Status: types.PENDING, ServiceAccount: "sa-123"}
+	processedStatement := types.ProcessedStatement{Status: types.PENDING, Principal: "sa-123"}
 	runningStatement := types.ProcessedStatement{Status: types.RUNNING}
 	completedStatement := types.ProcessedStatement{Status: types.COMPLETED}
 	s.store.EXPECT().ProcessStatement(statementToExecute).Return(&processedStatement, nil)
@@ -200,7 +200,7 @@ func (s *StatementControllerTestSuite) TestExecuteStatementWaitsForCompletedStat
 
 func (s *StatementControllerTestSuite) TestExecuteStatementWaitsForFailedState() {
 	statementToExecute := "select 1;"
-	processedStatement := types.ProcessedStatement{Status: types.PENDING, ServiceAccount: "sa-123"}
+	processedStatement := types.ProcessedStatement{Status: types.PENDING, Principal: "sa-123"}
 	runningStatement := types.ProcessedStatement{Status: types.RUNNING}
 	failedStatement := types.ProcessedStatement{Status: types.FAILED}
 	s.store.EXPECT().ProcessStatement(statementToExecute).Return(&processedStatement, nil)
@@ -220,7 +220,7 @@ func (s *StatementControllerTestSuite) TestExecuteStatementWaitsForFailedState()
 
 func (s *StatementControllerTestSuite) TestExecuteStatementWaitsForNonEmptyPageToken() {
 	statementToExecute := "select 1;"
-	processedStatement := types.ProcessedStatement{Status: types.PENDING, ServiceAccount: "sa-123"}
+	processedStatement := types.ProcessedStatement{Status: types.PENDING, Principal: "sa-123"}
 	runningStatement := types.ProcessedStatement{Status: types.RUNNING}
 	runningStatementWithNextPage := types.ProcessedStatement{Status: types.RUNNING, PageToken: "not-empty"}
 	s.store.EXPECT().ProcessStatement(statementToExecute).Return(&processedStatement, nil)
@@ -240,7 +240,7 @@ func (s *StatementControllerTestSuite) TestExecuteStatementWaitsForNonEmptyPageT
 
 func (s *StatementControllerTestSuite) TestExecuteStatementReturnsWhenUserDetaches() {
 	statementToExecute := "select 1;"
-	processedStatement := types.ProcessedStatement{Status: types.PENDING, ServiceAccount: "sa-123"}
+	processedStatement := types.ProcessedStatement{Status: types.PENDING, Principal: "sa-123"}
 	runningStatement := types.ProcessedStatement{Status: types.RUNNING}
 	s.store.EXPECT().ProcessStatement(statementToExecute).Return(&processedStatement, nil)
 	s.store.EXPECT().WaitPendingStatement(gomock.Any(), processedStatement).Return(&runningStatement, nil)

--- a/pkg/flink/internal/controller/statement_controller_test.go
+++ b/pkg/flink/internal/controller/statement_controller_test.go
@@ -163,6 +163,7 @@ func (s *StatementControllerTestSuite) TestExecuteStatementPrintsWarningWhenNoSe
 		StatementName: "test-statement",
 		StatusDetail:  "status detail message",
 		Status:        types.PENDING,
+		Principal:     "u-123",
 	}
 	completedStatement := processedStatement
 	completedStatement.Status = types.COMPLETED

--- a/pkg/flink/types/statement.go
+++ b/pkg/flink/types/statement.go
@@ -23,8 +23,9 @@ const (
 
 // Custom Internal type that shall be used internally by the client
 type ProcessedStatement struct {
+	Statement         string `json:"statement"`
 	StatementName     string `json:"statement_name"`
-	Kind              string `json:"statement"`
+	Kind              string `json:"kind"`
 	ComputePool       string `json:"compute_pool"`
 	Principal         string `json:"principal"`
 	Status            PHASE  `json:"status"`
@@ -39,6 +40,7 @@ type ProcessedStatement struct {
 func NewProcessedStatement(statementObj flinkgatewayv1beta1.SqlV1beta1Statement) *ProcessedStatement {
 	statement := strings.ToLower(strings.TrimSpace(statementObj.Spec.GetStatement()))
 	return &ProcessedStatement{
+		Statement:         statementObj.Spec.GetStatement(),
 		StatementName:     statementObj.GetName(),
 		ComputePool:       statementObj.Spec.GetComputePoolId(),
 		Principal:         statementObj.Spec.GetPrincipal(),

--- a/pkg/flink/types/statement.go
+++ b/pkg/flink/types/statement.go
@@ -26,7 +26,7 @@ type ProcessedStatement struct {
 	StatementName     string `json:"statement_name"`
 	Kind              string `json:"statement"`
 	ComputePool       string `json:"compute_pool"`
-	ServiceAccount    string `json:"service_account"`
+	Principal         string `json:"principal"`
 	Status            PHASE  `json:"status"`
 	StatusDetail      string `json:"status_detail,omitempty"` // Shown at the top before the table
 	IsLocalStatement  bool
@@ -41,7 +41,7 @@ func NewProcessedStatement(statementObj flinkgatewayv1beta1.SqlV1beta1Statement)
 	return &ProcessedStatement{
 		StatementName:     statementObj.GetName(),
 		ComputePool:       statementObj.Spec.GetComputePoolId(),
-		ServiceAccount:    statementObj.Spec.GetPrincipal(),
+		Principal:         statementObj.Spec.GetPrincipal(),
 		StatusDetail:      statementObj.Status.GetDetail(),
 		Status:            PHASE(statementObj.Status.GetPhase()),
 		ResultSchema:      statementObj.Status.GetResultSchema(),


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->
The user identity warning was not displayed anymore, because the principal is now always set (either to the SA or the user ID). 
This is fixed now + the warning will only be shown for INSERT and STATEMENT SET statements, because the 4 hour time limit is only relevant for those.