### PR TITLE
Fix Flink feature flag

### DIFF
--- a/internal/iam/command_rbac_role_binding.go
+++ b/internal/iam/command_rbac_role_binding.go
@@ -162,17 +162,20 @@ func (c *roleBindingCommand) parseCommon(cmd *cobra.Command) (*roleBindingOption
 /*
 Helper function to add flags for all the legal scopes/clusters for the command.
 */
-func addClusterFlags(cmd *cobra.Command, cfg *config.Config, cliCommand *pcmd.CLICommand, ctx *dynamicconfig.DynamicContext) {
+func addClusterFlags(cmd *cobra.Command, cfg *config.Config, cliCommand *pcmd.CLICommand) {
 	if cfg.IsCloudLogin() {
 		cmd.Flags().String("environment", "", "Environment ID for scope of role-binding operation.")
 		cmd.Flags().Bool("current-environment", false, "Use current environment ID for scope.")
-		if cfg.IsTest || featureflags.Manager.BoolVariation("cli.flink.open_preview", ctx, config.CliLaunchDarklyClient, true, false) {
-			cmd.Flags().String("flink-region", "", "Flink region ID for the role binding.")
-		}
 		cmd.Flags().String("cloud-cluster", "", "Cloud cluster ID for the role binding.")
 		cmd.Flags().String("kafka-cluster", "", "Kafka cluster ID for the role binding.")
 		cmd.Flags().String("schema-registry-cluster", "", "Schema Registry cluster ID for the role binding.")
 		cmd.Flags().String("ksql-cluster", "", "ksqlDB cluster name for the role binding.")
+
+		dc := dynamicconfig.New(cfg, nil)
+		_ = dc.ParseFlagsIntoConfig(cmd)
+		if cfg.IsTest || featureflags.Manager.BoolVariation("cli.flink.open_preview", dc.Context(), config.CliLaunchDarklyClient, true, false) {
+			cmd.Flags().String("flink-region", "", "Flink region ID for the role binding.")
+		}
 	} else {
 		cmd.Flags().String("kafka-cluster", "", "Kafka cluster ID for the role binding.")
 		cmd.Flags().String("schema-registry-cluster", "", "Schema Registry cluster ID for the role binding.")

--- a/internal/iam/command_rbac_role_binding.go
+++ b/internal/iam/command_rbac_role_binding.go
@@ -166,16 +166,17 @@ func addClusterFlags(cmd *cobra.Command, cfg *config.Config, cliCommand *pcmd.CL
 	if cfg.IsCloudLogin() {
 		cmd.Flags().String("environment", "", "Environment ID for scope of role-binding operation.")
 		cmd.Flags().Bool("current-environment", false, "Use current environment ID for scope.")
-		cmd.Flags().String("cloud-cluster", "", "Cloud cluster ID for the role binding.")
-		cmd.Flags().String("kafka-cluster", "", "Kafka cluster ID for the role binding.")
-		cmd.Flags().String("schema-registry-cluster", "", "Schema Registry cluster ID for the role binding.")
-		cmd.Flags().String("ksql-cluster", "", "ksqlDB cluster name for the role binding.")
 
 		dc := dynamicconfig.New(cfg, nil)
 		_ = dc.ParseFlagsIntoConfig(cmd)
 		if cfg.IsTest || featureflags.Manager.BoolVariation("cli.flink.open_preview", dc.Context(), config.CliLaunchDarklyClient, true, false) {
 			cmd.Flags().String("flink-region", "", "Flink region ID for the role binding.")
 		}
+
+		cmd.Flags().String("cloud-cluster", "", "Cloud cluster ID for the role binding.")
+		cmd.Flags().String("kafka-cluster", "", "Kafka cluster ID for the role binding.")
+		cmd.Flags().String("schema-registry-cluster", "", "Schema Registry cluster ID for the role binding.")
+		cmd.Flags().String("ksql-cluster", "", "ksqlDB cluster name for the role binding.")
 	} else {
 		cmd.Flags().String("kafka-cluster", "", "Kafka cluster ID for the role binding.")
 		cmd.Flags().String("schema-registry-cluster", "", "Schema Registry cluster ID for the role binding.")

--- a/internal/iam/command_rbac_role_binding_create.go
+++ b/internal/iam/command_rbac_role_binding_create.go
@@ -79,7 +79,7 @@ func (c *roleBindingCommand) newCreateCommand() *cobra.Command {
 
 	cmd.Flags().String("role", "", "Role name of the new role binding.")
 	cmd.Flags().String("principal", "", "Qualified principal name for the role binding.")
-	addClusterFlags(cmd, c.cfg, c.CLICommand, c.Context)
+	addClusterFlags(cmd, c.cfg, c.CLICommand)
 	cmd.Flags().String("resource", "", "Qualified resource name for the role binding.")
 	cmd.Flags().Bool("prefix", false, "Whether the provided resource name is treated as a prefix pattern.")
 	pcmd.AddOutputFlag(cmd)

--- a/internal/iam/command_rbac_role_binding_delete.go
+++ b/internal/iam/command_rbac_role_binding_delete.go
@@ -37,7 +37,7 @@ func (c *roleBindingCommand) newDeleteCommand() *cobra.Command {
 	cmd.Flags().String("role", "", "Role name of the existing role binding.")
 	cmd.Flags().String("principal", "", "Qualified principal name associated with the role binding.")
 	pcmd.AddForceFlag(cmd)
-	addClusterFlags(cmd, c.cfg, c.CLICommand, c.Context)
+	addClusterFlags(cmd, c.cfg, c.CLICommand)
 	cmd.Flags().String("resource", "", "Qualified resource name for the role binding.")
 	cmd.Flags().Bool("prefix", false, "Whether the provided resource name is treated as a prefix pattern.")
 	pcmd.AddOutputFlag(cmd)


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
This feature flag gets evaluated before the command is run (while flags are being listed) so it needs user information. We need to call `ParseFlagsIntoConfig` here.

Test & Review
-------------
Tested manually in prod