### PR TITLE
[CIAM-3594] Use Camel case for resource types

### DIFF
--- a/internal/iam/command_rbac_role_binding.go
+++ b/internal/iam/command_rbac_role_binding.go
@@ -493,6 +493,12 @@ func (c *roleBindingCommand) parseV2RoleBinding(cmd *cobra.Command) (*mdsv2.IamV
 		if resourceType == "Cluster" {
 			resourceType = "kafka"
 		}
+		if resourceType == "ServiceAccount" {
+			resourceType = "service-account"
+		}
+		if resourceType == "ComputePool" {
+			resourceType = "compute-pool"
+		}
 
 		if role == "" {
 			if err := c.validateResourceTypeV2(resourceType); err != nil {


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
We want to use camel case for resource types, but when actually calling MDS v2 API, the CRN is not in camel case, ex. `crn://confluent.cloud/organization=6157fa3e-9ae3-4470-a5ee-b38f911bf780/service-account=sa-stgcc1moxj6`. This PR adds support for ServiceAccount and ComputePool, which are translated to service-account and compute-pool respectively in the CRN. 

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
Tested in stag:
```
 confluent iam rbac role-binding create --principal User:u-67w7nj --role WorkloadIdentityAssigner --resource "ServiceAccount:sa-stgcc1moxj6"

+-----------------+--------------------------+
| Principal       | User:u-67w7nj            |
| Email           |                          |
| Role            | WorkloadIdentityAssigner |
| Environment     |                          |
| Cloud Cluster   |                          |
| Cluster Type    |                          |
| Logical Cluster |                          |
| Resource Type   | ServiceAccount           |
| Name            | sa-stgcc1moxj6           |
| Pattern Type    | LITERAL                  |
+-----------------+--------------------------+

```

Open Questions / Follow-ups
---------------------------
<!--
Optional: Anything open to discussion for the reviewer, out of scope of this PR, or follow-ups.
-->
