### PR TITLE
removed op flag that is always enabled by default

### DIFF
--- a/internal/flink/command.go
+++ b/internal/flink/command.go
@@ -21,7 +21,7 @@ func New(cfg *config.Config, prerunner pcmd.PreRunner) *cobra.Command {
 
 	c := &command{pcmd.NewAuthenticatedCLICommand(cmd, prerunner)}
 
-	cmd.AddCommand(c.newComputePoolCommand(cfg))
+	cmd.AddCommand(c.newComputePoolCommand())
 	cmd.AddCommand(c.newRegionCommand())
 	cmd.AddCommand(c.newShellCommand(cfg, prerunner))
 	cmd.AddCommand(c.newStatementCommand())

--- a/internal/flink/command_compute_pool.go
+++ b/internal/flink/command_compute_pool.go
@@ -6,9 +6,6 @@ import (
 	"github.com/spf13/cobra"
 
 	pcmd "github.com/confluentinc/cli/v3/pkg/cmd"
-	"github.com/confluentinc/cli/v3/pkg/config"
-	dynamicconfig "github.com/confluentinc/cli/v3/pkg/dynamic-config"
-	"github.com/confluentinc/cli/v3/pkg/featureflags"
 )
 
 type computePoolOut struct {
@@ -21,23 +18,18 @@ type computePoolOut struct {
 	Status     string `human:"Status" serialized:"status"`
 }
 
-func (c *command) newComputePoolCommand(cfg *config.Config) *cobra.Command {
+func (c *command) newComputePoolCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "compute-pool",
 		Short: "Manage Flink compute pools.",
 	}
 
+	cmd.AddCommand(c.newComputePoolCreateCommand())
+	cmd.AddCommand(c.newComputePoolDeleteCommand())
 	cmd.AddCommand(c.newComputePoolDescribeCommand())
 	cmd.AddCommand(c.newComputePoolListCommand())
 	cmd.AddCommand(c.newComputePoolUpdateCommand())
 	cmd.AddCommand(c.newComputePoolUseCommand())
-
-	dc := dynamicconfig.New(cfg, nil)
-	_ = dc.ParseFlagsIntoConfig(cmd)
-	if cfg.IsTest || featureflags.Manager.BoolVariation("cli.flink.open_preview", dc.Context(), config.CliLaunchDarklyClient, true, false) {
-		cmd.AddCommand(c.newComputePoolCreateCommand())
-		cmd.AddCommand(c.newComputePoolDeleteCommand())
-	}
 
 	return cmd
 }

--- a/internal/iam/command_rbac_role_binding.go
+++ b/internal/iam/command_rbac_role_binding.go
@@ -14,9 +14,7 @@ import (
 
 	pcmd "github.com/confluentinc/cli/v3/pkg/cmd"
 	"github.com/confluentinc/cli/v3/pkg/config"
-	dynamicconfig "github.com/confluentinc/cli/v3/pkg/dynamic-config"
 	"github.com/confluentinc/cli/v3/pkg/errors"
-	"github.com/confluentinc/cli/v3/pkg/featureflags"
 	"github.com/confluentinc/cli/v3/pkg/output"
 	presource "github.com/confluentinc/cli/v3/pkg/resource"
 	"github.com/confluentinc/cli/v3/pkg/types"
@@ -166,14 +164,8 @@ func addClusterFlags(cmd *cobra.Command, cfg *config.Config, cliCommand *pcmd.CL
 	if cfg.IsCloudLogin() {
 		cmd.Flags().String("environment", "", "Environment ID for scope of role-binding operation.")
 		cmd.Flags().Bool("current-environment", false, "Use current environment ID for scope.")
-
-		dc := dynamicconfig.New(cfg, nil)
-		_ = dc.ParseFlagsIntoConfig(cmd)
-		if cfg.IsTest || featureflags.Manager.BoolVariation("cli.flink.open_preview", dc.Context(), config.CliLaunchDarklyClient, true, false) {
-			cmd.Flags().String("flink-region", "", "Flink region ID for the role binding.")
-		}
-
 		cmd.Flags().String("cloud-cluster", "", "Cloud cluster ID for the role binding.")
+		cmd.Flags().String("flink-region", "", "Flink region ID for the role binding.")
 		cmd.Flags().String("kafka-cluster", "", "Kafka cluster ID for the role binding.")
 		cmd.Flags().String("schema-registry-cluster", "", "Schema Registry cluster ID for the role binding.")
 		cmd.Flags().String("ksql-cluster", "", "ksqlDB cluster name for the role binding.")

--- a/internal/iam/command_rbac_role_binding_create.go
+++ b/internal/iam/command_rbac_role_binding_create.go
@@ -7,10 +7,8 @@ import (
 	"github.com/spf13/cobra"
 
 	pcmd "github.com/confluentinc/cli/v3/pkg/cmd"
-	"github.com/confluentinc/cli/v3/pkg/config"
 	"github.com/confluentinc/cli/v3/pkg/errors"
 	"github.com/confluentinc/cli/v3/pkg/examples"
-	"github.com/confluentinc/cli/v3/pkg/featureflags"
 )
 
 func (c *roleBindingCommand) newCreateCommand() *cobra.Command {
@@ -53,19 +51,15 @@ func (c *roleBindingCommand) newCreateCommand() *cobra.Command {
 				Text: `Grant the "ResourceOwner" role to principal "User:u-123456" and subject "test" in schema context "schema_context" for Schema Registry "lsrc-123456" in the environment "env-12345":`,
 				Code: `confluent iam rbac role-binding create --principal User:u-123456 --role ResourceOwner --environment env-12345 --schema-registry-cluster lsrc-123456 --resource "Subject::.schema_context:test"`,
 			},
+			examples.Example{
+				Text: `Grant the "FlinkDeveloper" role to principal "User:u-123456" in environment "env-12345":`,
+				Code: "confluent iam rbac role-binding create --principal User:u-123456 --role FlinkDeveloper --environment env-12345",
+			},
+			examples.Example{
+				Text: `Grant the "FlinkDeveloper" role to principal "User:u-123456" in environment "env-12345" for compute pool "lfcp-123456" in Flink region "us-east-2":`,
+				Code: "confluent iam rbac role-binding create --principal User:u-123456 --role FlinkDeveloper --environment env-12345 --flink-region aws.us-east-2 --resource ComputePool:lfcp-123456",
+			},
 		)
-		if c.cfg.IsTest || featureflags.Manager.BoolVariation("cli.flink.open_preview", c.Context, config.CliLaunchDarklyClient, true, false) {
-			exs = append(exs,
-				examples.Example{
-					Text: `Grant the role "FlinkDeveloper" to the principal "User:u-123456", in the environment "env-12345":`,
-					Code: "confluent iam rbac role-binding create --principal User:u-123456 --role FlinkDeveloper --environment env-12345",
-				},
-				examples.Example{
-					Text: `Grant the role "FlinkDeveloper" to the principal "User:u-123456", in the environment "env-12345" for the compute pool "lfcp-123456" in the Flink region "us-east-2":`,
-					Code: "confluent iam rbac role-binding create --principal User:u-123456 --role FlinkDeveloper --environment env-12345 --flink-region aws.us-east-2 --resource ComputePool:lfcp-123456",
-				},
-			)
-		}
 	} else {
 		exs = append(exs,
 			examples.Example{

--- a/test/fixtures/output/iam/rbac/role-binding/create-help.golden
+++ b/test/fixtures/output/iam/rbac/role-binding/create-help.golden
@@ -32,11 +32,11 @@ Grant the "ResourceOwner" role to principal "User:u-123456" and subject "test" i
 
   $ confluent iam rbac role-binding create --principal User:u-123456 --role ResourceOwner --environment env-12345 --schema-registry-cluster lsrc-123456 --resource "Subject::.schema_context:test"
 
-Grant the role "FlinkDeveloper" to the principal "User:u-123456", in the environment "env-12345":
+Grant the "FlinkDeveloper" role to principal "User:u-123456" in environment "env-12345":
 
   $ confluent iam rbac role-binding create --principal User:u-123456 --role FlinkDeveloper --environment env-12345
 
-Grant the role "FlinkDeveloper" to the principal "User:u-123456", in the environment "env-12345" for the compute pool "lfcp-123456" in the Flink region "us-east-2":
+Grant the "FlinkDeveloper" role to principal "User:u-123456" in environment "env-12345" for compute pool "lfcp-123456" in Flink region "us-east-2":
 
   $ confluent iam rbac role-binding create --principal User:u-123456 --role FlinkDeveloper --environment env-12345 --flink-region aws.us-east-2 --resource ComputePool:lfcp-123456
 
@@ -45,8 +45,8 @@ Flags:
       --principal string                 REQUIRED: Qualified principal name for the role binding.
       --environment string               Environment ID for scope of role-binding operation.
       --current-environment              Use current environment ID for scope.
-      --flink-region string              Flink region ID for the role binding.
       --cloud-cluster string             Cloud cluster ID for the role binding.
+      --flink-region string              Flink region ID for the role binding.
       --kafka-cluster string             Kafka cluster ID for the role binding.
       --schema-registry-cluster string   Schema Registry cluster ID for the role binding.
       --ksql-cluster string              ksqlDB cluster name for the role binding.

--- a/test/fixtures/output/iam/rbac/role-binding/delete-help.golden
+++ b/test/fixtures/output/iam/rbac/role-binding/delete-help.golden
@@ -14,8 +14,8 @@ Flags:
       --force                            Skip the deletion confirmation prompt.
       --environment string               Environment ID for scope of role-binding operation.
       --current-environment              Use current environment ID for scope.
-      --flink-region string              Flink region ID for the role binding.
       --cloud-cluster string             Cloud cluster ID for the role binding.
+      --flink-region string              Flink region ID for the role binding.
       --kafka-cluster string             Kafka cluster ID for the role binding.
       --schema-registry-cluster string   Schema Registry cluster ID for the role binding.
       --ksql-cluster string              ksqlDB cluster name for the role binding.

--- a/test/fixtures/output/iam/rbac/role-binding/delete-missing-role-cloud.golden
+++ b/test/fixtures/output/iam/rbac/role-binding/delete-missing-role-cloud.golden
@@ -13,8 +13,8 @@ Flags:
       --force                            Skip the deletion confirmation prompt.
       --environment string               Environment ID for scope of role-binding operation.
       --current-environment              Use current environment ID for scope.
-      --flink-region string              Flink region ID for the role binding.
       --cloud-cluster string             Cloud cluster ID for the role binding.
+      --flink-region string              Flink region ID for the role binding.
       --kafka-cluster string             Kafka cluster ID for the role binding.
       --schema-registry-cluster string   Schema Registry cluster ID for the role binding.
       --ksql-cluster string              ksqlDB cluster name for the role binding.


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- PLACEHOLDER

New Features
- PLACEHOLDER

Bug Fixes
- PLACEHOLDER

Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok
   * no: DO NOT MERGE until the required features are live in prod  

What
----
Flink op flag is always enabled in prod, we should remove it
References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
<!--
Has it been tested? How?
Copy and paste any instructions or steps that can save the reviewer time.
-->

Open Questions / Follow-ups
---------------------------
<!--
Optional: Anything open to discussion for the reviewer, out of scope of this PR, or follow-ups.
-->
