### PR TITLE
Fix bug preventing users from registering two schemas in `confluent kafka topic produce`

### DIFF
--- a/internal/kafka/command_topic_consume.go
+++ b/internal/kafka/command_topic_consume.go
@@ -190,7 +190,7 @@ func (c *command) consume(cmd *cobra.Command, args []string) error {
 		_ = os.RemoveAll(schemaPath)
 	}()
 
-	subject := topicNameStrategy(topic)
+	subject := topic
 	schemaRegistryContext, err := cmd.Flags().GetString("schema-registry-context")
 	if err != nil {
 		return err

--- a/internal/kafka/command_topic_produce.go
+++ b/internal/kafka/command_topic_produce.go
@@ -240,7 +240,7 @@ func (c *command) initSchemaAndGetInfo(cmd *cobra.Command, topic, mode string) (
 		_ = os.RemoveAll(schemaDir)
 	}()
 
-	subject := topicNameStrategy(topic)
+	subject := topicNameStrategy(topic, mode)
 
 	// Deprecated
 	var schemaId optional.Int32

--- a/internal/kafka/command_topic_produce_onprem.go
+++ b/internal/kafka/command_topic_produce_onprem.go
@@ -183,7 +183,7 @@ func prepareSerializer(cmd *cobra.Command, topic, mode string) (string, string, 
 		return "", "", nil, err
 	}
 
-	return valueFormat, topicNameStrategy(topic), serializer, nil
+	return valueFormat, topicNameStrategy(topic, mode), serializer, nil
 }
 
 func (c *command) registerSchemaOnPrem(cmd *cobra.Command, schemaCfg *sr.RegisterSchemaConfigs) ([]byte, map[string]string, error) {

--- a/internal/kafka/utils.go
+++ b/internal/kafka/utils.go
@@ -1,6 +1,7 @@
 package kafka
 
 import (
+	"fmt"
 	_nethttp "net/http"
 
 	cmkv2 "github.com/confluentinc/ccloud-sdk-go-v2/cmk/v2"
@@ -168,6 +169,6 @@ func getCmkClusterStatus(cluster *cmkv2.CmkV2Cluster) string {
 	return cluster.Status.Phase
 }
 
-func topicNameStrategy(topic string) string {
-	return topic + "-value"
+func topicNameStrategy(topic, mode string) string {
+	return fmt.Sprintf("%s-%s", topic, mode)
 }


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- PLACEHOLDER

New Features
- PLACEHOLDER

Bug Fixes
- Fix an issue in `confluent kafka topic produce` that could prevent users from using schema formats for both `--key-format` and `--value-format` at the same time

Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
Discovered this bug while investigating the delimiter issue.

If the user provides filepaths instead of IDs for both `--key-format` and `--value-format`, the CLI attempts to register both under the same subject `topic-value`. This causes the second registration to fail unless the same schema is used for both flags.

This PR changes the naming so that schemas for key-format are registered as `topic-key` instead of `topic-value`.

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
Manual testing

Open Questions / Follow-ups
---------------------------
<!--
Optional: Anything open to discussion for the reviewer, out of scope of this PR, or follow-ups.
-->
