### PR TITLE
fix: remove environment flag for compute pool use command

### DIFF
--- a/internal/flink/command_compute_pool_use.go
+++ b/internal/flink/command_compute_pool_use.go
@@ -19,8 +19,6 @@ func (c *command) newComputePoolUseCommand() *cobra.Command {
 		RunE:              c.computePoolUse,
 	}
 
-	pcmd.AddOutputFlag(cmd)
-
 	return cmd
 }
 

--- a/internal/flink/command_compute_pool_use.go
+++ b/internal/flink/command_compute_pool_use.go
@@ -19,7 +19,6 @@ func (c *command) newComputePoolUseCommand() *cobra.Command {
 		RunE:              c.computePoolUse,
 	}
 
-	pcmd.AddEnvironmentFlag(cmd, c.AuthenticatedCLICommand)
 	pcmd.AddOutputFlag(cmd)
 
 	return cmd

--- a/pkg/errors/error_message.go
+++ b/pkg/errors/error_message.go
@@ -200,7 +200,7 @@ const (
 	JavaExecNotFondErrorMsg         = "could not find java executable, please install java or set JAVA_HOME"
 	NothingToDestroyErrorMsg        = "nothing to destroy"
 	ComputePoolNotFoundErrorMsg     = `Flink compute pool "%s" not found or access forbidden.`
-	ComputePoolNotFoundSuggestions  = "List available Flink compute pools with `confluent flink compute-pool list`"
+	ComputePoolNotFoundSuggestions  = "List available Flink compute pools with `confluent flink compute-pool list` and make sure you have selected the compute pool's environment with `confluent environment use`"
 	FailedToReadPortsErrorMsg       = "failed to read local ports from config"
 	FailedToReadPortsSuggestions    = "Restart Confluent Local with `confluent local kafka stop` and `confluent local kafka start`"
 	InstallAndStartDockerSuggestion = "Make sure Docker is installed following the guide: `https://docs.docker.com/engine/install/` and Docker daemon is running."

--- a/pkg/errors/error_message.go
+++ b/pkg/errors/error_message.go
@@ -200,7 +200,7 @@ const (
 	JavaExecNotFondErrorMsg         = "could not find java executable, please install java or set JAVA_HOME"
 	NothingToDestroyErrorMsg        = "nothing to destroy"
 	ComputePoolNotFoundErrorMsg     = `Flink compute pool "%s" not found or access forbidden`
-	ComputePoolNotFoundSuggestions  = "List available Flink compute pools with `confluent flink compute-pool list` and make sure you have selected the compute pool's environment with `confluent environment use`"
+	ComputePoolNotFoundSuggestions  = "List available Flink compute pools with `confluent flink compute-pool list`.\nMake sure you have selected the compute pool's environment with `confluent environment use`."
 	FailedToReadPortsErrorMsg       = "failed to read local ports from config"
 	FailedToReadPortsSuggestions    = "Restart Confluent Local with `confluent local kafka stop` and `confluent local kafka start`"
 	InstallAndStartDockerSuggestion = "Make sure Docker is installed following the guide: `https://docs.docker.com/engine/install/` and Docker daemon is running."

--- a/pkg/errors/error_message.go
+++ b/pkg/errors/error_message.go
@@ -199,7 +199,7 @@ const (
 	MacVersionErrorMsg              = "macOS version >= %s is required (detected: %s)"
 	JavaExecNotFondErrorMsg         = "could not find java executable, please install java or set JAVA_HOME"
 	NothingToDestroyErrorMsg        = "nothing to destroy"
-	ComputePoolNotFoundErrorMsg     = `Flink compute pool "%s" not found or access forbidden.`
+	ComputePoolNotFoundErrorMsg     = `Flink compute pool "%s" not found or access forbidden`
 	ComputePoolNotFoundSuggestions  = "List available Flink compute pools with `confluent flink compute-pool list` and make sure you have selected the compute pool's environment with `confluent environment use`"
 	FailedToReadPortsErrorMsg       = "failed to read local ports from config"
 	FailedToReadPortsSuggestions    = "Restart Confluent Local with `confluent local kafka stop` and `confluent local kafka start`"

--- a/test/fixtures/output/flink/compute-pool/use-fail.golden
+++ b/test/fixtures/output/flink/compute-pool/use-fail.golden
@@ -1,0 +1,5 @@
+Error: Flink compute pool "lfcp-999999" not found or access forbidden: resource not found: 403 Forbidden
+
+Suggestions:
+    List available Flink compute pools with `confluent flink compute-pool list`.
+    Make sure you have selected the compute pool's environment with `confluent environment use`.

--- a/test/fixtures/output/flink/compute-pool/use-help.golden
+++ b/test/fixtures/output/flink/compute-pool/use-help.golden
@@ -4,8 +4,7 @@ Usage:
   confluent flink compute-pool use <id> [flags]
 
 Flags:
-      --environment string   Environment ID.
-  -o, --output string        Specify the output format as "human", "json", or "yaml". (default "human")
+  -o, --output string   Specify the output format as "human", "json", or "yaml". (default "human")
 
 Global Flags:
   -h, --help            Show help for this command.

--- a/test/fixtures/output/flink/compute-pool/use-help.golden
+++ b/test/fixtures/output/flink/compute-pool/use-help.golden
@@ -3,9 +3,6 @@ Choose a Flink compute pool to be used in subsequent commands which support pass
 Usage:
   confluent flink compute-pool use <id> [flags]
 
-Flags:
-  -o, --output string   Specify the output format as "human", "json", or "yaml". (default "human")
-
 Global Flags:
   -h, --help            Show help for this command.
       --unsafe-trace    Equivalent to -vvvv, but also log HTTP requests and responses which might contain plaintext secrets.

--- a/test/flink_test.go
+++ b/test/flink_test.go
@@ -31,6 +31,7 @@ func (s *CLITestSuite) TestFlinkComputePoolDelete() {
 
 func (s *CLITestSuite) TestFlinkComputePoolUse() {
 	tests := []CLITest{
+		{args: "flink compute-pool use lfcp-999999", login: "cloud", fixture: "flink/compute-pool/use-fail.golden", exitCode: 1},
 		{args: "flink compute-pool use lfcp-123456", login: "cloud", fixture: "flink/compute-pool/use.golden"},
 		{args: "flink compute-pool describe", fixture: "flink/compute-pool/describe-after-use.golden"},
 		{args: "flink compute-pool list", fixture: "flink/compute-pool/list-after-use.golden"},


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->
Since `compute-pool use` will not switch environments for you, we ended up receiving some bug reports of people being confused why their use command didn't go through. By removing the flag we force users to manually switch, avoiding this confusion.
