### PR TITLE
Remove single-use global string constants

### DIFF
--- a/internal/api-key/command_create.go
+++ b/internal/api-key/command_create.go
@@ -155,7 +155,7 @@ func (c *command) create(cmd *cobra.Command, _ []string) error {
 		if err := c.Context.UseAPIKey(userKey.Key, clusterId); err != nil {
 			return errors.NewWrapErrorWithSuggestions(err, errors.APIKeyUseFailedErrorMsg, fmt.Sprintf(errors.APIKeyUseFailedSuggestions, userKey.Key))
 		}
-		output.Printf(errors.UseAPIKeyMsg, userKey.Key)
+		output.Printf(useAPIKeyMsg, userKey.Key)
 	}
 
 	return nil

--- a/internal/api-key/command_store.go
+++ b/internal/api-key/command_store.go
@@ -128,6 +128,6 @@ func (c *command) store(cmd *cobra.Command, args []string) error {
 	if err := c.keystore.StoreAPIKey(&config.APIKeyPair{Key: key, Secret: secret}, cluster.ID); err != nil {
 		return errors.Wrap(err, errors.UnableToStoreAPIKeyErrorMsg)
 	}
-	output.ErrPrintf(errors.StoredAPIKeyMsg, key)
+	output.ErrPrintf("Stored API secret for API key \"%s\".\n", key)
 	return nil
 }

--- a/internal/api-key/command_use.go
+++ b/internal/api-key/command_use.go
@@ -11,6 +11,8 @@ import (
 	"github.com/confluentinc/cli/v3/pkg/resource"
 )
 
+const useAPIKeyMsg = "Using API Key \"%s\".\n"
+
 func (c *command) newUseCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "use <api-key>",
@@ -53,6 +55,6 @@ func (c *command) use(cmd *cobra.Command, args []string) error {
 		return errors.NewWrapErrorWithSuggestions(err, errors.APIKeyUseFailedErrorMsg, fmt.Sprintf(errors.APIKeyUseFailedSuggestions, args[0]))
 	}
 
-	output.Printf(errors.UseAPIKeyMsg, args[0])
+	output.Printf(useAPIKeyMsg, args[0])
 	return nil
 }

--- a/internal/asyncapi/command_export.go
+++ b/internal/asyncapi/command_export.go
@@ -117,7 +117,7 @@ func (c *command) export(cmd *cobra.Command, _ []string) error {
 	messages := make(map[string]spec.Message)
 	var schemaContextPrefix string
 	if flags.schemaContext != "default" {
-		log.CliLogger.Debugf("Using schema context \"%s\"\n", flags.schemaContext)
+		log.CliLogger.Debugf(`Using schema context "%s"`, flags.schemaContext)
 		schemaContextPrefix = fmt.Sprintf(":.%s:", flags.schemaContext)
 	}
 	channelCount := 0

--- a/internal/byok/command_create.go
+++ b/internal/byok/command_create.go
@@ -188,9 +188,9 @@ func renderAzureEncryptionPolicy(key *byokv1.ByokV1Key) (string, error) {
 func getPostCreateStepInstruction(key *byokv1.ByokV1Key) string {
 	switch {
 	case key.Key.ByokV1AwsKey != nil:
-		return errors.CopyByokAwsPermissionsHeaderMsg
+		return `Copy and append these permissions into the key policy "Statements" field of the ARN in your AWS key management system to authorize access for your Confluent Cloud cluster.`
 	case key.Key.ByokV1AzureKey != nil:
-		return errors.RunByokAzurePermissionsHeaderMsg
+		return "To ensure the key vault has the correct role assignments, please run the following azure-cli command (certified for azure-cli v2.45):"
 	default:
 		return ""
 	}

--- a/internal/cluster/command_unregister.go
+++ b/internal/cluster/command_unregister.go
@@ -63,6 +63,6 @@ func (c *unregisterCommand) unregister(cmd *cobra.Command, _ []string) error {
 		return cluster.HandleClusterError(err, httpResp)
 	}
 
-	output.Printf(errors.UnregisteredClusterMsg, clusterName)
+	output.Printf("Successfully unregistered cluster \"%s\" from the Cluster Registry.\n", clusterName)
 	return nil
 }

--- a/internal/connect/command_cluster_pause.go
+++ b/internal/connect/command_cluster_pause.go
@@ -65,7 +65,7 @@ func (c *clusterCommand) pause(cmd *cobra.Command, args []string) error {
 			return err
 		}
 
-		output.Printf(errors.PausedConnectorMsg, id)
+		output.Printf("Paused connector \"%s\".\n", id)
 	}
 
 	return nil

--- a/internal/connect/command_cluster_resume.go
+++ b/internal/connect/command_cluster_resume.go
@@ -65,7 +65,7 @@ func (c *clusterCommand) resume(_ *cobra.Command, args []string) error {
 			return err
 		}
 
-		output.Printf("Paused connector \"%s\".\n", id)
+		output.Printf("Resumed connector \"%s\".\n", id)
 	}
 
 	return nil

--- a/internal/connect/command_cluster_resume.go
+++ b/internal/connect/command_cluster_resume.go
@@ -65,7 +65,7 @@ func (c *clusterCommand) resume(_ *cobra.Command, args []string) error {
 			return err
 		}
 
-		output.Printf(errors.ResumedConnectorMsg, id)
+		output.Printf("Paused connector \"%s\".\n", id)
 	}
 
 	return nil

--- a/internal/kafka/command_cluster_describe.go
+++ b/internal/kafka/command_cluster_describe.go
@@ -103,7 +103,7 @@ func (c *clusterCommand) outputKafkaClusterDescription(cmd *cobra.Command, clust
 		topicCount, err := c.getTopicCountForKafkaCluster(cluster)
 		// topicCount is 0 when err != nil, and will be omitted by `omitempty`
 		if err != nil {
-			log.CliLogger.Infof(errors.OmitTopicCountMsg, err)
+			log.CliLogger.Infof("The topic count will be omitted as Kafka topics for this cluster could not be retrieved: %v", err)
 		}
 		out.TopicCount = topicCount
 	}

--- a/internal/kafka/command_cluster_use.go
+++ b/internal/kafka/command_cluster_use.go
@@ -41,6 +41,6 @@ func (c *clusterCommand) use(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	output.ErrPrintf(errors.UseKafkaClusterMsg, clusterID, c.Context.GetCurrentEnvironment())
+	output.ErrPrintf("Set Kafka cluster \"%s\" as the active cluster for environment \"%s\".\n", clusterID, c.Context.GetCurrentEnvironment())
 	return nil
 }

--- a/internal/kafka/command_link.go
+++ b/internal/kafka/command_link.go
@@ -12,6 +12,8 @@ const (
 	dryrunFlagName     = "dry-run"
 )
 
+const createdLinkResourceMsg = "Created %s \"%s\" with configs:\n%s\n"
+
 type linkCommand struct {
 	*pcmd.AuthenticatedCLICommand
 }

--- a/internal/kafka/command_link.go
+++ b/internal/kafka/command_link.go
@@ -12,7 +12,7 @@ const (
 	dryrunFlagName     = "dry-run"
 )
 
-const createdLinkResourceMsg = "Created %s \"%s\" with configs:\n%s\n"
+const createdLinkResourceMsg = `Created %s "%s" with configs:`
 
 type linkCommand struct {
 	*pcmd.AuthenticatedCLICommand

--- a/internal/kafka/command_link_create.go
+++ b/internal/kafka/command_link_create.go
@@ -196,11 +196,13 @@ func (c *linkCommand) create(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	msg := fmt.Sprintf(createdLinkResourceMsg, resource.ClusterLink, linkName, linkConfigsCommandOutput(configMap))
+	msg := fmt.Sprintf(createdLinkResourceMsg, resource.ClusterLink, linkName)
 	if dryRun {
 		msg = utils.AddDryRunPrefix(msg)
 	}
-	output.Print(msg)
+
+	output.Println(msg)
+	output.Println(linkConfigsCommandOutput(configMap))
 
 	return nil
 }

--- a/internal/kafka/command_link_create.go
+++ b/internal/kafka/command_link_create.go
@@ -196,7 +196,7 @@ func (c *linkCommand) create(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	msg := fmt.Sprintf(errors.CreatedLinkResourceMsg, resource.ClusterLink, linkName, linkConfigsCommandOutput(configMap))
+	msg := fmt.Sprintf(createdLinkResourceMsg, resource.ClusterLink, linkName, linkConfigsCommandOutput(configMap))
 	if dryRun {
 		msg = utils.AddDryRunPrefix(msg)
 	}

--- a/internal/kafka/command_link_create_onprem.go
+++ b/internal/kafka/command_link_create_onprem.go
@@ -138,11 +138,13 @@ func (c *linkCommand) createOnPrem(cmd *cobra.Command, args []string) error {
 		return handleOpenApiError(httpResp, err, client)
 	}
 
-	msg := fmt.Sprintf(createdLinkResourceMsg, resource.ClusterLink, linkName, linkConfigsCommandOutput(configMap))
+	msg := fmt.Sprintf(createdLinkResourceMsg, resource.ClusterLink, linkName)
 	if dryRun {
 		msg = utils.AddDryRunPrefix(msg)
 	}
-	output.Print(msg)
+
+	output.Println(msg)
+	output.Println(linkConfigsCommandOutput(configMap))
 
 	return nil
 }

--- a/internal/kafka/command_link_create_onprem.go
+++ b/internal/kafka/command_link_create_onprem.go
@@ -138,7 +138,7 @@ func (c *linkCommand) createOnPrem(cmd *cobra.Command, args []string) error {
 		return handleOpenApiError(httpResp, err, client)
 	}
 
-	msg := fmt.Sprintf(errors.CreatedLinkResourceMsg, resource.ClusterLink, linkName, linkConfigsCommandOutput(configMap))
+	msg := fmt.Sprintf(createdLinkResourceMsg, resource.ClusterLink, linkName, linkConfigsCommandOutput(configMap))
 	if dryRun {
 		msg = utils.AddDryRunPrefix(msg)
 	}

--- a/internal/kafka/command_topic.go
+++ b/internal/kafka/command_topic.go
@@ -172,11 +172,11 @@ func addApiKeyToCluster(cmd *cobra.Command, cluster *config.KafkaClusterConfig) 
 }
 
 func ProduceToTopic(cmd *cobra.Command, keyMetaInfo []byte, valueMetaInfo []byte, topic string, keySerializer serdes.SerializationProvider, valueSerializer serdes.SerializationProvider, producer *ckafka.Producer) error {
+	keys := "Ctrl-C or Ctrl-D"
 	if runtime.GOOS == "windows" {
-		output.ErrPrintf(errors.StartingProducerMsg, "Ctrl-C")
-	} else {
-		output.ErrPrintf(errors.StartingProducerMsg, "Ctrl-C or Ctrl-D")
+		keys = "Ctrl-C"
 	}
+	output.ErrPrintf("Starting Kafka Producer. Use %s to exit.\n", keys)
 
 	var scanErr error
 	input, scan := PrepareInputChannel(&scanErr)

--- a/internal/kafka/command_topic_update.go
+++ b/internal/kafka/command_topic_update.go
@@ -148,7 +148,7 @@ func (c *command) update(cmd *cobra.Command, args []string) error {
 			ReadOnly: readOnlyConfigs[config.Name],
 		})
 		if readOnlyConfigs[config.Name] {
-			readOnlyConfigNotUpdatedString = fmt.Sprintf(" %s", errors.ReadOnlyConfigNotUpdatedMsg)
+			readOnlyConfigNotUpdatedString = " (read-only configs were not updated)"
 		}
 	}
 

--- a/internal/kafka/command_topic_update_onprem.go
+++ b/internal/kafka/command_topic_update_onprem.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/confluentinc/cli/v3/pkg/broker"
 	pcmd "github.com/confluentinc/cli/v3/pkg/cmd"
-	"github.com/confluentinc/cli/v3/pkg/errors"
 	"github.com/confluentinc/cli/v3/pkg/examples"
 	"github.com/confluentinc/cli/v3/pkg/kafkarest"
 	"github.com/confluentinc/cli/v3/pkg/output"
@@ -90,7 +89,7 @@ func UpdateTopic(cmd *cobra.Command, restClient *kafkarestv3.APIClient, restCont
 		return output.SerializedOutput(cmd, data)
 	}
 
-	output.Printf(errors.UpdateTopicConfigMsg, topicName)
+	output.Printf("Updated the following configuration values for topic \"%s\":\n", topicName)
 
 	list := output.NewList(cmd)
 	for _, config := range data {

--- a/internal/kafka/confluent_kafka.go
+++ b/internal/kafka/confluent_kafka.go
@@ -267,7 +267,7 @@ func RunConsumer(consumer *ckafka.Consumer, groupHandler *GroupHandler) error {
 	for run {
 		select {
 		case <-signals: // Trap SIGINT to trigger a shutdown.
-			output.ErrPrintln(errors.StoppingConsumerMsg)
+			output.ErrPrintln("Stopping Consumer.")
 			if _, err := consumer.Commit(); err != nil {
 				log.CliLogger.Warnf("Failed to commit current consumer offset: %v", err)
 			}

--- a/internal/ksql/command_cluster_configureacls.go
+++ b/internal/ksql/command_cluster_configureacls.go
@@ -60,7 +60,8 @@ func (c *ksqlCommand) configureACLs(cmd *cobra.Command, args []string) error {
 	}
 
 	if ksqlCluster.Spec.KafkaCluster.GetId() != kafkaCluster.ID {
-		output.ErrPrintf(errors.KsqlDBNotBackedByKafkaMsg, args[0], ksqlCluster.Spec.KafkaCluster.GetId(), kafkaCluster.ID, ksqlCluster.Spec.KafkaCluster.GetId())
+		output.ErrPrintf("The ksqlDB cluster \"%s\" is backed by \"%s\" which is not the current Kafka cluster \"%s\".\n", args[0], ksqlCluster.Spec.KafkaCluster.GetId(), kafkaCluster.ID)
+		output.ErrPrintf("To switch to the correct cluster, use `confluent kafka cluster use %s`.\n", ksqlCluster.Spec.KafkaCluster.GetId())
 	}
 
 	credentialIdentity := ksqlCluster.Spec.CredentialIdentity.GetId()

--- a/internal/ksql/command_cluster_create.go
+++ b/internal/ksql/command_cluster_create.go
@@ -82,7 +82,7 @@ func (c *ksqlCommand) create(cmd *cobra.Command, args []string) error {
 	}
 	ticker.Stop()
 	if endpoint == "" {
-		output.ErrPrintln(errors.EndPointNotPopulatedMsg)
+		output.ErrPrintln("Endpoint not yet populated. To obtain the endpoint, use `confluent ksql cluster describe`.")
 	}
 
 	srCluster, _ := c.Context.FetchSchemaRegistryByEnvironmentId(environmentId)

--- a/internal/local/command_destroy.go
+++ b/internal/local/command_destroy.go
@@ -42,7 +42,7 @@ func (c *command) runDestroyCommand(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	output.Printf(errors.DestroyDeletingMsg, dir)
+	output.Printf("Deleting: %s\n", dir)
 	if err := c.cc.RemoveCurrentDir(); err != nil {
 		return err
 	}

--- a/internal/local/command_service.go
+++ b/internal/local/command_service.go
@@ -272,7 +272,7 @@ func (c *command) startService(service, configFile string) error {
 		return err
 	}
 
-	output.Printf(errors.StartingServiceMsg, writeServiceName(service))
+	output.Printf("Starting %s\n", writeServiceName(service))
 
 	spin := spinner.New()
 	spin.Start()
@@ -443,7 +443,7 @@ func (c *command) stopService(service string) error {
 		return c.printStatus(service)
 	}
 
-	output.Printf(errors.StoppingServiceMsg, writeServiceName(service))
+	output.Printf("Stopping %s\n", writeServiceName(service))
 
 	spin := spinner.New()
 	spin.Start()
@@ -563,7 +563,7 @@ func (c *command) printStatus(service string) error {
 		status = color.GreenString("UP")
 	}
 
-	output.Printf(errors.ServiceStatusMsg, writeServiceName(service), status)
+	output.Printf("%s is [%s]\n", writeServiceName(service), status)
 	return nil
 }
 

--- a/internal/local/command_service_connect.go
+++ b/internal/local/command_service_connect.go
@@ -345,7 +345,8 @@ func (c *command) runConnectPluginListCommand(_ *cobra.Command, _ []string) erro
 		return err
 	}
 
-	output.Printf(errors.AvailableConnectPluginsMsg, out)
+	output.Println("Available Connect Plugins:")
+	output.Println(out)
 	return nil
 }
 

--- a/internal/local/command_services.go
+++ b/internal/local/command_services.go
@@ -175,7 +175,8 @@ func (c *command) runServicesListCommand(_ *cobra.Command, _ []string) error {
 		serviceNames[i] = writeServiceName(service)
 	}
 
-	output.Printf(errors.AvailableServicesMsg, local.BuildTabbedList(serviceNames))
+	output.Println("Available Services:")
+	output.Println(local.BuildTabbedList(serviceNames))
 	return nil
 }
 
@@ -470,6 +471,6 @@ func (c *command) notifyConfluentCurrent() error {
 		return err
 	}
 
-	output.Printf(errors.UsingConfluentCurrentMsg, dir)
+	output.Printf("Using CONFLUENT_CURRENT: %s\n", dir)
 	return nil
 }

--- a/internal/login/command.go
+++ b/internal/login/command.go
@@ -196,7 +196,8 @@ func (c *command) printRemainingFreeCredit(client *ccloudv1.Client, currentOrg *
 
 	// only print remaining free credit if there is any unexpired promo code and there is no payment method yet
 	if remainingFreeCredit > 0 {
-		output.ErrPrintf(errors.RemainingFreeCreditMsg, admin.ConvertToUSD(remainingFreeCredit))
+		output.ErrPrintf("Free credits: $%.2f USD remaining\n", admin.ConvertToUSD(remainingFreeCredit))
+		output.ErrPrintln("You are currently using a free trial version of Confluent Cloud. Add a payment method with `confluent admin payment update` to avoid an interruption in service once your trial ends.")
 	}
 }
 

--- a/internal/logout/command.go
+++ b/internal/logout/command.go
@@ -49,7 +49,7 @@ func (c *Command) logout(cmd *cobra.Command, _ []string) error {
 	if c.Config.Config.Context() != nil {
 		username, err := c.netrcHandler.RemoveNetrcCredentials(c.cfg.IsCloudLogin(), c.Config.Config.Context().GetNetrcMachineName())
 		if err == nil {
-			log.CliLogger.Warnf("Removed credentials for user \"%s\" from netrc file \"%s\"\n", username, c.netrcHandler.GetFileName())
+			log.CliLogger.Warnf(`Removed credentials for user "%s" from netrc file "%s"`, username, c.netrcHandler.GetFileName())
 		} else if !strings.Contains(err.Error(), "login credentials not found") && !strings.Contains(err.Error(), "keyword expected") {
 			// return err when other than NetrcCredentialsNotFoundErrorMsg or parsing error
 			return err

--- a/internal/logout/command.go
+++ b/internal/logout/command.go
@@ -9,7 +9,6 @@ import (
 	pauth "github.com/confluentinc/cli/v3/pkg/auth"
 	pcmd "github.com/confluentinc/cli/v3/pkg/cmd"
 	"github.com/confluentinc/cli/v3/pkg/config"
-	"github.com/confluentinc/cli/v3/pkg/errors"
 	"github.com/confluentinc/cli/v3/pkg/log"
 	"github.com/confluentinc/cli/v3/pkg/netrc"
 	"github.com/confluentinc/cli/v3/pkg/output"
@@ -50,7 +49,7 @@ func (c *Command) logout(cmd *cobra.Command, _ []string) error {
 	if c.Config.Config.Context() != nil {
 		username, err := c.netrcHandler.RemoveNetrcCredentials(c.cfg.IsCloudLogin(), c.Config.Config.Context().GetNetrcMachineName())
 		if err == nil {
-			log.CliLogger.Warnf(errors.RemoveNetrcCredentialsMsg, username, c.netrcHandler.GetFileName())
+			log.CliLogger.Warnf("Removed credentials for user \"%s\" from netrc file \"%s\"\n", username, c.netrcHandler.GetFileName())
 		} else if !strings.Contains(err.Error(), "login credentials not found") && !strings.Contains(err.Error(), "keyword expected") {
 			// return err when other than NetrcCredentialsNotFoundErrorMsg or parsing error
 			return err
@@ -61,6 +60,6 @@ func (c *Command) logout(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	output.Println(errors.LoggedOutMsg)
+	output.Println("You are now logged out.")
 	return nil
 }

--- a/internal/schema-registry/command_exporter.go
+++ b/internal/schema-registry/command_exporter.go
@@ -10,6 +10,8 @@ import (
 	"github.com/confluentinc/cli/v3/pkg/utils"
 )
 
+const exporterActionMsg = "%s schema exporter \"%s\".\n"
+
 func (c *command) newExporterCommand(cfg *config.Config) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:         "exporter",

--- a/internal/schema-registry/command_exporter_pause.go
+++ b/internal/schema-registry/command_exporter_pause.go
@@ -5,7 +5,6 @@ import (
 
 	pcmd "github.com/confluentinc/cli/v3/pkg/cmd"
 	"github.com/confluentinc/cli/v3/pkg/config"
-	"github.com/confluentinc/cli/v3/pkg/errors"
 	"github.com/confluentinc/cli/v3/pkg/output"
 )
 
@@ -49,6 +48,6 @@ func (c *command) exporterPause(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	output.Printf(errors.ExporterActionMsg, "Paused", args[0])
+	output.Printf(exporterActionMsg, "Paused", args[0])
 	return nil
 }

--- a/internal/schema-registry/command_exporter_reset.go
+++ b/internal/schema-registry/command_exporter_reset.go
@@ -5,7 +5,6 @@ import (
 
 	pcmd "github.com/confluentinc/cli/v3/pkg/cmd"
 	"github.com/confluentinc/cli/v3/pkg/config"
-	"github.com/confluentinc/cli/v3/pkg/errors"
 	"github.com/confluentinc/cli/v3/pkg/output"
 )
 
@@ -49,6 +48,6 @@ func (c *command) exporterReset(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	output.Printf(errors.ExporterActionMsg, "Reset", args[0])
+	output.Printf(exporterActionMsg, "Reset", args[0])
 	return nil
 }

--- a/internal/schema-registry/command_exporter_resume.go
+++ b/internal/schema-registry/command_exporter_resume.go
@@ -5,7 +5,6 @@ import (
 
 	pcmd "github.com/confluentinc/cli/v3/pkg/cmd"
 	"github.com/confluentinc/cli/v3/pkg/config"
-	"github.com/confluentinc/cli/v3/pkg/errors"
 	"github.com/confluentinc/cli/v3/pkg/output"
 )
 
@@ -49,6 +48,6 @@ func (c *command) exporterResume(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	output.Printf(errors.ExporterActionMsg, "Resumed", args[0])
+	output.Printf(exporterActionMsg, "Resumed", args[0])
 	return nil
 }

--- a/internal/schema-registry/schema_utilities.go
+++ b/internal/schema-registry/schema_utilities.go
@@ -13,7 +13,6 @@ import (
 
 	srsdk "github.com/confluentinc/schema-registry-sdk-go"
 
-	"github.com/confluentinc/cli/v3/pkg/errors"
 	"github.com/confluentinc/cli/v3/pkg/output"
 	schemaregistry "github.com/confluentinc/cli/v3/pkg/schema-registry"
 	"github.com/confluentinc/cli/v3/pkg/utils"
@@ -64,7 +63,7 @@ func RegisterSchemaWithAuth(cmd *cobra.Command, schemaCfg *RegisterSchemaConfigs
 			return 0, err
 		}
 	} else {
-		output.Printf(errors.RegisteredSchemaMsg, response.Id)
+		output.Printf("Successfully registered schema with ID \"%d\".\n", response.Id)
 	}
 
 	return response.Id, nil

--- a/internal/secret/command_file_update.go
+++ b/internal/secret/command_file_update.go
@@ -3,7 +3,6 @@ package secret
 import (
 	"github.com/spf13/cobra"
 
-	"github.com/confluentinc/cli/v3/pkg/errors"
 	"github.com/confluentinc/cli/v3/pkg/output"
 )
 
@@ -49,6 +48,6 @@ func (c *command) update(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	output.ErrPrintln(errors.UpdateSecretFileMsg)
+	output.Println("Updated the encrypted secrets.")
 	return nil
 }

--- a/internal/stream-share/command_provider_invite_resend.go
+++ b/internal/stream-share/command_provider_invite_resend.go
@@ -4,7 +4,6 @@ import (
 	"github.com/spf13/cobra"
 
 	pcmd "github.com/confluentinc/cli/v3/pkg/cmd"
-	"github.com/confluentinc/cli/v3/pkg/errors"
 	"github.com/confluentinc/cli/v3/pkg/examples"
 	"github.com/confluentinc/cli/v3/pkg/output"
 )
@@ -35,6 +34,6 @@ func (c *command) resendEmailInvite(_ *cobra.Command, args []string) error {
 		return err
 	}
 
-	output.Printf(errors.ResendInviteMsg, shareId)
+	output.Printf("Sent invitation for \"%s\".\n", shareId)
 	return nil
 }

--- a/internal/stream-share/command_provider_opt_in.go
+++ b/internal/stream-share/command_provider_opt_in.go
@@ -3,7 +3,6 @@ package streamshare
 import (
 	"github.com/spf13/cobra"
 
-	"github.com/confluentinc/cli/v3/pkg/errors"
 	"github.com/confluentinc/cli/v3/pkg/output"
 )
 
@@ -20,6 +19,6 @@ func (c *command) optIn(_ *cobra.Command, _ []string) error {
 		return err
 	}
 
-	output.Println(errors.OptInMsg)
+	output.Println("Successfully opted in to Stream Sharing.")
 	return nil
 }

--- a/internal/stream-share/command_provider_opt_out.go
+++ b/internal/stream-share/command_provider_opt_out.go
@@ -3,7 +3,6 @@ package streamshare
 import (
 	"github.com/spf13/cobra"
 
-	"github.com/confluentinc/cli/v3/pkg/errors"
 	"github.com/confluentinc/cli/v3/pkg/output"
 )
 
@@ -29,6 +28,6 @@ func (c *command) optOut(_ *cobra.Command, _ []string) error {
 		return err
 	}
 
-	output.Println(errors.OptOutMsg)
+	output.Println("Successfully opted out of Stream Sharing.")
 	return nil
 }

--- a/internal/update/command.go
+++ b/internal/update/command.go
@@ -110,24 +110,24 @@ func (c *command) update(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	output.ErrPrintln(errors.CheckingForUpdatesMsg)
+	output.ErrPrintln("Checking for updates...")
 	latestMajorVersion, latestMinorVersion, err := c.client.CheckForUpdates(pversion.CLIName, c.version.Version, true)
 	if err != nil {
 		return errors.NewUpdateClientWrapError(err, errors.CheckingForUpdateErrorMsg)
 	}
 
 	if latestMajorVersion == "" && latestMinorVersion == "" {
-		output.Println(errors.UpToDateMsg)
+		output.Println("Already up to date.")
 		return nil
 	}
 
 	if latestMajorVersion != "" && latestMinorVersion == "" && !major {
-		output.Printf(errors.MajorVersionUpdateMsg, pversion.CLIName)
+		output.Printf("The only available update is a major version update. Use `%s update --major` to accept the update.\n", pversion.CLIName)
 		return nil
 	}
 
 	if latestMajorVersion == "" && major {
-		output.Print(errors.NoMajorVersionUpdateMsg)
+		output.Print("No major version updates are available.\n")
 		return nil
 	}
 

--- a/internal/update/command.go
+++ b/internal/update/command.go
@@ -122,12 +122,12 @@ func (c *command) update(cmd *cobra.Command, _ []string) error {
 	}
 
 	if latestMajorVersion != "" && latestMinorVersion == "" && !major {
-		output.Printf("The only available update is a major version update. Use `%s update --major` to accept the update.\n", pversion.CLIName)
+		output.Println("The only available update is a major version update. Use `confluent update --major` to accept the update.")
 		return nil
 	}
 
 	if latestMajorVersion == "" && major {
-		output.Print("No major version updates are available.\n")
+		output.Println("No major version updates are available.")
 		return nil
 	}
 

--- a/pkg/auth/login_credentials_manager.go
+++ b/pkg/auth/login_credentials_manager.go
@@ -2,6 +2,7 @@
 package auth
 
 import (
+	"fmt"
 	"os"
 	"runtime"
 	"slices"
@@ -21,6 +22,10 @@ import (
 	"github.com/confluentinc/cli/v3/pkg/output"
 	"github.com/confluentinc/cli/v3/pkg/secret"
 )
+
+const stopNonInteractiveMsg = "remove these credentials or use the `--prompt` flag to bypass non-interactive login"
+
+var foundCredentialsForUserFromKeychainMessage = fmt.Sprintf(`Found credentials for user "%%s" from keychain (%s).`, stopNonInteractiveMsg)
 
 type Credentials struct {
 	Username string
@@ -143,7 +148,7 @@ func (h *LoginCredentialsManagerImpl) getEnvVarCredentials(userEnvVar, passwordE
 	if password == "" {
 		return username, ""
 	}
-	log.CliLogger.Warnf(errors.FoundEnvCredMsg, username, userEnvVar, passwordEnvVar)
+	log.CliLogger.Warnf(`Found credentials for user "%s" from environment variables "%s" and "%s" (%s)`, username, userEnvVar, passwordEnvVar, stopNonInteractiveMsg)
 	return username, password
 }
 
@@ -240,7 +245,7 @@ func (h *LoginCredentialsManagerImpl) GetCredentialsFromNetrc(filterParams netrc
 			return nil, err
 		}
 
-		log.CliLogger.Debugf(errors.FoundNetrcCredMsg, netrcMachine.User, h.netrcHandler.GetFileName())
+		log.CliLogger.Debugf(foundCredentialsForUserFromKeychainMessage, netrcMachine.User, h.netrcHandler.GetFileName())
 		return &Credentials{Username: netrcMachine.User, Password: netrcMachine.Password}, nil
 	}
 }
@@ -362,7 +367,7 @@ func (h *LoginCredentialsManagerImpl) GetOnPremPrerunCredentialsFromNetrc(cmd *c
 		if err != nil {
 			return nil, err
 		}
-		log.CliLogger.Debugf(errors.FoundNetrcCredMsg, netrcMachine.User, h.netrcHandler.GetFileName())
+		log.CliLogger.Debugf(foundCredentialsForUserFromKeychainMessage, netrcMachine.User, h.netrcHandler.GetFileName())
 		return &Credentials{Username: netrcMachine.User, Password: netrcMachine.Password, PrerunLoginURL: machineContextInfo.URL, PrerunLoginCaCertPath: machineContextInfo.CaCertPath}, nil
 	}
 }
@@ -372,7 +377,7 @@ func (h *LoginCredentialsManagerImpl) GetCredentialsFromKeychain(cfg *config.Con
 		if runtime.GOOS == "darwin" {
 			username, password, err := keychain.Read(isCloud, ctxName, url)
 			if err == nil && password != "" {
-				log.CliLogger.Debugf(errors.FoundKeychainCredMsg, username)
+				log.CliLogger.Debugf(`Found credentials for user "%s" from keychain (%s)`, username, stopNonInteractiveMsg)
 				return &Credentials{Username: username, Password: password}, nil
 			}
 			return nil, errors.New(errors.NoValidKeychainCredentialErrorMsg)

--- a/pkg/auth/sso/auth_sso_flow.go
+++ b/pkg/auth/sso/auth_sso_flow.go
@@ -23,10 +23,8 @@ func Login(authURL string, noBrowser bool, connectionName string) (string, strin
 	if noBrowser {
 		// no browser flag does not need to launch the server
 		// it prints the url and has the user copy this into their browser instead
-		url := state.getAuthorizationCodeUrl(connectionName, isOkta)
-
 		output.Println("Navigate to the following link in your browser to authenticate:")
-		output.Println(url)
+		output.Println(state.getAuthorizationCodeUrl(connectionName, isOkta))
 		output.Println()
 		output.Println("After authenticating in your browser, paste the code here:")
 

--- a/pkg/auth/sso/auth_sso_flow.go
+++ b/pkg/auth/sso/auth_sso_flow.go
@@ -25,7 +25,7 @@ func Login(authURL string, noBrowser bool, connectionName string) (string, strin
 		// it prints the url and has the user copy this into their browser instead
 		url := state.getAuthorizationCodeUrl(connectionName, isOkta)
 
-		output.Println("Navigate to the following link in your browser to authenticate:", url)
+		output.Println("Navigate to the following link in your browser to authenticate:")
 		output.Println(url)
 		output.Println()
 		output.Println("After authenticating in your browser, paste the code here:")

--- a/pkg/auth/sso/auth_sso_flow.go
+++ b/pkg/auth/sso/auth_sso_flow.go
@@ -2,7 +2,6 @@ package sso
 
 import (
 	"bufio"
-	"fmt"
 	"os"
 	"strings"
 	"time"
@@ -10,6 +9,7 @@ import (
 	"github.com/pkg/browser"
 
 	"github.com/confluentinc/cli/v3/pkg/errors"
+	"github.com/confluentinc/cli/v3/pkg/output"
 )
 
 func Login(authURL string, noBrowser bool, connectionName string) (string, string, error) {
@@ -24,7 +24,11 @@ func Login(authURL string, noBrowser bool, connectionName string) (string, strin
 		// no browser flag does not need to launch the server
 		// it prints the url and has the user copy this into their browser instead
 		url := state.getAuthorizationCodeUrl(connectionName, isOkta)
-		fmt.Printf(errors.NoBrowserSSOInstructionsMsg, url)
+
+		output.Println("Navigate to the following link in your browser to authenticate:", url)
+		output.Println(url)
+		output.Println()
+		output.Println("After authenticating in your browser, paste the code here:")
 
 		// wait for the user to paste the code
 		// the code should come in the format {state}/{auth0_auth_code}

--- a/pkg/cmd/prerunner.go
+++ b/pkg/cmd/prerunner.go
@@ -29,7 +29,7 @@ import (
 	"github.com/confluentinc/cli/v3/pkg/version"
 )
 
-const autoLoginMsg = "Successful auto-login with non-interactive credentials.\n"
+const autoLoginMsg = "Successful auto-login with non-interactive credentials."
 
 type wrongLoginCommandError struct {
 	errorString      string

--- a/pkg/cmd/prerunner_test.go
+++ b/pkg/cmd/prerunner_test.go
@@ -515,7 +515,7 @@ func TestPrerun_AutoLogin(t *testing.T) {
 
 			if !test.wantErr {
 				require.NoError(t, err)
-				require.NotContains(t, out, errors.AutoLoginMsg)
+				require.NotContains(t, out, "Successful auto log in with non-interactive credentials.\n")
 				require.NotContains(t, out, fmt.Sprintf(errors.LoggedInAsMsg, username))
 			} else {
 				require.Error(t, err)

--- a/pkg/config/context.go
+++ b/pkg/config/context.go
@@ -406,14 +406,17 @@ func (c *Context) GetNetrcMachineName() string {
 func printApiKeysDictErrorMessage(missingKey, mismatchKey, missingSecret bool, cluster *KafkaClusterConfig, contextName string) {
 	var problems []string
 	if missingKey {
-		problems = append(problems, errors.APIKeyMissingMsg)
+		problems = append(problems, "API key missing")
 	}
 	if mismatchKey {
-		problems = append(problems, errors.KeyPairMismatchMsg)
+		problems = append(problems, "key of the dictionary does not match API key of the pair")
 	}
 	if missingSecret {
-		problems = append(problems, errors.APISecretMissingMsg)
+		problems = append(problems, "API secret missing")
 	}
-	problemString := strings.Join(problems, ", ")
-	output.ErrPrintf(errors.APIKeysMapAutofixMsg, cluster.ID, contextName, problemString, cluster.ID)
+
+	output.ErrPrintf("There are malformed API key pair entries in the dictionary for cluster \"%s\" under context \"%s\".\n", cluster.ID, contextName)
+	output.ErrPrintf("The issues are the following: %s.\n", strings.Join(problems, ", "))
+	output.ErrPrintln("Deleting the malformed entries.")
+	output.ErrPrintf("You can re-add the API key pair with `confluent api-key store --resource %s`\n", cluster.ID)
 }

--- a/pkg/config/kafka_cluster_context.go
+++ b/pkg/config/kafka_cluster_context.go
@@ -3,7 +3,6 @@ package config
 import (
 	"fmt"
 
-	"github.com/confluentinc/cli/v3/pkg/errors"
 	"github.com/confluentinc/cli/v3/pkg/output"
 )
 
@@ -220,7 +219,9 @@ func (k *KafkaClusterContext) validateKafkaClusterConfig(cluster *KafkaClusterCo
 		}
 	}
 	if _, ok := cluster.APIKeys[cluster.APIKey]; cluster.APIKey != "" && !ok {
-		output.ErrPrintf(errors.CurrentAPIKeyAutofixMsg, cluster.APIKey, cluster.ID, k.Context.Name, cluster.ID)
+		output.ErrPrintf("Current API key \"%s\" of resource \"%s\" under context \"%s\" is not found.\n", cluster.APIKey, cluster.ID, k.Context.Name)
+		output.ErrPrintln("Removing current API key setting for the resource.")
+		output.ErrPrintf("You can re-add the API key with `confluent api-key store --resource %s` and then set current API key with `confluent api-key use`.\n", cluster.ID)
 		cluster.APIKey = ""
 		if err := k.Context.Save(); err != nil {
 			panic(fmt.Sprintf("Unable to reset current APIKey for cluster '%s' in context '%s'.", cluster.ID, k.Context.Name))

--- a/pkg/errors/strings.go
+++ b/pkg/errors/strings.go
@@ -1,126 +1,14 @@
 package errors
 
 const (
-	// api-key command
-	StoredAPIKeyMsg = "Stored API secret for API key \"%s\".\n"
-	UseAPIKeyMsg    = "Using API Key \"%s\".\n"
-
-	// auth commands
-	LoggedInAsMsg                = "Logged in as \"%s\".\n"
-	LoggedInAsMsgWithOrg         = "Logged in as \"%s\" for organization \"%s\" (\"%s\").\n"
-	LoggedInUsingEnvMsg          = "Using environment \"%s\".\n"
-	LoggedOutMsg                 = "You are now logged out."
-	RemoveNetrcCredentialsMsg    = "Removed credentials for user \"%s\" from netrc file \"%s\"\n"
-	RemoveKeychainCredentialsMsg = "Removed credentials for user \"%s\" from keychain\n"
-	StopNonInteractiveMsg        = "(remove these credentials or use the `--prompt` flag to bypass non-interactive login)"
-	FoundEnvCredMsg              = "Found credentials for user \"%s\" from environment variables \"%s\" and \"%s\" " +
-		StopNonInteractiveMsg + ".\n"
-	FoundNetrcCredMsg = "Found credentials for user \"%s\" from netrc file \"%s\" " +
-		StopNonInteractiveMsg + ".\n"
-	FoundKeychainCredMsg = "Found credentials for user \"%s\" from keychain " +
-		StopNonInteractiveMsg + ".\n"
-	RemainingFreeCreditMsg = "Free credits: $%.2f USD remaining\n" +
-		"You are currently using a free trial version of Confluent Cloud. Add a payment method with `confluent admin payment update` to avoid an interruption in service once your trial ends.\n"
-	CloudSignUpMsg     = "Success! Welcome to Confluent Cloud.\n"
-	FreeTrialSignUpMsg = "Congratulations! You now have $%.2f USD to spend during the first 60 days. No credit card is required.\n"
-
-	// confluent cluster command
-	UnregisteredClusterMsg = "Successfully unregistered the cluster %s from the Cluster Registry.\n"
-
-	// connector commands
-	PausedConnectorMsg  = "Paused connector \"%s\".\n"
-	ResumedConnectorMsg = "Resumed connector \"%s\".\n"
-
-	// kafka cluster commands
-	UseKafkaClusterMsg               = "Set Kafka cluster \"%s\" as the active cluster for environment \"%s\".\n"
-	CopyByokAwsPermissionsHeaderMsg  = `Copy and append these permissions into the key policy "Statements" field of the ARN in your AWS key management system to authorize access for your Confluent Cloud cluster.`
-	RunByokAzurePermissionsHeaderMsg = "To ensure the key vault has the correct role assignments, please run the following azure-cli command (certified for azure-cli v2.45):"
-
-	// kafka topic commands
-	StartingProducerMsg         = "Starting Kafka Producer. Use %s to exit.\n"
-	StoppingConsumerMsg         = "Stopping Consumer."
-	StartingConsumerMsg         = "Starting Kafka Consumer. Use Ctrl-C to exit."
-	UpdateTopicConfigMsg        = "Updated the following configuration values for topic \"%s\":\n"
-	UpdateTopicConfigRestMsg    = "Updated the following configuration values for topic \"%s\"%s:\n"
-	ReadOnlyConfigNotUpdatedMsg = "(read-only configs were not updated)"
-	OmitTopicCountMsg           = "The topic count will be omitted as Kafka topics for this cluster could not be retrieved: %v"
-
-	// kafka REST proxy
-	MDSTokenNotFoundMsg = "No session token found, please enter user credentials. To avoid being prompted, run `confluent login`."
-
-	// ksql commands
-	EndPointNotPopulatedMsg   = "Endpoint not yet populated. To obtain the endpoint, use `confluent ksql cluster describe`."
-	KsqlDBNotBackedByKafkaMsg = "The ksqlDB cluster \"%s\" is backed by \"%s\" which is not the current Kafka cluster \"%s\".\nTo switch to the correct cluster, use `confluent kafka cluster use %s`.\n"
-
-	// local commands
-	AvailableServicesMsg       = "Available Services:\n%s\n"
-	UsingConfluentCurrentMsg   = "Using CONFLUENT_CURRENT: %s\n"
-	AvailableConnectPluginsMsg = "Available Connect Plugins:\n%s\n"
-	StartingServiceMsg         = "Starting %s\n"
-	StoppingServiceMsg         = "Stopping %s\n"
-	ServiceStatusMsg           = "%s is [%s]\n"
-	DestroyDeletingMsg         = "Deleting: %s\n"
-
-	// schema-registry commands
-	RegisteredSchemaMsg = "Successfully registered schema with ID \"%d\".\n"
-	ExporterActionMsg   = "%s schema exporter \"%s\".\n"
-
-	// secret commands
-	UpdateSecretFileMsg = "Updated the encrypted secrets."
-
-	// update command
-	CheckingForUpdatesMsg   = "Checking for updates..."
-	UpToDateMsg             = "Already up to date."
-	MajorVersionUpdateMsg   = "The only available update is a major version update. Use `%s update --major` to accept the update.\n"
-	NoMajorVersionUpdateMsg = "No major version updates are available.\n"
-
-	// cmd package
-	NotifyMajorUpdateMsg = "A major version update is available for %s from (current: %s, latest: %s).\nTo view release notes and install the update, please run `%s update --major`.\n\n"
-	NotifyMinorUpdateMsg = "A minor version update is available for %s from (current: %s, latest: %s).\nTo view release notes and install the update, please run `%s update`.\n\n"
-	AutoLoginMsg         = "Successful auto log in with non-interactive credentials.\n"
-
-	// config package
-	APIKeyMissingMsg     = "API key missing"
-	KeyPairMismatchMsg   = "key of the dictionary does not match API key of the pair"
-	APISecretMissingMsg  = "API secret missing"
-	APIKeysMapAutofixMsg = "There are malformed API key pair entries in the dictionary for cluster \"%s\" under context \"%s\".\n" +
-		"The issues are the following: %s.\n" +
-		"Deleting the malformed entries.\n" +
-		"You can re-add the API key pair with `confluent api-key store --resource %s`\n"
-	CurrentAPIKeyAutofixMsg = "Current API key \"%s\" of resource \"%s\" under context \"%s\" is not found.\n" +
-		"Removing current API key setting for the resource.\n" +
-		"You can re-add the API key with `confluent api-key store --resource %s'` and then set current API key with `confluent api-key use`.\n"
-
-	// sso package
-	NoBrowserSSOInstructionsMsg = "Navigate to the following link in your browser to authenticate:\n" +
-		"%s\n" +
-		"\n" +
-		"After authenticating in your browser, paste the code here:\n"
-
-	// update package
-	PromptToDownloadDescriptionMsg = "New version of %s is available\n" +
-		"Current Version: %s\n" +
-		"Latest Version:  %s\n" +
-		"\n" +
-		"%s"
-	InvalidChoiceMsg = "%s is not a valid choice"
-
-	// General
-	CreatedResourceMsg            = "Created %s \"%s\".\n"
-	CreatedLinkResourceMsg        = "Created %s \"%s\" with configs:\n%s\n"
-	DeleteResourceConfirmMsg      = "Are you sure you want to delete %s \"%s\"?\nTo confirm, type \"%s\". To cancel, press Ctrl-C"
-	DeleteResourceConfirmYesNoMsg = `Are you sure you want to delete %s "%s"?`
-	DeleteACLConfirmMsg           = "Are you sure you want to delete the ACL corresponding to these parameters?"
-	DeleteACLsConfirmMsg          = "Are you sure you want to delete the ACLs corresponding to these parameters?"
-	RequestedDeleteResourceMsg    = "Requested to delete %s \"%s\".\n"
-	UpdatedResourceMsg            = "Updated %s \"%s\".\n"
-	UsingResourceMsg              = "Using %s \"%s\".\n"
-	UnsetResourceMsg              = "Unset %s \"%s\".\n"
-
-	UpdateSuccessMsg = "Updated the %s of %s \"%s\" to \"%v\".\n"
-
-	// Stream Sharing commands
-	ResendInviteMsg = "Sent invitation for \"%s\".\n"
-	OptInMsg        = "Successfully opted in to Stream Sharing."
-	OptOutMsg       = "Successfully opted out of Stream Sharing."
+	CreatedResourceMsg       = "Created %s \"%s\".\n"
+	DeleteResourceConfirmMsg = "Are you sure you want to delete %s \"%s\"?\nTo confirm, type \"%s\". To cancel, press Ctrl-C"
+	LoggedInAsMsg            = "Logged in as \"%s\".\n"
+	LoggedInAsMsgWithOrg     = "Logged in as \"%s\" for organization \"%s\" (\"%s\").\n"
+	LoggedInUsingEnvMsg      = "Using environment \"%s\".\n"
+	StartingConsumerMsg      = "Starting Kafka Consumer. Use Ctrl-C to exit."
+	UnsetResourceMsg         = "Unset %s \"%s\".\n"
+	UpdateSuccessMsg         = "Updated the %s of %s \"%s\" to \"%v\".\n"
+	UpdatedResourceMsg       = "Updated %s \"%s\".\n"
+	UsingResourceMsg         = "Using %s \"%s\".\n"
 )

--- a/pkg/form/field.go
+++ b/pkg/form/field.go
@@ -42,7 +42,7 @@ func (f Field) validate(val string) (any, error) {
 		case "N", "NO":
 			return false, nil
 		}
-		return false, fmt.Errorf(errors.InvalidChoiceMsg, val)
+		return false, fmt.Errorf("%s is not a valid choice", val)
 	}
 
 	if val == "" && f.DefaultValue != nil {

--- a/pkg/keychain/keychain_darwin.go
+++ b/pkg/keychain/keychain_darwin.go
@@ -54,7 +54,7 @@ func Delete(isCloud bool, ctxName string) error {
 				return err
 			}
 
-			log.CliLogger.Warnf(errors.RemoveKeychainCredentialsMsg, username)
+			log.CliLogger.Warnf("Removed credentials for user \"%s\" from keychain\n", username)
 			break
 		}
 	}

--- a/pkg/keychain/keychain_darwin.go
+++ b/pkg/keychain/keychain_darwin.go
@@ -54,7 +54,7 @@ func Delete(isCloud bool, ctxName string) error {
 				return err
 			}
 
-			log.CliLogger.Warnf("Removed credentials for user \"%s\" from keychain\n", username)
+			log.CliLogger.Warnf(`Removed credentials for user "%s" from keychain`, username)
 			break
 		}
 	}

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -28,9 +28,9 @@ type pluginInfo struct {
 // SearchPath goes through the files in the user's $PATH and checks if they are plugins
 func SearchPath(cfg *config.Config) map[string][]string {
 	if runtime.GOOS == "windows" {
-		log.CliLogger.Debugf("Searching $PATH and %%USERPROFILE%%\\.confluent\\plugins for plugins. Plugins can be disabled in %s.\n", cfg.GetFilename())
+		log.CliLogger.Debugf(`Searching $PATH and %%USERPROFILE%%\.confluent\plugins for plugins. Plugins can be disabled in %s.`, cfg.GetFilename())
 	}
-	log.CliLogger.Debugf("Searching $PATH and ~/.confluent/plugins for plugins. Plugins can be disabled in %s.\n", cfg.GetFilename())
+	log.CliLogger.Debugf("Searching $PATH and ~/.confluent/plugins for plugins. Plugins can be disabled in %s.", cfg.GetFilename())
 
 	pathDirList := filepath.SplitList(os.Getenv("PATH"))
 	pluginDir := filepath.Join(os.Getenv("HOME"), ".confluent", "plugins")
@@ -94,7 +94,7 @@ func FindPlugin(cmd *cobra.Command, args []string, cfg *config.Config) *pluginIn
 	for len(plugin.name) > len(pversion.CLIName) {
 		if pluginPathList, ok := pluginMap[plugin.name]; ok {
 			if cmd, _, _ := cmd.Find(args); strings.ReplaceAll(cmd.CommandPath(), " ", "-") == plugin.name {
-				log.CliLogger.Warnf("[WARN] User plugin %s is ignored because its command line invocation matches existing CLI command `%s`.\n", pluginPathList[0], cmd.CommandPath())
+				log.CliLogger.Warnf("[WARN] User plugin %s is ignored because its command line invocation matches existing CLI command `%s`.", pluginPathList[0], cmd.CommandPath())
 				break
 			}
 			plugin.args = append([]string{pluginPathList[0]}, plugin.args...)

--- a/pkg/update/client.go
+++ b/pkg/update/client.go
@@ -166,7 +166,11 @@ func (c *client) PromptToDownload(cliName, currVersion, latestVersion, releaseNo
 		confirm = false
 	}
 
-	fmt.Fprintf(c.Out, errors.PromptToDownloadDescriptionMsg, cliName, currVersion, latestVersion, releaseNotes)
+	fmt.Fprintf(c.Out, "New version of %s is available\n", cliName)
+	fmt.Fprintf(c.Out, "Current Version: %s\n", currVersion)
+	fmt.Fprintf(c.Out, "Latest Version:  %s\n", latestVersion)
+	fmt.Fprintln(c.Out)
+	fmt.Fprint(c.Out, releaseNotes)
 
 	if !confirm {
 		return true

--- a/test/login_test.go
+++ b/test/login_test.go
@@ -26,7 +26,7 @@ var (
 	passwordPlaceholder     = "<PASSWORD_PLACEHOLDER>"
 	loggedInAsOutput        = fmt.Sprintf(errors.LoggedInAsMsg, "good@user.com")
 	loggedInAsWithOrgOutput = fmt.Sprintf(errors.LoggedInAsMsgWithOrg, "good@user.com", "abc-123", "Confluent")
-	loggedInEnvOutput       = fmt.Sprintf(errors.LoggedInUsingEnvMsg, "a-595")
+	loggedInEnvOutput       = "Using environment \"a-595\".\n"
 )
 
 func (s *CLITestSuite) TestLogin_VariousOrgSuspensionStatus() {
@@ -39,7 +39,7 @@ func (s *CLITestSuite) TestLogin_VariousOrgSuspensionStatus() {
 		output := runCommand(t, testBin, env, args, 0, "")
 		require.Contains(t, output, loggedInAsWithOrgOutput)
 		require.Contains(t, output, loggedInEnvOutput)
-		require.Contains(t, output, fmt.Sprintf(errors.RemainingFreeCreditMsg, 40.00))
+		require.Contains(t, output, "Free credits: $40.00 USD remaining\nYou are currently using a free trial version of Confluent Cloud. Add a payment method with `confluent admin payment update` to avoid an interruption in service once your trial ends.\n")
 	})
 
 	s.T().Run("non-free-trial organization login", func(t *testing.T) {
@@ -62,7 +62,7 @@ func (s *CLITestSuite) TestLogin_VariousOrgSuspensionStatus() {
 		env := []string{fmt.Sprintf("%s=end-of-free-trial-suspended@user.com", pauth.ConfluentCloudEmail), fmt.Sprintf("%s=pass1", pauth.ConfluentCloudPassword)}
 		output := runCommand(t, testBin, env, args, 0, "")
 		require.Contains(t, output, fmt.Sprintf(errors.LoggedInAsMsgWithOrg, "end-of-free-trial-suspended@user.com", "abc-123", "Confluent"))
-		require.Contains(t, output, fmt.Sprintf(errors.LoggedInUsingEnvMsg, "a-595"))
+		require.Contains(t, output, "Using environment \"a-595\".\n")
 		require.Contains(t, output, fmt.Sprintf(errors.EndOfFreeTrialErrorMsg, "test-org"))
 	})
 }
@@ -83,7 +83,7 @@ func (s *CLITestSuite) TestLogin_CcloudErrors() {
 		env := []string{fmt.Sprintf("%s=expired@user.com", pauth.ConfluentCloudEmail), fmt.Sprintf("%s=pass1", pauth.ConfluentCloudPassword)}
 		output := runCommand(t, testBin, env, args, 0, "")
 		require.Contains(t, output, fmt.Sprintf(errors.LoggedInAsMsgWithOrg, "expired@user.com", "abc-123", "Confluent"))
-		require.Contains(t, output, fmt.Sprintf(errors.LoggedInUsingEnvMsg, "a-595"))
+		require.Contains(t, output, "Using environment \"a-595\".\n")
 		output = runCommand(t, testBin, []string{}, "kafka cluster list", 1, "")
 		require.Contains(t, output, errors.ExpiredTokenErrorMsg)
 		require.Contains(t, output, errors.ComposeSuggestionsMessage(errors.ExpiredTokenSuggestions))
@@ -92,10 +92,10 @@ func (s *CLITestSuite) TestLogin_CcloudErrors() {
 	s.T().Run("malformed token", func(t *testing.T) {
 		env := []string{fmt.Sprintf("%s=malformed@user.com", pauth.ConfluentCloudEmail), fmt.Sprintf("%s=pass1", pauth.ConfluentCloudPassword)}
 		output := runCommand(t, testBin, env, "logout", 0, "")
-		require.Contains(t, output, errors.LoggedOutMsg)
+		require.Contains(t, output, "You are now logged out.")
 		output = runCommand(t, testBin, env, args, 0, "")
 		require.Contains(t, output, fmt.Sprintf(errors.LoggedInAsMsgWithOrg, "malformed@user.com", "abc-123", "Confluent"))
-		require.Contains(t, output, fmt.Sprintf(errors.LoggedInUsingEnvMsg, "a-595"))
+		require.Contains(t, output, "Using environment \"a-595\".\n")
 
 		output = runCommand(t, testBin, []string{}, "kafka cluster list", 1, "")
 		require.Contains(t, output, errors.CorruptedTokenErrorMsg)
@@ -105,10 +105,10 @@ func (s *CLITestSuite) TestLogin_CcloudErrors() {
 	s.T().Run("invalid jwt", func(t *testing.T) {
 		env := []string{fmt.Sprintf("%s=invalid@user.com", pauth.ConfluentCloudEmail), fmt.Sprintf("%s=pass1", pauth.ConfluentCloudPassword)}
 		output := runCommand(t, testBin, env, "logout", 0, "")
-		require.Contains(t, output, errors.LoggedOutMsg)
+		require.Contains(t, output, "You are now logged out.")
 		output = runCommand(t, testBin, env, args, 0, "")
 		require.Contains(t, output, fmt.Sprintf(errors.LoggedInAsMsgWithOrg, "invalid@user.com", "abc-123", "Confluent"))
-		require.Contains(t, output, fmt.Sprintf(errors.LoggedInUsingEnvMsg, "a-595"))
+		require.Contains(t, output, "Using environment \"a-595\".\n")
 
 		output = runCommand(t, testBin, []string{}, "kafka cluster list", 1, "")
 		require.Contains(t, output, errors.CorruptedTokenErrorMsg)

--- a/test/logout_test.go
+++ b/test/logout_test.go
@@ -6,7 +6,6 @@ import (
 	"path/filepath"
 
 	"github.com/confluentinc/cli/v3/pkg/auth"
-	"github.com/confluentinc/cli/v3/pkg/errors"
 	"github.com/confluentinc/cli/v3/pkg/utils"
 )
 
@@ -51,7 +50,7 @@ func (s *CLITestSuite) TestLogout_RemoveUsernamePassword() {
 		s.Require().Contains(utils.NormalizeNewLines(string(got)), "saved_credentials")
 
 		output = runCommand(s.T(), test.bin, env, "logout -vvvv", 0, "")
-		s.Contains(output, errors.LoggedOutMsg)
+		s.Contains(output, "You are now logged out.")
 
 		got, err = os.ReadFile(configFile)
 		s.NoError(err)
@@ -97,7 +96,7 @@ func (s *CLITestSuite) TestLogout_RemoveUsernamePasswordFail() {
 		// run login to provide context, then logout command and check output
 		runCommand(s.T(), test.bin, env, "login --url "+test.loginURL, 0, "") // without save flag so the netrc file won't be modified
 		output := runCommand(s.T(), test.bin, env, "logout", 0, "")
-		s.Contains(output, errors.LoggedOutMsg)
+		s.Contains(output, "You are now logged out.")
 
 		got, err = os.ReadFile(configFile)
 		s.NoError(err)


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
Cleaning up the global namespace, starting with string constants that are better suited to be defined in the function in which they are used. This makes it easier to find bugs and quicker to read code. I deleted about 20 strings from this list that weren't being used.

Test & Review
-------------
Tests still pass