### PR TITLE
feat: improve latency by not waiting for RUNNING/COMPLETED status

### DIFF
--- a/pkg/flink/internal/store/store.go
+++ b/pkg/flink/internal/store/store.go
@@ -226,7 +226,7 @@ func (s *Store) waitForPendingStatement(ctx context.Context, statementName strin
 				return nil, types.NewStatementErrorFailureMsg(err, statusDetail)
 			}
 
-			// TODO: HACK TO IMPROVE LATENCY
+			// TODO: remove this if backend fixes latency problem/the RUNNING state is set with the ResultsSchema
 			if statementObj.Status.ResultSchema != nil {
 				processedStatement := types.NewProcessedStatement(statementObj)
 				// if it's a SELECT statement we manually set the status to RUNNING, otherwise COMPLETED

--- a/pkg/flink/internal/store/store.go
+++ b/pkg/flink/internal/store/store.go
@@ -226,6 +226,18 @@ func (s *Store) waitForPendingStatement(ctx context.Context, statementName strin
 				return nil, types.NewStatementErrorFailureMsg(err, statusDetail)
 			}
 
+			// TODO: HACK TO IMPROVE LATENCY
+			if statementObj.Status.ResultSchema != nil {
+				processedStatement := types.NewProcessedStatement(statementObj)
+				// if it's a SELECT statement we manually set the status to RUNNING, otherwise COMPLETED
+				processedStatement.Status = types.COMPLETED
+				if processedStatement.IsSelectStatement {
+					processedStatement.Status = types.RUNNING
+				}
+				processedStatement.StatusDetail = statusDetail
+				return processedStatement, nil
+			}
+
 			phase = types.PHASE(statementObj.Status.GetPhase())
 			if phase != types.PENDING {
 				processedStatement := types.NewProcessedStatement(statementObj)


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->
It seems like the Result schema is returned quite a bit earlier than the statement status is changed to RUNNING/COMPLETED. This hack makes use of that and just manually sets the status to RUNNING (for select statements) or COMPLETED (for all other statements) and returns early from the WaitForPendingStatement loop.
This improves the latency quite a bit (about 4 seconds for SELECT 1 on prod).

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
<!--
Has it been tested? How?
Copy and paste any instructions or steps that can save the reviewer time.
-->

Open Questions / Follow-ups
---------------------------
<!--
Optional: Anything open to discussion for the reviewer, out of scope of this PR, or follow-ups.
-->
