### PR TITLE
[TRAFFIC-9357][TRAFFIC-9358]: Add `confluent network private-link attachment connection list|describe` commands

### DIFF
--- a/internal/network/command.go
+++ b/internal/network/command.go
@@ -236,6 +236,6 @@ func addNetworkFlag(cmd *cobra.Command, c *pcmd.AuthenticatedCLICommand) {
 }
 
 func (c *command) addPrivateLinkAttachmentFlag(cmd *cobra.Command) {
-	cmd.Flags().String("attachment", "", "ID of the private link attachment.")
+	cmd.Flags().String("attachment", "", "Private link attachment ID.")
 	pcmd.RegisterFlagCompletionFunc(cmd, "attachment", c.validPrivateLinkAttachmentArgs)
 }

--- a/internal/network/command.go
+++ b/internal/network/command.go
@@ -234,3 +234,8 @@ func addNetworkFlag(cmd *cobra.Command, c *pcmd.AuthenticatedCLICommand) {
 		return autocompleteNetworks(c.V2Client, environmentId)
 	})
 }
+
+func (c *command) addPrivateLinkAttachmentFlag(cmd *cobra.Command) {
+	cmd.Flags().String("attachment", "", "ID of the private link attachment.")
+	pcmd.RegisterFlagCompletionFunc(cmd, "attachment", c.validPrivateLinkAttachmentArgs)
+}

--- a/internal/network/command_private_link_attachment.go
+++ b/internal/network/command_private_link_attachment.go
@@ -26,6 +26,7 @@ func (c *command) newPrivateLinkAttachmentCommand() *cobra.Command {
 		Short: "Manage private link attachments.",
 	}
 
+	cmd.AddCommand(c.newPrivateLinkAttachmentConnectionCommand())
 	cmd.AddCommand(c.newPrivateLinkAttachmentCreateCommand())
 	cmd.AddCommand(c.newPrivateLinkAttachmentDeleteCommand())
 	cmd.AddCommand(c.newPrivateLinkAttachmentDescribeCommand())

--- a/internal/network/command_private_link_attachment_connection.go
+++ b/internal/network/command_private_link_attachment_connection.go
@@ -1,0 +1,64 @@
+package network
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	networkingprivatelinkv1 "github.com/confluentinc/ccloud-sdk-go-v2/networking-privatelink/v1"
+
+	"github.com/confluentinc/cli/v3/pkg/errors"
+	"github.com/confluentinc/cli/v3/pkg/output"
+)
+
+type privateLinkAttachmentConnectionOut struct {
+	Id                        string `human:"ID" serialized:"id"`
+	Name                      string `human:"Name" serialized:"name"`
+	Cloud                     string `human:"Cloud" serialized:"cloud"`
+	PrivateLinkAttachmentId   string `human:"Private Link Attachment ID" serialized:"private_link_attachment_id"`
+	Phase                     string `human:"Phase" serialized:"phase"`
+	AwsVpcEndpointId          string `human:"AWS VPC Endpoint ID,omitempty" serialized:"aws_vpc_endpoint_id,omitempty"`
+	AwsVpcEndpointServiceName string `human:"AWS VPC Endpoint Service Name,omitempty" serialized:"aws_vpc_endpoint_service_name,omitempty"`
+}
+
+func (c *command) newPrivateLinkAttachmentConnectionCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "connection",
+		Short: "Manage private link attachment connections.",
+	}
+
+	cmd.AddCommand(c.newPrivateLinkAttachmentConnectionDescribeCommand())
+	cmd.AddCommand(c.newPrivateLinkAttachmentConnectionListCommand())
+
+	return cmd
+}
+
+func printPrivateLinkAttachmentConnectionTable(cmd *cobra.Command, connection networkingprivatelinkv1.NetworkingV1PrivateLinkAttachmentConnection) error {
+	if connection.Spec == nil {
+		return fmt.Errorf(errors.CorruptedNetworkResponseErrorMsg, "spec")
+	}
+	if connection.Status == nil {
+		return fmt.Errorf(errors.CorruptedNetworkResponseErrorMsg, "status")
+	}
+
+	out := &privateLinkAttachmentConnectionOut{
+		Id:                      connection.GetId(),
+		Name:                    connection.Spec.GetDisplayName(),
+		PrivateLinkAttachmentId: connection.Spec.PrivateLinkAttachment.GetId(),
+		Phase:                   connection.Status.GetPhase(),
+	}
+
+	if connection.Spec.Cloud != nil && connection.Spec.Cloud.NetworkingV1AwsPrivateLinkAttachmentConnection != nil {
+		out.Cloud = CloudAws
+		out.AwsVpcEndpointId = connection.Spec.Cloud.NetworkingV1AwsPrivateLinkAttachmentConnection.GetVpcEndpointId()
+	}
+
+	if connection.Status.Cloud != nil && connection.Status.Cloud.NetworkingV1AwsPrivateLinkAttachmentConnectionStatus != nil {
+		out.AwsVpcEndpointServiceName = connection.Status.Cloud.NetworkingV1AwsPrivateLinkAttachmentConnectionStatus.GetVpcEndpointServiceName()
+	}
+
+	table := output.NewTable(cmd)
+	table.Add(out)
+
+	return table.Print()
+}

--- a/internal/network/command_private_link_attachment_connection.go
+++ b/internal/network/command_private_link_attachment_connection.go
@@ -59,6 +59,5 @@ func printPrivateLinkAttachmentConnectionTable(cmd *cobra.Command, connection ne
 
 	table := output.NewTable(cmd)
 	table.Add(out)
-
 	return table.Print()
 }

--- a/internal/network/command_private_link_attachment_connection_describe.go
+++ b/internal/network/command_private_link_attachment_connection_describe.go
@@ -1,0 +1,36 @@
+package network
+
+import (
+	"github.com/spf13/cobra"
+
+	pcmd "github.com/confluentinc/cli/v3/pkg/cmd"
+)
+
+func (c *command) newPrivateLinkAttachmentConnectionDescribeCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "describe <id>",
+		Short: "Describe a private link attachment connection.",
+		Args:  cobra.ExactArgs(1),
+		RunE:  c.privateLinkAttachmentConnectionDescribe,
+	}
+
+	pcmd.AddContextFlag(cmd, c.CLICommand)
+	pcmd.AddEnvironmentFlag(cmd, c.AuthenticatedCLICommand)
+	pcmd.AddOutputFlag(cmd)
+
+	return cmd
+}
+
+func (c *command) privateLinkAttachmentConnectionDescribe(cmd *cobra.Command, args []string) error {
+	environmentId, err := c.Context.EnvironmentId()
+	if err != nil {
+		return err
+	}
+
+	connection, err := c.V2Client.GetPrivateLinkAttachmentConnection(environmentId, args[0])
+	if err != nil {
+		return err
+	}
+
+	return printPrivateLinkAttachmentConnectionTable(cmd, connection)
+}

--- a/internal/network/command_private_link_attachment_connection_list.go
+++ b/internal/network/command_private_link_attachment_connection_list.go
@@ -7,32 +7,46 @@ import (
 
 	pcmd "github.com/confluentinc/cli/v3/pkg/cmd"
 	"github.com/confluentinc/cli/v3/pkg/errors"
+	"github.com/confluentinc/cli/v3/pkg/examples"
 	"github.com/confluentinc/cli/v3/pkg/output"
 )
 
 func (c *command) newPrivateLinkAttachmentConnectionListCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:               "list <private-link-attachment-id>",
-		Short:             "List connections for a private link attachment.",
-		Args:              cobra.ExactArgs(1),
-		ValidArgsFunction: pcmd.NewValidArgsFunction(c.validPrivateLinkAttachmentArgs),
-		RunE:              c.privateLinkAttachmentConnectionList,
+		Use:   "list",
+		Short: "List connections for a private link attachment.",
+		Args:  cobra.NoArgs,
+		RunE:  c.privateLinkAttachmentConnectionList,
+		Example: examples.BuildExampleString(
+			examples.Example{
+				Text: `List connections for private link attachment "platt-123456".`,
+				Code: "confluent network private-link attachment connection list --attachment platt-123456",
+			},
+		),
 	}
 
+	c.addPrivateLinkAttachmentFlag(cmd)
 	pcmd.AddContextFlag(cmd, c.CLICommand)
 	pcmd.AddEnvironmentFlag(cmd, c.AuthenticatedCLICommand)
 	pcmd.AddOutputFlag(cmd)
 
+	cobra.CheckErr(cmd.MarkFlagRequired("attachment"))
+
 	return cmd
 }
 
-func (c *command) privateLinkAttachmentConnectionList(cmd *cobra.Command, args []string) error {
+func (c *command) privateLinkAttachmentConnectionList(cmd *cobra.Command, _ []string) error {
+	attachment, err := cmd.Flags().GetString("attachment")
+	if err != nil {
+		return err
+	}
+
 	environmentId, err := c.Context.EnvironmentId()
 	if err != nil {
 		return err
 	}
 
-	connections, err := c.V2Client.ListPrivateLinkAttachmentConnections(environmentId, args[0])
+	connections, err := c.V2Client.ListPrivateLinkAttachmentConnections(environmentId, attachment)
 	if err != nil {
 		return err
 	}

--- a/internal/network/command_private_link_attachment_connection_list.go
+++ b/internal/network/command_private_link_attachment_connection_list.go
@@ -1,0 +1,69 @@
+package network
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	pcmd "github.com/confluentinc/cli/v3/pkg/cmd"
+	"github.com/confluentinc/cli/v3/pkg/errors"
+	"github.com/confluentinc/cli/v3/pkg/output"
+)
+
+func (c *command) newPrivateLinkAttachmentConnectionListCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:               "list <private-link-attachment-id>",
+		Short:             "List connections for a private link attachment.",
+		Args:              cobra.ExactArgs(1),
+		ValidArgsFunction: pcmd.NewValidArgsFunction(c.validPrivateLinkAttachmentArgs),
+		RunE:              c.privateLinkAttachmentConnectionList,
+	}
+
+	pcmd.AddContextFlag(cmd, c.CLICommand)
+	pcmd.AddEnvironmentFlag(cmd, c.AuthenticatedCLICommand)
+	pcmd.AddOutputFlag(cmd)
+
+	return cmd
+}
+
+func (c *command) privateLinkAttachmentConnectionList(cmd *cobra.Command, args []string) error {
+	environmentId, err := c.Context.EnvironmentId()
+	if err != nil {
+		return err
+	}
+
+	connections, err := c.V2Client.ListPrivateLinkAttachmentConnections(environmentId, args[0])
+	if err != nil {
+		return err
+	}
+
+	list := output.NewList(cmd)
+	for _, connection := range connections {
+		if connection.Spec == nil {
+			return fmt.Errorf(errors.CorruptedNetworkResponseErrorMsg, "spec")
+		}
+		if connection.Status == nil {
+			return fmt.Errorf(errors.CorruptedNetworkResponseErrorMsg, "status")
+		}
+
+		out := &privateLinkAttachmentConnectionOut{
+			Id:                      connection.GetId(),
+			Name:                    connection.Spec.GetDisplayName(),
+			PrivateLinkAttachmentId: connection.Spec.PrivateLinkAttachment.GetId(),
+			Phase:                   connection.Status.GetPhase(),
+		}
+
+		if connection.Spec.Cloud != nil && connection.Spec.Cloud.NetworkingV1AwsPrivateLinkAttachmentConnection != nil {
+			out.Cloud = CloudAws
+			out.AwsVpcEndpointId = connection.Spec.Cloud.NetworkingV1AwsPrivateLinkAttachmentConnection.GetVpcEndpointId()
+		}
+
+		if connection.Status.Cloud != nil && connection.Status.Cloud.NetworkingV1AwsPrivateLinkAttachmentConnectionStatus != nil {
+			out.AwsVpcEndpointServiceName = connection.Status.Cloud.NetworkingV1AwsPrivateLinkAttachmentConnectionStatus.GetVpcEndpointServiceName()
+		}
+
+		list.Add(out)
+	}
+
+	return list.Print()
+}

--- a/pkg/ccloudv2/networking_privatelink.go
+++ b/pkg/ccloudv2/networking_privatelink.go
@@ -71,3 +71,38 @@ func (c *Client) CreatePrivateLinkAttachment(attachment networkingprivatelinkv1.
 	resp, httpResp, err := c.NetworkingPrivateLinkClient.PrivateLinkAttachmentsNetworkingV1Api.CreateNetworkingV1PrivateLinkAttachment(c.networkingPrivateLinkApiContext()).NetworkingV1PrivateLinkAttachment(attachment).Execute()
 	return resp, errors.CatchCCloudV2Error(err, httpResp)
 }
+
+func (c *Client) ListPrivateLinkAttachmentConnections(environment, attachmentId string) ([]networkingprivatelinkv1.NetworkingV1PrivateLinkAttachmentConnection, error) {
+	var list []networkingprivatelinkv1.NetworkingV1PrivateLinkAttachmentConnection
+
+	done := false
+	pageToken := ""
+	for !done {
+		page, err := c.executeListPrivateLinkAttachmentConnections(environment, attachmentId, pageToken)
+		if err != nil {
+			return nil, err
+		}
+		list = append(list, page.GetData()...)
+
+		pageToken, done, err = extractNextPageToken(page.GetMetadata().Next)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return list, nil
+}
+
+func (c *Client) executeListPrivateLinkAttachmentConnections(environment, attachmentId, pageToken string) (networkingprivatelinkv1.NetworkingV1PrivateLinkAttachmentConnectionList, error) {
+	req := c.NetworkingPrivateLinkClient.PrivateLinkAttachmentConnectionsNetworkingV1Api.ListNetworkingV1PrivateLinkAttachmentConnections(c.networkingPrivateLinkApiContext()).Environment(environment).SpecPrivateLinkAttachment(attachmentId).PageSize(ccloudV2ListPageSize)
+	if pageToken != "" {
+		req = req.PageToken(pageToken)
+	}
+
+	resp, httpResp, err := req.Execute()
+	return resp, errors.CatchCCloudV2Error(err, httpResp)
+}
+
+func (c *Client) GetPrivateLinkAttachmentConnection(environment, id string) (networkingprivatelinkv1.NetworkingV1PrivateLinkAttachmentConnection, error) {
+	resp, httpResp, err := c.NetworkingPrivateLinkClient.PrivateLinkAttachmentConnectionsNetworkingV1Api.GetNetworkingV1PrivateLinkAttachmentConnection(c.networkingPrivateLinkApiContext(), id).Environment(environment).Execute()
+	return resp, errors.CatchCCloudV2Error(err, httpResp)
+}

--- a/test/fixtures/output/network/private-link/attachment/connection/describe-aws-json.golden
+++ b/test/fixtures/output/network/private-link/attachment/connection/describe-aws-json.golden
@@ -1,0 +1,9 @@
+{
+  "id": "plattc-111111",
+  "name": "aws-plattc",
+  "cloud": "AWS",
+  "private_link_attachment_id": "platt-111111",
+  "phase": "READY",
+  "aws_vpc_endpoint_id": "vpce-01234567890abcdef",
+  "aws_vpc_endpoint_service_name": "com.amazonaws.vpce.us-west-2.vpce-svc-01234567890abcdef"
+}

--- a/test/fixtures/output/network/private-link/attachment/connection/describe-aws-provisioning.golden
+++ b/test/fixtures/output/network/private-link/attachment/connection/describe-aws-provisioning.golden
@@ -1,0 +1,8 @@
++----------------------------+------------------------+
+| ID                         | plattc-111112          |
+| Name                       | aws-plattc             |
+| Cloud                      | AWS                    |
+| Private Link Attachment ID | platt-111111           |
+| Phase                      | PROVISIONING           |
+| AWS VPC Endpoint ID        | vpce-01234567890abcdef |
++----------------------------+------------------------+

--- a/test/fixtures/output/network/private-link/attachment/connection/describe-aws.golden
+++ b/test/fixtures/output/network/private-link/attachment/connection/describe-aws.golden
@@ -1,0 +1,9 @@
++-------------------------------+---------------------------------------------------------+
+| ID                            | plattc-111111                                           |
+| Name                          | aws-plattc                                              |
+| Cloud                         | AWS                                                     |
+| Private Link Attachment ID    | platt-111111                                            |
+| Phase                         | READY                                                   |
+| AWS VPC Endpoint ID           | vpce-01234567890abcdef                                  |
+| AWS VPC Endpoint Service Name | com.amazonaws.vpce.us-west-2.vpce-svc-01234567890abcdef |
++-------------------------------+---------------------------------------------------------+

--- a/test/fixtures/output/network/private-link/attachment/connection/describe-help.golden
+++ b/test/fixtures/output/network/private-link/attachment/connection/describe-help.golden
@@ -1,0 +1,14 @@
+Describe a private link attachment connection.
+
+Usage:
+  confluent network private-link attachment connection describe <id> [flags]
+
+Flags:
+      --context string       CLI context name.
+      --environment string   Environment ID.
+  -o, --output string        Specify the output format as "human", "json", or "yaml". (default "human")
+
+Global Flags:
+  -h, --help            Show help for this command.
+      --unsafe-trace    Equivalent to -vvvv, but also log HTTP requests and responses which might contain plaintext secrets.
+  -v, --verbose count   Increase verbosity (-v for warn, -vv for info, -vvv for debug, -vvvv for trace).

--- a/test/fixtures/output/network/private-link/attachment/connection/describe-invalid.golden
+++ b/test/fixtures/output/network/private-link/attachment/connection/describe-invalid.golden
@@ -1,0 +1,1 @@
+Error: 404 Not Found

--- a/test/fixtures/output/network/private-link/attachment/connection/describe-missing-id.golden
+++ b/test/fixtures/output/network/private-link/attachment/connection/describe-missing-id.golden
@@ -1,0 +1,14 @@
+Error: accepts 1 arg(s), received 0
+Usage:
+  confluent network private-link attachment connection describe <id> [flags]
+
+Flags:
+      --context string       CLI context name.
+      --environment string   Environment ID.
+  -o, --output string        Specify the output format as "human", "json", or "yaml". (default "human")
+
+Global Flags:
+  -h, --help            Show help for this command.
+      --unsafe-trace    Equivalent to -vvvv, but also log HTTP requests and responses which might contain plaintext secrets.
+  -v, --verbose count   Increase verbosity (-v for warn, -vv for info, -vvv for debug, -vvvv for trace).
+

--- a/test/fixtures/output/network/private-link/attachment/connection/help.golden
+++ b/test/fixtures/output/network/private-link/attachment/connection/help.golden
@@ -1,0 +1,15 @@
+Manage private link attachment connections.
+
+Usage:
+  confluent network private-link attachment connection [command]
+
+Available Commands:
+  describe    Describe a private link attachment connection.
+  list        List connections for a private link attachment.
+
+Global Flags:
+  -h, --help            Show help for this command.
+      --unsafe-trace    Equivalent to -vvvv, but also log HTTP requests and responses which might contain plaintext secrets.
+  -v, --verbose count   Increase verbosity (-v for warn, -vv for info, -vvv for debug, -vvvv for trace).
+
+Use "confluent network private-link attachment connection [command] --help" for more information about a command.

--- a/test/fixtures/output/network/private-link/attachment/connection/list-autocomplete.golden
+++ b/test/fixtures/output/network/private-link/attachment/connection/list-autocomplete.golden
@@ -1,0 +1,5 @@
+platt-111111	aws-platt-1
+platt-111112	aws-platt-2
+platt-111113	aws-platt-3
+:4
+Completion ended with directive: ShellCompDirectiveNoFileComp

--- a/test/fixtures/output/network/private-link/attachment/connection/list-help.golden
+++ b/test/fixtures/output/network/private-link/attachment/connection/list-help.golden
@@ -1,0 +1,14 @@
+List connections for a private link attachment.
+
+Usage:
+  confluent network private-link attachment connection list <private-link-attachment-id> [flags]
+
+Flags:
+      --context string       CLI context name.
+      --environment string   Environment ID.
+  -o, --output string        Specify the output format as "human", "json", or "yaml". (default "human")
+
+Global Flags:
+  -h, --help            Show help for this command.
+      --unsafe-trace    Equivalent to -vvvv, but also log HTTP requests and responses which might contain plaintext secrets.
+  -v, --verbose count   Increase verbosity (-v for warn, -vv for info, -vvv for debug, -vvvv for trace).

--- a/test/fixtures/output/network/private-link/attachment/connection/list-help.golden
+++ b/test/fixtures/output/network/private-link/attachment/connection/list-help.golden
@@ -9,7 +9,7 @@ List connections for private link attachment "platt-123456".
   $ confluent network private-link attachment connection list --attachment platt-123456
 
 Flags:
-      --attachment string    REQUIRED: ID of the private link attachment.
+      --attachment string    REQUIRED: Private link attachment ID.
       --context string       CLI context name.
       --environment string   Environment ID.
   -o, --output string        Specify the output format as "human", "json", or "yaml". (default "human")

--- a/test/fixtures/output/network/private-link/attachment/connection/list-help.golden
+++ b/test/fixtures/output/network/private-link/attachment/connection/list-help.golden
@@ -1,9 +1,15 @@
 List connections for a private link attachment.
 
 Usage:
-  confluent network private-link attachment connection list <private-link-attachment-id> [flags]
+  confluent network private-link attachment connection list [flags]
+
+Examples:
+List connections for private link attachment "platt-123456".
+
+  $ confluent network private-link attachment connection list --attachment platt-123456
 
 Flags:
+      --attachment string    REQUIRED: ID of the private link attachment.
       --context string       CLI context name.
       --environment string   Environment ID.
   -o, --output string        Specify the output format as "human", "json", or "yaml". (default "human")

--- a/test/fixtures/output/network/private-link/attachment/connection/list-invalid.golden
+++ b/test/fixtures/output/network/private-link/attachment/connection/list-invalid.golden
@@ -1,0 +1,1 @@
+None found.

--- a/test/fixtures/output/network/private-link/attachment/connection/list-json.golden
+++ b/test/fixtures/output/network/private-link/attachment/connection/list-json.golden
@@ -1,0 +1,28 @@
+[
+  {
+    "id": "plattc-111111",
+    "name": "aws-plattc-1",
+    "cloud": "AWS",
+    "private_link_attachment_id": "platt-111111",
+    "phase": "PROVISIONING",
+    "aws_vpc_endpoint_id": "vpce-01234567890abcdef"
+  },
+  {
+    "id": "plattc-111112",
+    "name": "aws-plattc-2",
+    "cloud": "AWS",
+    "private_link_attachment_id": "platt-111111",
+    "phase": "READY",
+    "aws_vpc_endpoint_id": "vpce-01234567890abcdef",
+    "aws_vpc_endpoint_service_name": "com.amazonaws.vpce.us-west-2.vpce-svc-01234567890abcdef"
+  },
+  {
+    "id": "plattc-111113",
+    "name": "aws-plattc-3",
+    "cloud": "AWS",
+    "private_link_attachment_id": "platt-111111",
+    "phase": "READY",
+    "aws_vpc_endpoint_id": "vpce-01234567890abcdef",
+    "aws_vpc_endpoint_service_name": "com.amazonaws.vpce.us-west-2.vpce-svc-01234567890abcdef"
+  }
+]

--- a/test/fixtures/output/network/private-link/attachment/connection/list-missing-args.golden
+++ b/test/fixtures/output/network/private-link/attachment/connection/list-missing-args.golden
@@ -1,0 +1,14 @@
+Error: accepts 1 arg(s), received 0
+Usage:
+  confluent network private-link attachment connection list <private-link-attachment-id> [flags]
+
+Flags:
+      --context string       CLI context name.
+      --environment string   Environment ID.
+  -o, --output string        Specify the output format as "human", "json", or "yaml". (default "human")
+
+Global Flags:
+  -h, --help            Show help for this command.
+      --unsafe-trace    Equivalent to -vvvv, but also log HTTP requests and responses which might contain plaintext secrets.
+  -v, --verbose count   Increase verbosity (-v for warn, -vv for info, -vvv for debug, -vvvv for trace).
+

--- a/test/fixtures/output/network/private-link/attachment/connection/list-missing-flags.golden
+++ b/test/fixtures/output/network/private-link/attachment/connection/list-missing-flags.golden
@@ -8,7 +8,7 @@ List connections for private link attachment "platt-123456".
   $ confluent network private-link attachment connection list --attachment platt-123456
 
 Flags:
-      --attachment string    REQUIRED: ID of the private link attachment.
+      --attachment string    REQUIRED: Private link attachment ID.
       --context string       CLI context name.
       --environment string   Environment ID.
   -o, --output string        Specify the output format as "human", "json", or "yaml". (default "human")

--- a/test/fixtures/output/network/private-link/attachment/connection/list-missing-flags.golden
+++ b/test/fixtures/output/network/private-link/attachment/connection/list-missing-flags.golden
@@ -1,8 +1,14 @@
-Error: accepts 1 arg(s), received 0
+Error: required flag(s) "attachment" not set
 Usage:
-  confluent network private-link attachment connection list <private-link-attachment-id> [flags]
+  confluent network private-link attachment connection list [flags]
+
+Examples:
+List connections for private link attachment "platt-123456".
+
+  $ confluent network private-link attachment connection list --attachment platt-123456
 
 Flags:
+      --attachment string    REQUIRED: ID of the private link attachment.
       --context string       CLI context name.
       --environment string   Environment ID.
   -o, --output string        Specify the output format as "human", "json", or "yaml". (default "human")

--- a/test/fixtures/output/network/private-link/attachment/connection/list.golden
+++ b/test/fixtures/output/network/private-link/attachment/connection/list.golden
@@ -1,0 +1,5 @@
+       ID       |     Name     | Cloud | Private Link Attachment ID |    Phase     |  AWS VPC Endpoint ID   |              AWS VPC Endpoint Service Name               
+----------------+--------------+-------+----------------------------+--------------+------------------------+----------------------------------------------------------
+  plattc-111111 | aws-plattc-1 | AWS   | platt-111111               | PROVISIONING | vpce-01234567890abcdef |                                                          
+  plattc-111112 | aws-plattc-2 | AWS   | platt-111111               | READY        | vpce-01234567890abcdef | com.amazonaws.vpce.us-west-2.vpce-svc-01234567890abcdef  
+  plattc-111113 | aws-plattc-3 | AWS   | platt-111111               | READY        | vpce-01234567890abcdef | com.amazonaws.vpce.us-west-2.vpce-svc-01234567890abcdef  

--- a/test/fixtures/output/network/private-link/attachment/help.golden
+++ b/test/fixtures/output/network/private-link/attachment/help.golden
@@ -4,6 +4,7 @@ Usage:
   confluent network private-link attachment [command]
 
 Available Commands:
+  connection  Manage private link attachment connections.
   create      Create a private link attachment.
   delete      Delete one or more private link attachments.
   describe    Describe a private link attachment.

--- a/test/network_test.go
+++ b/test/network_test.go
@@ -456,11 +456,11 @@ func (s *CLITestSuite) TestNetworkPrivateLinkAttachment_Autocomplete() {
 
 func (s *CLITestSuite) TestNetworkPrivateLinkAttachmentConnectionList() {
 	tests := []CLITest{
-		{args: "network pl attachment connection list platt-111111", fixture: "network/private-link/attachment/connection/list.golden"},
-		{args: "network private-link attachment connection list", fixture: "network/private-link/attachment/connection/list-missing-args.golden", exitCode: 1},
-		{args: "network private-link attachment connection list platt-111111", fixture: "network/private-link/attachment/connection/list.golden"},
-		{args: "network private-link attachment connection list platt-invalid", fixture: "network/private-link/attachment/connection/list-invalid.golden"},
-		{args: "network private-link attachment connection list platt-111111 --output json", fixture: "network/private-link/attachment/connection/list-json.golden"},
+		{args: "network pl attachment connection list --attachment platt-111111", fixture: "network/private-link/attachment/connection/list.golden"},
+		{args: "network private-link attachment connection list", fixture: "network/private-link/attachment/connection/list-missing-flags.golden", exitCode: 1},
+		{args: "network private-link attachment connection list --attachment platt-111111", fixture: "network/private-link/attachment/connection/list.golden"},
+		{args: "network private-link attachment connection list --attachment platt-invalid", fixture: "network/private-link/attachment/connection/list-invalid.golden"},
+		{args: "network private-link attachment connection list --attachment platt-111111 --output json", fixture: "network/private-link/attachment/connection/list-json.golden"},
 	}
 
 	for _, test := range tests {
@@ -477,6 +477,17 @@ func (s *CLITestSuite) TestNetworkPrivateLinkAttachmentConnectionDescribe() {
 		{args: "network private-link attachment connection describe plattc-111111 --output json", fixture: "network/private-link/attachment/connection/describe-aws-json.golden"},
 		{args: "network private-link attachment connection describe", fixture: "network/private-link/attachment/connection/describe-missing-id.golden", exitCode: 1},
 		{args: "network private-link attachment connection describe plattc-invalid", fixture: "network/private-link/attachment/connection/describe-invalid.golden", exitCode: 1},
+	}
+
+	for _, test := range tests {
+		test.login = "cloud"
+		s.runIntegrationTest(test)
+	}
+}
+
+func (s *CLITestSuite) TestNetworkPrivateLinkAttachmentConnection_Autocomplete() {
+	tests := []CLITest{
+		{args: `__complete network private-link attachment connection list --attachment ""`, login: "cloud", fixture: "network/private-link/attachment/connection/list-autocomplete.golden"},
 	}
 
 	for _, test := range tests {

--- a/test/network_test.go
+++ b/test/network_test.go
@@ -453,3 +453,34 @@ func (s *CLITestSuite) TestNetworkPrivateLinkAttachment_Autocomplete() {
 		s.runIntegrationTest(test)
 	}
 }
+
+func (s *CLITestSuite) TestNetworkPrivateLinkAttachmentConnectionList() {
+	tests := []CLITest{
+		{args: "network pl attachment connection list platt-111111", fixture: "network/private-link/attachment/connection/list.golden"},
+		{args: "network private-link attachment connection list", fixture: "network/private-link/attachment/connection/list-missing-args.golden", exitCode: 1},
+		{args: "network private-link attachment connection list platt-111111", fixture: "network/private-link/attachment/connection/list.golden"},
+		{args: "network private-link attachment connection list platt-invalid", fixture: "network/private-link/attachment/connection/list-invalid.golden"},
+		{args: "network private-link attachment connection list platt-111111 --output json", fixture: "network/private-link/attachment/connection/list-json.golden"},
+	}
+
+	for _, test := range tests {
+		test.login = "cloud"
+		s.runIntegrationTest(test)
+	}
+}
+
+func (s *CLITestSuite) TestNetworkPrivateLinkAttachmentConnectionDescribe() {
+	tests := []CLITest{
+		{args: "network pl attachment connection describe plattc-111111", fixture: "network/private-link/attachment/connection/describe-aws.golden"},
+		{args: "network private-link attachment connection describe plattc-111111", fixture: "network/private-link/attachment/connection/describe-aws.golden"},
+		{args: "network private-link attachment connection describe plattc-111112", fixture: "network/private-link/attachment/connection/describe-aws-provisioning.golden"},
+		{args: "network private-link attachment connection describe plattc-111111 --output json", fixture: "network/private-link/attachment/connection/describe-aws-json.golden"},
+		{args: "network private-link attachment connection describe", fixture: "network/private-link/attachment/connection/describe-missing-id.golden", exitCode: 1},
+		{args: "network private-link attachment connection describe plattc-invalid", fixture: "network/private-link/attachment/connection/describe-invalid.golden", exitCode: 1},
+	}
+
+	for _, test := range tests {
+		test.login = "cloud"
+		s.runIntegrationTest(test)
+	}
+}

--- a/test/test-server/ccloudv2_router.go
+++ b/test/test-server/ccloudv2_router.go
@@ -65,6 +65,8 @@ var ccloudV2Routes = []route{
 	{"/networking/v1/private-link-accesses/{id}", handleNetworkingPrivateLinkAccess},
 	{"/networking/v1/private-link-attachments", handleNetworkingPrivateLinkAttachments},
 	{"/networking/v1/private-link-attachments/{id}", handleNetworkingPrivateLinkAttachment},
+	{"/networking/v1/private-link-attachment-connections", handleNetworkingPrivateLinkAttachmentConnections},
+	{"/networking/v1/private-link-attachment-connections/{id}", handleNetworkingPrivateLinkAttachmentConnection},
 	{"/networking/v1/transit-gateway-attachments", handleNetworkingTransitGatewayAttachments},
 	{"/networking/v1/transit-gateway-attachments/{id}", handleNetworkingTransitGatewayAttachment},
 	{"/org/v2/environments", handleOrgEnvironments},


### PR DESCRIPTION
What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->
Note that this is merging into the feature branch https://github.com/confluentinc/cli/tree/traffic-8850-network-cli. We will merge commits into main from this feature branch after all of the commands for network are implemented

* Add `confluent network private-link attachment connection`
* Add `confluent network private-link attachment connection list`
* Add `confluent network private-link attachment connection describe`


References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->
[CLI Commands Design](https://confluentinc.atlassian.net/wiki/spaces/PM/pages/2987394300/1-pager+--+Network+CLI)
[Implementation 1-Pager](https://confluentinc.atlassian.net/wiki/spaces/~712020463029eabbac401bbe1b033ce0d3a00e/pages/3136749631/Network+CLI)

Test & Review
-------------
<!--
Has it been tested? How?
Copy and paste any instructions or steps that can save the reviewer time.
-->
Added integration tests.

Performed manual tests

Open Questions / Follow-ups
---------------------------
<!--
Optional: Anything open to discussion for the reviewer, out of scope of this PR, or follow-ups.
-->
Please see the questions below.