### PR TITLE
Add `flink statement create --wait`

### DIFF
--- a/test/fixtures/output/flink/statement/create-help.golden
+++ b/test/fixtures/output/flink/statement/create-help.golden
@@ -17,6 +17,7 @@ Flags:
       --compute-pool string      Flink compute pool ID.
       --service-account string   Service account ID.
       --database string          The database which will be used as the default database. When using Kafka, this is the cluster name.
+      --wait                     Block until the statement is running or has failed.
       --environment string       Environment ID.
       --context string           CLI context name.
   -o, --output string            Specify the output format as "human", "json", or "yaml". (default "human")

--- a/test/fixtures/output/flink/statement/create-no-name-yaml.golden
+++ b/test/fixtures/output/flink/statement/create-no-name-yaml.golden
@@ -1,5 +1,0 @@
-creation_date: 2023-01-01T00:00:00Z
-name: [0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}
-statement: INSERT \* INTO table;
-compute_pool: lfcp-123456
-status: PENDING

--- a/test/fixtures/output/flink/statement/create-no-name-yaml.golden
+++ b/test/fixtures/output/flink/statement/create-no-name-yaml.golden
@@ -1,0 +1,5 @@
+creation_date: 2023-01-01T00:00:00Z
+name: [0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}
+statement: INSERT \* INTO table;
+compute_pool: lfcp-123456
+status: PENDING

--- a/test/fixtures/output/flink/statement/create-wait.golden
+++ b/test/fixtures/output/flink/statement/create-wait.golden
@@ -1,0 +1,8 @@
++---------------+-------------------------------+
+| Creation Date | 2022-01-01 00:00:00 +0000 UTC |
+| Name          | my-statement                  |
+| Statement     | CREATE TABLE test;            |
+| Compute Pool  | pool-123456                   |
+| Status        | COMPLETED                     |
+| Status Detail | SQL statement is completed    |
++---------------+-------------------------------+

--- a/test/flink_test.go
+++ b/test/flink_test.go
@@ -62,9 +62,6 @@ func (s *CLITestSuite) TestFlinkRegion() {
 
 func (s *CLITestSuite) TestFlinkStatement() {
 	tests := []CLITest{
-		{args: `flink statement create my-statement --sql "INSERT * INTO table;" --compute-pool lfcp-123456 --service-account sa-123456`, fixture: "flink/statement/create.golden"},
-		{args: `flink statement create my-statement --sql "INSERT * INTO table;" --compute-pool lfcp-123456`, fixture: "flink/statement/create-service-account-warning.golden"},
-		{args: `flink statement create --sql "INSERT * INTO table;" --compute-pool lfcp-123456 --service-account sa-123456 -o yaml`, fixture: "flink/statement/create-no-name-yaml.golden", regex: true},
 		{args: "flink statement delete my-statement --force --cloud aws --region eu-west-1", fixture: "flink/statement/delete.golden"},
 		{args: "flink statement list --cloud aws --region eu-west-1", fixture: "flink/statement/list.golden"},
 		{args: "flink statement list --cloud aws --region eu-west-1 -o yaml", fixture: "flink/statement/list-yaml.golden"},
@@ -73,6 +70,21 @@ func (s *CLITestSuite) TestFlinkStatement() {
 		{args: "flink statement stop my-statement --region eu-west-1 --cloud aws", fixture: "flink/statement/stop.golden"},
 		{args: "flink statement exception list my-statement --cloud aws --region eu-west-1", fixture: "flink/statement/exception/list.golden"},
 		{args: "flink statement exception list my-statement --cloud aws --region eu-west-1 -o yaml", fixture: "flink/statement/exception/list-yaml.golden"},
+	}
+
+	for _, test := range tests {
+		test.login = "cloud"
+		s.runIntegrationTest(test)
+	}
+}
+
+func (s *CLITestSuite) TestFlinkStatementCreate() {
+	tests := []CLITest{
+		{args: `flink statement create my-statement --sql "INSERT * INTO table;" --compute-pool lfcp-123456 --service-account sa-123456`, fixture: "flink/statement/create.golden"},
+		{args: `flink statement create my-statement --sql "INSERT * INTO table;" --compute-pool lfcp-123456 --service-account sa-123456 -o yaml`, fixture: "flink/statement/create-yaml.golden", regex: true},
+		{args: `flink statement create my-statement --sql "INSERT * INTO table;" --compute-pool lfcp-123456`, fixture: "flink/statement/create-service-account-warning.golden"},
+		{args: `flink statement create --sql "INSERT * INTO table;" --compute-pool lfcp-123456 --service-account sa-123456`, fixture: "flink/statement/create-no-name.golden", regex: true},
+		{args: `flink statement create my-statement --sql "INSERT * INTO table;" --compute-pool lfcp-123456 --service-account sa-123456 --wait`, fixture: "flink/statement/create-wait.golden"},
 	}
 
 	for _, test := range tests {

--- a/test/flink_test.go
+++ b/test/flink_test.go
@@ -81,9 +81,8 @@ func (s *CLITestSuite) TestFlinkStatement() {
 func (s *CLITestSuite) TestFlinkStatementCreate() {
 	tests := []CLITest{
 		{args: `flink statement create my-statement --sql "INSERT * INTO table;" --compute-pool lfcp-123456 --service-account sa-123456`, fixture: "flink/statement/create.golden"},
-		{args: `flink statement create my-statement --sql "INSERT * INTO table;" --compute-pool lfcp-123456 --service-account sa-123456 -o yaml`, fixture: "flink/statement/create-yaml.golden", regex: true},
+		{args: `flink statement create my-statement --sql "INSERT * INTO table;" --compute-pool lfcp-123456 --service-account sa-123456 -o yaml`, fixture: "flink/statement/create-no-name-yaml.golden", regex: true},
 		{args: `flink statement create my-statement --sql "INSERT * INTO table;" --compute-pool lfcp-123456`, fixture: "flink/statement/create-service-account-warning.golden"},
-		{args: `flink statement create --sql "INSERT * INTO table;" --compute-pool lfcp-123456 --service-account sa-123456`, fixture: "flink/statement/create-no-name.golden", regex: true},
 		{args: `flink statement create my-statement --sql "INSERT * INTO table;" --compute-pool lfcp-123456 --service-account sa-123456 --wait`, fixture: "flink/statement/create-wait.golden"},
 	}
 

--- a/test/flink_test.go
+++ b/test/flink_test.go
@@ -81,9 +81,9 @@ func (s *CLITestSuite) TestFlinkStatement() {
 func (s *CLITestSuite) TestFlinkStatementCreate() {
 	tests := []CLITest{
 		{args: `flink statement create my-statement --sql "INSERT * INTO table;" --compute-pool lfcp-123456 --service-account sa-123456`, fixture: "flink/statement/create.golden"},
-		{args: `flink statement create my-statement --sql "INSERT * INTO table;" --compute-pool lfcp-123456 --service-account sa-123456 -o yaml`, fixture: "flink/statement/create-no-name-yaml.golden", regex: true},
 		{args: `flink statement create my-statement --sql "INSERT * INTO table;" --compute-pool lfcp-123456`, fixture: "flink/statement/create-service-account-warning.golden"},
 		{args: `flink statement create my-statement --sql "INSERT * INTO table;" --compute-pool lfcp-123456 --service-account sa-123456 --wait`, fixture: "flink/statement/create-wait.golden"},
+		{args: `flink statement create --sql "INSERT * INTO table;" --compute-pool lfcp-123456 --service-account sa-123456 -o yaml`, fixture: "flink/statement/create-no-name-yaml.golden", regex: true},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
Add `--wait` flag to `confluent flink statement create` that blocks until the statement status is no longer "PENDING"

```
% confluent flink statement create --compute-pool lfcp-9w8jwy --sql "SELECT CURRENT_TIMESTAMP;" --wait
[WARN] No service account provided. To ensure that your statements run continuously, use a service account instead of your user identity with `confluent iam service-account use` or `--service-account`. Otherwise, statements will stop running after 4 hours.
+---------------+--------------------------------------+
| Creation Date | 2023-09-27 21:28:18 +0000 UTC        |
| Name          | f08be65a-4800-4ea8-b74d-a467c94e12c3 |
| Statement     | SELECT CURRENT_TIMESTAMP;            |
| Compute Pool  | lfcp-9w8jwy                          |
| Status        | RUNNING                              |
+---------------+--------------------------------------+
```

References
----------
https://docs.google.com/document/d/1dZ5pmVdvTYykJqJX2tAk_elxCITRuAt90x5tXSd8RDA/edit

Test & Review
-------------
Integration test and manual testing