### PR TITLE
[CLI-2825] Add `print-offset` in confluent kafka topic consume

### DIFF
--- a/internal/kafka/command_topic_consume.go
+++ b/internal/kafka/command_topic_consume.go
@@ -44,7 +44,7 @@ func (c *command) newConsumeCommand() *cobra.Command {
 	pcmd.AddKeyFormatFlag(cmd)
 	pcmd.AddValueFormatFlag(cmd)
 	cmd.Flags().Bool("print-key", false, "Print key of the message.")
-	cmd.Flags().Bool("print-offset", false, "Print offset of the message.")
+	cmd.Flags().Bool("print-offset", false, "Print partition number and offset of the message.")
 	cmd.Flags().Bool("full-header", false, "Print complete content of message headers.")
 	cmd.Flags().String("delimiter", "\t", "The delimiter separating each key and value.")
 	cmd.Flags().Bool("timestamp", false, "Print message timestamp in milliseconds.")

--- a/internal/kafka/command_topic_consume.go
+++ b/internal/kafka/command_topic_consume.go
@@ -44,6 +44,7 @@ func (c *command) newConsumeCommand() *cobra.Command {
 	pcmd.AddKeyFormatFlag(cmd)
 	pcmd.AddValueFormatFlag(cmd)
 	cmd.Flags().Bool("print-key", false, "Print key of the message.")
+	cmd.Flags().Bool("print-offset", false, "Print offset of the message.")
 	cmd.Flags().Bool("full-header", false, "Print complete content of message headers.")
 	cmd.Flags().String("delimiter", "\t", "The delimiter separating each key and value.")
 	cmd.Flags().Bool("timestamp", false, "Print message timestamp in milliseconds.")
@@ -91,6 +92,11 @@ func (c *command) consume(cmd *cobra.Command, args []string) error {
 	}
 
 	printKey, err := cmd.Flags().GetBool("print-key")
+	if err != nil {
+		return err
+	}
+
+	printOffset, err := cmd.Flags().GetBool("print-offset")
 	if err != nil {
 		return err
 	}
@@ -206,11 +212,12 @@ func (c *command) consume(cmd *cobra.Command, args []string) error {
 		Out:         cmd.OutOrStdout(),
 		Subject:     subject,
 		Properties: ConsumerProperties{
-			PrintKey:   printKey,
-			FullHeader: fullHeader,
-			Timestamp:  timestamp,
-			Delimiter:  delimiter,
-			SchemaPath: schemaPath,
+			PrintKey:    printKey,
+			PrintOffset: printOffset,
+			FullHeader:  fullHeader,
+			Timestamp:   timestamp,
+			Delimiter:   delimiter,
+			SchemaPath:  schemaPath,
 		},
 	}
 	return RunConsumer(consumer, groupHandler)

--- a/internal/kafka/confluent_kafka.go
+++ b/internal/kafka/confluent_kafka.go
@@ -236,7 +236,7 @@ func consumeMessage(message *ckafka.Message, h *GroupHandler) error {
 		}
 	}
 
-	messageString, err := getMessageString(message, valueDeserializer, h.Properties.Timestamp, h.Properties.PrintOffset)
+	messageString, err := getMessageString(message, valueDeserializer, h.Properties)
 	if err != nil {
 		return err
 	}
@@ -257,17 +257,17 @@ func consumeMessage(message *ckafka.Message, h *GroupHandler) error {
 	return nil
 }
 
-func getMessageString(message *ckafka.Message, valueDeserializer serdes.DeserializationProvider, timestamp bool, printOffset bool) (string, error) {
+func getMessageString(message *ckafka.Message, valueDeserializer serdes.DeserializationProvider, properties ConsumerProperties) (string, error) {
 	messageString, err := valueDeserializer.Deserialize(message.Value)
 	if err != nil {
 		return "", err
 	}
 
 	var info []string
-	if timestamp {
+	if properties.Timestamp {
 		info = append(info, fmt.Sprintf("Timestamp:%d", message.Timestamp.UnixMilli()))
 	}
-	if printOffset {
+	if properties.PrintOffset {
 		info = append(info, fmt.Sprintf("Partition:%d Offset:%s", message.TopicPartition.Partition, message.TopicPartition.Offset.String()))
 	}
 	if len(info) > 0 {

--- a/internal/kafka/confluent_kafka.go
+++ b/internal/kafka/confluent_kafka.go
@@ -235,7 +235,7 @@ func consumeMessage(message *ckafka.Message, h *GroupHandler) error {
 		}
 	}
 
-	jsonMessage, err := valueDeserializer.Deserialize(message.Value)
+	messageString, err := valueDeserializer.Deserialize(message.Value)
 	if err != nil {
 		return err
 	}
@@ -246,13 +246,16 @@ func consumeMessage(message *ckafka.Message, h *GroupHandler) error {
 	}
 
 	if h.Properties.PrintOffset {
-		info += fmt.Sprintf(" Partition:%d Offset:%s", message.TopicPartition.Partition, message.TopicPartition.Offset.String())
+		if len(info) > 0 {
+			info = fmt.Sprintf("%s ", info)
+		}
+		info += fmt.Sprintf("Partition:%d Offset:%s", message.TopicPartition.Partition, message.TopicPartition.Offset.String())
 	}
 	if len(info) > 0 {
-		jsonMessage = fmt.Sprintf("[%s]\t%s", info, jsonMessage)
+		messageString = fmt.Sprintf("%s\t%s", info, messageString)
 	}
 
-	if _, err := fmt.Fprintln(h.Out, jsonMessage); err != nil {
+	if _, err := fmt.Fprintln(h.Out, messageString); err != nil {
 		return err
 	}
 

--- a/internal/kafka/confluent_kafka.go
+++ b/internal/kafka/confluent_kafka.go
@@ -245,9 +245,7 @@ func consumeMessage(message *ckafka.Message, h *GroupHandler) error {
 	}
 
 	if h.Properties.PrintOffset {
-		partition := message.TopicPartition.Partition
-		offset := message.TopicPartition.Offset.String()
-		jsonMessage = fmt.Sprintf("Offset: [%d:%s]\t%s", partition, offset, jsonMessage)
+		jsonMessage = fmt.Sprintf("[Partition:Offset]: [%d:%s]\t%s", message.TopicPartition.Partition, message.TopicPartition.Offset.String(), jsonMessage)
 	}
 
 	if _, err := fmt.Fprintln(h.Out, jsonMessage); err != nil {

--- a/internal/kafka/confluent_kafka.go
+++ b/internal/kafka/confluent_kafka.go
@@ -240,12 +240,16 @@ func consumeMessage(message *ckafka.Message, h *GroupHandler) error {
 		return err
 	}
 
+	info := ""
 	if h.Properties.Timestamp {
-		jsonMessage = fmt.Sprintf("Timestamp: %d\t%s", message.Timestamp.UnixMilli(), jsonMessage)
+		info += fmt.Sprintf("Timestamp:%d", message.Timestamp.UnixMilli())
 	}
 
 	if h.Properties.PrintOffset {
-		jsonMessage = fmt.Sprintf("[Partition:Offset]: [%d:%s]\t%s", message.TopicPartition.Partition, message.TopicPartition.Offset.String(), jsonMessage)
+		info += fmt.Sprintf(" Partition:%d Offset:%s", message.TopicPartition.Partition, message.TopicPartition.Offset.String())
+	}
+	if len(info) > 0 {
+		jsonMessage = fmt.Sprintf("[%s]\t%s", info, jsonMessage)
 	}
 
 	if _, err := fmt.Fprintln(h.Out, jsonMessage); err != nil {

--- a/internal/kafka/confluent_kafka.go
+++ b/internal/kafka/confluent_kafka.go
@@ -46,11 +46,12 @@ var (
 )
 
 type ConsumerProperties struct {
-	Delimiter  string
-	FullHeader bool
-	PrintKey   bool
-	Timestamp  bool
-	SchemaPath string
+	Delimiter   string
+	FullHeader  bool
+	PrintKey    bool
+	PrintOffset bool
+	Timestamp   bool
+	SchemaPath  string
 }
 
 // GroupHandler instances are used to handle individual topic-partition claims.
@@ -241,6 +242,12 @@ func consumeMessage(message *ckafka.Message, h *GroupHandler) error {
 
 	if h.Properties.Timestamp {
 		jsonMessage = fmt.Sprintf("Timestamp: %d\t%s", message.Timestamp.UnixMilli(), jsonMessage)
+	}
+
+	if h.Properties.PrintOffset {
+		partition := message.TopicPartition.Partition
+		offset := message.TopicPartition.Offset.String()
+		jsonMessage = fmt.Sprintf("Offset: [%d:%s]\t%s", partition, offset, jsonMessage)
 	}
 
 	if _, err := fmt.Fprintln(h.Out, jsonMessage); err != nil {

--- a/internal/kafka/confluent_kafka.go
+++ b/internal/kafka/confluent_kafka.go
@@ -268,7 +268,8 @@ func getMessageString(message *ckafka.Message, valueDeserializer serdes.Deserial
 		info = append(info, fmt.Sprintf("Timestamp:%d", message.Timestamp.UnixMilli()))
 	}
 	if properties.PrintOffset {
-		info = append(info, fmt.Sprintf("Partition:%d Offset:%s", message.TopicPartition.Partition, message.TopicPartition.Offset.String()))
+		info = append(info, fmt.Sprintf("Partition:%d", message.TopicPartition.Partition))
+		info = append(info, fmt.Sprintf("Offset:%s", message.TopicPartition.Offset.String()))
 	}
 	if len(info) > 0 {
 		messageString = fmt.Sprintf("%s\t%s", strings.Join(info, " "), messageString)

--- a/internal/kafka/confluent_kafka_test.go
+++ b/internal/kafka/confluent_kafka_test.go
@@ -1,0 +1,25 @@
+package kafka
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/confluentinc/cli/v3/pkg/serdes"
+	ckafka "github.com/confluentinc/confluent-kafka-go/kafka"
+)
+
+func TestGetMessageString(t *testing.T) {
+	message := &ckafka.Message{
+		Value:          []byte("message"),
+		TopicPartition: ckafka.TopicPartition{Offset: 2, Partition: 1},
+		Timestamp:      time.Date(1997, time.July, 5, 0, 0, 0, 0, time.UTC),
+	}
+	valueDeserializer, err := serdes.GetDeserializationProvider("string")
+	require.NoError(t, err)
+	actual, err := getMessageString(message, valueDeserializer, true, true)
+	require.NoError(t, err)
+	expected := "Timestamp:868060800000 Partition:1 Offset:2	message"
+	require.Equal(t, expected, actual)
+}

--- a/internal/kafka/confluent_kafka_test.go
+++ b/internal/kafka/confluent_kafka_test.go
@@ -18,7 +18,7 @@ func TestGetMessageString(t *testing.T) {
 	}
 	valueDeserializer, err := serdes.GetDeserializationProvider("string")
 	require.NoError(t, err)
-	actual, err := getMessageString(message, valueDeserializer, true, true)
+	actual, err := getMessageString(message, valueDeserializer, ConsumerProperties{PrintOffset: true, Timestamp: true})
 	require.NoError(t, err)
 	expected := "Timestamp:868060800000 Partition:1 Offset:2	message"
 	require.Equal(t, expected, actual)

--- a/internal/kafka/confluent_kafka_test.go
+++ b/internal/kafka/confluent_kafka_test.go
@@ -6,8 +6,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/confluentinc/cli/v3/pkg/serdes"
 	ckafka "github.com/confluentinc/confluent-kafka-go/kafka"
+
+	"github.com/confluentinc/cli/v3/pkg/serdes"
 )
 
 func TestGetMessageString(t *testing.T) {

--- a/test/fixtures/output/kafka/topic/consume-help.golden
+++ b/test/fixtures/output/kafka/topic/consume-help.golden
@@ -18,6 +18,7 @@ Flags:
       --key-format string                   Format of message key as "string", "avro", "integer", "jsonschema", or "protobuf". Note that schema references are not supported for Avro. (default "string")
       --value-format string                 Format message value as "string", "avro", "integer", "jsonschema", or "protobuf". Note that schema references are not supported for Avro. (default "string")
       --print-key                           Print key of the message.
+      --print-offset                        Print offset of the message.
       --full-header                         Print complete content of message headers.
       --delimiter string                    The delimiter separating each key and value. (default "\t")
       --timestamp                           Print message timestamp in milliseconds.

--- a/test/fixtures/output/kafka/topic/consume-help.golden
+++ b/test/fixtures/output/kafka/topic/consume-help.golden
@@ -18,7 +18,7 @@ Flags:
       --key-format string                   Format of message key as "string", "avro", "integer", "jsonschema", or "protobuf". Note that schema references are not supported for Avro. (default "string")
       --value-format string                 Format message value as "string", "avro", "integer", "jsonschema", or "protobuf". Note that schema references are not supported for Avro. (default "string")
       --print-key                           Print key of the message.
-      --print-offset                        Print offset of the message.
+      --print-offset                        Print partition number and offset of the message.
       --full-header                         Print complete content of message headers.
       --delimiter string                    The delimiter separating each key and value. (default "\t")
       --timestamp                           Print message timestamp in milliseconds.


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- PLACEHOLDER

New Features
- Add `--print-offset` to `confluent kafka topic consume` for printing partition number and offset of each message

Bug Fixes
- PLACEHOLDER

Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->
```
mhe@C02DV0KVMD6T cli % confluent kafka topic consume -b tester --print-offset --timestamp
Starting Kafka Consumer. Use Ctrl-C to exit.
Timestamp:1696896989560 Partition:3 Offset:0	6
Timestamp:1696896990093 Partition:3 Offset:1	7
```

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
<!--
Has it been tested? How?
Copy and paste any instructions or steps that can save the reviewer time.
-->

Open Questions / Follow-ups
---------------------------
<!--
Optional: Anything open to discussion for the reviewer, out of scope of this PR, or follow-ups.
-->
