### PR TITLE
fix: make sure to send all non-local properties instead of just the sql ones

### DIFF
--- a/pkg/flink/internal/store/store.go
+++ b/pkg/flink/internal/store/store.go
@@ -83,7 +83,7 @@ func (s *Store) ProcessStatement(statement string) (*types.ProcessedStatement, *
 
 	// Process remote statements
 	computePoolId := s.appOptions.GetComputePoolId()
-	properties := s.Properties.GetSqlProperties()
+	properties := s.Properties.GetNonLocalProperties()
 
 	var principal string
 	serviceAccount := s.Properties.Get(config.ConfigKeyServiceAccount)

--- a/pkg/flink/internal/store/store_test.go
+++ b/pkg/flink/internal/store/store_test.go
@@ -1121,13 +1121,14 @@ func (s *StoreTestSuite) TestProcessStatementWithServiceAccount() {
 	statement := "SELECT * FROM table"
 	statusDetailMessage := "Test status detail message"
 
+	nonLocalProperties := store.Properties.GetNonLocalProperties()
 	statementObj := flinkgatewayv1beta1.SqlV1beta1Statement{
 		Status: &flinkgatewayv1beta1.SqlV1beta1StatementStatus{
 			Phase:  "PENDING",
 			Detail: &statusDetailMessage,
 		},
 		Spec: &flinkgatewayv1beta1.SqlV1beta1StatementSpec{
-			Properties:    &map[string]string{}, // only sql properties are passed to the gateway
+			Properties:    &nonLocalProperties, // only non-local properties are passed to the gateway
 			ComputePoolId: &appOptions.ComputePoolId,
 			Statement:     &statement,
 		},
@@ -1173,13 +1174,14 @@ func (s *StoreTestSuite) TestProcessStatementWithUserIdentity() {
 
 	statement := "SELECT * FROM table"
 	statusDetailMessage := "Test status detail message"
+	nonLocalProperties := store.Properties.GetNonLocalProperties()
 	statementObj := flinkgatewayv1beta1.SqlV1beta1Statement{
 		Status: &flinkgatewayv1beta1.SqlV1beta1StatementStatus{
 			Phase:  "PENDING",
 			Detail: &statusDetailMessage,
 		},
 		Spec: &flinkgatewayv1beta1.SqlV1beta1StatementSpec{
-			Properties:    &map[string]string{}, // only sql properties are passed to the gateway
+			Properties:    &nonLocalProperties, // only non-local properties are passed to the gateway
 			ComputePoolId: &appOptions.ComputePoolId,
 			Statement:     &statement,
 		},
@@ -1210,12 +1212,13 @@ func (s *StoreTestSuite) TestProcessStatementFailsOnError() {
 
 	statement := "SELECT * FROM table"
 	statusDetailMessage := "test status detail message"
+	nonLocalProperties := store.Properties.GetNonLocalProperties()
 	statementObj := flinkgatewayv1beta1.SqlV1beta1Statement{
 		Status: &flinkgatewayv1beta1.SqlV1beta1StatementStatus{
 			Detail: &statusDetailMessage,
 		},
 		Spec: &flinkgatewayv1beta1.SqlV1beta1StatementSpec{
-			Properties:    &map[string]string{}, // only sql properties are passed to the gateway
+			Properties:    &nonLocalProperties, // only non-local properties are passed to the gateway
 			ComputePoolId: &appOptions.ComputePoolId,
 			Statement:     &statement,
 		},

--- a/pkg/flink/internal/store/user_properties.go
+++ b/pkg/flink/internal/store/user_properties.go
@@ -59,15 +59,15 @@ func (p *UserProperties) GetProperties() map[string]string {
 	return p.properties
 }
 
-// GetSqlProperties returns only the properties that should be sent when creating a statement (identified by the 'sql.' prefix)
-func (p *UserProperties) GetSqlProperties() map[string]string {
-	sqlProperties := map[string]string{}
+// GetNonLocalProperties returns only the properties that should be sent when creating a statement (identified by not having the 'client.' prefix)
+func (p *UserProperties) GetNonLocalProperties() map[string]string {
+	nonLocalProperties := map[string]string{}
 	for key, value := range p.properties {
-		if strings.HasPrefix(key, config.ConfigNamespaceSql) {
-			sqlProperties[key] = value
+		if !strings.HasPrefix(key, config.ConfigNamespaceClient) {
+			nonLocalProperties[key] = value
 		}
 	}
-	return sqlProperties
+	return nonLocalProperties
 }
 
 func (p *UserProperties) Delete(key string) {

--- a/pkg/flink/internal/store/user_properties_test.go
+++ b/pkg/flink/internal/store/user_properties_test.go
@@ -168,9 +168,12 @@ func (s *UserPropertiesTestSuite) TestToSortedSlice() {
 	})
 }
 
-func (s *UserPropertiesTestSuite) TestShouldOnlyReturnSqlNamespaceProperties() {
+func (s *UserPropertiesTestSuite) TestShouldOnlyReturnNonLocalNamespaceProperties() {
 	s.userProperties.Set(config.ConfigKeyResultsTimeout, "1000")
 	s.userProperties.Set(config.ConfigKeyCatalog, "test-catalog")
 
-	require.Equal(s.T(), map[string]string{config.ConfigKeyCatalog: "test-catalog"}, s.userProperties.GetSqlProperties())
+	require.Equal(s.T(), map[string]string{
+		config.ConfigKeyCatalog: "test-catalog",
+		"default-key":           "default-value",
+	}, s.userProperties.GetNonLocalProperties())
 }


### PR DESCRIPTION

Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->
We filtered all properties that didn't contain `sql.` prefix. This is incorrect, we should only filter out those that do have the `client.` prefix

