### PR TITLE
Remove trailing slashes from the config platform name

### DIFF
--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -109,7 +109,7 @@ func PersistCCloudCredentialsToConfig(config *config.Config, client *ccloudv1.Cl
 
 func addOrUpdateContext(cfg *config.Config, isCloud bool, credentials *Credentials, ctxName, url string, state *config.ContextState, caCertPath, orgResourceId string, save bool) error {
 	platform := &config.Platform{
-		Name:       strings.TrimPrefix(url, "https://"),
+		Name:       strings.TrimSuffix(strings.TrimPrefix(url, "https://"), "/"),
 		Server:     url,
 		CaCertPath: caCertPath,
 	}

--- a/test/login_test.go
+++ b/test/login_test.go
@@ -329,3 +329,22 @@ func (s *CLITestSuite) TestLogin_SsoCodeInvalidFormat() {
 
 	s.runIntegrationTest(test)
 }
+
+func (s *CLITestSuite) TestLogin_RemoveSlashFromPlatformName() {
+	resetConfiguration(s.T(), false)
+
+	configFile := filepath.Join(os.Getenv("HOME"), ".confluent", "config.json")
+
+	args := fmt.Sprintf("login --url %s/", s.TestBackend.GetCloudUrl())
+	env := []string{fmt.Sprintf("%s=good@user.com", pauth.ConfluentCloudEmail), fmt.Sprintf("%s=pass1", pauth.ConfluentCloudPassword)}
+
+	_ = runCommand(s.T(), testBin, env, args, 0, "")
+
+	got, err := os.ReadFile(configFile)
+	s.NoError(err)
+	data := config.Config{}
+	err = json.Unmarshal(got, &data)
+	s.NoError(err)
+
+	s.Equal(s.TestBackend.GetCloudUrl(), data.Context().PlatformName)
+}


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- PLACEHOLDER

New Features
- PLACEHOLDER

Bug Fixes
- PLACEHOLDER

Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
If users log in with a Confluent gov url with a trailing `/`, the CLI will fail to encrypt the auth refresh token. To determine if a token is an unencrypted Confluent gov refresh token, the code checks the config platform name against a list of hostnames without the trailing `/`. Because of this, the code fails to encrypt the token.

Since the unencrypted refresh token generally contains invalid base64 characters, running most commands after login will yield base64 data errors.

This PR trims `/` from the end of the platform name before it's added to the config.

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
Manual testing with `confluent login --url confluent.cloud/`

Open Questions / Follow-ups
---------------------------
<!--
Optional: Anything open to discussion for the reviewer, out of scope of this PR, or follow-ups.
-->
