### PR TITLE
Improve error suggestions and remove references to `resourceId`

### DIFF
--- a/internal/flink/command_shell.go
+++ b/internal/flink/command_shell.go
@@ -80,8 +80,6 @@ func (c *command) startFlinkSqlClient(prerunner pcmd.PreRunner, cmd *cobra.Comma
 		return nil
 	}
 
-	resourceId := c.Context.GetOrganization().GetResourceId()
-
 	environmentId, err := cmd.Flags().GetString("environment")
 	if err != nil {
 		return err
@@ -150,18 +148,20 @@ func (c *command) startFlinkSqlClient(prerunner pcmd.PreRunner, cmd *cobra.Comma
 
 	verbose, _ := cmd.Flags().GetCount("verbose")
 
-	client.StartApp(flinkGatewayClient, c.authenticated(prerunner.Authenticated(c.AuthenticatedCLICommand), cmd, jwtValidator), types.ApplicationOptions{
+	opts := types.ApplicationOptions{
 		Context:          c.Context,
 		UnsafeTrace:      unsafeTrace,
 		UserAgent:        c.Version.UserAgent,
 		EnvironmentName:  catalog,
 		EnvironmentId:    environmentId,
-		OrgResourceId:    resourceId,
+		OrganizationId:   c.Context.GetOrganization().GetResourceId(),
 		Database:         database,
 		ComputePoolId:    computePool,
 		ServiceAccountId: serviceAccount,
 		Verbose:          verbose > 0,
-	}, reportUsage(cmd, c.Config.Config, unsafeTrace))
+	}
+
+	client.StartApp(flinkGatewayClient, c.authenticated(prerunner.Authenticated(c.AuthenticatedCLICommand), cmd, jwtValidator), opts, reportUsage(cmd, c.Config.Config, unsafeTrace))
 	return nil
 }
 

--- a/internal/flink/command_statement_create.go
+++ b/internal/flink/command_statement_create.go
@@ -31,7 +31,7 @@ func (c *command) newStatementCreateCommand() *cobra.Command {
 			},
 			examples.Example{
 				Text: `Create a Flink SQL statement named "my-statement" in compute pool "lfcp-123456" with service account "sa-123456" and using Kafka cluster "my-cluster" as the default database.`,
-				Code: `confluent flink statement create my-statement --sql "SELECT * FROM my-cluster.my-topic;" --compute-pool lfcp-123456 --service-account sa-123456 --database my-cluster`,
+				Code: `confluent flink statement create my-statement --sql "SELECT * FROM my-topic;" --compute-pool lfcp-123456 --service-account sa-123456 --database my-cluster`,
 			},
 		),
 	}

--- a/internal/iam/command_rbac_role_binding_create.go
+++ b/internal/iam/command_rbac_role_binding_create.go
@@ -111,7 +111,10 @@ func (c *roleBindingCommand) create(cmd *cobra.Command, _ []string) error {
 		}
 
 		if httpResp != nil && httpResp.StatusCode != http.StatusOK && httpResp.StatusCode != http.StatusCreated && httpResp.StatusCode != http.StatusNoContent {
-			return errors.NewErrorWithSuggestions(fmt.Sprintf(httpStatusCodeErrorMsg, httpResp.StatusCode), httpStatusCodeSuggestions)
+			return errors.NewErrorWithSuggestions(
+				fmt.Sprintf(httpStatusCodeErrorMsg, httpResp.StatusCode),
+				httpStatusCodeSuggestions,
+			)
 		}
 
 		return displayCreateAndDeleteOutput(cmd, options)

--- a/internal/iam/command_rbac_role_binding_delete.go
+++ b/internal/iam/command_rbac_role_binding_delete.go
@@ -73,7 +73,10 @@ func (c *roleBindingCommand) delete(cmd *cobra.Command, _ []string) error {
 		}
 
 		if httpResp != nil && httpResp.StatusCode != http.StatusOK && httpResp.StatusCode != http.StatusNoContent {
-			return errors.NewErrorWithSuggestions(fmt.Sprintf(httpStatusCodeErrorMsg, httpResp.StatusCode), httpStatusCodeSuggestions)
+			return errors.NewErrorWithSuggestions(
+				fmt.Sprintf(httpStatusCodeErrorMsg, httpResp.StatusCode),
+				httpStatusCodeSuggestions,
+			)
 		}
 
 		return displayCreateAndDeleteOutput(cmd, options)

--- a/internal/iam/command_rbac_role_describe.go
+++ b/internal/iam/command_rbac_role_describe.go
@@ -14,11 +14,12 @@ import (
 	"github.com/confluentinc/cli/v3/pkg/errors"
 	"github.com/confluentinc/cli/v3/pkg/featureflags"
 	"github.com/confluentinc/cli/v3/pkg/output"
+	"github.com/confluentinc/cli/v3/pkg/utils"
 )
 
 const (
 	unknownRoleErrorMsg    = `unknown role "%s"`
-	unknownRoleSuggestions = "The available roles are: %s."
+	unknownRoleSuggestions = "The available roles are %s."
 )
 
 func (c *roleCommand) newDescribeCommand() *cobra.Command {
@@ -75,8 +76,10 @@ func (c *roleCommand) ccloudDescribe(cmd *cobra.Command, role string) error {
 			return err
 		}
 
-		suggestionsMsg := fmt.Sprintf(unknownRoleSuggestions, strings.Join(roleNames, ", "))
-		return errors.NewErrorWithSuggestions(fmt.Sprintf(unknownRoleErrorMsg, role), suggestionsMsg)
+		return errors.NewErrorWithSuggestions(
+			fmt.Sprintf(unknownRoleErrorMsg, role),
+			fmt.Sprintf(unknownRoleSuggestions, utils.ArrayToCommaDelimitedString(roleNames, "and")),
+		)
 	}
 
 	if output.GetFormat(cmd).IsSerialized() {
@@ -101,8 +104,10 @@ func (c *roleCommand) confluentDescribe(cmd *cobra.Command, role string) error {
 			if err != nil {
 				return err
 			}
-			suggestionsMsg := fmt.Sprintf(unknownRoleSuggestions, strings.Join(availableRoleNames, ","))
-			return errors.NewErrorWithSuggestions(fmt.Sprintf(unknownRoleErrorMsg, role), suggestionsMsg)
+			return errors.NewErrorWithSuggestions(
+				fmt.Sprintf(unknownRoleErrorMsg, role),
+				fmt.Sprintf(unknownRoleSuggestions, utils.ArrayToCommaDelimitedString(availableRoleNames, "and")),
+			)
 		}
 
 		return err

--- a/internal/iam/command_user_update.go
+++ b/internal/iam/command_user_update.go
@@ -33,16 +33,16 @@ func (c *userCommand) update(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	resourceId := args[0]
-	if resource.LookupType(resourceId) != resource.User {
+	id := args[0]
+	if resource.LookupType(id) != resource.User {
 		return errors.Errorf(badResourceIdErrorMsg, "u")
 	}
 
 	update := iamv2.IamV2UserUpdate{FullName: iamv2.PtrString(fullName)}
-	if _, err := c.V2Client.UpdateIamUser(resourceId, update); err != nil {
-		return errors.Errorf(`failed to update %s "%s": %v`, resource.User, resourceId, err)
+	if _, err := c.V2Client.UpdateIamUser(id, update); err != nil {
+		return errors.Errorf(`failed to update %s "%s": %v`, resource.User, id, err)
 	}
 
-	output.ErrPrintf(c.Config.EnableColor, errors.UpdateSuccessMsg, "full name", "user", resourceId, fullName)
+	output.ErrPrintf(c.Config.EnableColor, errors.UpdateSuccessMsg, "full name", "user", id, fullName)
 	return nil
 }

--- a/internal/kafka/command_cluster_update.go
+++ b/internal/kafka/command_cluster_update.go
@@ -55,7 +55,10 @@ func (c *clusterCommand) update(cmd *cobra.Command, args []string) error {
 	clusterID := args[0]
 	currentCluster, _, err := c.V2Client.DescribeKafkaCluster(clusterID, environmentId)
 	if err != nil {
-		return errors.NewErrorWithSuggestions(fmt.Sprintf(errors.KafkaClusterNotFoundErrorMsg, clusterID), errors.ChooseRightEnvironmentSuggestions)
+		return errors.NewErrorWithSuggestions(
+			fmt.Sprintf(errors.KafkaClusterNotFoundErrorMsg, clusterID),
+			errors.ChooseRightEnvironmentSuggestions,
+		)
 	}
 
 	update := cmkv2.CmkV2ClusterUpdate{

--- a/internal/kafka/command_cluster_update.go
+++ b/internal/kafka/command_cluster_update.go
@@ -52,17 +52,17 @@ func (c *clusterCommand) update(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	clusterID := args[0]
-	currentCluster, _, err := c.V2Client.DescribeKafkaCluster(clusterID, environmentId)
+	id := args[0]
+	currentCluster, _, err := c.V2Client.DescribeKafkaCluster(id, environmentId)
 	if err != nil {
 		return errors.NewErrorWithSuggestions(
-			fmt.Sprintf(errors.KafkaClusterNotFoundErrorMsg, clusterID),
+			fmt.Sprintf(errors.KafkaClusterNotFoundErrorMsg, id),
 			errors.ChooseRightEnvironmentSuggestions,
 		)
 	}
 
 	update := cmkv2.CmkV2ClusterUpdate{
-		Id:   cmkv2.PtrString(clusterID),
+		Id:   cmkv2.PtrString(id),
 		Spec: &cmkv2.CmkV2ClusterSpecUpdate{Environment: &cmkv2.EnvScopedObjectReference{Id: environmentId}},
 	}
 
@@ -89,14 +89,14 @@ func (c *clusterCommand) update(cmd *cobra.Command, args []string) error {
 		update.Spec.Config = &cmkv2.CmkV2ClusterSpecUpdateConfigOneOf{CmkV2Dedicated: &cmkv2.CmkV2Dedicated{Kind: "Dedicated", Cku: updatedCku}}
 	}
 
-	updatedCluster, err := c.V2Client.UpdateKafkaCluster(clusterID, update)
+	updatedCluster, err := c.V2Client.UpdateKafkaCluster(id, update)
 	if err != nil {
 		return errors.NewWrapErrorWithSuggestions(err, "failed to update Kafka cluster", "A cluster can't be updated while still provisioning. If you just created this cluster, retry in a few minutes.")
 	}
 
 	ctx := c.Context.Config.Context()
 	c.Context.Config.SetOverwrittenCurrentKafkaCluster(ctx.KafkaClusterContext.GetActiveKafkaClusterId())
-	ctx.KafkaClusterContext.SetActiveKafkaCluster(clusterID)
+	ctx.KafkaClusterContext.SetActiveKafkaCluster(id)
 
 	return c.outputKafkaClusterDescription(cmd, &updatedCluster, true)
 }

--- a/internal/kafka/command_cluster_use.go
+++ b/internal/kafka/command_cluster_use.go
@@ -34,7 +34,10 @@ func (c *clusterCommand) use(cmd *cobra.Command, args []string) error {
 	clusterID := args[0]
 
 	if _, err := c.Context.FindKafkaCluster(clusterID); err != nil {
-		return errors.NewErrorWithSuggestions(fmt.Sprintf(errors.KafkaClusterNotFoundErrorMsg, clusterID), errors.ChooseRightEnvironmentSuggestions)
+		return errors.NewErrorWithSuggestions(
+			fmt.Sprintf(errors.KafkaClusterNotFoundErrorMsg, clusterID),
+			errors.ChooseRightEnvironmentSuggestions,
+		)
 	}
 
 	if err := c.Context.SetActiveKafkaCluster(clusterID); err != nil {

--- a/internal/kafka/command_cluster_use.go
+++ b/internal/kafka/command_cluster_use.go
@@ -31,19 +31,19 @@ func (c *clusterCommand) newUseCommand(cfg *config.Config) *cobra.Command {
 }
 
 func (c *clusterCommand) use(cmd *cobra.Command, args []string) error {
-	clusterID := args[0]
+	id := args[0]
 
-	if _, err := c.Context.FindKafkaCluster(clusterID); err != nil {
+	if _, err := c.Context.FindKafkaCluster(id); err != nil {
 		return errors.NewErrorWithSuggestions(
-			fmt.Sprintf(errors.KafkaClusterNotFoundErrorMsg, clusterID),
+			fmt.Sprintf(errors.KafkaClusterNotFoundErrorMsg, id),
 			errors.ChooseRightEnvironmentSuggestions,
 		)
 	}
 
-	if err := c.Context.SetActiveKafkaCluster(clusterID); err != nil {
+	if err := c.Context.SetActiveKafkaCluster(id); err != nil {
 		return err
 	}
 
-	output.ErrPrintf(c.Config.EnableColor, "Set Kafka cluster \"%s\" as the active cluster for environment \"%s\".\n", clusterID, c.Context.GetCurrentEnvironment())
+	output.ErrPrintf(c.Config.EnableColor, "Set Kafka cluster \"%s\" as the active cluster for environment \"%s\".\n", id, c.Context.GetCurrentEnvironment())
 	return nil
 }

--- a/internal/kafka/command_topic.go
+++ b/internal/kafka/command_topic.go
@@ -117,7 +117,10 @@ func (c *command) validateTopic(client *ckafka.AdminClient, topic string, cluste
 	}
 	if !foundTopic {
 		log.CliLogger.Trace("validateTopic failed due to topic not being found in the client's topic list")
-		return errors.NewErrorWithSuggestions(fmt.Sprintf(errors.TopicDoesNotExistOrMissingPermissionsErrorMsg, topic), fmt.Sprintf(errors.TopicDoesNotExistOrMissingPermissionsSuggestions, cluster.ID, cluster.ID, cluster.ID))
+		return errors.NewErrorWithSuggestions(
+			fmt.Sprintf(errors.TopicDoesNotExistOrMissingPermissionsErrorMsg, topic),
+			fmt.Sprintf(errors.TopicDoesNotExistOrMissingPermissionsSuggestions, cluster.ID, cluster.ID, cluster.ID),
+		)
 	}
 
 	log.CliLogger.Tracef("validateTopic succeeded")

--- a/internal/kafka/command_topic_consume_onprem.go
+++ b/internal/kafka/command_topic_consume_onprem.go
@@ -106,7 +106,10 @@ func (c *command) consumeOnPrem(cmd *cobra.Command, args []string) error {
 
 	consumer, err := newOnPremConsumer(cmd, c.clientID, configFile, config)
 	if err != nil {
-		return errors.NewErrorWithSuggestions(fmt.Errorf(errors.FailedToCreateConsumerErrorMsg, err).Error(), errors.OnPremConfigGuideSuggestions)
+		return errors.NewErrorWithSuggestions(
+			fmt.Sprintf(errors.FailedToCreateConsumerErrorMsg, err),
+			errors.OnPremConfigGuideSuggestions,
+		)
 	}
 	log.CliLogger.Tracef("Create consumer succeeded")
 

--- a/internal/kafka/command_topic_onprem.go
+++ b/internal/kafka/command_topic_onprem.go
@@ -27,7 +27,10 @@ func ValidateTopic(adminClient *ckafka.AdminClient, topic string) error {
 	}
 	if !foundTopic {
 		log.CliLogger.Tracef("validateTopic failed due to topic not being found in the client's topic list")
-		return errors.NewErrorWithSuggestions(fmt.Sprintf(errors.TopicDoesNotExistOrMissingPermissionsErrorMsg, topic), fmt.Sprintf(errors.TopicDoesNotExistOrMissingPermissionsSuggestions, "<cluster-id>", "<cluster-id>", "<cluster-id>"))
+		return errors.NewErrorWithSuggestions(
+			fmt.Sprintf(errors.TopicDoesNotExistOrMissingPermissionsErrorMsg, topic),
+			fmt.Sprintf(errors.TopicDoesNotExistOrMissingPermissionsSuggestions, "<cluster-id>", "<cluster-id>", "<cluster-id>"),
+		)
 	}
 
 	log.CliLogger.Tracef("validateTopic succeeded")

--- a/internal/kafka/command_topic_produce_onprem.go
+++ b/internal/kafka/command_topic_produce_onprem.go
@@ -75,7 +75,10 @@ func (c *command) produceOnPrem(cmd *cobra.Command, args []string) error {
 
 	producer, err := newOnPremProducer(cmd, c.clientID, configFile, config)
 	if err != nil {
-		return errors.NewErrorWithSuggestions(fmt.Errorf(errors.FailedToCreateProducerErrorMsg, err).Error(), errors.OnPremConfigGuideSuggestions)
+		return errors.NewErrorWithSuggestions(
+			fmt.Sprintf(errors.FailedToCreateProducerErrorMsg, err),
+			errors.OnPremConfigGuideSuggestions,
+		)
 	}
 	defer producer.Close()
 	log.CliLogger.Tracef("Create producer succeeded")

--- a/internal/local/command_kafka_start.go
+++ b/internal/local/command_kafka_start.go
@@ -362,17 +362,23 @@ func checkMachineArch() error {
 		return nil
 	}
 
-	cmd := exec.Command("uname", "-m") // outputs system architecture info
-	output, err := cmd.Output()
+	// output system architecture info
+	output, err := exec.Command("uname", "-m").Output()
 	if err != nil {
 		return err
 	}
+
 	systemArch := strings.TrimSpace(string(output))
 	if systemArch == "x86_64" {
 		systemArch = "amd64"
 	}
+
 	if systemArch != runtime.GOARCH {
-		return errors.NewErrorWithSuggestions(fmt.Sprintf(`binary architecture "%s" does not match system architecture "%s"`, runtime.GOARCH, systemArch), "Download the CLI with the correct architecture to continue.")
+		return errors.NewErrorWithSuggestions(
+			fmt.Sprintf(`binary architecture "%s" does not match system architecture "%s"`, runtime.GOARCH, systemArch),
+			"Download the CLI with the correct architecture to continue.",
+		)
 	}
+
 	return nil
 }

--- a/internal/local/command_kafka_topic_consume.go
+++ b/internal/local/command_kafka_topic_consume.go
@@ -70,7 +70,10 @@ func (c *command) kafkaTopicConsume(cmd *cobra.Command, args []string) error {
 	}
 	consumer, err := newOnPremConsumer(cmd, c.getPlaintextBootstrapServers())
 	if err != nil {
-		return errors.NewErrorWithSuggestions(fmt.Errorf(errors.FailedToCreateConsumerErrorMsg, err).Error(), errors.OnPremConfigGuideSuggestions)
+		return errors.NewErrorWithSuggestions(
+			fmt.Sprintf(errors.FailedToCreateConsumerErrorMsg, err),
+			errors.OnPremConfigGuideSuggestions,
+		)
 	}
 	log.CliLogger.Tracef("Create consumer succeeded")
 

--- a/internal/local/command_kafka_topic_produce.go
+++ b/internal/local/command_kafka_topic_produce.go
@@ -48,7 +48,10 @@ func (c *command) kafkaTopicProduce(cmd *cobra.Command, args []string) error {
 	}
 	producer, err := newOnPremProducer(cmd, c.getPlaintextBootstrapServers())
 	if err != nil {
-		return errors.NewErrorWithSuggestions(fmt.Errorf(errors.FailedToCreateProducerErrorMsg, err).Error(), errors.OnPremConfigGuideSuggestions)
+		return errors.NewErrorWithSuggestions(
+			fmt.Sprintf(errors.FailedToCreateProducerErrorMsg, err),
+			errors.OnPremConfigGuideSuggestions,
+		)
 	}
 	defer producer.Close()
 	log.CliLogger.Tracef("Create producer succeeded")

--- a/internal/login/command.go
+++ b/internal/login/command.go
@@ -114,19 +114,19 @@ func (c *command) login(cmd *cobra.Command, _ []string) error {
 }
 
 func (c *command) loginCCloud(cmd *cobra.Command, url string) error {
-	orgResourceId := c.getOrgResourceId(cmd)
+	organizationId := c.getOrganizationId(cmd)
 
 	noBrowser, err := cmd.Flags().GetBool("no-browser")
 	if err != nil {
 		return err
 	}
 
-	credentials, err := c.getCCloudCredentials(cmd, url, orgResourceId)
+	credentials, err := c.getCCloudCredentials(cmd, url, organizationId)
 	if err != nil {
 		return err
 	}
 
-	token, refreshToken, err := c.authTokenHandler.GetCCloudTokens(c.ccloudClientFactory, url, credentials, noBrowser, orgResourceId)
+	token, refreshToken, err := c.authTokenHandler.GetCCloudTokens(c.ccloudClientFactory, url, credentials, noBrowser, organizationId)
 
 	endOfFreeTrialErr, isEndOfFreeTrialErr := err.(*errors.EndOfFreeTrialError)
 
@@ -203,7 +203,7 @@ func (c *command) printRemainingFreeCredit(client *ccloudv1.Client, currentOrg *
 
 // Order of precedence: env vars > config file > netrc file > prompt
 // i.e. if login credentials found in env vars then acquire token using env vars and skip checking for credentials else where
-func (c *command) getCCloudCredentials(cmd *cobra.Command, url, orgResourceId string) (*pauth.Credentials, error) {
+func (c *command) getCCloudCredentials(cmd *cobra.Command, url, organizationId string) (*pauth.Credentials, error) {
 	client := c.ccloudClientFactory.AnonHTTPClientFactory(url)
 	c.loginCredentialsManager.SetCloudClient(client)
 
@@ -212,7 +212,7 @@ func (c *command) getCCloudCredentials(cmd *cobra.Command, url, orgResourceId st
 		return nil, err
 	}
 	if prompt {
-		return pauth.GetLoginCredentials(c.loginCredentialsManager.GetCloudCredentialsFromPrompt(orgResourceId))
+		return pauth.GetLoginCredentials(c.loginCredentialsManager.GetCloudCredentialsFromPrompt(organizationId))
 	}
 
 	filterParams := netrc.NetrcMachineParams{
@@ -225,12 +225,12 @@ func (c *command) getCCloudCredentials(cmd *cobra.Command, url, orgResourceId st
 	}
 
 	return pauth.GetLoginCredentials(
-		c.loginCredentialsManager.GetCloudCredentialsFromEnvVar(orgResourceId),
+		c.loginCredentialsManager.GetCloudCredentialsFromEnvVar(organizationId),
 		c.loginCredentialsManager.GetSsoCredentialsFromConfig(c.cfg, url),
 		c.loginCredentialsManager.GetCredentialsFromKeychain(c.cfg, true, filterParams.Name, url),
 		c.loginCredentialsManager.GetCredentialsFromConfig(c.cfg, filterParams),
 		c.loginCredentialsManager.GetCredentialsFromNetrc(filterParams),
-		c.loginCredentialsManager.GetCloudCredentialsFromPrompt(orgResourceId),
+		c.loginCredentialsManager.GetCloudCredentialsFromPrompt(organizationId),
 	)
 }
 
@@ -422,7 +422,7 @@ func validateURL(url string, isCCloud bool) (string, string, error) {
 	return url, strings.Join(msg, " and "), nil
 }
 
-func (c *command) getOrgResourceId(cmd *cobra.Command) string {
+func (c *command) getOrganizationId(cmd *cobra.Command) string {
 	return pauth.GetLoginOrganization(
 		c.loginOrganizationManager.GetLoginOrganizationFromFlag(cmd),
 		c.loginOrganizationManager.GetLoginOrganizationFromEnvironmentVariable(),

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -107,7 +107,7 @@ func PersistCCloudCredentialsToConfig(config *config.Config, client *ccloudv1.Cl
 	return ctx.CurrentEnvironment, user.GetOrganization(), nil
 }
 
-func addOrUpdateContext(cfg *config.Config, isCloud bool, credentials *Credentials, ctxName, url string, state *config.ContextState, caCertPath, orgResourceId string, save bool) error {
+func addOrUpdateContext(cfg *config.Config, isCloud bool, credentials *Credentials, ctxName, url string, state *config.ContextState, caCertPath, organizationId string, save bool) error {
 	platform := &config.Platform{
 		Name:       strings.TrimSuffix(strings.TrimPrefix(url, "https://"), "/"),
 		Server:     url,
@@ -165,9 +165,9 @@ func addOrUpdateContext(cfg *config.Config, isCloud bool, credentials *Credentia
 
 		ctx.Credential = credential
 		ctx.CredentialName = credential.Name
-		ctx.LastOrgId = orgResourceId
+		ctx.LastOrgId = organizationId
 	} else {
-		if err := cfg.AddContext(ctxName, platform.Name, credential.Name, map[string]*config.KafkaClusterConfig{}, "", state, orgResourceId, ""); err != nil {
+		if err := cfg.AddContext(ctxName, platform.Name, credential.Name, map[string]*config.KafkaClusterConfig{}, "", state, organizationId, ""); err != nil {
 			return err
 		}
 	}

--- a/pkg/auth/auth_token_handler.go
+++ b/pkg/auth/auth_token_handler.go
@@ -16,8 +16,8 @@ import (
 )
 
 type AuthTokenHandler interface {
-	GetCCloudTokens(clientFactory CCloudClientFactory, url string, credentials *Credentials, noBrowser bool, orgResourceId string) (string, string, error)
-	GetConfluentToken(mdsClient *mdsv1.APIClient, credentials *Credentials) (string, error)
+	GetCCloudTokens(CCloudClientFactory, string, *Credentials, bool, string) (string, string, error)
+	GetConfluentToken(*mdsv1.APIClient, *Credentials) (string, error)
 }
 
 type AuthTokenHandlerImpl struct{}
@@ -26,18 +26,18 @@ func NewAuthTokenHandler() AuthTokenHandler {
 	return &AuthTokenHandlerImpl{}
 }
 
-func (a *AuthTokenHandlerImpl) GetCCloudTokens(clientFactory CCloudClientFactory, url string, credentials *Credentials, noBrowser bool, orgResourceId string) (string, string, error) {
+func (a *AuthTokenHandlerImpl) GetCCloudTokens(clientFactory CCloudClientFactory, url string, credentials *Credentials, noBrowser bool, organizationId string) (string, string, error) {
 	client := clientFactory.AnonHTTPClientFactory(url)
 
 	if credentials.AuthRefreshToken != "" {
 		if credentials.IsSSO {
-			if token, refreshToken, err := a.refreshCCloudSSOToken(client, credentials.AuthRefreshToken, orgResourceId); err == nil {
+			if token, refreshToken, err := a.refreshCCloudSSOToken(client, credentials.AuthRefreshToken, organizationId); err == nil {
 				return token, refreshToken, nil
 			}
 		} else {
 			req := &ccloudv1.AuthenticateRequest{
 				RefreshToken:  credentials.AuthRefreshToken,
-				OrgResourceId: orgResourceId,
+				OrgResourceId: organizationId,
 			}
 			if res, err := client.Auth.Login(req); err == nil {
 				return res.GetToken(), res.GetRefreshToken(), nil
@@ -47,7 +47,7 @@ func (a *AuthTokenHandlerImpl) GetCCloudTokens(clientFactory CCloudClientFactory
 
 	// If SSO refresh token is missing or expired, ask for a new one
 	if credentials.IsSSO {
-		token, refreshToken, err := a.getCCloudSSOToken(client, noBrowser, credentials.Username, orgResourceId)
+		token, refreshToken, err := a.getCCloudSSOToken(client, noBrowser, credentials.Username, organizationId)
 		if err != nil {
 			return "", "", err
 		}
@@ -58,12 +58,12 @@ func (a *AuthTokenHandlerImpl) GetCCloudTokens(clientFactory CCloudClientFactory
 	}
 
 	client.HttpClient.Timeout = 30 * time.Second
-	log.CliLogger.Debugf("Making login request for %s for org id %s", credentials.Username, orgResourceId)
+	log.CliLogger.Debugf("Making login request for %s for org id %s", credentials.Username, organizationId)
 
 	req := &ccloudv1.AuthenticateRequest{
 		Email:         credentials.Username,
 		Password:      credentials.Password,
-		OrgResourceId: orgResourceId,
+		OrgResourceId: organizationId,
 	}
 
 	res, err := client.Auth.Login(req)
@@ -79,8 +79,8 @@ func (a *AuthTokenHandlerImpl) GetCCloudTokens(clientFactory CCloudClientFactory
 	return res.GetToken(), res.GetRefreshToken(), nil
 }
 
-func (a *AuthTokenHandlerImpl) getCCloudSSOToken(client *ccloudv1.Client, noBrowser bool, email, orgResourceId string) (string, string, error) {
-	connectionName, err := a.getSsoConnectionName(client, email, orgResourceId)
+func (a *AuthTokenHandlerImpl) getCCloudSSOToken(client *ccloudv1.Client, noBrowser bool, email, organizationId string) (string, string, error) {
+	connectionName, err := a.getSsoConnectionName(client, email, organizationId)
 	if err != nil {
 		log.CliLogger.Debugf("unable to obtain user SSO info: %v", err)
 		return "", "", errors.Errorf(`unable to obtain SSO info for user "%s"`, email)
@@ -96,7 +96,7 @@ func (a *AuthTokenHandlerImpl) getCCloudSSOToken(client *ccloudv1.Client, noBrow
 
 	req := &ccloudv1.AuthenticateRequest{
 		IdToken:       idToken,
-		OrgResourceId: orgResourceId,
+		OrgResourceId: organizationId,
 	}
 	res, err := login(client, req)
 	if err != nil {
@@ -106,11 +106,11 @@ func (a *AuthTokenHandlerImpl) getCCloudSSOToken(client *ccloudv1.Client, noBrow
 	return res.GetToken(), refreshToken, err
 }
 
-func (a *AuthTokenHandlerImpl) getSsoConnectionName(client *ccloudv1.Client, email, orgResourceId string) (string, error) {
+func (a *AuthTokenHandlerImpl) getSsoConnectionName(client *ccloudv1.Client, email, organizationId string) (string, error) {
 	req := &ccloudv1.GetLoginRealmRequest{
 		Email:         email,
 		ClientId:      sso.GetAuth0CCloudClientIdFromBaseUrl(client.BaseURL),
-		OrgResourceId: orgResourceId,
+		OrgResourceId: organizationId,
 	}
 	loginRealmReply, err := client.User.LoginRealm(req)
 	if err != nil {
@@ -122,7 +122,7 @@ func (a *AuthTokenHandlerImpl) getSsoConnectionName(client *ccloudv1.Client, ema
 	return "", nil
 }
 
-func (a *AuthTokenHandlerImpl) refreshCCloudSSOToken(client *ccloudv1.Client, refreshToken, orgResourceId string) (string, string, error) {
+func (a *AuthTokenHandlerImpl) refreshCCloudSSOToken(client *ccloudv1.Client, refreshToken, organizationId string) (string, string, error) {
 	idToken, refreshToken, err := sso.RefreshTokens(client.BaseURL, refreshToken)
 	if err != nil {
 		return "", "", err
@@ -130,7 +130,7 @@ func (a *AuthTokenHandlerImpl) refreshCCloudSSOToken(client *ccloudv1.Client, re
 
 	req := &ccloudv1.AuthenticateRequest{
 		IdToken:       idToken,
-		OrgResourceId: orgResourceId,
+		OrgResourceId: organizationId,
 	}
 
 	res, err := login(client, req)
@@ -157,7 +157,10 @@ func (a *AuthTokenHandlerImpl) checkSSOEmailMatchesLogin(client *ccloudv1.Client
 		return err
 	}
 	if getMeReply.GetUser().GetEmail() != loginEmail {
-		return errors.NewErrorWithSuggestions(fmt.Sprintf("expected SSO credentials for %s but got credentials for %s", loginEmail, getMeReply.GetUser().GetEmail()), "Please re-login and use the same email at the prompt and in the SSO portal.")
+		return errors.NewErrorWithSuggestions(
+			fmt.Sprintf("expected SSO credentials for %s but got credentials for %s", loginEmail, getMeReply.GetUser().GetEmail()),
+			"Please re-login and use the same email at the prompt and in the SSO portal.",
+		)
 	}
 	return nil
 }

--- a/pkg/auth/login_credentials_manager.go
+++ b/pkg/auth/login_credentials_manager.go
@@ -71,21 +71,21 @@ func GetLoginCredentials(credentialsFuncs ...func() (*Credentials, error)) (*Cre
 }
 
 type LoginCredentialsManager interface {
-	GetCloudCredentialsFromEnvVar(orgResourceId string) func() (*Credentials, error)
+	GetCloudCredentialsFromEnvVar(string) func() (*Credentials, error)
 	GetOnPremCredentialsFromEnvVar() func() (*Credentials, error)
-	GetSsoCredentialsFromConfig(cfg *config.Config, url string) func() (*Credentials, error)
-	GetCredentialsFromConfig(cfg *config.Config, filterParams netrc.NetrcMachineParams) func() (*Credentials, error)
-	GetCredentialsFromKeychain(cfg *config.Config, isCloud bool, ctxName, url string) func() (*Credentials, error)
-	GetCredentialsFromNetrc(filterParams netrc.NetrcMachineParams) func() (*Credentials, error)
-	GetCloudCredentialsFromPrompt(orgResourceId string) func() (*Credentials, error)
+	GetSsoCredentialsFromConfig(*config.Config, string) func() (*Credentials, error)
+	GetCredentialsFromConfig(*config.Config, netrc.NetrcMachineParams) func() (*Credentials, error)
+	GetCredentialsFromKeychain(*config.Config, bool, string, string) func() (*Credentials, error)
+	GetCredentialsFromNetrc(netrc.NetrcMachineParams) func() (*Credentials, error)
+	GetCloudCredentialsFromPrompt(string) func() (*Credentials, error)
 	GetOnPremCredentialsFromPrompt() func() (*Credentials, error)
 
-	GetPrerunCredentialsFromConfig(cfg *config.Config) func() (*Credentials, error)
+	GetPrerunCredentialsFromConfig(*config.Config) func() (*Credentials, error)
 	GetOnPremPrerunCredentialsFromEnvVar() func() (*Credentials, error)
 	GetOnPremPrerunCredentialsFromNetrc(*cobra.Command, netrc.NetrcMachineParams) func() (*Credentials, error)
 
 	// Needed SSO login for non-prod accounts
-	SetCloudClient(client *ccloudv1.Client)
+	SetCloudClient(*ccloudv1.Client)
 }
 
 type LoginCredentialsManagerImpl struct {
@@ -102,20 +102,20 @@ func NewLoginCredentialsManager(netrcHandler netrc.NetrcHandler, prompt form.Pro
 	}
 }
 
-func (h *LoginCredentialsManagerImpl) GetCloudCredentialsFromEnvVar(orgResourceId string) func() (*Credentials, error) {
+func (h *LoginCredentialsManagerImpl) GetCloudCredentialsFromEnvVar(organizationId string) func() (*Credentials, error) {
 	envVars := environmentVariables{
 		username:           ConfluentCloudEmail,
 		password:           ConfluentCloudPassword,
 		deprecatedUsername: DeprecatedConfluentCloudEmail,
 		deprecatedPassword: DeprecatedConfluentCloudPassword,
 	}
-	return h.getCredentialsFromEnvVarFunc(envVars, orgResourceId)
+	return h.getCredentialsFromEnvVarFunc(envVars, organizationId)
 }
 
-func (h *LoginCredentialsManagerImpl) getCredentialsFromEnvVarFunc(envVars environmentVariables, orgResourceId string) func() (*Credentials, error) {
+func (h *LoginCredentialsManagerImpl) getCredentialsFromEnvVarFunc(envVars environmentVariables, organizationId string) func() (*Credentials, error) {
 	return func() (*Credentials, error) {
 		email, password := h.getEnvVarCredentials(envVars.username, envVars.password)
-		if h.isSSOUser(email, orgResourceId) {
+		if h.isSSOUser(email, organizationId) {
 			log.CliLogger.Debugf("%s=%s belongs to an SSO user.", ConfluentCloudEmail, email)
 			return &Credentials{Username: email, IsSSO: true}, nil
 		}
@@ -262,11 +262,11 @@ func (h *LoginCredentialsManagerImpl) getNetrcMachine(filterParams netrc.NetrcMa
 	return netrcMachine, err
 }
 
-func (h *LoginCredentialsManagerImpl) GetCloudCredentialsFromPrompt(orgResourceId string) func() (*Credentials, error) {
+func (h *LoginCredentialsManagerImpl) GetCloudCredentialsFromPrompt(organizationId string) func() (*Credentials, error) {
 	return func() (*Credentials, error) {
 		output.Println(false, "Enter your Confluent Cloud credentials:")
 		email := h.promptForUser("Email")
-		if h.isSSOUser(email, orgResourceId) {
+		if h.isSSOUser(email, organizationId) {
 			log.CliLogger.Debug("Entered email belongs to an SSO user.")
 			return &Credentials{Username: email, IsSSO: true}, nil
 		}
@@ -302,7 +302,7 @@ func (h *LoginCredentialsManagerImpl) promptForPassword() string {
 	return f.Responses[passwordField].(string)
 }
 
-func (h *LoginCredentialsManagerImpl) isSSOUser(email, orgId string) bool {
+func (h *LoginCredentialsManagerImpl) isSSOUser(email, organizationId string) bool {
 	if h.client == nil {
 		return false
 	}
@@ -317,7 +317,7 @@ func (h *LoginCredentialsManagerImpl) isSSOUser(email, orgId string) bool {
 	req := &ccloudv1.GetLoginRealmRequest{
 		Email:         email,
 		ClientId:      auth0ClientId,
-		OrgResourceId: orgId,
+		OrgResourceId: organizationId,
 	}
 	res, err := h.client.User.LoginRealm(req)
 	// Fine to ignore non-nil err for this request: e.g. what if this fails due to invalid/malicious

--- a/pkg/cmd/prerunner.go
+++ b/pkg/cmd/prerunner.go
@@ -31,16 +31,6 @@ import (
 
 const autoLoginMsg = "Successful auto-login with non-interactive credentials."
 
-type wrongLoginCommandError struct {
-	errorString      string
-	suggestionString string
-}
-
-var wrongLoginCommandErrorWithSuggestion = wrongLoginCommandError{
-	"`%s` is not a Confluent Cloud command. Did you mean `%s`?",
-	"If you are a Confluent Cloud user, run `%s` instead.\n" +
-		"If you are attempting to connect to Confluent Platform, login with `confluent login --url <mds-url>` to use `%s`."}
-
 var wrongLoginCommandsMap = map[string]string{
 	"confluent cluster": "confluent kafka cluster",
 }
@@ -290,14 +280,14 @@ func (r *PreRun) ccloudAutoLogin(netrcMachineName string) error {
 	return nil
 }
 
-func (r *PreRun) getCCloudCredentials(netrcMachineName, url, orgResourceId string) (*pauth.Credentials, error) {
+func (r *PreRun) getCCloudCredentials(netrcMachineName, url, organizationId string) (*pauth.Credentials, error) {
 	filterParams := netrc.NetrcMachineParams{
 		Name:    netrcMachineName,
 		IsCloud: true,
 		URL:     url,
 	}
 	credentials, err := pauth.GetLoginCredentials(
-		r.LoginCredentialsManager.GetCloudCredentialsFromEnvVar(orgResourceId),
+		r.LoginCredentialsManager.GetCloudCredentialsFromEnvVar(organizationId),
 		r.LoginCredentialsManager.GetCredentialsFromKeychain(r.Config, true, filterParams.Name, url),
 		r.LoginCredentialsManager.GetPrerunCredentialsFromConfig(r.Config),
 		r.LoginCredentialsManager.GetCredentialsFromNetrc(filterParams),
@@ -308,7 +298,7 @@ func (r *PreRun) getCCloudCredentials(netrcMachineName, url, orgResourceId strin
 		return nil, err
 	}
 
-	token, refreshToken, err := r.AuthTokenHandler.GetCCloudTokens(r.CCloudClientFactory, url, credentials, false, orgResourceId)
+	token, refreshToken, err := r.AuthTokenHandler.GetCCloudTokens(r.CCloudClientFactory, url, credentials, false, organizationId)
 	if err != nil {
 		return nil, err
 	}
@@ -456,8 +446,10 @@ func (r *PreRun) AuthenticatedWithMDS(command *AuthenticatedCLICommand) func(*co
 				for topLevelCmd, suggestCmd := range wrongLoginCommandsMap {
 					if strings.HasPrefix(cmd.CommandPath(), topLevelCmd) {
 						suggestCmdPath := strings.Replace(cmd.CommandPath(), topLevelCmd, suggestCmd, 1)
-						return errors.NewErrorWithSuggestions(fmt.Sprintf(wrongLoginCommandErrorWithSuggestion.errorString, cmd.CommandPath(), suggestCmdPath),
-							fmt.Sprintf(wrongLoginCommandErrorWithSuggestion.suggestionString, suggestCmdPath, cmd.CommandPath()))
+						return errors.NewErrorWithSuggestions(
+							fmt.Sprintf("`%s` is not a Confluent Cloud command. Did you mean `%s`?", cmd.CommandPath(), suggestCmdPath),
+							fmt.Sprintf("If you are a Confluent Cloud user, run `%s` instead.\nIf you are attempting to connect to Confluent Platform, login with `confluent login --url <mds-url>` to use `%s`.", suggestCmdPath, cmd.CommandPath()),
+						)
 					}
 				}
 			}

--- a/pkg/cmd/prerunner_test.go
+++ b/pkg/cmd/prerunner_test.go
@@ -443,7 +443,7 @@ func TestPrerun_AutoLogin(t *testing.T) {
 			var confluentEnvVarCalled bool
 			var confluentNetrcCalled bool
 			r.LoginCredentialsManager = &climock.LoginCredentialsManager{
-				GetCloudCredentialsFromEnvVarFunc: func(orgResourceId string) func() (*pauth.Credentials, error) {
+				GetCloudCredentialsFromEnvVarFunc: func(_ string) func() (*pauth.Credentials, error) {
 					return func() (*pauth.Credentials, error) {
 						ccloudEnvVarCalled = true
 						return test.envVarReturn.creds, test.envVarReturn.err
@@ -548,8 +548,8 @@ func TestPrerun_ReLoginToLastOrgUsed(t *testing.T) {
 		},
 	}
 	r.AuthTokenHandler = &climock.AuthTokenHandler{
-		GetCCloudTokensFunc: func(_ pauth.CCloudClientFactory, _ string, _ *pauth.Credentials, _ bool, orgResourceId string) (string, string, error) {
-			require.Equal(t, "o-555", orgResourceId) // validate correct org id is used
+		GetCCloudTokensFunc: func(_ pauth.CCloudClientFactory, _ string, _ *pauth.Credentials, _ bool, organizationId string) (string, string, error) {
+			require.Equal(t, "o-555", organizationId)
 			return validAuthToken, "", nil
 		},
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -488,7 +488,7 @@ func (c *Config) FindContext(name string) (*Context, error) {
 	return context, nil
 }
 
-func (c *Config) AddContext(name, platformName, credentialName string, kafkaClusters map[string]*KafkaClusterConfig, kafka string, state *ContextState, orgResourceId, envId string) error {
+func (c *Config) AddContext(name, platformName, credentialName string, kafkaClusters map[string]*KafkaClusterConfig, kafka string, state *ContextState, organizationId, environmentId string) error {
 	if _, ok := c.Contexts[name]; ok {
 		return fmt.Errorf(errors.ContextAlreadyExistsErrorMsg, name)
 	}
@@ -503,7 +503,7 @@ func (c *Config) AddContext(name, platformName, credentialName string, kafkaClus
 		return fmt.Errorf(`platform "%s" not found`, platformName)
 	}
 
-	ctx, err := newContext(name, platform, credential, kafkaClusters, kafka, state, c, orgResourceId, envId)
+	ctx, err := newContext(name, platform, credential, kafkaClusters, kafka, state, c, organizationId, environmentId)
 	if err != nil {
 		return err
 	}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -840,10 +840,10 @@ func TestKafkaClusterContext_SetAndGetActiveKafkaCluster_NonEnv(t *testing.T) {
 }
 
 func TestKafkaClusterContext_AddAndGetKafkaClusterConfig(t *testing.T) {
-	clusterID := "lkc-abcdefg"
+	id := "lkc-abcdefg"
 
 	kcc := &KafkaClusterConfig{
-		ID:        clusterID,
+		ID:        id,
 		Name:      "lit",
 		Bootstrap: "http://test",
 		APIKeys: map[string]*APIKeyPair{
@@ -858,15 +858,15 @@ func TestKafkaClusterContext_AddAndGetKafkaClusterConfig(t *testing.T) {
 		testInputs := SetupTestInputs(isCloud)
 		kafkaClusterContext := testInputs.statefulConfig.Context().KafkaClusterContext
 		kafkaClusterContext.AddKafkaClusterConfig(kcc)
-		reflect.DeepEqual(kcc, kafkaClusterContext.GetKafkaClusterConfig(clusterID))
+		reflect.DeepEqual(kcc, kafkaClusterContext.GetKafkaClusterConfig(id))
 	}
 }
 
 func TestKafkaClusterContext_DeleteAPIKey(t *testing.T) {
-	clusterID := "lkc-abcdefg"
+	id := "lkc-abcdefg"
 	apiKey := "akey"
 	kcc := &KafkaClusterConfig{
-		ID:        clusterID,
+		ID:        id,
 		Name:      "lit",
 		Bootstrap: "http://test",
 		APIKeys: map[string]*APIKeyPair{
@@ -883,7 +883,7 @@ func TestKafkaClusterContext_DeleteAPIKey(t *testing.T) {
 		kafkaClusterContext.AddKafkaClusterConfig(kcc)
 
 		kafkaClusterContext.DeleteApiKey(apiKey)
-		kcc := kafkaClusterContext.GetKafkaClusterConfig(clusterID)
+		kcc := kafkaClusterContext.GetKafkaClusterConfig(id)
 		if _, ok := kcc.APIKeys[apiKey]; ok {
 			t.Errorf("DeleteAPIKey did not delete the API key.")
 		}
@@ -894,10 +894,10 @@ func TestKafkaClusterContext_DeleteAPIKey(t *testing.T) {
 }
 
 func TestKafkaClusterContext_RemoveKafkaCluster(t *testing.T) {
-	clusterID := "lkc-abcdefg"
+	id := "lkc-abcdefg"
 	apiKey := "akey"
 	kcc := &KafkaClusterConfig{
-		ID:        clusterID,
+		ID:        id,
 		Name:      "lit",
 		Bootstrap: "http://test",
 		APIKeys: map[string]*APIKeyPair{
@@ -912,11 +912,11 @@ func TestKafkaClusterContext_RemoveKafkaCluster(t *testing.T) {
 		testInputs := SetupTestInputs(isCloud)
 		kafkaClusterContext := testInputs.statefulConfig.Context().KafkaClusterContext
 		kafkaClusterContext.AddKafkaClusterConfig(kcc)
-		kafkaClusterContext.SetActiveKafkaCluster(clusterID)
-		require.Equal(t, clusterID, kafkaClusterContext.GetActiveKafkaClusterId())
+		kafkaClusterContext.SetActiveKafkaCluster(id)
+		require.Equal(t, id, kafkaClusterContext.GetActiveKafkaClusterId())
 
-		kafkaClusterContext.RemoveKafkaCluster(clusterID)
-		_, ok := kafkaClusterContext.KafkaClusterConfigs[clusterID]
+		kafkaClusterContext.RemoveKafkaCluster(id)
+		_, ok := kafkaClusterContext.KafkaClusterConfigs[id]
 		require.False(t, ok)
 		require.Empty(t, kafkaClusterContext.GetActiveKafkaClusterId())
 	}

--- a/pkg/config/context.go
+++ b/pkg/config/context.go
@@ -33,7 +33,7 @@ type Context struct {
 	Config     *Config       `json:"-"`
 }
 
-func newContext(name string, platform *Platform, credential *Credential, kafkaClusters map[string]*KafkaClusterConfig, kafka string, state *ContextState, config *Config, orgResourceId, envId string) (*Context, error) {
+func newContext(name string, platform *Platform, credential *Credential, kafkaClusters map[string]*KafkaClusterConfig, kafka string, state *ContextState, config *Config, organizationId, environmentId string) (*Context, error) {
 	ctx := &Context{
 		Name:               name,
 		NetrcMachineName:   name,
@@ -41,11 +41,11 @@ func newContext(name string, platform *Platform, credential *Credential, kafkaCl
 		PlatformName:       platform.Name,
 		Credential:         credential,
 		CredentialName:     credential.Name,
-		CurrentEnvironment: envId,
+		CurrentEnvironment: environmentId,
 		Environments:       map[string]*EnvironmentContext{},
 		State:              state,
 		Config:             config,
-		LastOrgId:          orgResourceId,
+		LastOrgId:          organizationId,
 	}
 	ctx.KafkaClusterContext = NewKafkaClusterContext(ctx, kafka, kafkaClusters)
 	if err := ctx.validate(); err != nil {

--- a/pkg/config/mock.go
+++ b/pkg/config/mock.go
@@ -199,10 +199,10 @@ func createAPIKeyPair(apiKey, apiSecret string) *APIKeyPair {
 	}
 }
 
-func createKafkaCluster(clusterID, clusterName string, apiKeyPair *APIKeyPair) *KafkaClusterConfig {
+func createKafkaCluster(id, name string, apiKeyPair *APIKeyPair) *KafkaClusterConfig {
 	return &KafkaClusterConfig{
-		ID:         clusterID,
-		Name:       clusterName,
+		ID:         id,
+		Name:       name,
 		Bootstrap:  bootstrapServer,
 		APIKeys:    map[string]*APIKeyPair{apiKeyPair.Key: apiKeyPair},
 		APIKey:     apiKeyPair.Key,

--- a/pkg/deletion/deletion.go
+++ b/pkg/deletion/deletion.go
@@ -84,8 +84,10 @@ func ConfirmDeletionWithString(cmd *cobra.Command, promptMsg, stringToType strin
 		return nil
 	}
 
-	DeleteResourceConfirmSuggestions := "Use the `--force` flag to delete without a confirmation prompt."
-	return errors.NewErrorWithSuggestions(fmt.Sprintf(`input does not match "%s"`, stringToType), DeleteResourceConfirmSuggestions)
+	return errors.NewErrorWithSuggestions(
+		fmt.Sprintf(`input does not match "%s"`, stringToType),
+		"Use the `--force` flag to delete without a confirmation prompt.",
+	)
 }
 
 func DeleteWithoutMessage(args []string, callDeleteEndpoint func(string) error) ([]string, error) {

--- a/pkg/dynamic-config/client.go
+++ b/pkg/dynamic-config/client.go
@@ -8,24 +8,24 @@ import (
 	"github.com/confluentinc/cli/v3/pkg/errors"
 )
 
-func (d *DynamicContext) FetchAPIKeyError(apiKey, clusterID string) error {
+func (d *DynamicContext) FetchAPIKeyError(apiKey, clusterId string) error {
 	// check if this is API key exists server-side
 	key, httpResp, err := d.V2Client.GetApiKey(apiKey)
 	if err != nil {
 		return errors.CatchCCloudV2Error(err, httpResp)
 	}
 	// check if the key is for the right cluster
-	ok := key.Spec.Resource.Id == clusterID
+	ok := key.Spec.Resource.Id == clusterId
 	// this means the requested api-key belongs to a different cluster
 	if !ok {
 		return errors.NewErrorWithSuggestions(
-			fmt.Sprintf(`invalid API key "%s" for resource "%s"`, apiKey, clusterID),
+			fmt.Sprintf(`invalid API key "%s" for resource "%s"`, apiKey, clusterId),
 			fmt.Sprintf("To list API key that belongs to resource \"%s\", use `confluent api-key list --resource %s`.\n"+
-				"To create new API key for resource \"%s\", use `confluent api-key create --resource %s`.", clusterID, clusterID, clusterID, clusterID),
+				"To create new API key for resource \"%s\", use `confluent api-key create --resource %s`.", clusterId, clusterId, clusterId, clusterId),
 		)
 	}
 	// the requested api-key exists, but the secret is not saved locally
-	return &errors.UnconfiguredAPISecretError{APIKey: apiKey, ClusterID: clusterID}
+	return &errors.UnconfiguredAPISecretError{APIKey: apiKey, ClusterID: clusterId}
 }
 
 func (d *DynamicContext) FetchSchemaRegistryByEnvironmentId(accountId string) (srcmv2.SrcmV2Cluster, error) {

--- a/pkg/errors/catcher.go
+++ b/pkg/errors/catcher.go
@@ -192,14 +192,14 @@ func CatchCCloudV2Error(err error, r *http.Response) error {
 	return err
 }
 
-func CatchResourceNotFoundError(err error, resourceId string) error {
+func CatchResourceNotFoundError(err error, id string) error {
 	if err == nil {
 		return nil
 	}
 
 	if _, ok := err.(*KafkaClusterNotFoundError); ok || isResourceNotFoundError(err) {
-		errorMsg := fmt.Sprintf(ResourceNotFoundErrorMsg, resourceId)
-		suggestionsMsg := fmt.Sprintf(ResourceNotFoundSuggestions, resourceId)
+		errorMsg := fmt.Sprintf(ResourceNotFoundErrorMsg, id)
+		suggestionsMsg := fmt.Sprintf(ResourceNotFoundSuggestions, id)
 		return NewErrorWithSuggestions(errorMsg, suggestionsMsg)
 	}
 

--- a/pkg/flink/internal/store/store.go
+++ b/pkg/flink/internal/store/store.go
@@ -97,7 +97,7 @@ func (s *Store) ProcessStatement(statement string) (*types.ProcessedStatement, *
 		createSqlV1beta1Statement(statement, statementName, computePoolId, properties),
 		principal,
 		s.appOptions.GetEnvironmentId(),
-		s.appOptions.GetOrgResourceId(),
+		s.appOptions.GetOrganizationId(),
 	)
 	if err != nil {
 		status := statementObj.GetStatus()
@@ -147,7 +147,7 @@ func (s *Store) FetchStatementResults(statement types.ProcessedStatement) (*type
 	}
 
 	// Process remote statements that are now running or completed
-	statementResultObj, err := s.authenticatedGatewayClient().GetStatementResults(s.appOptions.GetEnvironmentId(), statement.StatementName, s.appOptions.GetOrgResourceId(), statement.PageToken)
+	statementResultObj, err := s.authenticatedGatewayClient().GetStatementResults(s.appOptions.GetEnvironmentId(), statement.StatementName, s.appOptions.GetOrganizationId(), statement.PageToken)
 	if err != nil {
 		return nil, &types.StatementError{Message: err.Error()}
 	}
@@ -169,7 +169,7 @@ func (s *Store) FetchStatementResults(statement types.ProcessedStatement) (*type
 }
 
 func (s *Store) DeleteStatement(statementName string) bool {
-	if err := s.authenticatedGatewayClient().DeleteStatement(s.appOptions.GetEnvironmentId(), statementName, s.appOptions.GetOrgResourceId()); err != nil {
+	if err := s.authenticatedGatewayClient().DeleteStatement(s.appOptions.GetEnvironmentId(), statementName, s.appOptions.GetOrganizationId()); err != nil {
 		log.CliLogger.Warnf("Failed to delete the statement: %v", err)
 		return false
 	}
@@ -178,7 +178,7 @@ func (s *Store) DeleteStatement(statementName string) bool {
 }
 
 func (s *Store) StopStatement(statementName string) bool {
-	statement, err := s.authenticatedGatewayClient().GetStatement(s.appOptions.GetEnvironmentId(), statementName, s.appOptions.GetOrgResourceId())
+	statement, err := s.authenticatedGatewayClient().GetStatement(s.appOptions.GetEnvironmentId(), statementName, s.appOptions.GetOrganizationId())
 
 	if err != nil {
 		log.CliLogger.Warnf("Failed to fetch statement to stop it: %v", err)
@@ -192,7 +192,7 @@ func (s *Store) StopStatement(statementName string) bool {
 	}
 	spec.SetStopped(true)
 
-	if err := s.authenticatedGatewayClient().UpdateStatement(s.appOptions.GetEnvironmentId(), statementName, s.appOptions.GetOrgResourceId(), statement); err != nil {
+	if err := s.authenticatedGatewayClient().UpdateStatement(s.appOptions.GetEnvironmentId(), statementName, s.appOptions.GetOrganizationId(), statement); err != nil {
 		log.CliLogger.Warnf("Failed to stop the statement: %v", err)
 		return false
 	}
@@ -218,7 +218,7 @@ func (s *Store) waitForPendingStatement(ctx context.Context, statementName strin
 			return nil, &types.StatementError{Message: "result retrieval aborted. Statement will be deleted", StatusCode: 499}
 		default:
 			start := time.Now()
-			statementObj, err := s.authenticatedGatewayClient().GetStatement(s.appOptions.GetEnvironmentId(), statementName, s.appOptions.GetOrgResourceId())
+			statementObj, err := s.authenticatedGatewayClient().GetStatement(s.appOptions.GetEnvironmentId(), statementName, s.appOptions.GetOrganizationId())
 			getRequestDuration = time.Since(start)
 
 			statusDetail := s.getStatusDetail(statementObj)
@@ -300,7 +300,7 @@ func (s *Store) getStatusDetail(statementObj flinkgatewayv1beta1.SqlV1beta1State
 	}
 
 	// if the status detail field is empty, we check if there's an exception instead
-	exceptionsResponse, err := s.authenticatedGatewayClient().GetExceptions(s.appOptions.GetEnvironmentId(), statementObj.GetName(), s.appOptions.GetOrgResourceId())
+	exceptionsResponse, err := s.authenticatedGatewayClient().GetExceptions(s.appOptions.GetEnvironmentId(), statementObj.GetName(), s.appOptions.GetOrganizationId())
 	if err != nil {
 		return ""
 	}
@@ -368,7 +368,7 @@ func (s *Store) WaitForTerminalStatementState(ctx context.Context, statement typ
 			output.Println(false, "Detached from statement.")
 			return &statement, nil
 		default:
-			statementObj, err := s.authenticatedGatewayClient().GetStatement(s.appOptions.GetEnvironmentId(), statement.StatementName, s.appOptions.GetOrgResourceId())
+			statementObj, err := s.authenticatedGatewayClient().GetStatement(s.appOptions.GetEnvironmentId(), statement.StatementName, s.appOptions.GetOrganizationId())
 			status := statementObj.GetStatus()
 			statusDetail := status.GetDetail()
 			if err != nil {

--- a/pkg/flink/internal/store/store_test.go
+++ b/pkg/flink/internal/store/store_test.go
@@ -49,7 +49,7 @@ func TestStoreProcessLocalStatement(t *testing.T) {
 	client := ccloudv2.NewFlinkGatewayClient("url", "userAgent", false, "authToken")
 	mockAppController := mock.NewMockApplicationControllerInterface(gomock.NewController(t))
 	appOptions := types.ApplicationOptions{
-		OrgResourceId:   "orgId",
+		OrganizationId:  "orgId",
 		EnvironmentName: "envName",
 		Database:        "database",
 	}
@@ -85,8 +85,8 @@ func TestWaitForPendingStatement3(t *testing.T) {
 
 	client := mock.NewMockGatewayClientInterface(gomock.NewController(t))
 	appOptions := types.ApplicationOptions{
-		OrgResourceId: "orgId",
-		EnvironmentId: "envId",
+		OrganizationId: "orgId",
+		EnvironmentId:  "envId",
 	}
 	s := &Store{
 		client:           client,
@@ -115,8 +115,8 @@ func TestWaitForPendingTimesout(t *testing.T) {
 
 	client := mock.NewMockGatewayClientInterface(gomock.NewController(t))
 	appOptions := types.ApplicationOptions{
-		OrgResourceId: "orgId",
-		EnvironmentId: "envId",
+		OrganizationId: "orgId",
+		EnvironmentId:  "envId",
 	}
 	s := &Store{
 		client:           client,
@@ -149,8 +149,8 @@ func TestWaitForPendingHitsErrorRetryLimit(t *testing.T) {
 
 	client := mock.NewMockGatewayClientInterface(gomock.NewController(t))
 	appOptions := types.ApplicationOptions{
-		OrgResourceId: "orgId",
-		EnvironmentId: "envId",
+		OrganizationId: "orgId",
+		EnvironmentId:  "envId",
 	}
 	s := &Store{
 		client:           client,
@@ -181,8 +181,8 @@ func TestWaitForPendingEventuallyCompletes(t *testing.T) {
 
 	client := mock.NewMockGatewayClientInterface(gomock.NewController(t))
 	appOptions := types.ApplicationOptions{
-		OrgResourceId: "orgId",
-		EnvironmentId: "envId",
+		OrganizationId: "orgId",
+		EnvironmentId:  "envId",
 	}
 	s := &Store{
 		client:           client,
@@ -219,8 +219,8 @@ func TestWaitForPendingStatementErrors(t *testing.T) {
 	waitTime := time.Millisecond * 1
 	client := mock.NewMockGatewayClientInterface(gomock.NewController(t))
 	appOptions := types.ApplicationOptions{
-		OrgResourceId: "orgId",
-		EnvironmentId: "envId",
+		OrganizationId: "orgId",
+		EnvironmentId:  "envId",
 	}
 	s := &Store{
 		client:           client,
@@ -253,8 +253,8 @@ func TestCancelPendingStatement(t *testing.T) {
 
 	client := mock.NewMockGatewayClientInterface(gomock.NewController(t))
 	appOptions := types.ApplicationOptions{
-		OrgResourceId: "orgId",
-		EnvironmentId: "envId",
+		OrganizationId: "orgId",
+		EnvironmentId:  "envId",
 	}
 	s := &Store{
 		client:           client,
@@ -786,7 +786,7 @@ func (s *StoreTestSuite) TestStopStatement() {
 	client := mock.NewMockGatewayClientInterface(ctrl)
 	mockAppController := mock.NewMockApplicationControllerInterface(ctrl)
 	appOptions := types.ApplicationOptions{
-		OrgResourceId:   "orgId",
+		OrganizationId:  "orgId",
 		EnvironmentId:   "envId",
 		EnvironmentName: "envName",
 		Database:        "database",
@@ -815,7 +815,7 @@ func (s *StoreTestSuite) TestStopStatementFailsOnGetError() {
 	client := mock.NewMockGatewayClientInterface(ctrl)
 	mockAppController := mock.NewMockApplicationControllerInterface(ctrl)
 	appOptions := types.ApplicationOptions{
-		OrgResourceId:   "orgId",
+		OrganizationId:  "orgId",
 		EnvironmentId:   "envId",
 		EnvironmentName: "envName",
 		Database:        "database",
@@ -839,7 +839,7 @@ func (s *StoreTestSuite) TestStopStatementFailsOnNilSpecError() {
 	client := mock.NewMockGatewayClientInterface(ctrl)
 	mockAppController := mock.NewMockApplicationControllerInterface(ctrl)
 	appOptions := types.ApplicationOptions{
-		OrgResourceId:   "orgId",
+		OrganizationId:  "orgId",
 		EnvironmentId:   "envId",
 		EnvironmentName: "envName",
 		Database:        "database",
@@ -865,7 +865,7 @@ func (s *StoreTestSuite) TestStopStatementFailsOnUpdateError() {
 	client := mock.NewMockGatewayClientInterface(ctrl)
 	mockAppController := mock.NewMockApplicationControllerInterface(ctrl)
 	appOptions := types.ApplicationOptions{
-		OrgResourceId:   "orgId",
+		OrganizationId:  "orgId",
 		EnvironmentId:   "envId",
 		EnvironmentName: "envName",
 		Database:        "database",
@@ -888,7 +888,7 @@ func (s *StoreTestSuite) TestDeleteStatement() {
 	client := mock.NewMockGatewayClientInterface(ctrl)
 	mockAppController := mock.NewMockApplicationControllerInterface(ctrl)
 	appOptions := types.ApplicationOptions{
-		OrgResourceId:   "orgId",
+		OrganizationId:  "orgId",
 		EnvironmentId:   "envId",
 		EnvironmentName: "envName",
 		Database:        "database",
@@ -909,7 +909,7 @@ func (s *StoreTestSuite) TestDeleteStatementFailsOnError() {
 	client := mock.NewMockGatewayClientInterface(ctrl)
 	mockAppController := mock.NewMockApplicationControllerInterface(ctrl)
 	appOptions := types.ApplicationOptions{
-		OrgResourceId:   "orgId",
+		OrganizationId:  "orgId",
 		EnvironmentId:   "envId",
 		EnvironmentName: "envName",
 		Database:        "database",
@@ -931,7 +931,7 @@ func (s *StoreTestSuite) TestFetchResultsNoRetryWithCompletedStatement() {
 	client := mock.NewMockGatewayClientInterface(ctrl)
 	mockAppController := mock.NewMockApplicationControllerInterface(ctrl)
 	appOptions := types.ApplicationOptions{
-		OrgResourceId:   "orgId",
+		OrganizationId:  "orgId",
 		EnvironmentId:   "envId",
 		EnvironmentName: "envName",
 		Database:        "database",
@@ -960,7 +960,7 @@ func (s *StoreTestSuite) TestFetchResultsWithRunningStatement() {
 	client := mock.NewMockGatewayClientInterface(ctrl)
 	mockAppController := mock.NewMockApplicationControllerInterface(ctrl)
 	appOptions := types.ApplicationOptions{
-		OrgResourceId:   "orgId",
+		OrganizationId:  "orgId",
 		EnvironmentId:   "envId",
 		EnvironmentName: "envName",
 		Database:        "database",
@@ -989,7 +989,7 @@ func (s *StoreTestSuite) TestFetchResultsNoRetryWhenPageTokenExists() {
 	client := mock.NewMockGatewayClientInterface(ctrl)
 	mockAppController := mock.NewMockApplicationControllerInterface(ctrl)
 	appOptions := types.ApplicationOptions{
-		OrgResourceId:   "orgId",
+		OrganizationId:  "orgId",
 		EnvironmentId:   "envId",
 		EnvironmentName: "envName",
 		Database:        "database",
@@ -1019,7 +1019,7 @@ func (s *StoreTestSuite) TestFetchResultsNoRetryWhenResultsExist() {
 	client := mock.NewMockGatewayClientInterface(ctrl)
 	mockAppController := mock.NewMockApplicationControllerInterface(ctrl)
 	appOptions := types.ApplicationOptions{
-		OrgResourceId:   "orgId",
+		OrganizationId:  "orgId",
 		EnvironmentId:   "envId",
 		EnvironmentName: "envName",
 		Database:        "database",
@@ -1106,9 +1106,9 @@ func TestTimeout(t *testing.T) {
 func (s *StoreTestSuite) TestProcessStatementWithServiceAccount() {
 	client := mock.NewMockGatewayClientInterface(gomock.NewController(s.T()))
 	appOptions := &types.ApplicationOptions{
-		OrgResourceId: "orgId",
-		EnvironmentId: "envId",
-		ComputePoolId: "computePoolId",
+		OrganizationId: "orgId",
+		EnvironmentId:  "envId",
+		ComputePoolId:  "computePoolId",
 	}
 	serviceAccountId := "sa-123"
 	store := Store{
@@ -1134,7 +1134,7 @@ func (s *StoreTestSuite) TestProcessStatementWithServiceAccount() {
 		},
 	}
 
-	client.EXPECT().CreateStatement(SqlV1beta1StatementMatcher{statementObj}, serviceAccountId, appOptions.EnvironmentId, appOptions.OrgResourceId).
+	client.EXPECT().CreateStatement(SqlV1beta1StatementMatcher{statementObj}, serviceAccountId, appOptions.EnvironmentId, appOptions.OrganizationId).
 		Return(statementObj, nil)
 
 	processedStatement, err := store.ProcessStatement(statement)
@@ -1158,9 +1158,9 @@ func (s *StoreTestSuite) TestProcessStatementWithUserIdentity() {
 		AuthRefreshToken: "v1.abc",
 	}
 	appOptions := &types.ApplicationOptions{
-		OrgResourceId: "orgId",
-		EnvironmentId: "envId",
-		ComputePoolId: "computePoolId",
+		OrganizationId: "orgId",
+		EnvironmentId:  "envId",
+		ComputePoolId:  "computePoolId",
 		Context: &dynamicconfig.DynamicContext{
 			Context: &config.Context{State: contextState, Config: &config.Config{}},
 		},
@@ -1187,7 +1187,7 @@ func (s *StoreTestSuite) TestProcessStatementWithUserIdentity() {
 		},
 	}
 
-	client.EXPECT().CreateStatement(SqlV1beta1StatementMatcher{statementObj}, user, appOptions.EnvironmentId, appOptions.OrgResourceId).
+	client.EXPECT().CreateStatement(SqlV1beta1StatementMatcher{statementObj}, user, appOptions.EnvironmentId, appOptions.OrganizationId).
 		Return(statementObj, nil)
 
 	processedStatement, err := store.ProcessStatement(statement)
@@ -1199,9 +1199,9 @@ func (s *StoreTestSuite) TestProcessStatementFailsOnError() {
 	client := mock.NewMockGatewayClientInterface(gomock.NewController(s.T()))
 	serviceAccountId := "serviceAccountId"
 	appOptions := &types.ApplicationOptions{
-		OrgResourceId: "orgId",
-		EnvironmentId: "envId",
-		ComputePoolId: "computePoolId",
+		OrganizationId: "orgId",
+		EnvironmentId:  "envId",
+		ComputePoolId:  "computePoolId",
 	}
 	store := Store{
 		Properties:       NewUserProperties(map[string]string{flinkconfig.ConfigKeyServiceAccount: serviceAccountId, "TestProp": "TestVal"}, map[string]string{}),
@@ -1225,7 +1225,7 @@ func (s *StoreTestSuite) TestProcessStatementFailsOnError() {
 	}
 	returnedError := errors.New("test error")
 
-	client.EXPECT().CreateStatement(SqlV1beta1StatementMatcher{statementObj}, serviceAccountId, appOptions.EnvironmentId, appOptions.OrgResourceId).
+	client.EXPECT().CreateStatement(SqlV1beta1StatementMatcher{statementObj}, serviceAccountId, appOptions.EnvironmentId, appOptions.OrganizationId).
 		Return(statementObj, returnedError)
 
 	expectedError := &types.StatementError{
@@ -1241,9 +1241,9 @@ func (s *StoreTestSuite) TestProcessStatementFailsOnError() {
 func (s *StoreTestSuite) TestProcessStatementUsesUserProvidedStatementName() {
 	client := mock.NewMockGatewayClientInterface(gomock.NewController(s.T()))
 	appOptions := &types.ApplicationOptions{
-		OrgResourceId: "orgId",
-		EnvironmentId: "envId",
-		ComputePoolId: "computePoolId",
+		OrganizationId: "orgId",
+		EnvironmentId:  "envId",
+		ComputePoolId:  "computePoolId",
 	}
 	serviceAccountId := "sa-123"
 	statementName := "test-statement"
@@ -1270,7 +1270,7 @@ func (s *StoreTestSuite) TestProcessStatementUsesUserProvidedStatementName() {
 		},
 	}
 
-	client.EXPECT().CreateStatement(SqlV1beta1StatementMatcher{statementObj}, serviceAccountId, appOptions.EnvironmentId, appOptions.OrgResourceId).
+	client.EXPECT().CreateStatement(SqlV1beta1StatementMatcher{statementObj}, serviceAccountId, appOptions.EnvironmentId, appOptions.OrganizationId).
 		Return(statementObj, nil)
 
 	processedStatement, err := store.ProcessStatement(statement)
@@ -1283,8 +1283,8 @@ func (s *StoreTestSuite) TestProcessStatementUsesUserProvidedStatementName() {
 func (s *StoreTestSuite) TestWaitPendingStatement() {
 	client := mock.NewMockGatewayClientInterface(gomock.NewController(s.T()))
 	appOptions := &types.ApplicationOptions{
-		OrgResourceId: "orgId",
-		EnvironmentId: "envId",
+		OrganizationId: "orgId",
+		EnvironmentId:  "envId",
 	}
 	store := Store{
 		Properties:       NewUserProperties(map[string]string{"TestProp": "TestVal"}, map[string]string{}),
@@ -1345,8 +1345,8 @@ func (s *StoreTestSuite) TestWaitPendingStatementNoWaitForRunningStatement() {
 func (s *StoreTestSuite) TestWaitPendingStatementFailsOnWaitError() {
 	client := mock.NewMockGatewayClientInterface(gomock.NewController(s.T()))
 	appOptions := &types.ApplicationOptions{
-		OrgResourceId: "orgId",
-		EnvironmentId: "envId",
+		OrganizationId: "orgId",
+		EnvironmentId:  "envId",
 	}
 	store := Store{
 		Properties:       NewUserProperties(map[string]string{"TestProp": "TestVal"}, map[string]string{}),
@@ -1381,8 +1381,8 @@ func (s *StoreTestSuite) TestWaitPendingStatementFailsOnWaitError() {
 func (s *StoreTestSuite) TestWaitPendingStatementFailsOnNonCompletedOrRunningStatementPhase() {
 	client := mock.NewMockGatewayClientInterface(gomock.NewController(s.T()))
 	appOptions := &types.ApplicationOptions{
-		OrgResourceId: "orgId",
-		EnvironmentId: "envId",
+		OrganizationId: "orgId",
+		EnvironmentId:  "envId",
 	}
 	store := Store{
 		Properties:       NewUserProperties(map[string]string{"TestProp": "TestVal"}, map[string]string{}),
@@ -1418,8 +1418,8 @@ func (s *StoreTestSuite) TestWaitPendingStatementFailsOnNonCompletedOrRunningSta
 func (s *StoreTestSuite) TestWaitPendingStatementFetchesExceptionOnFailedStatementWithEmptyStatusDetail() {
 	client := mock.NewMockGatewayClientInterface(gomock.NewController(s.T()))
 	appOptions := &types.ApplicationOptions{
-		OrgResourceId: "orgId",
-		EnvironmentId: "envId",
+		OrganizationId: "orgId",
+		EnvironmentId:  "envId",
 	}
 	store := Store{
 		Properties:       NewUserProperties(map[string]string{"TestProp": "TestVal"}, map[string]string{}),
@@ -1462,8 +1462,8 @@ func (s *StoreTestSuite) TestWaitPendingStatementFetchesExceptionOnFailedStateme
 func (s *StoreTestSuite) TestGetStatusDetail() {
 	client := mock.NewMockGatewayClientInterface(gomock.NewController(s.T()))
 	appOptions := &types.ApplicationOptions{
-		OrgResourceId: "orgId",
-		EnvironmentId: "envId",
+		OrganizationId: "orgId",
+		EnvironmentId:  "envId",
 	}
 	store := Store{
 		Properties:       NewUserProperties(map[string]string{"TestProp": "TestVal"}, map[string]string{}),
@@ -1498,8 +1498,8 @@ func (s *StoreTestSuite) TestGetStatusDetail() {
 func (s *StoreTestSuite) TestGetStatusDetailReturnsWhenStatusNoFailedOrFailing() {
 	client := mock.NewMockGatewayClientInterface(gomock.NewController(s.T()))
 	appOptions := &types.ApplicationOptions{
-		OrgResourceId: "orgId",
-		EnvironmentId: "envId",
+		OrganizationId: "orgId",
+		EnvironmentId:  "envId",
 	}
 	store := Store{
 		Properties:       NewUserProperties(map[string]string{"TestProp": "TestVal"}, map[string]string{}),
@@ -1529,8 +1529,8 @@ func (s *StoreTestSuite) TestGetStatusDetailReturnsWhenStatusNoFailedOrFailing()
 func (s *StoreTestSuite) TestGetStatusDetailReturnsWhenStatusDetailFilled() {
 	client := mock.NewMockGatewayClientInterface(gomock.NewController(s.T()))
 	appOptions := &types.ApplicationOptions{
-		OrgResourceId: "orgId",
-		EnvironmentId: "envId",
+		OrganizationId: "orgId",
+		EnvironmentId:  "envId",
 	}
 	store := Store{
 		Properties:       NewUserProperties(map[string]string{"TestProp": "TestVal"}, map[string]string{}),
@@ -1554,8 +1554,8 @@ func (s *StoreTestSuite) TestGetStatusDetailReturnsWhenStatusDetailFilled() {
 func (s *StoreTestSuite) TestGetStatusDetailReturnsEmptyWhenNoExceptionsAvailable() {
 	client := mock.NewMockGatewayClientInterface(gomock.NewController(s.T()))
 	appOptions := &types.ApplicationOptions{
-		OrgResourceId: "orgId",
-		EnvironmentId: "envId",
+		OrganizationId: "orgId",
+		EnvironmentId:  "envId",
 	}
 	store := Store{
 		Properties:       NewUserProperties(map[string]string{"TestProp": "TestVal"}, map[string]string{}),
@@ -1653,8 +1653,8 @@ func (s *StoreTestSuite) TestNewProcessedStatementSetsIsSelectStatement() {
 func TestWaitForTerminalStateDoesNotStartWhenAlreadyInTerminalState(t *testing.T) {
 	client := mock.NewMockGatewayClientInterface(gomock.NewController(t))
 	appOptions := types.ApplicationOptions{
-		OrgResourceId: "orgId",
-		EnvironmentId: "envId",
+		OrganizationId: "orgId",
+		EnvironmentId:  "envId",
 	}
 	s := &Store{
 		client:           client,
@@ -1672,8 +1672,8 @@ func TestWaitForTerminalStateDoesNotStartWhenAlreadyInTerminalState(t *testing.T
 func TestWaitForTerminalStateStopsWhenTerminalState(t *testing.T) {
 	client := mock.NewMockGatewayClientInterface(gomock.NewController(t))
 	appOptions := types.ApplicationOptions{
-		OrgResourceId: "orgId",
-		EnvironmentId: "envId",
+		OrganizationId: "orgId",
+		EnvironmentId:  "envId",
 	}
 	s := &Store{
 		client:           client,
@@ -1701,8 +1701,8 @@ func TestWaitForTerminalStateStopsWhenTerminalState(t *testing.T) {
 func TestWaitForTerminalStateStopsWhenUserDetaches(t *testing.T) {
 	client := mock.NewMockGatewayClientInterface(gomock.NewController(t))
 	appOptions := types.ApplicationOptions{
-		OrgResourceId: "orgId",
-		EnvironmentId: "envId",
+		OrganizationId: "orgId",
+		EnvironmentId:  "envId",
 	}
 	s := &Store{
 		client:           client,
@@ -1733,8 +1733,8 @@ func TestWaitForTerminalStateStopsWhenUserDetaches(t *testing.T) {
 func TestWaitForTerminalStateStopsOnError(t *testing.T) {
 	client := mock.NewMockGatewayClientInterface(gomock.NewController(t))
 	appOptions := types.ApplicationOptions{
-		OrgResourceId: "orgId",
-		EnvironmentId: "envId",
+		OrganizationId: "orgId",
+		EnvironmentId:  "envId",
 	}
 	s := &Store{
 		client:           client,

--- a/pkg/flink/internal/store/store_utils_test.go
+++ b/pkg/flink/internal/store/store_utils_test.go
@@ -148,7 +148,7 @@ func TestProcessResetStatement(t *testing.T) {
 	// Create a new store
 	client := ccloudv2.NewFlinkGatewayClient("url", "userAgent", false, "authToken")
 	appOptions := types.ApplicationOptions{
-		OrgResourceId:    "orgId",
+		OrganizationId:   "orgId",
 		EnvironmentName:  "envName",
 		Database:         "database",
 		ServiceAccountId: "sa-123",
@@ -217,7 +217,7 @@ func TestProcessUseStatement(t *testing.T) {
 	// Create a new store
 	client := ccloudv2.NewFlinkGatewayClient("url", "userAgent", false, "authToken")
 	appOptions := types.ApplicationOptions{
-		OrgResourceId:   "orgId",
+		OrganizationId:  "orgId",
 		EnvironmentName: "envName",
 		Database:        "database",
 	}

--- a/pkg/flink/types/application_options.go
+++ b/pkg/flink/types/application_options.go
@@ -9,7 +9,7 @@ type ApplicationOptions struct {
 	UserAgent        string
 	EnvironmentId    string
 	EnvironmentName  string
-	OrgResourceId    string
+	OrganizationId   string
 	Database         string
 	ComputePoolId    string
 	ServiceAccountId string
@@ -45,9 +45,9 @@ func (a *ApplicationOptions) GetEnvironmentName() string {
 	return ""
 }
 
-func (a *ApplicationOptions) GetOrgResourceId() string {
+func (a *ApplicationOptions) GetOrganizationId() string {
 	if a != nil {
-		return a.OrgResourceId
+		return a.OrganizationId
 	}
 	return ""
 }

--- a/pkg/kafkarest/kafkarest.go
+++ b/pkg/kafkarest/kafkarest.go
@@ -27,7 +27,10 @@ func NewError(url string, err error, httpResp *http.Response) error {
 	switch e := err.(type) {
 	case *neturl.Error:
 		if strings.Contains(e.Error(), SelfSignedCertError) || strings.Contains(e.Error(), UnauthorizedCertError) {
-			return errors.NewErrorWithSuggestions(fmt.Sprintf(errors.KafkaRestConnectionErrorMsg, url, e.Err), errors.KafkaRestCertErrorSuggestions)
+			return errors.NewErrorWithSuggestions(
+				fmt.Sprintf(errors.KafkaRestConnectionErrorMsg, url, e.Err),
+				errors.KafkaRestCertErrorSuggestions,
+			)
 		}
 		return errors.Errorf(errors.KafkaRestConnectionErrorMsg, url, e.Err)
 	case cckafkarestv3.GenericOpenAPIError:

--- a/pkg/plugin/bash_plugin_installer.go
+++ b/pkg/plugin/bash_plugin_installer.go
@@ -28,7 +28,10 @@ func (b *BashPluginInstaller) CheckVersion(ver *version.Version) error {
 
 	out, err := versionCmd.Output()
 	if err != nil {
-		return errors.NewErrorWithSuggestions(fmt.Sprintf(programNotFoundErrorMsg, "bash"), programNotFoundSuggestions)
+		return errors.NewErrorWithSuggestions(
+			fmt.Sprintf(programNotFoundErrorMsg, "bash"),
+			programNotFoundSuggestions,
+		)
 	}
 
 	for _, word := range strings.Split(string(out), " ") {

--- a/pkg/plugin/go_plugin_installer.go
+++ b/pkg/plugin/go_plugin_installer.go
@@ -26,7 +26,10 @@ func (g *GoPluginInstaller) CheckVersion(ver *version.Version) error {
 
 	out, err := versionCmd.Output()
 	if err != nil {
-		return errors.NewErrorWithSuggestions(fmt.Sprintf(programNotFoundErrorMsg, "go"), programNotFoundSuggestions)
+		return errors.NewErrorWithSuggestions(
+			fmt.Sprintf(programNotFoundErrorMsg, "go"),
+			programNotFoundSuggestions,
+		)
 	}
 
 	for _, word := range strings.Split(string(out), " ") {

--- a/pkg/plugin/python_plugin_installer.go
+++ b/pkg/plugin/python_plugin_installer.go
@@ -42,7 +42,10 @@ func (p *PythonPluginInstaller) CheckVersion(ver *version.Version) error {
 		out, err = versionCmd.Output()
 	}
 	if err != nil {
-		return errors.NewErrorWithSuggestions(fmt.Sprintf(programNotFoundErrorMsg, "python"), programNotFoundSuggestions)
+		return errors.NewErrorWithSuggestions(
+			fmt.Sprintf(programNotFoundErrorMsg, "python"),
+			programNotFoundSuggestions,
+		)
 	}
 
 	for _, word := range strings.Split(string(out), " ") {

--- a/pkg/resource/resource.go
+++ b/pkg/resource/resource.go
@@ -50,6 +50,7 @@ const (
 	EnvironmentPrefix           = "env"
 	IdentityPoolPrefix          = "pool"
 	IdentityProviderPrefix      = "op"
+	FlinkComputePoolPrefix      = "lfcp"
 	KafkaClusterPrefix          = "lkc"
 	KsqlClusterPrefix           = "lksqlc"
 	SchemaRegistryClusterPrefix = "lsrc"
@@ -62,6 +63,7 @@ var prefixToResource = map[string]string{
 	EnvironmentPrefix:           Environment,
 	IdentityPoolPrefix:          IdentityPool,
 	IdentityProviderPrefix:      IdentityProvider,
+	FlinkComputePoolPrefix:      FlinkComputePool,
 	KafkaClusterPrefix:          KafkaCluster,
 	KsqlClusterPrefix:           KsqlCluster,
 	SchemaRegistryClusterPrefix: SchemaRegistryCluster,
@@ -80,12 +82,12 @@ var resourceToPrefix = map[string]string{
 	User:                  UserPrefix,
 }
 
-func LookupType(resourceId string) string {
-	if resourceId == Cloud {
+func LookupType(id string) string {
+	if id == Cloud {
 		return Cloud
 	}
 
-	if x := strings.SplitN(resourceId, "-", 2); len(x) == 2 {
+	if x := strings.SplitN(id, "-", 2); len(x) == 2 {
 		prefix := x[0]
 		if resource, ok := prefixToResource[prefix]; ok {
 			return resource
@@ -102,9 +104,9 @@ func ValidatePrefixes(resourceType string, args []string) error {
 	}
 
 	var malformed []string
-	for _, resourceId := range args {
-		if LookupType(resourceId) != resourceType {
-			malformed = append(malformed, resourceId)
+	for _, id := range args {
+		if LookupType(id) != resourceType {
+			malformed = append(malformed, id)
 		}
 	}
 

--- a/test/fixtures/output/flink/statement/create-help.golden
+++ b/test/fixtures/output/flink/statement/create-help.golden
@@ -10,7 +10,7 @@ Create a Flink SQL statement in the current compute pool.
 
 Create a Flink SQL statement named "my-statement" in compute pool "lfcp-123456" with service account "sa-123456" and using Kafka cluster "my-cluster" as the default database.
 
-  $ confluent flink statement create my-statement --sql "SELECT * FROM my-cluster.my-topic;" --compute-pool lfcp-123456 --service-account sa-123456 --database my-cluster
+  $ confluent flink statement create my-statement --sql "SELECT * FROM my-topic;" --compute-pool lfcp-123456 --service-account sa-123456 --database my-cluster
 
 Flags:
       --sql string               REQUIRED: The Flink SQL statement.

--- a/test/fixtures/output/iam/rbac/role/describe-invalid-role-cloud.golden
+++ b/test/fixtures/output/iam/rbac/role/describe-invalid-role-cloud.golden
@@ -1,4 +1,4 @@
 Error: unknown role "InvalidRole"
 
 Suggestions:
-    The available roles are: CCloudRoleBindingAdmin, CloudClusterAdmin, EnvironmentAdmin, OrganizationAdmin.
+    The available roles are "CCloudRoleBindingAdmin", "CloudClusterAdmin", "EnvironmentAdmin", and "OrganizationAdmin".

--- a/test/test-server/ccloud_handlers.go
+++ b/test/test-server/ccloud_handlers.go
@@ -51,27 +51,26 @@ var (
 const (
 	serviceAccountId                 = int32(12345)
 	serviceAccountResourceId         = "sa-12345"
-	groupMappingResourceId           = "pool-abc"
-	identityProviderResourceId       = "op-12345"
-	identityPoolResourceId           = "pool-12345"
+	groupMappingId                   = "pool-abc"
+	identityProviderId               = "op-12345"
+	identityPoolId                   = "pool-12345"
 	deactivatedUserId                = int32(6666)
-	deactivatedResourceId            = "sa-6666"
+	deactivatedUserResourceId        = "sa-6666"
 	auditLogServiceAccountId         = int32(1337)
 	auditLogServiceAccountResourceId = "sa-1337"
-	PromoTestCode                    = "PromoTestCode"
 )
 
 // Handler for: "/api/me"
 func handleMe(t *testing.T, isAuditLogEnabled bool) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		orgResourceId := os.Getenv("CONFLUENT_CLOUD_ORGANIZATION_ID")
-		if orgResourceId == "" {
-			orgResourceId = "abc-123"
+		organizationId := os.Getenv("CONFLUENT_CLOUD_ORGANIZATION_ID")
+		if organizationId == "" {
+			organizationId = "abc-123"
 		}
 
 		org := &ccloudv1.Organization{
 			Id:         42,
-			ResourceId: orgResourceId,
+			ResourceId: organizationId,
 			Name:       "Confluent",
 		}
 		if isAuditLogEnabled {

--- a/test/test-server/iam_handlers.go
+++ b/test/test-server/iam_handlers.go
@@ -22,8 +22,8 @@ var (
 	keyStoreV2       = map[string]*apikeysv2.IamV2ApiKey{}
 	keyTime          = apikeysv2.PtrTime(time.Date(1999, time.February, 24, 0, 0, 0, 0, time.UTC))
 	roleBindingStore = []mdsv2.IamV2RoleBinding{
-		buildRoleBinding("rb-00000", identityPoolResourceId, "OrganizationAdmin",
-			"crn://confluent.cloud/organization=abc-123/identity-provider="+identityProviderResourceId),
+		buildRoleBinding("rb-00000", identityPoolId, "OrganizationAdmin",
+			"crn://confluent.cloud/organization=abc-123/identity-provider="+identityProviderId),
 		buildRoleBinding("rb-11aaa", "u-11aaa", "OrganizationAdmin",
 			"crn://confluent.cloud/organization=abc-123"),
 		buildRoleBinding("rb-12345", "sa-12345", "OrganizationAdmin",
@@ -183,7 +183,7 @@ func handleIamUsers(t *testing.T) http.HandlerFunc {
 			}
 			userId := r.URL.Query().Get("id")
 			if userId != "" {
-				if userId == deactivatedResourceId {
+				if userId == deactivatedUserResourceId {
 					users = []iamv2.IamV2User{}
 				}
 			}
@@ -295,7 +295,7 @@ func handleIamRoleBindings(t *testing.T) http.HandlerFunc {
 func handleIamIdentityProvider(t *testing.T) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		id := mux.Vars(r)["id"]
-		if id != identityProviderResourceId && id != "op-67890" {
+		if id != identityProviderId && id != "op-67890" {
 			err := writeResourceNotFoundError(w)
 			require.NoError(t, err)
 			return
@@ -329,7 +329,7 @@ func handleIamIdentityProviders(t *testing.T) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		switch r.Method {
 		case http.MethodGet:
-			identityProvider := buildIamProvider(identityProviderResourceId, "identity-provider", "providing identities.", "https://company.provider.com", "https://company.provider.com/oauth2/v1/keys")
+			identityProvider := buildIamProvider(identityProviderId, "identity-provider", "providing identities.", "https://company.provider.com", "https://company.provider.com/oauth2/v1/keys")
 			anotherIdentityProvider := buildIamProvider("op-abc", "another-provider", "providing identities.", "https://company.provider.com", "https://company.provider.com/oauth2/v1/keys")
 			err := json.NewEncoder(w).Encode(identityproviderv2.IamV2IdentityProviderList{Data: []identityproviderv2.IamV2IdentityProvider{identityProvider, anotherIdentityProvider}})
 			require.NoError(t, err)
@@ -364,7 +364,7 @@ func handleIamRoleBinding(t *testing.T) http.HandlerFunc {
 func handleIamIdentityPool(t *testing.T) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		id := mux.Vars(r)["id"]
-		if id != identityPoolResourceId && id != "pool-55555" {
+		if id != identityPoolId && id != "pool-55555" {
 			err := writeResourceNotFoundError(w)
 			require.NoError(t, err)
 			return
@@ -398,7 +398,7 @@ func handleIamIdentityPools(t *testing.T) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		switch r.Method {
 		case http.MethodGet:
-			identityPool := buildIamPool(identityPoolResourceId, "identity-pool", "pooling identities", "sub", `claims.iss="https://company.provider.com"`)
+			identityPool := buildIamPool(identityPoolId, "identity-pool", "pooling identities", "sub", `claims.iss="https://company.provider.com"`)
 			anotherIdentityPool := buildIamPool("pool-abc", "another-pool", "another description", "sub", "true")
 			err := json.NewEncoder(w).Encode(identityproviderv2.IamV2IdentityPoolList{Data: []identityproviderv2.IamV2IdentityPool{identityPool, anotherIdentityPool}})
 			require.NoError(t, err)
@@ -452,7 +452,7 @@ func handleIamGroupMappings(t *testing.T) http.HandlerFunc {
 		groupMapping := buildIamGroupMapping("pool-12345", "my-group-mapping", "new description", `"engineering" in claims.group || "marketing" in claims.group`)
 		switch r.Method {
 		case http.MethodGet:
-			anotherMapping := buildIamGroupMapping(groupMappingResourceId, "another-group-mapping", "another description", "true")
+			anotherMapping := buildIamGroupMapping(groupMappingId, "another-group-mapping", "another description", "true")
 			err := json.NewEncoder(w).Encode(ssov2.IamV2SsoGroupMappingList{Data: []ssov2.IamV2SsoGroupMapping{groupMapping, anotherMapping}})
 			require.NoError(t, err)
 		case http.MethodPost:
@@ -469,7 +469,7 @@ func handleIamGroupMappings(t *testing.T) http.HandlerFunc {
 func handleIamGroupMapping(t *testing.T) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		id := mux.Vars(r)["id"]
-		if id != groupMappingResourceId && id != "pool-def" {
+		if id != groupMappingId && id != "pool-def" {
 			err := writeResourceNotFoundError(w)
 			require.NoError(t, err)
 			return
@@ -492,11 +492,11 @@ func handleIamGroupMapping(t *testing.T) http.HandlerFunc {
 	}
 }
 
-func buildIamUser(email, name, resourceId, authType string) iamv2.IamV2User {
+func buildIamUser(email, fullName, id, authType string) iamv2.IamV2User {
 	return iamv2.IamV2User{
 		Email:    iamv2.PtrString(email),
-		FullName: iamv2.PtrString(name),
-		Id:       iamv2.PtrString(resourceId),
+		FullName: iamv2.PtrString(fullName),
+		Id:       iamv2.PtrString(id),
 		AuthType: iamv2.PtrString(authType),
 	}
 }


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
With the exception of a few deprecated APIs, we've fully switched from dealing with numeric IDs to resource IDs. Thus, we can simply call resource IDs "IDs" now.

Test & Review
-------------
Updated relevant tests