### PR TITLE
fix: display proper ID for flink region list command

### DIFF
--- a/internal/flink/command_region_list.go
+++ b/internal/flink/command_region_list.go
@@ -11,9 +11,10 @@ import (
 )
 
 type regionOut struct {
-	Id    string `human:"ID" serialized:"id"`
-	Name  string `human:"Name" serialized:"name"`
-	Cloud string `human:"Cloud" serialized:"cloud"`
+	Id         string `human:"ID" serialized:"id"`
+	Name       string `human:"Name" serialized:"name"`
+	Cloud      string `human:"Cloud" serialized:"cloud"`
+	RegionName string `human:"Region Name" serialized:"region_name"`
 }
 
 func (c *command) newRegionListCommand() *cobra.Command {
@@ -50,9 +51,10 @@ func (c *command) regionList(cmd *cobra.Command, args []string) error {
 	list := output.NewList(cmd)
 	for _, region := range regions {
 		list.Add(&regionOut{
-			Id:    region.GetRegionName(),
-			Name:  region.GetDisplayName(),
-			Cloud: region.GetCloud(),
+			Id:         region.GetId(),
+			Name:       region.GetDisplayName(),
+			Cloud:      region.GetCloud(),
+			RegionName: region.GetRegionName(),
 		})
 	}
 	return list.Print()

--- a/test/fixtures/output/flink/region/list-cloud.golden
+++ b/test/fixtures/output/flink/region/list-cloud.golden
@@ -1,3 +1,3 @@
-     ID     |        Name        | Cloud  
-------------+--------------------+--------
-  eu-west-1 | Europe (eu-west-1) | AWS    
+       ID       |        Name        | Cloud | Region Name  
+----------------+--------------------+-------+--------------
+  aws.eu-west-1 | Europe (eu-west-1) | AWS   | eu-west-1    

--- a/test/fixtures/output/flink/region/list-json.golden
+++ b/test/fixtures/output/flink/region/list-json.golden
@@ -1,12 +1,14 @@
 [
   {
-    "id": "eu-west-1",
+    "id": "aws.eu-west-1",
     "name": "Europe (eu-west-1)",
-    "cloud": "AWS"
+    "cloud": "AWS",
+    "region_name": "eu-west-1"
   },
   {
-    "id": "europe-west3-a",
+    "id": "gcp.europe-west3-a",
     "name": "Frankfurt (europe-west3-a)",
-    "cloud": "GCP"
+    "cloud": "GCP",
+    "region_name": "europe-west3-a"
   }
 ]

--- a/test/fixtures/output/flink/region/list.golden
+++ b/test/fixtures/output/flink/region/list.golden
@@ -1,4 +1,4 @@
-        ID       |            Name            | Cloud  
------------------+----------------------------+--------
-  eu-west-1      | Europe (eu-west-1)         | AWS    
-  europe-west3-a | Frankfurt (europe-west3-a) | GCP    
+          ID         |            Name            | Cloud |  Region Name    
+---------------------+----------------------------+-------+-----------------
+  aws.eu-west-1      | Europe (eu-west-1)         | AWS   | eu-west-1       
+  gcp.europe-west3-a | Frankfurt (europe-west3-a) | GCP   | europe-west3-a  


### PR DESCRIPTION

Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->
Fixes the region list command which did not output the proper ID. As a result people got error messages in subsequent commands, because they were using the incorrect region ID.