### PR TITLE
feat: add panic recovery wrapper for goroutines

### DIFF
--- a/pkg/flink/app/application.go
+++ b/pkg/flink/app/application.go
@@ -86,13 +86,11 @@ func StartApp(client ccloudv2.GatewayClientInterface, tokenRefreshFunc func() er
 
 func (a *Application) readEvalPrintLoop() {
 	for a.isAuthenticated() {
-		a.readEvalPrint()
+		utils.WithCustomPanicRecovery(a.readEvalPrint, a.panicRecovery)()
 	}
 }
 
 func (a *Application) readEvalPrint() {
-	defer a.panicRecovery()
-
 	userInput := a.inputController.GetUserInput()
 	if a.inputController.HasUserEnabledReverseSearch() {
 		a.inputController.StartReverseSearch()
@@ -114,12 +112,10 @@ func (a *Application) readEvalPrint() {
 }
 
 func (a *Application) panicRecovery() {
-	if r := recover(); r != nil {
-		a.statementController.CleanupStatement()
-		a.interactiveOutputController = controller.NewInteractiveOutputController(components.NewTableView(), a.resultFetcher, a.appOptions.GetVerbose())
-		a.reportUsage()
-		utils.OutputErr("Error: internal error occurred")
-	}
+	a.statementController.CleanupStatement()
+	a.interactiveOutputController = controller.NewInteractiveOutputController(components.NewTableView(), a.resultFetcher, a.appOptions.GetVerbose())
+	a.reportUsage()
+	utils.OutputErr("Error: internal error occurred")
 }
 
 func (a *Application) isAuthenticated() bool {

--- a/pkg/flink/app/application_test.go
+++ b/pkg/flink/app/application_test.go
@@ -1,7 +1,6 @@
 package app
 
 import (
-	"github.com/confluentinc/cli/v3/pkg/flink/internal/utils"
 	"sync"
 	"testing"
 
@@ -13,6 +12,7 @@ import (
 	"github.com/confluentinc/cli/v3/pkg/errors"
 	"github.com/confluentinc/cli/v3/pkg/flink/internal/controller"
 	"github.com/confluentinc/cli/v3/pkg/flink/internal/history"
+	"github.com/confluentinc/cli/v3/pkg/flink/internal/utils"
 	"github.com/confluentinc/cli/v3/pkg/flink/test"
 	"github.com/confluentinc/cli/v3/pkg/flink/test/mock"
 	"github.com/confluentinc/cli/v3/pkg/flink/types"

--- a/pkg/flink/app/application_test.go
+++ b/pkg/flink/app/application_test.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"github.com/confluentinc/cli/v3/pkg/flink/internal/utils"
 	"sync"
 	"testing"
 
@@ -271,7 +272,7 @@ func (s *ApplicationTestSuite) TestPanicRecovery() {
 	s.statementController.EXPECT().CleanupStatement()
 
 	// When
-	actual := test.RunAndCaptureSTDOUT(s.T(), s.app.readEvalPrint)
+	actual := test.RunAndCaptureSTDOUT(s.T(), utils.WithCustomPanicRecovery(s.app.readEvalPrint, s.app.panicRecovery))
 
 	// Then
 	cupaloy.SnapshotT(s.T(), actual)

--- a/pkg/flink/internal/controller/statement_controller.go
+++ b/pkg/flink/internal/controller/statement_controller.go
@@ -95,7 +95,9 @@ func (c *StatementController) waitForStatementToBeReadyOrError(processedStatemen
 	ctx, cancelWaitPendingStatement := context.WithCancel(context.Background())
 	defer cancelWaitPendingStatement()
 
-	go c.listenForUserInputEvent(ctx, c.userInputIsOneOf(isCancelEvent), cancelWaitPendingStatement)
+	go utils.WithPanicRecovery(func() {
+		c.listenForUserInputEvent(ctx, c.userInputIsOneOf(isCancelEvent), cancelWaitPendingStatement)
+	})()
 
 	readyStatement, err := c.store.WaitPendingStatement(ctx, processedStatement)
 	if err != nil {
@@ -132,7 +134,9 @@ func (c *StatementController) waitForStatementToBeInTerminalStateOrError(process
 	ctx, cancelWaitForTerminalStatementState := context.WithCancel(context.Background())
 	defer cancelWaitForTerminalStatementState()
 
-	go c.listenForUserInputEvent(ctx, c.userInputIsOneOf(isDetachEvent, isCancelEvent), cancelWaitForTerminalStatementState)
+	go utils.WithPanicRecovery(func() {
+		c.listenForUserInputEvent(ctx, c.userInputIsOneOf(isDetachEvent, isCancelEvent), cancelWaitForTerminalStatementState)
+	})()
 
 	output.Printf(false, "Statement phase is %s.\n", readyStatementWithResults.Status)
 	col := fColor.New(color.AccentColor)

--- a/pkg/flink/internal/utils/.snapshots/TestCustomPanicRecovery
+++ b/pkg/flink/internal/utils/.snapshots/TestCustomPanicRecovery
@@ -1,0 +1,2 @@
+This is a custom panic recovery
+

--- a/pkg/flink/internal/utils/.snapshots/TestCustomPanicRecoveryIsSafeWhenCustomRecoveryFuncPanics
+++ b/pkg/flink/internal/utils/.snapshots/TestCustomPanicRecoveryIsSafeWhenCustomRecoveryFuncPanics
@@ -1,0 +1,2 @@
+Error: internal error occurred
+

--- a/pkg/flink/internal/utils/.snapshots/TestDefaultPanicRecovery
+++ b/pkg/flink/internal/utils/.snapshots/TestDefaultPanicRecovery
@@ -1,0 +1,2 @@
+Error: internal error occurred
+

--- a/pkg/flink/internal/utils/panic.go
+++ b/pkg/flink/internal/utils/panic.go
@@ -1,0 +1,20 @@
+package utils
+
+func WithPanicRecovery(fn func()) func() {
+	return WithCustomPanicRecovery(fn, func() {
+		OutputErr("Error: internal error occurred")
+	})
+}
+
+func WithCustomPanicRecovery(fn func(), customRecovery func()) func() {
+	return func() {
+		defer func() {
+			if r := recover(); r != nil {
+				if customRecovery != nil {
+					WithPanicRecovery(customRecovery)()
+				}
+			}
+		}()
+		fn()
+	}
+}

--- a/pkg/flink/internal/utils/panic_test.go
+++ b/pkg/flink/internal/utils/panic_test.go
@@ -1,9 +1,11 @@
 package utils
 
 import (
-	"github.com/bradleyjkemp/cupaloy"
-	"github.com/confluentinc/cli/v3/pkg/flink/test"
 	"testing"
+
+	"github.com/bradleyjkemp/cupaloy"
+
+	"github.com/confluentinc/cli/v3/pkg/flink/test"
 )
 
 func TestDefaultPanicRecovery(t *testing.T) {

--- a/pkg/flink/internal/utils/panic_test.go
+++ b/pkg/flink/internal/utils/panic_test.go
@@ -1,0 +1,36 @@
+package utils
+
+import (
+	"github.com/bradleyjkemp/cupaloy"
+	"github.com/confluentinc/cli/v3/pkg/flink/test"
+	"testing"
+)
+
+func TestDefaultPanicRecovery(t *testing.T) {
+	stdout := test.RunAndCaptureSTDOUT(t, WithPanicRecovery(func() {
+		panic("a panic")
+	}))
+	cupaloy.SnapshotT(t, stdout)
+}
+
+func TestCustomPanicRecovery(t *testing.T) {
+	stdout := test.RunAndCaptureSTDOUT(t, WithCustomPanicRecovery(
+		func() {
+			panic("a panic")
+		},
+		func() {
+			OutputInfo("This is a custom panic recovery")
+		}))
+	cupaloy.SnapshotT(t, stdout)
+}
+
+func TestCustomPanicRecoveryIsSafeWhenCustomRecoveryFuncPanics(t *testing.T) {
+	stdout := test.RunAndCaptureSTDOUT(t, WithCustomPanicRecovery(
+		func() {
+			panic("a panic")
+		},
+		func() {
+			panic("Still safe if we panic here")
+		}))
+	cupaloy.SnapshotT(t, stdout)
+}


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->
Adds a panic recovery wrapper that can be used when spawning goroutines. This wrapper ensures we recover from panics inside goroutines, so they don't crash our main routine.

