### PR TITLE
Remove extra API call during `kafka cluster create`

### DIFF
--- a/internal/kafka/command_cluster_create.go
+++ b/internal/kafka/command_cluster_create.go
@@ -3,12 +3,12 @@ package kafka
 import (
 	"bytes"
 	"fmt"
+	"net/http"
 	"strings"
 	"text/template"
 
 	"github.com/spf13/cobra"
 
-	ccloudv1 "github.com/confluentinc/ccloud-sdk-go-v1-public"
 	cmkv2 "github.com/confluentinc/ccloud-sdk-go-v2/cmk/v2"
 
 	"github.com/confluentinc/cli/v3/pkg/ccstructs"
@@ -92,15 +92,6 @@ func (c *clusterCommand) create(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	clouds, err := c.Client.EnvironmentMetadata.Get()
-	if err != nil {
-		return err
-	}
-
-	if err := checkCloudAndRegion(cloud, region, clouds); err != nil {
-		return err
-	}
-
 	availabilityString, err := cmd.Flags().GetString("availability")
 	if err != nil {
 		return err
@@ -156,17 +147,15 @@ func (c *clusterCommand) create(cmd *cobra.Command, args []string) error {
 		keyGlobalObjectReference = &cmkv2.GlobalObjectReference{Id: key.GetId()}
 	}
 
-	createCluster := cmkv2.CmkV2Cluster{
-		Spec: &cmkv2.CmkV2ClusterSpec{
-			Environment:  &cmkv2.EnvScopedObjectReference{Id: environmentId},
-			DisplayName:  cmkv2.PtrString(args[0]),
-			Cloud:        cmkv2.PtrString(cloud),
-			Region:       cmkv2.PtrString(region),
-			Availability: cmkv2.PtrString(availability),
-			Config:       setCmkClusterConfig(clusterType, 1, encryptionKey),
-			Byok:         keyGlobalObjectReference,
-		},
-	}
+	createCluster := cmkv2.CmkV2Cluster{Spec: &cmkv2.CmkV2ClusterSpec{
+		Environment:  &cmkv2.EnvScopedObjectReference{Id: environmentId},
+		DisplayName:  cmkv2.PtrString(args[0]),
+		Cloud:        cmkv2.PtrString(cloud),
+		Region:       cmkv2.PtrString(region),
+		Availability: cmkv2.PtrString(availability),
+		Config:       setCmkClusterConfig(clusterType, 1, encryptionKey),
+		Byok:         keyGlobalObjectReference,
+	}}
 
 	if cmd.Flags().Changed("cku") {
 		cku, err := cmd.Flags().GetInt("cku")
@@ -184,7 +173,7 @@ func (c *clusterCommand) create(cmd *cobra.Command, args []string) error {
 
 	kafkaCluster, httpResp, err := c.V2Client.CreateKafkaCluster(createCluster)
 	if err != nil {
-		return errors.CatchClusterConfigurationNotValidError(err, httpResp)
+		return catchClusterConfigurationNotValidError(err, httpResp, cloud, region)
 	}
 
 	if output.GetFormat(cmd) == output.Human {
@@ -192,30 +181,6 @@ func (c *clusterCommand) create(cmd *cobra.Command, args []string) error {
 	}
 
 	return c.outputKafkaClusterDescription(cmd, &kafkaCluster, false)
-}
-
-func checkCloudAndRegion(cloudId, regionId string, clouds []*ccloudv1.CloudMetadata) error {
-	for _, cloud := range clouds {
-		if cloudId == cloud.GetId() {
-			for _, region := range cloud.GetRegions() {
-				if regionId == region.GetId() {
-					if region.GetIsSchedulable() {
-						return nil
-					} else {
-						break
-					}
-				}
-			}
-			return errors.NewErrorWithSuggestions(
-				fmt.Sprintf(`"%s" is not an available region for "%s"`, regionId, cloudId),
-				fmt.Sprintf("To view a list of available regions for \"%s\", use `confluent kafka region list --cloud %s`.", cloudId, cloudId),
-			)
-		}
-	}
-	return errors.NewErrorWithSuggestions(
-		fmt.Sprintf(`"%s" is not an available cloud provider`, cloudId),
-		"To view a list of available cloud providers and regions, use `confluent kafka region list`.",
-	)
 }
 
 func (c *clusterCommand) validateGcpEncryptionKey(cloud, accountId string) error {
@@ -320,4 +285,32 @@ func getKafkaProvisionEstimate(sku ccstructs.Sku) string {
 	default:
 		return fmt.Sprintf(fmtEstimate, "5 minutes")
 	}
+}
+
+func catchClusterConfigurationNotValidError(err error, r *http.Response, cloud, region string) error {
+	if err == nil || r == nil {
+		return err
+	}
+
+	err = errors.CatchCCloudV2Error(err, r)
+	if strings.Contains(err.Error(), "Service provider must be set to AWS, GCP or AZURE.") {
+		return errors.NewErrorWithSuggestions(
+			fmt.Sprintf(`"%s" is not an available cloud provider`, cloud),
+			"To view a list of available cloud providers and regions, use `confluent kafka region list`.",
+		)
+	}
+	if strings.Contains(err.Error(), "Unable to schedule given the cloud and/or region in request is invalid or unavailable") {
+		return errors.NewErrorWithSuggestions(
+			fmt.Sprintf(`"%s" is not an available region for "%s"`, region, cloud),
+			fmt.Sprintf("To view a list of available regions for \"%s\", use `confluent kafka region list --cloud %s`.", cloud, cloud),
+		)
+	}
+	if strings.Contains(err.Error(), "CKU must be greater") {
+		return errors.New("CKU must be greater than 1 for multi-zone dedicated clusters")
+	}
+	if strings.Contains(err.Error(), "Durability must be HIGH for an Enterprise cluster") {
+		return errors.New(`availability must be "multi-zone" for enterprise clusters`)
+	}
+
+	return err
 }

--- a/internal/kafka/command_cluster_create.go
+++ b/internal/kafka/command_cluster_create.go
@@ -293,13 +293,14 @@ func catchClusterConfigurationNotValidError(err error, r *http.Response, cloud, 
 	}
 
 	err = errors.CatchCCloudV2Error(err, r)
-	if strings.Contains(err.Error(), "Service provider must be set to AWS, GCP or AZURE.") {
+
+	if err.Error() == "Service provider must be set to AWS, GCP or AZURE." {
 		return errors.NewErrorWithSuggestions(
 			fmt.Sprintf(`"%s" is not an available cloud provider`, cloud),
 			"To view a list of available cloud providers and regions, use `confluent kafka region list`.",
 		)
 	}
-	if strings.Contains(err.Error(), "Unable to schedule given the cloud and/or region in request is invalid or unavailable") {
+	if err.Error() == "Unable to schedule given the cloud and/or region in request is invalid or unavailable" {
 		return errors.NewErrorWithSuggestions(
 			fmt.Sprintf(`"%s" is not an available region for "%s"`, region, cloud),
 			fmt.Sprintf("To view a list of available regions for \"%s\", use `confluent kafka region list --cloud %s`.", cloud, cloud),

--- a/pkg/errors/catcher_test.go
+++ b/pkg/errors/catcher_test.go
@@ -9,14 +9,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestCatchClustersExceedError(t *testing.T) {
-	res := &http.Response{Body: io.NopCloser(strings.NewReader(`{"errors":[{"detail":"Your environment is currently limited to 50 kafka clusters"}]}`))}
-
-	err := CatchClusterConfigurationNotValidError(New("402 Payment Required"), res)
-	require.Error(t, err)
-	require.Equal(t, err.Error(), "Your environment is currently limited to 50 kafka clusters")
-}
-
 func TestCatchServiceAccountExceedError(t *testing.T) {
 	res := &http.Response{Body: io.NopCloser(strings.NewReader(`{"errors":[{"detail":"Your environment is currently limited to 1000 service accounts"}]}`))}
 

--- a/test/test-server/cli_handler.go
+++ b/test/test-server/cli_handler.go
@@ -16,7 +16,7 @@ func handleFeedbacks(t *testing.T) http.HandlerFunc {
 		req := new(cliv1.CliV1Feedback)
 		err := json.NewDecoder(r.Body).Decode(req)
 		require.NoError(t, err)
-		if len(*req.Content) > 20 {
+		if len(req.GetContent()) > 20 {
 			w.WriteHeader(http.StatusForbidden)
 			err = writeErrorJson(w, "feedback exceeds the maximum length")
 			require.NoError(t, err)

--- a/test/test-server/cmk_handlers.go
+++ b/test/test-server/cmk_handlers.go
@@ -22,10 +22,10 @@ func handleCmkKafkaClusterCreate(t *testing.T) http.HandlerFunc {
 
 		cluster := &cmkv2.CmkV2Cluster{
 			Spec: &cmkv2.CmkV2ClusterSpec{
-				DisplayName:            cmkv2.PtrString(*req.Spec.DisplayName),
-				Cloud:                  cmkv2.PtrString(*req.Spec.Cloud),
-				Region:                 cmkv2.PtrString(*req.Spec.Region),
-				Config:                 new(cmkv2.CmkV2ClusterSpecConfigOneOf),
+				DisplayName:            cmkv2.PtrString(req.Spec.GetDisplayName()),
+				Cloud:                  cmkv2.PtrString(req.Spec.GetCloud()),
+				Region:                 cmkv2.PtrString(req.Spec.GetRegion()),
+				Config:                 &cmkv2.CmkV2ClusterSpecConfigOneOf{},
 				KafkaBootstrapEndpoint: cmkv2.PtrString("SASL_SSL://kafka-endpoint"),
 				HttpEndpoint:           cmkv2.PtrString("https://pkc-endpoint"),
 				Availability:           req.Spec.Availability,
@@ -74,8 +74,9 @@ func handleCmkKafkaClusterCreate(t *testing.T) http.HandlerFunc {
 	}
 }
 
-func writeError(w http.ResponseWriter, s string) error {
-	body := errors.ErrorResponseBody{Errors: []errors.ErrorDetail{{Detail: s}}}
+func writeError(w http.ResponseWriter, detail string) error {
+	w.WriteHeader(http.StatusUnprocessableEntity)
+	body := &errors.ErrorResponseBody{Errors: []errors.ErrorDetail{{Detail: detail}}}
 	return json.NewEncoder(w).Encode(body)
 }
 
@@ -88,32 +89,24 @@ func handleCmkClusters(t *testing.T) http.HandlerFunc {
 			cluster := cmkv2.CmkV2Cluster{
 				Id: cmkv2.PtrString("lkc-123"),
 				Spec: &cmkv2.CmkV2ClusterSpec{
-					DisplayName: cmkv2.PtrString("abc"),
-					Cloud:       cmkv2.PtrString("gcp"),
-					Region:      cmkv2.PtrString("us-central1"),
-					Config: &cmkv2.CmkV2ClusterSpecConfigOneOf{
-						CmkV2Basic: &cmkv2.CmkV2Basic{Kind: "Basic"},
-					},
+					DisplayName:  cmkv2.PtrString("abc"),
+					Cloud:        cmkv2.PtrString("gcp"),
+					Region:       cmkv2.PtrString("us-central1"),
+					Config:       &cmkv2.CmkV2ClusterSpecConfigOneOf{CmkV2Basic: &cmkv2.CmkV2Basic{Kind: "Basic"}},
 					Availability: cmkv2.PtrString("SINGLE_ZONE"),
 				},
-				Status: &cmkv2.CmkV2ClusterStatus{
-					Phase: "PROVISIONING",
-				},
+				Status: &cmkv2.CmkV2ClusterStatus{Phase: "PROVISIONING"},
 			}
 			clusterMultizone := cmkv2.CmkV2Cluster{
 				Id: cmkv2.PtrString("lkc-456"),
 				Spec: &cmkv2.CmkV2ClusterSpec{
-					DisplayName: cmkv2.PtrString("def"),
-					Cloud:       cmkv2.PtrString("gcp"),
-					Region:      cmkv2.PtrString("us-central1"),
-					Config: &cmkv2.CmkV2ClusterSpecConfigOneOf{
-						CmkV2Basic: &cmkv2.CmkV2Basic{Kind: "Basic"},
-					},
+					DisplayName:  cmkv2.PtrString("def"),
+					Cloud:        cmkv2.PtrString("gcp"),
+					Region:       cmkv2.PtrString("us-central1"),
+					Config:       &cmkv2.CmkV2ClusterSpecConfigOneOf{CmkV2Basic: &cmkv2.CmkV2Basic{Kind: "Basic"}},
 					Availability: cmkv2.PtrString("MULTI_ZONE"),
 				},
-				Status: &cmkv2.CmkV2ClusterStatus{
-					Phase: "PROVISIONING",
-				},
+				Status: &cmkv2.CmkV2ClusterStatus{Phase: "PROVISIONING"},
 			}
 			clusterList := &cmkv2.CmkV2ClusterList{Data: []cmkv2.CmkV2Cluster{cluster, clusterMultizone}}
 			err := json.NewEncoder(w).Encode(clusterList)
@@ -240,25 +233,22 @@ func handleCmkKafkaClusterGetListDeleteDescribe(t *testing.T) http.HandlerFunc {
 // Handler for GET/PUT "/cmk/v2/clusters/lkc-update"
 func handleCmkKafkaClusterUpdateRequest(t *testing.T) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		if r.Method == http.MethodGet {
+		switch r.Method {
+		case http.MethodGet:
 			cluster := getCmkBasicDescribeCluster("lkc-update", "lkc-update")
 			cluster.Status = &cmkv2.CmkV2ClusterStatus{Phase: "PROVISIONED"}
 			err := json.NewEncoder(w).Encode(cluster)
 			require.NoError(t, err)
-		}
-		// Update client call
-		if r.Method == http.MethodPatch {
+		case http.MethodPatch:
 			var req cmkv2.CmkV2Cluster
 			err := json.NewDecoder(r.Body).Decode(&req)
 			require.NoError(t, err)
-			req.Id = cmkv2.PtrString("lkc-update")
-			if req.Spec.Config != nil && req.Spec.Config.CmkV2Dedicated.Cku > 0 {
-			} else { // update name
-				cluster := getCmkBasicDescribeCluster(*req.Id, *req.Spec.DisplayName)
+			if req.Spec.Config == nil || req.Spec.Config.CmkV2Dedicated.Cku == 0 {
+				req.Id = cmkv2.PtrString("lkc-update")
+				cluster := getCmkBasicDescribeCluster(req.GetId(), req.Spec.GetDisplayName())
 				err := json.NewEncoder(w).Encode(cluster)
 				require.NoError(t, err)
 			}
-			require.NoError(t, err)
 		}
 	}
 }

--- a/test/test-server/cmk_handlers.go
+++ b/test/test-server/cmk_handlers.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	cmkv2 "github.com/confluentinc/ccloud-sdk-go-v2/cmk/v2"
+
 	"github.com/confluentinc/cli/v3/pkg/errors"
 )
 

--- a/test/test-server/connect_handler.go
+++ b/test/test-server/connect_handler.go
@@ -97,8 +97,8 @@ func handleConnectors(t *testing.T) http.HandlerFunc {
 			err := json.NewDecoder(r.Body).Decode(&request)
 			require.NoError(t, err)
 			connector := &connectv1.ConnectV1Connector{
-				Name:   *request.Name,
-				Config: *request.Config,
+				Name:   request.GetName(),
+				Config: request.GetConfig(),
 			}
 			err = json.NewEncoder(w).Encode(connector)
 			require.NoError(t, err)


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- PLACEHOLDER

New Features
- PLACEHOLDER

Bug Fixes
- PLACEHOLDER

Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
Remove call to ccloud-sdk-go-v1-public. This validation is already performed by the backend, so the extra API call is unnecessary.

Test & Review
-------------
Manually tested, make sure integration tests still pass