### PR TITLE
fix: truncate multi-line cells in the basic table properly

### DIFF
--- a/pkg/flink/internal/controller/basic_output_controller.go
+++ b/pkg/flink/internal/controller/basic_output_controller.go
@@ -73,6 +73,7 @@ func (c *BasicOutputController) createTable(rows [][]string) *tablewriter.Table 
 	rawTable := tablewriter.NewWriter(os.Stdout)
 	rawTable.SetAutoFormatHeaders(false)
 	rawTable.SetHeader(materializedStatementResults.GetHeaders())
+	rawTable.SetAutoWrapText(false)
 	rawTable.AppendBulk(rows)
 	return rawTable
 }

--- a/pkg/flink/internal/results/materialized_results_test.go
+++ b/pkg/flink/internal/results/materialized_results_test.go
@@ -572,6 +572,26 @@ func (s *MaterializedStatementResultsTestSuite) TestGetColumnWidths() {
 	require.Equal(s.T(), []int{5, 2}, materializedStatementResults.GetMaxWidthPerColumn())
 }
 
+func (s *MaterializedStatementResultsTestSuite) TestGetColumnWidthsWithMultiLineValues() {
+	headers := []string{"1234", "12"}
+	materializedStatementResults := types.NewMaterializedStatementResults(headers, 10)
+	materializedStatementResults.Append(types.StatementResultRow{
+		Operation: types.INSERT,
+		Fields: []types.StatementResultField{
+			types.AtomicStatementResultField{
+				Type:  types.VARCHAR,
+				Value: "12345 \n 123456789",
+			},
+			types.AtomicStatementResultField{
+				Type:  types.VARCHAR,
+				Value: "1\n123",
+			},
+		},
+	})
+
+	require.Equal(s.T(), []int{10, 3}, materializedStatementResults.GetMaxWidthPerColumn())
+}
+
 func (s *MaterializedStatementResultsTestSuite) TestGetColumnWidthsChangelogMode() {
 	headers := []string{"1234", "12"}
 	materializedStatementResults := types.NewMaterializedStatementResults(headers, 10)

--- a/pkg/flink/internal/results/result_formatter.go
+++ b/pkg/flink/internal/results/result_formatter.go
@@ -1,6 +1,10 @@
 package results
 
-import "github.com/samber/lo"
+import (
+	"github.com/samber/lo"
+
+	"github.com/confluentinc/cli/v3/pkg/flink/internal/utils"
+)
 
 type truncatedColumn struct {
 	idx            int
@@ -53,7 +57,7 @@ func GetTruncatedColumnWidths(columnWidths []int, maxCharacters int) []int {
 }
 
 func TruncateString(str string, maxCharCountToDisplay int) string {
-	if len(str) > maxCharCountToDisplay {
+	if utils.GetMaxStrWidth(str) > maxCharCountToDisplay {
 		if maxCharCountToDisplay <= 3 {
 			return "..."
 		}

--- a/pkg/flink/internal/results/result_formatter_test.go
+++ b/pkg/flink/internal/results/result_formatter_test.go
@@ -348,3 +348,39 @@ func (s *ResultFormatterTestSuite) TestFormatNestedField() {
 		require.Equal(s.T(), testCase.expected, formattedField)
 	}
 }
+
+func (s *ResultFormatterTestSuite) TestTruncateMultiLineStringShouldNotTruncate() {
+	testCases := []struct {
+		input                 string
+		expected              string
+		maxCharCountToDisplay int
+	}{
+		{
+			input:                 "SELECT * FROM \n table",
+			expected:              "SELECT * FROM \n table",
+			maxCharCountToDisplay: 15,
+		},
+		{
+			input:                 "SELECT * FROM \n table",
+			expected:              "SELECT * FR...",
+			maxCharCountToDisplay: 14,
+		},
+		// this looks strange in a table, because not the whole width of the cell is used, but then the text
+		// is still suddenly truncated. We could improve this case to only truncate starting from the line that actually
+		// crossed the max width threshold. The desired output in this case would be:
+		// SELECT * FROM
+		// table-with-a-real...
+		{
+			input:    "SELECT * FROM \n table-with-a-really-long-table-name",
+			expected: "SELECT * FROM \n t...",
+			// TODO: we should fix this to output this instead
+			// expected:              "SELECT * FROM \n table-with-a-real...",
+			maxCharCountToDisplay: 20,
+		},
+	}
+
+	for idx, testCase := range testCases {
+		output.Println(fmt.Sprintf("Evaluating test case #%v", idx))
+		require.Equal(s.T(), testCase.expected, TruncateString(testCase.input, testCase.maxCharCountToDisplay))
+	}
+}

--- a/pkg/flink/internal/utils/output.go
+++ b/pkg/flink/internal/utils/output.go
@@ -1,6 +1,8 @@
 package utils
 
 import (
+	"strings"
+
 	fColor "github.com/fatih/color"
 
 	"github.com/confluentinc/cli/v3/pkg/color"
@@ -33,4 +35,19 @@ func OutputWarn(s string) {
 func OutputWarnf(s string, args ...any) {
 	c := fColor.New(color.WarnColor)
 	output.Printf(c.Sprintln(s), args...)
+}
+
+func GetMaxStrWidth(str string) int {
+	// split the string by lines and find the longest line
+	lines := strings.Split(strings.ReplaceAll(str, "\r\n", "\n"), "\n")
+	maxWidth := 0
+	for idx, line := range lines {
+		lineLength := len(line) + 1
+		// the last line does not have a extra new line char that needs to be counted
+		if idx == len(lines)-1 {
+			lineLength = len(line)
+		}
+		maxWidth = max(maxWidth, lineLength)
+	}
+	return maxWidth
 }

--- a/pkg/flink/types/materialized_results.go
+++ b/pkg/flink/types/materialized_results.go
@@ -2,6 +2,8 @@ package types
 
 import (
 	"sync"
+
+	"github.com/confluentinc/cli/v3/pkg/flink/internal/utils"
 )
 
 type MaterializedStatementResultsIterator struct {
@@ -207,12 +209,12 @@ func (s *MaterializedStatementResults) GetMaxWidthPerColumn() []int {
 
 	columnWidths := make([]int, len(s.GetHeaders()))
 	for colIdx, column := range s.GetHeaders() {
-		columnWidths[colIdx] = max(len(column), columnWidths[colIdx])
+		columnWidths[colIdx] = max(utils.GetMaxStrWidth(column), columnWidths[colIdx])
 	}
 
 	s.ForEach(func(rowIdx int, row *StatementResultRow) {
 		for colIdx, field := range row.Fields {
-			columnWidths[colIdx] = max(len(field.ToString()), columnWidths[colIdx])
+			columnWidths[colIdx] = max(utils.GetMaxStrWidth(field.ToString()), columnWidths[colIdx])
 		}
 	})
 	return columnWidths


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->
We did not account for multi line values in the basic table, which led to us truncating those values too early. This should fix this, by only taking too longest line into consideration, when calculating the cell width.