### PR TITLE
[FLINK363] Remove erroneous override of special flink http client

### DIFF
--- a/pkg/ccloudv2/flink_gateway.go
+++ b/pkg/ccloudv2/flink_gateway.go
@@ -46,7 +46,6 @@ func NewFlinkGatewayClient(url, userAgent string, unsafeTrace bool, authToken st
 
 			return nil
 		})
-	cfg.HTTPClient = NewRetryableHttpClient(unsafeTrace)
 	cfg.Servers = flinkgatewayv1beta1.ServerConfigurations{{URL: url}}
 	cfg.UserAgent = userAgent
 


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->
n/a

Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->
Fixes a recently-introduced bug where we don't use the special flink client that follows redirects.  This was broken recently by https://github.com/confluentinc/cli/pull/2231

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->
https://confluentinc.atlassian.net/jira/software/c/projects/FLINKCC/issues/FLINKCC-363

Test & Review
-------------
<!--
Has it been tested? How?
Copy and paste any instructions or steps that can save the reviewer time.
-->

Open Questions / Follow-ups
---------------------------
<!--
Optional: Anything open to discussion for the reviewer, out of scope of this PR, or follow-ups.
-->
