### PR TITLE
[CLI-2829] Remove direct dependency on `github.com/pkg/errors`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -191,7 +191,7 @@ func (c *command) newDescribeCommand() *cobra.Command {
 func (c *command) describe(_ *cobra.Command, args []string) error {
     filename := c.CLICommand.Config.Config.Filename
     if filename == "" {
-        return errors.New("config file not found")
+        return fmt.Errorf("config file not found")
     }
 	
     n, err := strconv.Atoi(args[0])

--- a/go.mod
+++ b/go.mod
@@ -75,7 +75,6 @@ require (
 	github.com/panta/machineid v1.0.2
 	github.com/phayes/freeport v0.0.0-20220201140144-74d24b5ae9f5
 	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8
-	github.com/pkg/errors v0.9.1
 	github.com/rivo/tview v0.0.0-20230511053024-822bd067b165
 	github.com/samber/lo v1.38.1
 	github.com/sevlyar/retag v0.0.0-20190429052747-c3f10e304082
@@ -156,6 +155,7 @@ require (
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/runc v1.1.4 // indirect
 	github.com/pjbgf/sha1cd v0.3.0 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pkg/term v1.2.0-beta.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rivo/uniseg v0.4.3 // indirect

--- a/internal/api-key/command.go
+++ b/internal/api-key/command.go
@@ -33,7 +33,7 @@ const (
 	apiKeyUseFailedSuggestions          = "If you did not create this API key with the CLI or created it on another computer, you must first store the API key and secret locally with `confluent api-key store %s <secret>`."
 	nonKafkaNotImplementedErrorMsg      = "functionality not yet available for non-Kafka cluster resources"
 	refuseToOverrideSecretSuggestions   = "If you would like to override the existing secret stored for API key \"%s\", use the `--force` flag."
-	unableToStoreApiKeyErrorMsg         = "unable to store API key locally"
+	unableToStoreApiKeyErrorMsg         = "unable to store API key locally: %w"
 )
 
 func New(prerunner pcmd.PreRunner, keystore keystore.KeyStore, resolver pcmd.FlagResolver) *cobra.Command {

--- a/internal/api-key/command_create.go
+++ b/internal/api-key/command_create.go
@@ -140,7 +140,7 @@ func (c *command) create(cmd *cobra.Command, _ []string) error {
 
 	if resourceType == resource.KafkaCluster {
 		if err := c.keystore.StoreAPIKey(userKey, clusterId); err != nil {
-			return errors.Wrap(err, unableToStoreApiKeyErrorMsg)
+			return fmt.Errorf(unableToStoreApiKeyErrorMsg, err)
 		}
 	}
 
@@ -150,7 +150,7 @@ func (c *command) create(cmd *cobra.Command, _ []string) error {
 	}
 	if use {
 		if resourceType != resource.KafkaCluster {
-			return errors.Wrap(fmt.Errorf(nonKafkaNotImplementedErrorMsg), "`--use` set but ineffective")
+			return fmt.Errorf("`--use` set but ineffective: %s", nonKafkaNotImplementedErrorMsg)
 		}
 		if err := c.Context.UseAPIKey(userKey.Key, clusterId); err != nil {
 			return errors.NewWrapErrorWithSuggestions(err, apiKeyUseFailedErrorMsg, fmt.Sprintf(apiKeyUseFailedSuggestions, userKey.Key))

--- a/internal/api-key/command_create.go
+++ b/internal/api-key/command_create.go
@@ -150,7 +150,7 @@ func (c *command) create(cmd *cobra.Command, _ []string) error {
 	}
 	if use {
 		if resourceType != resource.KafkaCluster {
-			return errors.Wrap(errors.New(nonKafkaNotImplementedErrorMsg), "`--use` set but ineffective")
+			return errors.Wrap(fmt.Errorf(nonKafkaNotImplementedErrorMsg), "`--use` set but ineffective")
 		}
 		if err := c.Context.UseAPIKey(userKey.Key, clusterId); err != nil {
 			return errors.NewWrapErrorWithSuggestions(err, apiKeyUseFailedErrorMsg, fmt.Sprintf(apiKeyUseFailedSuggestions, userKey.Key))

--- a/internal/api-key/command_list.go
+++ b/internal/api-key/command_list.go
@@ -82,7 +82,7 @@ func (c *command) list(cmd *cobra.Command, _ []string) error {
 
 	if serviceAccount != "" {
 		if resource.LookupType(serviceAccount) != resource.ServiceAccount {
-			return errors.New(errors.BadServiceAccountIdErrorMsg)
+			return fmt.Errorf(errors.BadServiceAccountIdErrorMsg)
 		}
 		if _, ok := resourceIdToUserIdMap[serviceAccount]; !ok {
 			return errors.NewErrorWithSuggestions(

--- a/internal/api-key/command_store.go
+++ b/internal/api-key/command_store.go
@@ -134,7 +134,7 @@ func (c *command) store(cmd *cobra.Command, args []string) error {
 	}
 
 	if err := c.keystore.StoreAPIKey(&config.APIKeyPair{Key: key, Secret: secret}, cluster.ID); err != nil {
-		return errors.Wrap(err, unableToStoreApiKeyErrorMsg)
+		return fmt.Errorf(unableToStoreApiKeyErrorMsg, err)
 	}
 
 	output.ErrPrintf(c.Config.EnableColor, "Stored secret for API key \"%s\".\n", key)

--- a/internal/api-key/command_store.go
+++ b/internal/api-key/command_store.go
@@ -64,7 +64,7 @@ func (c *command) store(cmd *cobra.Command, args []string) error {
 	resourceType, clusterId, _, err := c.resolveResourceId(cmd, c.V2Client)
 	if err == nil && clusterId != "" {
 		if resourceType != resource.KafkaCluster {
-			return errors.Errorf(nonKafkaNotImplementedErrorMsg)
+			return fmt.Errorf(nonKafkaNotImplementedErrorMsg)
 		}
 		cluster, err = c.Context.FindKafkaCluster(clusterId)
 		if err != nil {

--- a/internal/api-key/command_use.go
+++ b/internal/api-key/command_use.go
@@ -41,7 +41,7 @@ func (c *command) use(cmd *cobra.Command, args []string) error {
 			return err
 		}
 		if resource.LookupType(resourceId) != resource.KafkaCluster {
-			return errors.Errorf(nonKafkaNotImplementedErrorMsg)
+			return fmt.Errorf(nonKafkaNotImplementedErrorMsg)
 		}
 		clusterId = resourceId
 	} else {

--- a/internal/asyncapi/account_details.go
+++ b/internal/asyncapi/account_details.go
@@ -13,7 +13,6 @@ import (
 	srsdk "github.com/confluentinc/schema-registry-sdk-go"
 
 	"github.com/confluentinc/cli/v3/pkg/config"
-	"github.com/confluentinc/cli/v3/pkg/errors"
 	"github.com/confluentinc/cli/v3/pkg/log"
 	schemaregistry "github.com/confluentinc/cli/v3/pkg/schema-registry"
 )
@@ -153,7 +152,7 @@ func (d *accountDetails) buildMessageEntity() *spec.MessageEntity {
 
 func catchOpenAPIError(err error) error {
 	if openAPIError, ok := err.(srsdk.GenericOpenAPIError); ok {
-		return errors.New(string(openAPIError.Body()))
+		return fmt.Errorf(string(openAPIError.Body()))
 	}
 	return err
 }

--- a/internal/asyncapi/account_details.go
+++ b/internal/asyncapi/account_details.go
@@ -104,7 +104,7 @@ func handlePrimitiveSchemas(schema string, err error) (map[string]any, error) {
 			return unmarshalledSchema, nil
 		}
 	}
-	return nil, fmt.Errorf("failed to unmarshal schema: %v", err)
+	return nil, fmt.Errorf("failed to unmarshal schema: %w", err)
 }
 
 func (d *accountDetails) getTopicDescription() error {
@@ -121,7 +121,7 @@ func (d *accountDetails) getTopicDescription() error {
 
 func (c *command) countAsyncApiUsage(details *accountDetails) error {
 	if err := details.srClient.AsyncapiPut(); err != nil {
-		return fmt.Errorf("failed to access AsyncAPI metric endpoint: %v", err)
+		return fmt.Errorf("failed to access AsyncAPI metric endpoint: %w", err)
 	}
 	return nil
 }

--- a/internal/asyncapi/command_export.go
+++ b/internal/asyncapi/command_export.go
@@ -178,7 +178,7 @@ func (c *command) getChannelDetails(details *accountDetails, flags *flags) error
 		if err.Error() == protobufErrorMessage {
 			return err
 		}
-		return fmt.Errorf("failed to get schema details: %v", err)
+		return fmt.Errorf("failed to get schema details: %w", err)
 	}
 	if err := details.getTags(); err != nil {
 		log.CliLogger.Warnf("Failed to get tags: %v", err)
@@ -261,11 +261,11 @@ func handlePanic() {
 func (c command) getMessageExamples(consumer *ckgo.Consumer, topicName, contentType string, srClient *schemaregistry.Client, valueFormatFlag string) (any, error) {
 	defer handlePanic()
 	if err := consumer.Subscribe(topicName, nil); err != nil {
-		return nil, fmt.Errorf(`failed to subscribe to topic "%s": %v`, topicName, err)
+		return nil, fmt.Errorf(`failed to subscribe to topic "%s": %w`, topicName, err)
 	}
 	message, err := consumer.ReadMessage(10 * time.Second)
 	if err != nil {
-		return nil, fmt.Errorf(`no example received for topic "%s": %v`, topicName, err)
+		return nil, fmt.Errorf(`no example received for topic "%s": %w`, topicName, err)
 	}
 	value := message.Value
 	var valueFormat string
@@ -314,7 +314,7 @@ func (c *command) getBindings(topicName string) (*bindings, error) {
 	var numPartitions int32
 	partitions, err := kafkaREST.CloudClient.ListKafkaPartitions(topicName)
 	if err != nil {
-		return nil, fmt.Errorf("unable to get topic partitions: %v", err)
+		return nil, fmt.Errorf("unable to get topic partitions: %w", err)
 	}
 	if partitions.Data != nil {
 		numPartitions = int32(len(partitions.Data))
@@ -375,7 +375,7 @@ func (c *command) getBindings(topicName string) (*bindings, error) {
 func (c *command) getClusterDetails(details *accountDetails, flags *flags) error {
 	clusterConfig, err := c.Context.GetKafkaClusterForCommand()
 	if err != nil {
-		return fmt.Errorf(`failed to find Kafka cluster: %v`, err)
+		return fmt.Errorf(`failed to find Kafka cluster: %w`, err)
 	}
 
 	if err := clusterConfig.DecryptAPIKeys(); err != nil {
@@ -511,7 +511,7 @@ func getMessageCompatibility(client *schemaregistry.Client, subject string) (map
 		log.CliLogger.Warnf("Failed to get subject level configuration: %v", err)
 		config, err = client.GetTopLevelConfig()
 		if err != nil {
-			return nil, fmt.Errorf("failed to get top level configuration: %v", err)
+			return nil, fmt.Errorf("failed to get top level configuration: %w", err)
 		}
 	}
 	return map[string]any{"x-messageCompatibility": config.CompatibilityLevel}, nil
@@ -594,7 +594,7 @@ func createConsumer(broker string, clusterCreds *config.APIKeyPair, groupId stri
 		"enable.auto.commit": "false",
 	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to create Kafka consumer: %v", err)
+		return nil, fmt.Errorf("failed to create Kafka consumer: %w", err)
 	}
 	return consumer, nil
 }

--- a/internal/asyncapi/command_import.go
+++ b/internal/asyncapi/command_import.go
@@ -330,7 +330,7 @@ func (c *command) updateTopic(topicName string, kafkaBinding kafkaBinding) error
 	}
 	log.CliLogger.Info("Overwriting topic configs")
 	if updateConfigs != nil {
-		if _, err = kafkaRest.CloudClient.UpdateKafkaTopicConfigBatch(topicName, kafkarestv3.AlterConfigBatchRequestData{Data: updateConfigs}); err != nil {
+		if _, err := kafkaRest.CloudClient.UpdateKafkaTopicConfigBatch(topicName, kafkarestv3.AlterConfigBatchRequestData{Data: updateConfigs}); err != nil {
 			return fmt.Errorf("unable to update topic configs: %w", err)
 		}
 	}

--- a/internal/asyncapi/command_import.go
+++ b/internal/asyncapi/command_import.go
@@ -214,7 +214,7 @@ func (c *command) addChannelToCluster(details *accountDetails, spec *Spec, topic
 	}
 	// If topic exists and overwrite flag is false, move to the next channel in spec
 	if topicExistedAlready && !overwrite {
-		return errors.New(parseErrorMessage)
+		return fmt.Errorf(parseErrorMessage)
 	}
 	// Register schema
 	schemaId, err := registerSchema(details, topicName, spec.Components)

--- a/internal/asyncapi/command_import.go
+++ b/internal/asyncapi/command_import.go
@@ -202,7 +202,7 @@ func fileToSpec(fileName string) (*Spec, error) {
 	}
 	spec := new(Spec)
 	if err := yaml.Unmarshal(asyncSpec, spec); err != nil {
-		return nil, fmt.Errorf("unable to unmarshal YAML file: %v", err)
+		return nil, fmt.Errorf("unable to unmarshal YAML file: %w", err)
 	}
 	return spec, nil
 }
@@ -240,7 +240,7 @@ func (c *command) addChannelToCluster(details *accountDetails, spec *Spec, topic
 	if (topicExistedAlready || newTopicCreated) && spec.Channels[topicName].Description != "" {
 		if err := addTopicDescription(details.srClient, fmt.Sprintf("%s:%s", details.kafkaClusterId, topicName),
 			spec.Channels[topicName].Description); err != nil {
-			return fmt.Errorf("unable to update topic description: %v", err)
+			return fmt.Errorf("unable to update topic description: %w", err)
 		}
 		output.Printf(c.Config.EnableColor, "Added description to topic \"%s\".\n", topicName)
 	}
@@ -330,9 +330,8 @@ func (c *command) updateTopic(topicName string, kafkaBinding kafkaBinding) error
 	}
 	log.CliLogger.Info("Overwriting topic configs")
 	if updateConfigs != nil {
-		_, err = kafkaRest.CloudClient.UpdateKafkaTopicConfigBatch(topicName, kafkarestv3.AlterConfigBatchRequestData{Data: updateConfigs})
-		if err != nil {
-			return fmt.Errorf("unable to update topic configs: %v", err)
+		if _, err = kafkaRest.CloudClient.UpdateKafkaTopicConfigBatch(topicName, kafkarestv3.AlterConfigBatchRequestData{Data: updateConfigs}); err != nil {
+			return fmt.Errorf("unable to update topic configs: %w", err)
 		}
 	}
 	output.Printf(c.Config.EnableColor, errors.UpdatedResourceMsg, resource.Topic, topicName)
@@ -402,7 +401,7 @@ func registerSchema(details *accountDetails, topicName string, components Compon
 
 		jsonSchema, err := yaml3.ToJSON(schema)
 		if err != nil {
-			return 0, fmt.Errorf("failed to encode schema as JSON: %v", err)
+			return 0, fmt.Errorf("failed to encode schema as JSON: %w", err)
 		}
 
 		req := srsdk.RegisterSchemaRequest{
@@ -412,7 +411,7 @@ func registerSchema(details *accountDetails, topicName string, components Compon
 		opts := &srsdk.RegisterOpts{Normalize: optional.NewBool(false)}
 		id, err := details.srClient.Register(subject, req, opts)
 		if err != nil {
-			return 0, fmt.Errorf("unable to register schema: %v", err)
+			return 0, fmt.Errorf("unable to register schema: %w", err)
 		}
 		output.Printf(false, "Registered schema \"%d\" under subject \"%s\".\n", id.Id, subject)
 		return id.Id, nil
@@ -426,7 +425,7 @@ func updateSubjectCompatibility(details *accountDetails, compatibility, subject 
 	req := srsdk.ConfigUpdateRequest{Compatibility: compatibility}
 	config, err := details.srClient.UpdateSubjectLevelConfig(subject, req)
 	if err != nil {
-		return fmt.Errorf("failed to update subject level compatibility: %v", err)
+		return fmt.Errorf("failed to update subject level compatibility: %w", err)
 	}
 	output.Printf(false, "Subject level compatibility updated to \"%s\" for subject \"%s\".\n", config.Compatibility, subject)
 	return nil
@@ -513,7 +512,7 @@ func addTagsUtil(details *accountDetails, tagDefConfigs []srsdk.TagDef, tagConfi
 		return err
 	})
 	if err != nil {
-		return fmt.Errorf("unable to create tag definition: %v", err)
+		return fmt.Errorf("unable to create tag definition: %w", err)
 	}
 	log.CliLogger.Debugf("Tag Definitions created")
 	tagOpts := &srsdk.CreateTagsOpts{Tag: optional.NewInterface(tagConfigs)}
@@ -522,7 +521,7 @@ func addTagsUtil(details *accountDetails, tagDefConfigs []srsdk.TagDef, tagConfi
 		return err
 	})
 	if err != nil {
-		return fmt.Errorf("unable to add tag to resource: %v", err)
+		return fmt.Errorf("unable to add tag to resource: %w", err)
 	}
 	return nil
 }

--- a/internal/audit-log/command_config_edit.go
+++ b/internal/audit-log/command_config_edit.go
@@ -44,7 +44,7 @@ func (c *configCommand) edit(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 	putSpec := mdsv1.AuditLogConfigSpec{}
-	if err = json.Unmarshal(edited, &putSpec); err != nil {
+	if err := json.Unmarshal(edited, &putSpec); err != nil {
 		return err
 	}
 	enc := json.NewEncoder(c.OutOrStdout())

--- a/internal/audit-log/command_describe.go
+++ b/internal/audit-log/command_describe.go
@@ -1,10 +1,11 @@
 package auditlog
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
 
 	pcmd "github.com/confluentinc/cli/v3/pkg/cmd"
-	"github.com/confluentinc/cli/v3/pkg/errors"
 	"github.com/confluentinc/cli/v3/pkg/output"
 )
 
@@ -43,7 +44,7 @@ func (c *describeCommand) describe(cmd *cobra.Command, _ []string) error {
 
 	auditLog := user.GetOrganization().GetAuditLog()
 	if auditLog.GetServiceAccountId() == 0 {
-		return errors.New("audit logs are not enabled for this organization")
+		return fmt.Errorf("audit logs are not enabled for this organization")
 	}
 
 	table := output.NewTable(cmd)

--- a/internal/audit-log/migration.go
+++ b/internal/audit-log/migration.go
@@ -189,7 +189,7 @@ func jsonConfigsToAuditLogConfigSpecs(clusterConfigs map[string]string) (map[str
 	for clusterId, auditConfig := range clusterConfigs {
 		var spec mdsv1.AuditLogConfigSpec
 		if err := json.Unmarshal([]byte(auditConfig), &spec); err != nil {
-			return nil, fmt.Errorf(`bad input file: the audit log configuration for cluster "%s" uses invalid JSON: %v`, clusterId, err)
+			return nil, fmt.Errorf(`bad input file: the audit log configuration for cluster "%s" uses invalid JSON: %w`, clusterId, err)
 		}
 		clusterAuditLogConfigSpecs[clusterId] = &spec
 	}

--- a/internal/billing/command_cost_list.go
+++ b/internal/billing/command_cost_list.go
@@ -73,12 +73,12 @@ func (c *command) list(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if err = c.checkDateFormat(startDate); err != nil {
-		return fmt.Errorf("invalid start date: %v", err)
+	if err := c.checkDateFormat(startDate); err != nil {
+		return fmt.Errorf("invalid start date: %w", err)
 	}
 
-	if err = c.checkDateFormat(startDate); err != nil {
-		return fmt.Errorf("invalid end date: %v", err)
+	if err := c.checkDateFormat(startDate); err != nil {
+		return fmt.Errorf("invalid end date: %w", err)
 	}
 
 	costs, err := c.V2Client.ListBillingCosts(startDate, endDate)

--- a/internal/byok/command_create.go
+++ b/internal/byok/command_create.go
@@ -121,7 +121,7 @@ func (c *command) create(cmd *cobra.Command, args []string) error {
 	} else if isAWSKey(keyString) {
 		keyReq = c.createAwsKeyRequest(keyString)
 	} else {
-		return fmt.Errorf(fmt.Sprintf("invalid key format: %s", keyString))
+		return fmt.Errorf("invalid key format: %s", keyString)
 	}
 
 	key, httpResp, err := c.V2Client.CreateByokKey(*keyReq)

--- a/internal/byok/command_create.go
+++ b/internal/byok/command_create.go
@@ -121,7 +121,7 @@ func (c *command) create(cmd *cobra.Command, args []string) error {
 	} else if isAWSKey(keyString) {
 		keyReq = c.createAwsKeyRequest(keyString)
 	} else {
-		return errors.New(fmt.Sprintf("invalid key format: %s", keyString))
+		return fmt.Errorf(fmt.Sprintf("invalid key format: %s", keyString))
 	}
 
 	key, httpResp, err := c.V2Client.CreateByokKey(*keyReq)
@@ -155,7 +155,7 @@ func getPolicyCommand(key *byokv1.ByokV1Key) (string, error) {
 func renderAWSEncryptionPolicy(roles []string) (string, error) {
 	buf := new(bytes.Buffer)
 	if err := encryptionKeyPolicyAws.Execute(buf, roles); err != nil {
-		return "", errors.New(failedToRenderKeyPolicyErrorMsg)
+		return "", fmt.Errorf(failedToRenderKeyPolicyErrorMsg)
 	}
 	return buf.String(), nil
 }
@@ -166,7 +166,7 @@ func renderAzureEncryptionPolicy(key *byokv1.ByokV1Key) (string, error) {
 	regex := regexp.MustCompile(`^https://([^/.]+).vault.azure.net`)
 	matches := regex.FindStringSubmatch(key.Key.ByokV1AzureKey.KeyId)
 	if matches == nil {
-		return "", errors.New(failedToRenderKeyPolicyErrorMsg)
+		return "", fmt.Errorf(failedToRenderKeyPolicyErrorMsg)
 	}
 
 	vaultName := matches[1]

--- a/internal/byok/command_describe.go
+++ b/internal/byok/command_describe.go
@@ -1,6 +1,8 @@
 package byok
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
 
 	byokv1 "github.com/confluentinc/ccloud-sdk-go-v2/byok/v1"
@@ -83,7 +85,7 @@ func (c *command) convertByokKeyToDescribeStruct(key *byokv1.ByokV1Key) (*descri
 		keyString = key.Key.ByokV1AzureKey.KeyId
 		roles = append(roles, key.Key.ByokV1AzureKey.GetApplicationId())
 	default:
-		return nil, errors.New(byokUnknownKeyTypeErrorMsg)
+		return nil, fmt.Errorf(byokUnknownKeyTypeErrorMsg)
 	}
 
 	updatedAt := ""

--- a/internal/byok/command_list.go
+++ b/internal/byok/command_list.go
@@ -1,7 +1,7 @@
 package byok
 
 import (
-	"errors"
+	"fmt"
 
 	"github.com/spf13/cobra"
 
@@ -64,7 +64,7 @@ func (c *command) list(cmd *cobra.Command, _ []string) error {
 		case key.Key.ByokV1AzureKey != nil:
 			keyString = key.Key.ByokV1AzureKey.KeyId
 		default:
-			return errors.New(byokUnknownKeyTypeErrorMsg)
+			return fmt.Errorf(byokUnknownKeyTypeErrorMsg)
 		}
 
 		updatedAt := ""

--- a/internal/cloud-signup/command.go
+++ b/internal/cloud-signup/command.go
@@ -1,11 +1,12 @@
 package cloudsignup
 
 import (
+	"fmt"
+
 	"github.com/pkg/browser"
 	"github.com/spf13/cobra"
 
 	pcmd "github.com/confluentinc/cli/v3/pkg/cmd"
-	"github.com/confluentinc/cli/v3/pkg/errors"
 	"github.com/confluentinc/cli/v3/pkg/form"
 	"github.com/confluentinc/cli/v3/pkg/output"
 )
@@ -36,7 +37,7 @@ func (c *command) cloudSignup(cmd *cobra.Command, _ []string) error {
 	}
 
 	if err := browser.OpenURL(signupUrl); err != nil {
-		return errors.Wrap(err, "unable to open web browser for cloud signup")
+		return fmt.Errorf("unable to open web browser for cloud signup: %w", err)
 	}
 
 	return nil

--- a/internal/cluster/command_describe.go
+++ b/internal/cluster/command_describe.go
@@ -7,7 +7,6 @@ import (
 
 	pauth "github.com/confluentinc/cli/v3/pkg/auth"
 	pcmd "github.com/confluentinc/cli/v3/pkg/cmd"
-	"github.com/confluentinc/cli/v3/pkg/errors"
 	"github.com/confluentinc/cli/v3/pkg/examples"
 	"github.com/confluentinc/cli/v3/pkg/output"
 	"github.com/confluentinc/cli/v3/pkg/types"
@@ -88,7 +87,7 @@ func getURL(cmd *cobra.Command) (string, error) {
 		return url, nil
 	}
 
-	return "", errors.New("pass the `--url` flag or set the `CONFLUENT_PLATFORM_MDS_URL` environment variable")
+	return "", fmt.Errorf("pass the `--url` flag or set the `CONFLUENT_PLATFORM_MDS_URL` environment variable")
 }
 
 func getCACertPath(cmd *cobra.Command) (string, error) {

--- a/internal/cluster/command_register.go
+++ b/internal/cluster/command_register.go
@@ -2,6 +2,7 @@ package cluster
 
 import (
 	"context"
+	"fmt"
 	"strconv"
 	"strings"
 
@@ -102,15 +103,15 @@ func (c *registerCommand) resolveClusterScope(cmd *cobra.Command) (*mdsv1.ScopeC
 	})
 
 	if scope.KafkaCluster == "" && nonKafkaScopesSet > 0 {
-		return nil, errors.New(errors.SpecifyKafkaIdErrorMsg)
+		return nil, fmt.Errorf(errors.SpecifyKafkaIdErrorMsg)
 	}
 
 	if scope.KafkaCluster == "" && nonKafkaScopesSet == 0 {
-		return nil, errors.New("must specify at least one cluster ID")
+		return nil, fmt.Errorf("must specify at least one cluster ID")
 	}
 
 	if nonKafkaScopesSet > 1 {
-		return nil, errors.New(errors.MoreThanOneNonKafkaErrorMsg)
+		return nil, fmt.Errorf(errors.MoreThanOneNonKafkaErrorMsg)
 	}
 
 	return scope, nil

--- a/internal/cluster/command_register.go
+++ b/internal/cluster/command_register.go
@@ -154,6 +154,6 @@ func (c *registerCommand) parseProtocol(cmd *cobra.Command) (mdsv1.Protocol, err
 	case "HTTPS":
 		return mdsv1.PROTOCOL_HTTPS, nil
 	default:
-		return "", errors.Errorf("protocol %s is currently not supported", protocol)
+		return "", fmt.Errorf("protocol %s is currently not supported", protocol)
 	}
 }

--- a/internal/cluster/command_unregister.go
+++ b/internal/cluster/command_unregister.go
@@ -2,6 +2,7 @@ package cluster
 
 import (
 	"context"
+	"fmt"
 	"slices"
 
 	"github.com/spf13/cobra"
@@ -11,7 +12,6 @@ import (
 	"github.com/confluentinc/cli/v3/pkg/cluster"
 	pcluster "github.com/confluentinc/cli/v3/pkg/cluster"
 	pcmd "github.com/confluentinc/cli/v3/pkg/cmd"
-	"github.com/confluentinc/cli/v3/pkg/errors"
 	"github.com/confluentinc/cli/v3/pkg/output"
 )
 
@@ -55,7 +55,7 @@ func (c *unregisterCommand) unregister(cmd *cobra.Command, _ []string) error {
 		return cluster.ClusterName == clusterName
 	})
 	if !found {
-		return errors.Errorf(`unknown cluster "%s"`, clusterName)
+		return fmt.Errorf(`unknown cluster "%s"`, clusterName)
 	}
 
 	httpResp, err = c.MDSClient.ClusterRegistryApi.DeleteNamedCluster(ctx, clusterName)

--- a/internal/cluster/scoped_id_service.go
+++ b/internal/cluster/scoped_id_service.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/confluentinc/cli/v3/pkg/errors"
 	"github.com/confluentinc/cli/v3/pkg/utils"
 )
 
@@ -66,7 +65,7 @@ func (s *ScopedIdService) DescribeCluster(url, caCertPath string) (*ScopedId, er
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, errors.Errorf("unable to fetch cluster metadata: %s - %s", resp.Status, body)
+		return nil, fmt.Errorf("unable to fetch cluster metadata: %s - %s", resp.Status, body)
 	}
 
 	meta := &ScopedId{}

--- a/internal/connect/command_cluster_pause.go
+++ b/internal/connect/command_cluster_pause.go
@@ -1,6 +1,8 @@
 package connect
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
 
 	connectv1 "github.com/confluentinc/ccloud-sdk-go-v2/connect/v1"
@@ -58,7 +60,7 @@ func (c *clusterCommand) pause(cmd *cobra.Command, args []string) error {
 	for _, id := range args {
 		connector, ok := connectorsById[id]
 		if !ok {
-			return errors.Errorf(errors.UnknownConnectorIdErrorMsg, id)
+			return fmt.Errorf(errors.UnknownConnectorIdErrorMsg, id)
 		}
 
 		if err := c.V2Client.PauseConnector(connector.Info.GetName(), environmentId, kafkaCluster.ID); err != nil {

--- a/internal/connect/command_cluster_resume.go
+++ b/internal/connect/command_cluster_resume.go
@@ -1,6 +1,8 @@
 package connect
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
 
 	connectv1 "github.com/confluentinc/ccloud-sdk-go-v2/connect/v1"
@@ -58,7 +60,7 @@ func (c *clusterCommand) resume(_ *cobra.Command, args []string) error {
 	for _, id := range args {
 		connector, ok := connectorsById[id]
 		if !ok {
-			return errors.Errorf(errors.UnknownConnectorIdErrorMsg, id)
+			return fmt.Errorf(errors.UnknownConnectorIdErrorMsg, id)
 		}
 
 		if err := c.V2Client.ResumeConnector(connector.Info.GetName(), environmentId, kafkaCluster.ID); err != nil {

--- a/internal/connect/command_cluster_update.go
+++ b/internal/connect/command_cluster_update.go
@@ -1,6 +1,8 @@
 package connect
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
 
 	pcmd "github.com/confluentinc/cli/v3/pkg/cmd"
@@ -68,7 +70,7 @@ func (c *clusterCommand) update(cmd *cobra.Command, args []string) error {
 			return err
 		}
 	} else {
-		return errors.New("one of `--config` or `--config-file` must be specified")
+		return fmt.Errorf("one of `--config` or `--config-file` must be specified")
 	}
 
 	connector, err := c.V2Client.GetConnectorExpansionById(args[0], environmentId, kafkaCluster.ID)

--- a/internal/connect/command_custom_plugin_create.go
+++ b/internal/connect/command_custom_plugin_create.go
@@ -1,6 +1,7 @@
 package connect
 
 import (
+	"fmt"
 	"path/filepath"
 	"strings"
 
@@ -8,7 +9,6 @@ import (
 
 	connectcustompluginv1 "github.com/confluentinc/ccloud-sdk-go-v2/connect-custom-plugin/v1"
 
-	"github.com/confluentinc/cli/v3/pkg/errors"
 	"github.com/confluentinc/cli/v3/pkg/examples"
 	"github.com/confluentinc/cli/v3/pkg/output"
 )
@@ -77,7 +77,7 @@ func (c *customPluginCommand) createCustomPlugin(cmd *cobra.Command, args []stri
 
 	extension := strings.ToLower(strings.TrimPrefix(filepath.Ext(pluginFileName), "."))
 	if extension != "zip" && extension != "jar" {
-		return errors.Errorf(`only file extensions ".jar" and ".zip" are allowed`)
+		return fmt.Errorf(`only file extensions ".jar" and ".zip" are allowed`)
 	}
 
 	request := *connectcustompluginv1.NewConnectV1PresignedUrlRequest()

--- a/internal/connect/command_event_describe.go
+++ b/internal/connect/command_event_describe.go
@@ -1,10 +1,11 @@
 package connect
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
 
 	pcmd "github.com/confluentinc/cli/v3/pkg/cmd"
-	"github.com/confluentinc/cli/v3/pkg/errors"
 	"github.com/confluentinc/cli/v3/pkg/output"
 )
 
@@ -32,7 +33,7 @@ func (c *eventCommand) describe(cmd *cobra.Command, _ []string) error {
 	auditLog := c.Context.GetOrganization().GetAuditLog()
 
 	if auditLog.GetClusterId() == "" {
-		return errors.New("Connect Log Events are not enabled for this organization")
+		return fmt.Errorf("Connect Log Events are not enabled for this organization")
 	}
 
 	table := output.NewTable(cmd)

--- a/internal/connect/command_plugin_install.go
+++ b/internal/connect/command_plugin_install.go
@@ -219,7 +219,7 @@ func getLocalManifest(archivePath string) (*cpstructs.Manifest, error) {
 		}
 	}
 
-	return nil, errors.Errorf(`failed to find manifest file inside local archive file "%s"`, archivePath)
+	return nil, fmt.Errorf(`failed to find manifest file inside local archive file "%s"`, archivePath)
 }
 
 func getPluginDirFromFlag(cmd *cobra.Command) (string, error) {
@@ -237,7 +237,7 @@ func getPluginDirFromFlag(cmd *cobra.Command) (string, error) {
 	}
 
 	if !utils.DoesPathExist(pluginDir) {
-		return "", errors.Errorf(invalidDirectoryErrorMsg, pluginDir)
+		return "", fmt.Errorf(invalidDirectoryErrorMsg, pluginDir)
 	}
 
 	return pluginDir, nil
@@ -256,7 +256,7 @@ func getWorkerConfigsFromFlag(cmd *cobra.Command) ([]string, error) {
 		}
 
 		if !utils.DoesPathExist(workerConfig) {
-			errs = multierror.Append(errs, errors.Errorf(`worker config file "%s" does not exist`, workerConfig))
+			errs = multierror.Append(errs, fmt.Errorf(`worker config file "%s" does not exist`, workerConfig))
 		}
 	}
 
@@ -359,11 +359,11 @@ func (c *pluginCommand) installFromRemote(client *hub.Client, pluginManifest *cp
 	checksumErrorMsg := `%s checksum for downloaded archive (%s) does not match checksum in manifest (%s) for plugin "%s"`
 	calculatedMd5Checksum := fmt.Sprintf("%x", md5.Sum(archive))
 	if calculatedMd5Checksum != pluginManifest.Archive.Md5 {
-		return errors.Errorf(checksumErrorMsg, "MD5", calculatedMd5Checksum, pluginManifest.Archive.Md5, pluginManifest.Name)
+		return fmt.Errorf(checksumErrorMsg, "MD5", calculatedMd5Checksum, pluginManifest.Archive.Md5, pluginManifest.Name)
 	}
 	calculatedSha1Checksum := fmt.Sprintf("%x", sha1.Sum(archive))
 	if calculatedSha1Checksum != pluginManifest.Archive.Sha1 {
-		return errors.Errorf(checksumErrorMsg, "SHA1", calculatedSha1Checksum, pluginManifest.Archive.Sha1, pluginManifest.Name)
+		return fmt.Errorf(checksumErrorMsg, "SHA1", calculatedSha1Checksum, pluginManifest.Archive.Sha1, pluginManifest.Name)
 	}
 
 	zipReader, err := zip.NewReader(bytes.NewReader(archive), int64(len(archive)))

--- a/internal/connect/command_plugin_install.go
+++ b/internal/connect/command_plugin_install.go
@@ -73,7 +73,7 @@ func (c *pluginCommand) install(cmd *cobra.Command, args []string) error {
 	}
 
 	if cmd.Flags().Changed("plugin-directory") && cmd.Flags().Changed("worker-configurations") && cmd.Flags().Changed("confluent-platform") {
-		return errors.New("at most two of `--plugin-directory`, `--worker-configurations`, and `--confluent-platform` may be set")
+		return fmt.Errorf("at most two of `--plugin-directory`, `--worker-configurations`, and `--confluent-platform` may be set")
 	}
 
 	client, err := c.GetHubClient()
@@ -266,7 +266,7 @@ func getWorkerConfigsFromFlag(cmd *cobra.Command) ([]string, error) {
 func existingPluginInstallation(pluginDir string, pluginManifest *cpstructs.Manifest) ([]string, error) {
 	// Bundled installations
 	if utils.DoesPathExist(filepath.Join(pluginDir, pluginManifest.Name)) {
-		return nil, errors.New("unable to install plugin because it is already bundled")
+		return nil, fmt.Errorf("unable to install plugin because it is already bundled")
 	}
 
 	// Other previous installations
@@ -302,7 +302,7 @@ func removePluginInstallations(previousInstallations []string, prompt form.Promp
 				return err
 			}
 			if !f.Responses["confirm"].(bool) {
-				return errors.New("previous versions must be uninstalled to continue")
+				return fmt.Errorf("previous versions must be uninstalled to continue")
 			}
 		}
 
@@ -431,7 +431,7 @@ func checkLicenseAcceptance(pluginManifest *cpstructs.Manifest, prompt form.Prom
 				return err
 			}
 			if !f.Responses["confirm"].(bool) {
-				return errors.New("you must accept all license agreements to install this plugin")
+				return fmt.Errorf("you must accept all license agreements to install this plugin")
 			}
 		}
 	}

--- a/internal/connect/install_utils.go
+++ b/internal/connect/install_utils.go
@@ -93,7 +93,7 @@ func getConfluentPlatformInstallation(cmd *cobra.Command, prompt form.Prompt, fo
 	}
 	choice, err := strconv.Atoi(f.Responses["installation"].(string))
 	if err != nil || choice < 1 || choice > len(installations) {
-		return nil, errors.Errorf("your choice must be in the range %d to %d (inclusive)", 1, len(installations))
+		return nil, fmt.Errorf("your choice must be in the range %d to %d (inclusive)", 1, len(installations))
 	}
 	return &installations[choice-1], nil
 }
@@ -227,7 +227,7 @@ func choosePluginDir(installation *platformInstallation, prompt form.Prompt, for
 	case "PACKAGE":
 		defaultPluginDir = "/usr/share/confluent-hub-components"
 	default:
-		return "", errors.Errorf(unexpectedInstallationErrorMsg, installation.Location.Type)
+		return "", fmt.Errorf(unexpectedInstallationErrorMsg, installation.Location.Type)
 	}
 
 	if force {
@@ -262,7 +262,7 @@ func choosePluginDir(installation *platformInstallation, prompt form.Prompt, for
 		return "", err
 	}
 	if !utils.DoesPathExist(inputDir) {
-		return "", errors.Errorf(invalidDirectoryErrorMsg, inputDir)
+		return "", fmt.Errorf(invalidDirectoryErrorMsg, inputDir)
 	}
 
 	output.Println(false, "")

--- a/internal/connect/install_utils.go
+++ b/internal/connect/install_utils.go
@@ -142,7 +142,7 @@ func findInstallationDirectories() ([]platformInstallation, error) {
 	// current directory
 	currentDirectory, err := os.Getwd()
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to determine current working directory")
+		return nil, fmt.Errorf("unable to determine current working directory: %w", err)
 	}
 	if hasArchiveInstallation(currentDirectory) {
 		installation := platformInstallation{
@@ -170,7 +170,7 @@ func findInstallationDirectories() ([]platformInstallation, error) {
 	// based on the client
 	cliPath, err := os.Executable()
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to determine path to CLI")
+		return nil, fmt.Errorf("unable to determine path to CLI: %w", err)
 	}
 	cliDirectory := filepath.Dir(cliPath)
 	cliUse := "CLI Installation Directory"
@@ -316,7 +316,7 @@ func runningWorkerConfigLocations(searchProcessCmd exec.Command) ([]WorkerConfig
 
 	out, err := searchProcessCmd.Output()
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to run shell command to locate running Connect worker processes")
+		return nil, fmt.Errorf("failed to run shell command to locate running Connect worker processes: %w", err)
 	}
 
 	var result []WorkerConfig
@@ -349,7 +349,7 @@ func chooseWorkerConfigs(cmd *cobra.Command, installation *platformInstallation,
 	var workerConfigs []WorkerConfig
 
 	if standardWorkerConfigs, err := standardWorkerConfigLocations(installation); err != nil {
-		return nil, errors.Wrap(err, "could not infer possible worker configuration file locations from standard candidates")
+		return nil, fmt.Errorf("could not infer possible worker configuration file locations from standard candidates: %w", err)
 	} else {
 		for _, workerConfig := range standardWorkerConfigs {
 			if utils.DoesPathExist(workerConfig.Path) {
@@ -366,7 +366,7 @@ func chooseWorkerConfigs(cmd *cobra.Command, installation *platformInstallation,
 	searchProcessCmd := exec.NewCommand("/bin/bash", "-c", commandStr)
 
 	if runningWorkerConfigs, err := runningWorkerConfigLocations(searchProcessCmd); err != nil {
-		return nil, errors.Wrap(err, "could not infer possible worker configuration file locations from running processes")
+		return nil, fmt.Errorf("could not infer possible worker configuration file locations from running processes: %w", err)
 	} else {
 		for _, workerConfig := range runningWorkerConfigs {
 			if utils.DoesPathExist(workerConfig.Path) {

--- a/internal/connect/install_utils.go
+++ b/internal/connect/install_utils.go
@@ -105,7 +105,7 @@ func getPlatformInstallationFromFlag(cmd *cobra.Command) (*platformInstallation,
 	}
 
 	if !hasArchiveInstallation(specifiedDirectory) {
-		return nil, errors.New("the directory specified with `--confluent-platform` does not correspond to a valid archive installation")
+		return nil, fmt.Errorf("the directory specified with `--confluent-platform` does not correspond to a valid archive installation")
 	}
 
 	return &platformInstallation{
@@ -307,7 +307,7 @@ func standardWorkerConfigLocations(installation *platformInstallation) ([]Worker
 		}
 		return result, nil
 	default:
-		return nil, errors.New(fmt.Sprintf(unexpectedInstallationErrorMsg, installation.Location.Type))
+		return nil, fmt.Errorf(fmt.Sprintf(unexpectedInstallationErrorMsg, installation.Location.Type))
 	}
 }
 

--- a/internal/connect/utils.go
+++ b/internal/connect/utils.go
@@ -25,7 +25,7 @@ func getConfig(cmd *cobra.Command) (*map[string]string, error) {
 
 	options, err := parseConfigFile(configFile)
 	if err != nil {
-		return nil, errors.Wrapf(err, errors.UnableToReadConfigurationFileErrorMsg, configFile)
+		return nil, fmt.Errorf(errors.UnableToReadConfigurationFileErrorMsg, configFile, err)
 	}
 
 	connectorType := options["confluent.connector.type"]
@@ -46,7 +46,7 @@ func getConfig(cmd *cobra.Command) (*map[string]string, error) {
 func parseConfigFile(filename string) (map[string]string, error) {
 	jsonFile, err := os.ReadFile(filename)
 	if err != nil {
-		return nil, errors.Wrapf(err, errors.UnableToReadConfigurationFileErrorMsg, filename)
+		return nil, fmt.Errorf(errors.UnableToReadConfigurationFileErrorMsg, filename, err)
 	}
 	if len(jsonFile) == 0 {
 		return nil, fmt.Errorf(`connector config file "%s" is empty`, filename)
@@ -56,7 +56,7 @@ func parseConfigFile(filename string) (map[string]string, error) {
 	var options map[string]any
 
 	if err := json.Unmarshal(jsonFile, &options); err != nil {
-		return nil, errors.Wrapf(err, errors.UnableToReadConfigurationFileErrorMsg, filename)
+		return nil, fmt.Errorf(errors.UnableToReadConfigurationFileErrorMsg, filename, err)
 	}
 
 	for key, val := range options {

--- a/internal/connect/utils.go
+++ b/internal/connect/utils.go
@@ -3,6 +3,7 @@ package connect
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 	"mime/multipart"
 	"net/http"
@@ -36,7 +37,7 @@ func getConfig(cmd *cobra.Command) (*map[string]string, error) {
 	_, classExists := options["connector.class"]
 
 	if connectorType != "CUSTOM" && (!nameExists || !classExists) {
-		return nil, errors.Errorf(`required configs "name" and "connector.class" missing from connector config file "%s"`, configFile)
+		return nil, fmt.Errorf(`required configs "name" and "connector.class" missing from connector config file "%s"`, configFile)
 	}
 
 	return &options, nil
@@ -48,7 +49,7 @@ func parseConfigFile(filename string) (map[string]string, error) {
 		return nil, errors.Wrapf(err, errors.UnableToReadConfigurationFileErrorMsg, filename)
 	}
 	if len(jsonFile) == 0 {
-		return nil, errors.Errorf(`connector config file "%s" is empty`, filename)
+		return nil, fmt.Errorf(`connector config file "%s" is empty`, filename)
 	}
 
 	kvPairs := make(map[string]string)
@@ -64,18 +65,18 @@ func parseConfigFile(filename string) (map[string]string, error) {
 		} else {
 			// We support object-as-a-value only for "config" key.
 			if key != "config" {
-				return nil, errors.Errorf(`only string values are permitted for the configuration "%s"`, key)
+				return nil, fmt.Errorf(`only string values are permitted for the configuration "%s"`, key)
 			}
 
 			configMap, ok := val.(map[string]any)
 			if !ok {
-				return nil, errors.Errorf(`value for the configuration "config" is malformed`)
+				return nil, fmt.Errorf(`value for the configuration "config" is malformed`)
 			}
 
 			for configKey, configVal := range configMap {
 				value, isString := configVal.(string)
 				if !isString {
-					return nil, errors.Errorf(`only string values are permitted for the configuration "%s"`, configKey)
+					return nil, fmt.Errorf(`only string values are permitted for the configuration "%s"`, configKey)
 				}
 				kvPairs[configKey] = value
 			}

--- a/internal/context/command_create.go
+++ b/internal/context/command_create.go
@@ -1,12 +1,12 @@
 package context
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/spf13/cobra"
 
 	pcmd "github.com/confluentinc/cli/v3/pkg/cmd"
-	"github.com/confluentinc/cli/v3/pkg/errors"
 	"github.com/confluentinc/cli/v3/pkg/examples"
 	"github.com/confluentinc/cli/v3/pkg/version"
 )
@@ -82,7 +82,7 @@ func (c *command) parseStringFlag(cmd *cobra.Command, name, prompt string, secur
 
 	val = strings.TrimSpace(val)
 	if val == "" {
-		return "", errors.Errorf("%s cannot be empty", name)
+		return "", fmt.Errorf("%s cannot be empty", name)
 	}
 
 	return val, nil

--- a/internal/iam/command_acl.go
+++ b/internal/iam/command_acl.go
@@ -46,7 +46,7 @@ func newAclCommand(prerunner pcmd.PreRunner) *cobra.Command {
 
 func (c *aclCommand) handleAclError(cmd *cobra.Command, err error, response *http.Response) error {
 	if response != nil && response.StatusCode == http.StatusNotFound {
-		return fmt.Errorf("unable to %s ACLs: %v", cmd.Name(), err)
+		return fmt.Errorf("unable to %s ACLs: %w", cmd.Name(), err)
 	}
 	return err
 }

--- a/internal/iam/command_acl_create.go
+++ b/internal/iam/command_acl_create.go
@@ -1,6 +1,8 @@
 package iam
 
 import (
+	"fmt"
+
 	"github.com/hashicorp/go-multierror"
 	"github.com/spf13/cobra"
 
@@ -62,7 +64,7 @@ func validateACLAddDelete(aclConfiguration *ACLConfiguration) *ACLConfiguration 
 	// deletion of too many acls at once. Expectation is that multi delete will be done via
 	// repeated invocation of the cli by external scripts.
 	if aclConfiguration.AclBinding.Entry.PermissionType == "" {
-		aclConfiguration.errors = multierror.Append(aclConfiguration.errors, errors.Errorf(errors.MustSetAllowOrDenyErrorMsg))
+		aclConfiguration.errors = multierror.Append(aclConfiguration.errors, fmt.Errorf(errors.MustSetAllowOrDenyErrorMsg))
 	}
 
 	if aclConfiguration.AclBinding.Pattern.PatternType == "" {
@@ -70,7 +72,7 @@ func validateACLAddDelete(aclConfiguration *ACLConfiguration) *ACLConfiguration 
 	}
 
 	if aclConfiguration.AclBinding.Pattern.ResourceType == "" {
-		aclConfiguration.errors = multierror.Append(aclConfiguration.errors, errors.Errorf(errors.MustSetResourceTypeErrorMsg,
+		aclConfiguration.errors = multierror.Append(aclConfiguration.errors, fmt.Errorf(errors.MustSetResourceTypeErrorMsg,
 			convertToFlags(mdsv1.ACLRESOURCETYPE_TOPIC, mdsv1.ACLRESOURCETYPE_GROUP,
 				mdsv1.ACLRESOURCETYPE_CLUSTER, mdsv1.ACLRESOURCETYPE_TRANSACTIONAL_ID)))
 	}

--- a/internal/iam/command_rbac_role_binding.go
+++ b/internal/iam/command_rbac_role_binding.go
@@ -466,7 +466,7 @@ func (c *roleBindingCommand) parseV2RoleBinding(cmd *cobra.Command) (*mdsv2.IamV
 		return nil, err
 	}
 	if cmd.Flags().Changed("principal") {
-		if err = c.validatePrincipalFormat(principal); err != nil {
+		if err := c.validatePrincipalFormat(principal); err != nil {
 			return nil, err
 		}
 	}

--- a/internal/iam/command_rbac_role_binding.go
+++ b/internal/iam/command_rbac_role_binding.go
@@ -228,20 +228,20 @@ func (c *roleBindingCommand) parseAndValidateScope(cmd *cobra.Command) (*mdsv1.M
 	})
 
 	if clusterName != "" && (scope.KafkaCluster != "" || nonKafkaScopesSet > 0) {
-		return nil, errors.New("cannot specify both cluster name and cluster scope")
+		return nil, fmt.Errorf("cannot specify both cluster name and cluster scope")
 	}
 
 	if clusterName == "" {
 		if scope.KafkaCluster == "" && nonKafkaScopesSet > 0 {
-			return nil, errors.New(errors.SpecifyKafkaIdErrorMsg)
+			return nil, fmt.Errorf(errors.SpecifyKafkaIdErrorMsg)
 		}
 
 		if scope.KafkaCluster == "" && nonKafkaScopesSet == 0 {
-			return nil, errors.New("must specify either cluster ID to indicate role binding scope or the cluster name")
+			return nil, fmt.Errorf("must specify either cluster ID to indicate role binding scope or the cluster name")
 		}
 
 		if nonKafkaScopesSet > 1 {
-			return nil, errors.New(errors.MoreThanOneNonKafkaErrorMsg)
+			return nil, fmt.Errorf(errors.MoreThanOneNonKafkaErrorMsg)
 		}
 
 		return &mdsv1.MdsScope{Clusters: *scope}, nil
@@ -430,7 +430,7 @@ func displayCreateAndDeleteOutput(cmd *cobra.Command, options *roleBindingOption
 	if options.resource != "" {
 		fieldsSelected = resourcePatternListFields
 		if len(options.resourcesRequest.ResourcePatterns) != 1 {
-			return errors.New("display error: number of resource pattern is not 1")
+			return fmt.Errorf("display error: number of resource pattern is not 1")
 		}
 		resourcePattern := options.resourcesRequest.ResourcePatterns[0]
 		out.ResourceType = resourcePattern.ResourceType
@@ -595,15 +595,15 @@ func (c *roleBindingCommand) parseV2BaseCrnPattern(cmd *cobra.Command) (string, 
 			return "", err
 		}
 		if clusterScopedRolesV2.Contains(role) && !cmd.Flags().Changed("cloud-cluster") {
-			return "", errors.New(specifyCloudClusterErrorMsg)
+			return "", fmt.Errorf(specifyCloudClusterErrorMsg)
 		}
 		if (environmentScopedRoles[role] || clusterScopedRolesV2.Contains(role)) && !cmd.Flags().Changed("current-environment") && !cmd.Flags().Changed("environment") {
-			return "", errors.New(specifyEnvironmentErrorMsg)
+			return "", fmt.Errorf(specifyEnvironmentErrorMsg)
 		}
 	}
 
 	if cmd.Flags().Changed("cloud-cluster") && !cmd.Flags().Changed("current-environment") && !cmd.Flags().Changed("environment") {
-		return "", errors.New(specifyEnvironmentErrorMsg)
+		return "", fmt.Errorf(specifyEnvironmentErrorMsg)
 	}
 	return crnPattern, nil
 }

--- a/internal/iam/command_rbac_role_binding_list.go
+++ b/internal/iam/command_rbac_role_binding_list.go
@@ -1,6 +1,7 @@
 package iam
 
 import (
+	"fmt"
 	"net/http"
 	"sort"
 	"strings"
@@ -14,7 +15,6 @@ import (
 	"github.com/confluentinc/mds-sdk-go-public/mdsv1"
 
 	pcmd "github.com/confluentinc/cli/v3/pkg/cmd"
-	"github.com/confluentinc/cli/v3/pkg/errors"
 	"github.com/confluentinc/cli/v3/pkg/examples"
 	"github.com/confluentinc/cli/v3/pkg/output"
 )
@@ -180,7 +180,7 @@ func (c *roleBindingCommand) confluentList(cmd *cobra.Command, options *roleBind
 	} else if cmd.Flags().Changed("role") {
 		return c.confluentListRolePrincipals(cmd, options)
 	}
-	return errors.New(principalOrRoleRequiredErrorMsg)
+	return fmt.Errorf(principalOrRoleRequiredErrorMsg)
 }
 
 func (c *roleBindingCommand) listPrincipalResources(cmd *cobra.Command, options *roleBindingOptions) error {
@@ -323,7 +323,7 @@ func (c *roleBindingCommand) ccloudList(cmd *cobra.Command, listRoleBinding *mds
 	} else if cmd.Flags().Changed("role") {
 		return c.ccloudListRolePrincipals(cmd, listRoleBinding)
 	}
-	return errors.New(principalOrRoleRequiredErrorMsg)
+	return fmt.Errorf(principalOrRoleRequiredErrorMsg)
 }
 
 func (c *roleBindingCommand) listMyRoleBindings(cmd *cobra.Command, listRoleBinding *mdsv2.IamV2RoleBinding) error {

--- a/internal/iam/command_service_account_delete.go
+++ b/internal/iam/command_service_account_delete.go
@@ -1,6 +1,8 @@
 package iam
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
 
 	pcmd "github.com/confluentinc/cli/v3/pkg/cmd"
@@ -48,7 +50,7 @@ func (c *serviceAccountCommand) delete(cmd *cobra.Command, args []string) error 
 
 	deleteFunc := func(id string) error {
 		if err := c.V2Client.DeleteIamServiceAccount(id); err != nil {
-			return errors.Errorf(errors.DeleteResourceErrorMsg, resource.ServiceAccount, id, err)
+			return fmt.Errorf(errors.DeleteResourceErrorMsg, resource.ServiceAccount, id, err)
 		}
 		return nil
 	}

--- a/internal/iam/command_service_account_update.go
+++ b/internal/iam/command_service_account_update.go
@@ -1,6 +1,8 @@
 package iam
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
 
 	iamv2 "github.com/confluentinc/ccloud-sdk-go-v2/iam/v2"
@@ -46,7 +48,7 @@ func (c *serviceAccountCommand) update(cmd *cobra.Command, args []string) error 
 	}
 
 	if resource.LookupType(args[0]) != resource.ServiceAccount {
-		return errors.New(errors.BadServiceAccountIdErrorMsg)
+		return fmt.Errorf(errors.BadServiceAccountIdErrorMsg)
 	}
 	serviceAccountId := args[0]
 

--- a/internal/iam/command_user_delete.go
+++ b/internal/iam/command_user_delete.go
@@ -1,6 +1,8 @@
 package iam
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
 
 	pcmd "github.com/confluentinc/cli/v3/pkg/cmd"
@@ -40,7 +42,7 @@ func (c *userCommand) delete(cmd *cobra.Command, args []string) error {
 
 	deleteFunc := func(id string) error {
 		if err := c.V2Client.DeleteIamUser(id); err != nil {
-			return errors.Errorf(errors.DeleteResourceErrorMsg, resource.User, id, err)
+			return fmt.Errorf(errors.DeleteResourceErrorMsg, resource.User, id, err)
 		}
 		return nil
 	}

--- a/internal/iam/command_user_invitation_create.go
+++ b/internal/iam/command_user_invitation_create.go
@@ -1,13 +1,13 @@
 package iam
 
 import (
+	"fmt"
 	"regexp"
 
 	"github.com/spf13/cobra"
 
 	iamv2 "github.com/confluentinc/ccloud-sdk-go-v2/iam/v2"
 
-	"github.com/confluentinc/cli/v3/pkg/errors"
 	"github.com/confluentinc/cli/v3/pkg/output"
 )
 
@@ -22,7 +22,7 @@ func (c invitationCommand) newCreateCommand() *cobra.Command {
 
 func (c invitationCommand) createInvitation(cmd *cobra.Command, args []string) error {
 	if !validateEmail(args[0]) {
-		return errors.New("invalid email structure")
+		return fmt.Errorf("invalid email structure")
 	}
 
 	req := iamv2.IamV2Invitation{Email: iamv2.PtrString(args[0])}

--- a/internal/iam/command_user_update.go
+++ b/internal/iam/command_user_update.go
@@ -40,7 +40,7 @@ func (c *userCommand) update(cmd *cobra.Command, args []string) error {
 
 	update := iamv2.IamV2UserUpdate{FullName: iamv2.PtrString(fullName)}
 	if _, err := c.V2Client.UpdateIamUser(resourceId, update); err != nil {
-		return errors.Errorf(`failed to update %s "%s": %v`, resource.User, resourceId, err)
+		return errors.Errorf(`failed to update %s "%s": %w`, resource.User, resourceId, err)
 	}
 
 	output.ErrPrintf(c.Config.EnableColor, errors.UpdateSuccessMsg, "full name", "user", resourceId, fullName)

--- a/internal/iam/command_user_update.go
+++ b/internal/iam/command_user_update.go
@@ -1,6 +1,8 @@
 package iam
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
 
 	iamv2 "github.com/confluentinc/ccloud-sdk-go-v2/iam/v2"
@@ -35,12 +37,12 @@ func (c *userCommand) update(cmd *cobra.Command, args []string) error {
 
 	resourceId := args[0]
 	if resource.LookupType(resourceId) != resource.User {
-		return errors.Errorf(badResourceIdErrorMsg, "u")
+		return fmt.Errorf(badResourceIdErrorMsg, "u")
 	}
 
 	update := iamv2.IamV2UserUpdate{FullName: iamv2.PtrString(fullName)}
 	if _, err := c.V2Client.UpdateIamUser(resourceId, update); err != nil {
-		return errors.Errorf(`failed to update %s "%s": %w`, resource.User, resourceId, err)
+		return fmt.Errorf(`failed to update %s "%s": %w`, resource.User, resourceId, err)
 	}
 
 	output.ErrPrintf(c.Config.EnableColor, errors.UpdateSuccessMsg, "full name", "user", resourceId, fullName)

--- a/internal/kafka/command_acl.go
+++ b/internal/kafka/command_acl.go
@@ -110,7 +110,7 @@ func (c *aclCommand) provisioningClusterCheck(lkc string) error {
 		return errors.CatchKafkaNotFoundError(err, lkc, httpResp)
 	}
 	if cluster.Status.Phase == ccloudv2.StatusProvisioning {
-		return errors.Errorf(errors.KafkaRestProvisioningErrorMsg, lkc)
+		return fmt.Errorf(errors.KafkaRestProvisioningErrorMsg, lkc)
 	}
 	return nil
 }

--- a/internal/kafka/command_clientconfig_create.go
+++ b/internal/kafka/command_clientconfig_create.go
@@ -332,7 +332,7 @@ func fetchConfigFile(configId string) (string, error) {
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return "", errors.Errorf("failed to get config file: error code %d", resp.StatusCode)
+		return "", fmt.Errorf("failed to get config file: error code %d", resp.StatusCode)
 	}
 
 	defer resp.Body.Close()

--- a/internal/kafka/command_cluster_create.go
+++ b/internal/kafka/command_cluster_create.go
@@ -120,7 +120,7 @@ func (c *clusterCommand) create(cmd *cobra.Command, args []string) error {
 	var encryptionKey string
 	if cmd.Flags().Changed("encryption-key") {
 		if cloud != "gcp" {
-			return errors.New("BYOK via `--encryption-key` is only available for GCP. Use `confluent byok create` to register AWS and Azure keys.")
+			return fmt.Errorf("BYOK via `--encryption-key` is only available for GCP. Use `confluent byok create` to register AWS and Azure keys.")
 		}
 
 		encryptionKey, err = cmd.Flags().GetString("encryption-key")
@@ -166,7 +166,7 @@ func (c *clusterCommand) create(cmd *cobra.Command, args []string) error {
 			return errors.NewErrorWithSuggestions("the `--cku` flag can only be used when creating a dedicated Kafka cluster", "Specify a dedicated cluster with `--type`.")
 		}
 		if cku <= 0 {
-			return errors.New(errors.CkuMoreThanZeroErrorMsg)
+			return fmt.Errorf(errors.CkuMoreThanZeroErrorMsg)
 		}
 		setClusterConfigCku(&createCluster, int32(cku))
 	}
@@ -307,10 +307,10 @@ func catchClusterConfigurationNotValidError(err error, r *http.Response, cloud, 
 		)
 	}
 	if strings.Contains(err.Error(), "CKU must be greater") {
-		return errors.New("CKU must be greater than 1 for multi-zone dedicated clusters")
+		return fmt.Errorf("CKU must be greater than 1 for multi-zone dedicated clusters")
 	}
 	if strings.Contains(err.Error(), "Durability must be HIGH for an Enterprise cluster") {
-		return errors.New(`availability must be "multi-zone" for enterprise clusters`)
+		return fmt.Errorf(`availability must be "multi-zone" for enterprise clusters`)
 	}
 
 	return err

--- a/internal/kafka/command_cluster_create.go
+++ b/internal/kafka/command_cluster_create.go
@@ -214,7 +214,7 @@ func (c *clusterCommand) validateGcpEncryptionKey(cloud, accountId string) error
 			continue
 		}
 		if !f.Responses["authorized"].(bool) {
-			return errors.Errorf("BYOK error: please authorize the key for the identity (%s)", externalID)
+			return fmt.Errorf("BYOK error: please authorize the key for the identity (%s)", externalID)
 		}
 		return nil
 	}

--- a/internal/kafka/command_cluster_describe.go
+++ b/internal/kafka/command_cluster_describe.go
@@ -1,6 +1,7 @@
 package kafka
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -83,7 +84,7 @@ func (c *clusterCommand) describe(cmd *cobra.Command, args []string) error {
 func (c *clusterCommand) getLkcForDescribe(args []string) (string, error) {
 	if len(args) > 0 {
 		if resource.LookupType(args[0]) != resource.KafkaCluster {
-			return "", errors.Errorf(errors.KafkaClusterMissingPrefixErrorMsg, args[0])
+			return "", fmt.Errorf(errors.KafkaClusterMissingPrefixErrorMsg, args[0])
 		}
 		return args[0], nil
 	}

--- a/internal/kafka/command_cluster_update.go
+++ b/internal/kafka/command_cluster_update.go
@@ -141,7 +141,7 @@ func (c *clusterCommand) validateKafkaClusterMetrics(currentCluster *cmkv2.CmkV2
 	}
 
 	if err := c.validateClusterLoad(*currentCluster.Id, isLatestMetric); err != nil {
-		return errors.Errorf("Looking at metrics in the last %s window:\n%v", window, err)
+		return fmt.Errorf("Looking at metrics in the last %s window:\n%v", window, err)
 	}
 
 	return nil

--- a/internal/kafka/command_cluster_update.go
+++ b/internal/kafka/command_cluster_update.go
@@ -69,7 +69,7 @@ func (c *clusterCommand) update(cmd *cobra.Command, args []string) error {
 			return err
 		}
 		if name == "" {
-			return errors.New("`--name` flag value must not be empty")
+			return fmt.Errorf("`--name` flag value must not be empty")
 		}
 		update.Spec.SetDisplayName(name)
 	}
@@ -101,14 +101,14 @@ func (c *clusterCommand) update(cmd *cobra.Command, args []string) error {
 func (c *clusterCommand) validateResize(cku int32, currentCluster *cmkv2.CmkV2Cluster) (int32, error) {
 	// Ensure the cluster is a Dedicated Cluster
 	if currentCluster.GetSpec().Config.CmkV2Dedicated == nil {
-		return 0, errors.New("failed to update Kafka cluster: cluster resize is only supported on dedicated clusters")
+		return 0, fmt.Errorf("failed to update Kafka cluster: cluster resize is only supported on dedicated clusters")
 	}
 	// Durability Checks
 	if currentCluster.Spec.GetAvailability() == highAvailability && cku <= 1 {
-		return 0, errors.New("`--cku` value must be greater than 1 for high durability")
+		return 0, fmt.Errorf("`--cku` value must be greater than 1 for high durability")
 	}
 	if cku == 0 {
-		return 0, errors.New(errors.CkuMoreThanZeroErrorMsg)
+		return 0, fmt.Errorf(errors.CkuMoreThanZeroErrorMsg)
 	}
 	// Cluster can't be resized while it's provisioning or being expanded already.
 	// Name _can_ be changed during these times, though.
@@ -150,7 +150,7 @@ func (c *clusterCommand) validateKafkaClusterMetrics(currentCluster *cmkv2.CmkV2
 func confirmShrink(promptMessage string) (bool, error) {
 	f := form.New(form.Field{ID: "proceed", Prompt: fmt.Sprintf("Validated cluster metrics and found that: %s\nDo you want to proceed with shrinking your kafka cluster?", promptMessage), IsYesOrNo: true})
 	if err := f.Prompt(form.NewPrompt()); err != nil {
-		return false, errors.New("cluster resize error: failed to read your confirmation")
+		return false, fmt.Errorf("cluster resize error: failed to read your confirmation")
 	}
 	if !f.Responses["proceed"].(bool) {
 		output.Println(false, "Not proceeding with kafka cluster shrink")

--- a/internal/kafka/command_link_create.go
+++ b/internal/kafka/command_link_create.go
@@ -337,7 +337,7 @@ func (c *linkCommand) addDestInitiatedLinkSecurityConfigToMap(cmd *cobra.Command
 		configMap[saslMechanismPropertyName] = plain
 		configMap[saslJaasConfigPropertyName] = getJaasValue(sourceApiKey, sourceApiSecret)
 	} else if sourceApiKey != "" || sourceApiSecret != "" {
-		return errors.New("--source-api-key and --source-api-secret must be supplied together")
+		return fmt.Errorf("--source-api-key and --source-api-secret must be supplied together")
 	}
 	return nil
 }
@@ -357,7 +357,7 @@ func (c *linkCommand) addSourceInitiatedLinkSecurityConfigToMap(cmd *cobra.Comma
 		configMap[localSaslMechanismPropertyName] = plain
 		configMap[localSaslJaasConfigPropertyName] = getJaasValue(sourceApiKey, sourceApiSecret)
 	} else if sourceApiKey != "" || sourceApiSecret != "" {
-		return errors.New("--source-api-key and --source-api-secret must be supplied together")
+		return fmt.Errorf("--source-api-key and --source-api-secret must be supplied together")
 	}
 	destinationApiKey, err := cmd.Flags().GetString(destinationApiKeyFlagName)
 	if err != nil {
@@ -373,7 +373,7 @@ func (c *linkCommand) addSourceInitiatedLinkSecurityConfigToMap(cmd *cobra.Comma
 		configMap[saslMechanismPropertyName] = plain
 		configMap[saslJaasConfigPropertyName] = getJaasValue(destinationApiKey, destinationApiSecret)
 	} else if destinationApiKey != "" || destinationApiSecret != "" {
-		return errors.New("--destination-api-key and --destination-api-secret must be supplied together")
+		return fmt.Errorf("--destination-api-key and --destination-api-secret must be supplied together")
 	}
 	return nil
 }

--- a/internal/kafka/command_link_create.go
+++ b/internal/kafka/command_link_create.go
@@ -8,7 +8,6 @@ import (
 	kafkarestv3 "github.com/confluentinc/ccloud-sdk-go-v2/kafkarest/v3"
 
 	pcmd "github.com/confluentinc/cli/v3/pkg/cmd"
-	"github.com/confluentinc/cli/v3/pkg/errors"
 	"github.com/confluentinc/cli/v3/pkg/examples"
 	"github.com/confluentinc/cli/v3/pkg/output"
 	"github.com/confluentinc/cli/v3/pkg/properties"
@@ -276,7 +275,7 @@ func (c *linkCommand) getConfigMapAndLinkMode(configMap map[string]string) (map[
 }
 
 func unrecognizedLinkModeErr(linkModeStr string) error {
-	return errors.Errorf(`unrecognized link.mode "%s". Use %s, %s, or %s.`, linkModeStr, DESTINATION, SOURCE, BIDIRECTIONAL)
+	return fmt.Errorf(`unrecognized link.mode "%s". Use %s, %s, or %s.`, linkModeStr, DESTINATION, SOURCE, BIDIRECTIONAL)
 }
 
 func (c *linkCommand) addSecurityConfigToMap(cmd *cobra.Command, linkModeMetadata *linkModeMetadata, configMap map[string]string) error {

--- a/internal/kafka/command_link_create_onprem.go
+++ b/internal/kafka/command_link_create_onprem.go
@@ -9,7 +9,6 @@ import (
 	"github.com/confluentinc/kafka-rest-sdk-go/kafkarestv3"
 
 	pcmd "github.com/confluentinc/cli/v3/pkg/cmd"
-	"github.com/confluentinc/cli/v3/pkg/errors"
 	"github.com/confluentinc/cli/v3/pkg/examples"
 	"github.com/confluentinc/cli/v3/pkg/output"
 	"github.com/confluentinc/cli/v3/pkg/properties"
@@ -96,7 +95,7 @@ func (c *linkCommand) createOnPrem(cmd *cobra.Command, args []string) error {
 
 	linkMode := linkModeMetadata.mode
 	if linkMode != Source && linkMode != Bidirectional {
-		return errors.New("only source-initiated or bidirectional links can be created for Confluent Platform from the CLI")
+		return fmt.Errorf("only source-initiated or bidirectional links can be created for Confluent Platform from the CLI")
 	}
 
 	if err := c.addSecurityConfigToMap(cmd, linkModeMetadata, configMap); err != nil {

--- a/internal/kafka/command_partition_reassignment_list.go
+++ b/internal/kafka/command_partition_reassignment_list.go
@@ -1,6 +1,7 @@
 package kafka
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/spf13/cobra"
@@ -8,7 +9,6 @@ import (
 	"github.com/confluentinc/kafka-rest-sdk-go/kafkarestv3"
 
 	pcmd "github.com/confluentinc/cli/v3/pkg/cmd"
-	"github.com/confluentinc/cli/v3/pkg/errors"
 	"github.com/confluentinc/cli/v3/pkg/examples"
 	"github.com/confluentinc/cli/v3/pkg/kafkarest"
 	"github.com/confluentinc/cli/v3/pkg/output"
@@ -70,7 +70,7 @@ func (c *partitionCommand) reassignmentList(cmd *cobra.Command, args []string) e
 			return err
 		}
 		if topic == "" {
-			return errors.New("must specify topic along with partition ID")
+			return fmt.Errorf("must specify topic along with partition ID")
 		}
 		var reassignmentGetResp kafkarestv3.ReassignmentData
 		reassignmentGetResp, resp, err = restClient.PartitionApi.ClustersClusterIdTopicsTopicNamePartitionsPartitionIdReassignmentGet(restContext, clusterId, topic, partitionId)

--- a/internal/kafka/command_topic.go
+++ b/internal/kafka/command_topic.go
@@ -134,7 +134,7 @@ func (c *command) provisioningClusterCheck(lkc string) error {
 		return errors.CatchKafkaNotFoundError(err, lkc, httpResp)
 	}
 	if cluster.Status.Phase == ccloudv2.StatusProvisioning {
-		return errors.Errorf(errors.KafkaRestProvisioningErrorMsg, lkc)
+		return fmt.Errorf(errors.KafkaRestProvisioningErrorMsg, lkc)
 	}
 	return nil
 }

--- a/internal/kafka/command_topic.go
+++ b/internal/kafka/command_topic.go
@@ -103,7 +103,7 @@ func (c *command) validateTopic(client *ckafka.AdminClient, topic string, cluste
 	metadata, err := client.GetMetadata(nil, true, int(timeout.Milliseconds()))
 	if err != nil {
 		if err.Error() == ckafka.ErrTransport.String() {
-			err = errors.New("API key may not be provisioned yet")
+			err = fmt.Errorf("API key may not be provisioned yet")
 		}
 		return fmt.Errorf("failed to obtain topics from client: %v", err)
 	}

--- a/internal/kafka/command_topic.go
+++ b/internal/kafka/command_topic.go
@@ -105,7 +105,7 @@ func (c *command) validateTopic(client *ckafka.AdminClient, topic string, cluste
 		if err.Error() == ckafka.ErrTransport.String() {
 			err = fmt.Errorf("API key may not be provisioned yet")
 		}
-		return fmt.Errorf("failed to obtain topics from client: %v", err)
+		return fmt.Errorf("failed to obtain topics from client: %w", err)
 	}
 
 	foundTopic := false

--- a/internal/kafka/command_topic_onprem.go
+++ b/internal/kafka/command_topic_onprem.go
@@ -15,7 +15,7 @@ func ValidateTopic(adminClient *ckafka.AdminClient, topic string) error {
 	timeout := 10 * time.Second
 	metadata, err := adminClient.GetMetadata(nil, true, int(timeout.Milliseconds()))
 	if err != nil {
-		return fmt.Errorf("failed to obtain topics from client: %v", err)
+		return fmt.Errorf("failed to obtain topics from client: %w", err)
 	}
 
 	var foundTopic bool

--- a/internal/kafka/command_topic_produce.go
+++ b/internal/kafka/command_topic_produce.go
@@ -101,7 +101,7 @@ func (c *command) produce(cmd *cobra.Command, args []string) error {
 	}
 
 	if cmd.Flags().Changed("key-format") && !parseKey {
-		return errors.New("`--parse-key` must be set when `key-format` is set")
+		return fmt.Errorf("`--parse-key` must be set when `key-format` is set")
 	}
 
 	configFile, err := cmd.Flags().GetString("config-file")
@@ -239,7 +239,7 @@ func serializeMessage(keyMetaInfo, valueMetaInfo []byte, data, delimiter string,
 func getKeyAndValue(schemaBased bool, data, delimiter string) (string, string, error) {
 	dataSplit := strings.Split(data, delimiter)
 	if len(dataSplit) < 2 {
-		return "", "", errors.New(missingKeyOrValueErrorMsg)
+		return "", "", fmt.Errorf(missingKeyOrValueErrorMsg)
 	}
 
 	if !schemaBased {
@@ -258,7 +258,7 @@ func getKeyAndValue(schemaBased bool, data, delimiter string) (string, string, e
 		}
 	}
 
-	return "", "", errors.New(missingOrMalformedKeyErrorMsg)
+	return "", "", fmt.Errorf(missingOrMalformedKeyErrorMsg)
 }
 
 func (c *command) initSchemaAndGetInfo(cmd *cobra.Command, topic, mode string) (serdes.SerializationProvider, []byte, error) {

--- a/internal/kafka/command_topic_produce_onprem.go
+++ b/internal/kafka/command_topic_produce_onprem.go
@@ -111,7 +111,7 @@ func (c *command) produceOnPrem(cmd *cobra.Command, args []string) error {
 	}
 
 	if cmd.Flags().Changed("key-format") && !parseKey {
-		return errors.New("`--parse-key` must be set when `key-format` is set")
+		return fmt.Errorf("`--parse-key` must be set when `key-format` is set")
 	}
 
 	keySchema, err := cmd.Flags().GetString("key-schema")

--- a/internal/kafka/confluent_kafka.go
+++ b/internal/kafka/confluent_kafka.go
@@ -314,7 +314,7 @@ func (h *GroupHandler) RequestSchema(value []byte) (string, map[string]string, e
 		return "", nil, errors.NewErrorWithSuggestions("unknown magic byte", fmt.Sprintf("Check that all messages from this topic are in the %s format.", h.ValueFormat))
 	}
 	if len(value) < messageOffset {
-		return "", nil, errors.New("failed to find schema ID in topic data")
+		return "", nil, fmt.Errorf("failed to find schema ID in topic data")
 	}
 
 	// Retrieve schema from cluster only if schema is specified.

--- a/internal/kafka/confluent_kafka_configs.go
+++ b/internal/kafka/confluent_kafka_configs.go
@@ -304,7 +304,7 @@ func GetOffsetWithFallback(cmd *cobra.Command) (ckafka.Offset, error) {
 			return ckafka.OffsetInvalid, err
 		}
 		if offset < 0 {
-			return ckafka.OffsetInvalid, errors.New("offset value must be a non-negative integer")
+			return ckafka.OffsetInvalid, fmt.Errorf("offset value must be a non-negative integer")
 		}
 		return ckafka.NewOffset(offset)
 	} else {

--- a/internal/kafka/metrics_utils.go
+++ b/internal/kafka/metrics_utils.go
@@ -8,7 +8,6 @@ import (
 	metricsv2 "github.com/confluentinc/ccloud-sdk-go-v2/metrics/v2"
 
 	"github.com/confluentinc/cli/v3/pkg/ccloudv2"
-	"github.com/confluentinc/cli/v3/pkg/errors"
 )
 
 const (
@@ -73,7 +72,7 @@ func (c *clusterCommand) validateClusterLoad(clusterId string, isLatestMetric bo
 	query := getMetricsApiRequest(ClusterLoadMetricName, "MAX", clusterId, isLatestMetric)
 	clusterLoadResponse, httpResp, err := client.MetricsDatasetQuery("cloud", query)
 	if err != nil && !ccloudv2.IsDataMatchesMoreThanOneSchemaError(err) || clusterLoadResponse == nil {
-		return errors.Errorf("could not retrieve cluster load metrics to validate request to shrink cluster, please try again in a few minutes: %w", err)
+		return fmt.Errorf("could not retrieve cluster load metrics to validate request to shrink cluster, please try again in a few minutes: %w", err)
 	}
 
 	if err := ccloudv2.UnmarshalFlatQueryResponseIfDataSchemaMatchError(err, clusterLoadResponse, httpResp); err != nil {

--- a/internal/kafka/metrics_utils.go
+++ b/internal/kafka/metrics_utils.go
@@ -73,7 +73,7 @@ func (c *clusterCommand) validateClusterLoad(clusterId string, isLatestMetric bo
 	query := getMetricsApiRequest(ClusterLoadMetricName, "MAX", clusterId, isLatestMetric)
 	clusterLoadResponse, httpResp, err := client.MetricsDatasetQuery("cloud", query)
 	if err != nil && !ccloudv2.IsDataMatchesMoreThanOneSchemaError(err) || clusterLoadResponse == nil {
-		return errors.Errorf("could not retrieve cluster load metrics to validate request to shrink cluster, please try again in a few minutes: %v", err)
+		return errors.Errorf("could not retrieve cluster load metrics to validate request to shrink cluster, please try again in a few minutes: %w", err)
 	}
 
 	if err := ccloudv2.UnmarshalFlatQueryResponseIfDataSchemaMatchError(err, clusterLoadResponse, httpResp); err != nil {

--- a/internal/kafka/utils.go
+++ b/internal/kafka/utils.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/confluentinc/cli/v3/pkg/ccloudv2"
 	"github.com/confluentinc/cli/v3/pkg/ccstructs"
-	"github.com/confluentinc/cli/v3/pkg/errors"
 	"github.com/confluentinc/cli/v3/pkg/kafkarest"
 )
 
@@ -70,13 +69,13 @@ func handleOpenApiError(httpResp *_nethttp.Response, err error, client *cpkafkar
 
 func isClusterResizeInProgress(currentCluster *cmkv2.CmkV2Cluster) error {
 	if currentCluster.Status.Phase == ccloudv2.StatusProvisioning {
-		return errors.New("your cluster is still provisioning, so it can't be updated yet; please retry in a few minutes")
+		return fmt.Errorf("your cluster is still provisioning, so it can't be updated yet; please retry in a few minutes")
 	}
 	if isExpanding(currentCluster) {
-		return errors.New("your cluster is expanding; please wait for that operation to complete before updating again")
+		return fmt.Errorf("your cluster is expanding; please wait for that operation to complete before updating again")
 	}
 	if isShrinking(currentCluster) {
-		return errors.New("your cluster is shrinking; please wait for that operation to complete before updating again")
+		return fmt.Errorf("your cluster is shrinking; please wait for that operation to complete before updating again")
 	}
 	return nil
 }

--- a/internal/ksql/command_cluster_configureacls.go
+++ b/internal/ksql/command_cluster_configureacls.go
@@ -109,7 +109,7 @@ func (c *ksqlCommand) getServiceAccount(cluster *ksqlv2.KsqldbcmV2Cluster) (stri
 			return strconv.Itoa(int(user.Id)), nil
 		}
 	}
-	return "", errors.Errorf(errors.KsqldbNoServiceAccountErrorMsg, cluster.GetId())
+	return "", fmt.Errorf(errors.KsqldbNoServiceAccountErrorMsg, cluster.GetId())
 }
 
 func buildACLBindings(serviceAccountId string, cluster *ksqlv2.KsqldbcmV2Cluster, topics []string) []*ccstructs.ACLBinding {

--- a/internal/ksql/command_cluster_delete.go
+++ b/internal/ksql/command_cluster_delete.go
@@ -2,6 +2,7 @@ package ksql
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"net/http"
 
@@ -14,7 +15,6 @@ import (
 	pauth "github.com/confluentinc/cli/v3/pkg/auth"
 	pcmd "github.com/confluentinc/cli/v3/pkg/cmd"
 	"github.com/confluentinc/cli/v3/pkg/deletion"
-	"github.com/confluentinc/cli/v3/pkg/errors"
 	"github.com/confluentinc/cli/v3/pkg/resource"
 )
 
@@ -95,7 +95,7 @@ func (c *ksqlCommand) deleteTopics(clusterId, endpoint string) error {
 		if err != nil {
 			return err
 		}
-		return errors.Errorf(`failed to terminate ksqlDB cluster "%s" due to "%s"`, clusterId, string(body))
+		return fmt.Errorf(`failed to terminate ksqlDB cluster "%s" due to "%s"`, clusterId, string(body))
 	}
 	return nil
 }

--- a/internal/local/command_destroy.go
+++ b/internal/local/command_destroy.go
@@ -1,10 +1,11 @@
 package local
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
 
 	"github.com/confluentinc/cli/v3/pkg/cmd"
-	"github.com/confluentinc/cli/v3/pkg/errors"
 	"github.com/confluentinc/cli/v3/pkg/examples"
 	"github.com/confluentinc/cli/v3/pkg/output"
 )
@@ -30,7 +31,7 @@ func NewDestroyCommand(prerunner cmd.PreRunner) *cobra.Command {
 
 func (c *command) runDestroyCommand(cmd *cobra.Command, _ []string) error {
 	if !c.cc.HasTrackingFile() {
-		return errors.New("nothing to destroy")
+		return fmt.Errorf("nothing to destroy")
 	}
 
 	if err := c.runServicesStopCommand(cmd, []string{}); err != nil {

--- a/internal/local/command_kafka_start.go
+++ b/internal/local/command_kafka_start.go
@@ -137,7 +137,7 @@ func (c *command) kafkaStart(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	if brokers < 1 || brokers > 4 {
-		return errors.New("--brokers must be an integer between 1 and 4, inclusive.")
+		return fmt.Errorf("--brokers must be an integer between 1 and 4, inclusive.")
 	}
 
 	if err := c.prepareAndSaveLocalPorts(cmd, brokers, c.Config.IsTest); err != nil {

--- a/internal/local/command_kafka_start.go
+++ b/internal/local/command_kafka_start.go
@@ -265,7 +265,7 @@ func (c *command) prepareAndSaveLocalPorts(cmd *cobra.Command, brokers int32, is
 	}
 
 	if err := c.Config.Save(); err != nil {
-		return errors.Wrap(err, "failed to save local ports to configuration file")
+		return fmt.Errorf("failed to save local ports to configuration file: %w", err)
 	}
 
 	return nil

--- a/internal/local/command_kafka_stop.go
+++ b/internal/local/command_kafka_stop.go
@@ -2,13 +2,13 @@ package local
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/docker/docker/api/types"
 	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/client"
 	"github.com/spf13/cobra"
 
-	"github.com/confluentinc/cli/v3/pkg/errors"
 	"github.com/confluentinc/cli/v3/pkg/log"
 	"github.com/confluentinc/cli/v3/pkg/output"
 )
@@ -61,7 +61,7 @@ func (c *command) stopAndRemoveConfluentLocal(dockerClient *client.Client) error
 
 	c.Config.LocalPorts = nil
 	if err := c.Config.Save(); err != nil {
-		return errors.Wrap(err, "failed to remove local ports from config")
+		return fmt.Errorf("failed to remove local ports from config: %w", err)
 	}
 
 	return nil

--- a/internal/local/command_kafka_topic.go
+++ b/internal/local/command_kafka_topic.go
@@ -57,7 +57,7 @@ func initKafkaRest(c *pcmd.CLICommand, cmd *cobra.Command) (*kafkarestv3.APIClie
 	}
 
 	if len(clusterListData.Data) < 1 {
-		return nil, "", errors.New("failed to obtain local cluster information")
+		return nil, "", fmt.Errorf("failed to obtain local cluster information")
 	}
 
 	return kafkaRestClient, clusterListData.Data[0].ClusterId, nil

--- a/internal/local/command_service.go
+++ b/internal/local/command_service.go
@@ -82,7 +82,7 @@ func (c *command) runServiceLogCommand(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 	if !exists {
-		return errors.Errorf("no log found: to run %s, use `confluent local services %s start`", writeOfficialServiceName(service), service)
+		return fmt.Errorf("no log found: to run %s, use `confluent local services %s start`", writeOfficialServiceName(service), service)
 	}
 
 	log, err := c.cc.GetLogFile(service)
@@ -412,7 +412,7 @@ func (c *command) startProcess(service string) error {
 	case err := <-errorsChan:
 		return err
 	case <-time.After(time.Second):
-		return errors.Errorf(errors.FailedToStartErrorMsg, writeServiceName(service))
+		return fmt.Errorf(errors.FailedToStartErrorMsg, writeServiceName(service))
 	}
 
 	open := make(chan bool)
@@ -428,7 +428,7 @@ func (c *command) startProcess(service string) error {
 	case <-open:
 		break
 	case <-time.After(90 * time.Second):
-		return errors.Errorf(errors.FailedToStartErrorMsg, writeServiceName(service))
+		return fmt.Errorf(errors.FailedToStartErrorMsg, writeServiceName(service))
 	}
 
 	return nil
@@ -548,7 +548,7 @@ func (c *command) killProcess(service string) error {
 	case err := <-errorsChan:
 		return err
 	case <-time.After(time.Second):
-		return errors.Errorf("%s failed to stop", writeServiceName(service))
+		return fmt.Errorf("%s failed to stop", writeServiceName(service))
 	}
 }
 

--- a/internal/local/command_service.go
+++ b/internal/local/command_service.go
@@ -684,7 +684,7 @@ func (c *command) checkJavaVersion(service string) error {
 		}
 		java = strings.TrimSuffix(string(out), "\n")
 		if java == "java not found" {
-			return errors.New("could not find java executable, please install java or set JAVA_HOME")
+			return fmt.Errorf("could not find java executable, please install java or set JAVA_HOME")
 		}
 	}
 
@@ -701,7 +701,7 @@ func (c *command) checkJavaVersion(service string) error {
 		return err
 	}
 	if !isValid {
-		return errors.New("the Confluent CLI requires Java version 1.8 or 1.11.\n" +
+		return fmt.Errorf("the Confluent CLI requires Java version 1.8 or 1.11.\n" +
 			"See https://docs.confluent.io/current/installation/versions-interoperability.html .\n" +
 			"If you have multiple versions of Java installed, you may need to set JAVA_HOME to the version you want Confluent to use.")
 	}

--- a/internal/local/command_services.go
+++ b/internal/local/command_services.go
@@ -13,7 +13,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/confluentinc/cli/v3/pkg/cmd"
-	"github.com/confluentinc/cli/v3/pkg/errors"
 	"github.com/confluentinc/cli/v3/pkg/examples"
 	"github.com/confluentinc/cli/v3/pkg/local"
 	"github.com/confluentinc/cli/v3/pkg/output"
@@ -442,7 +441,7 @@ func top(pids []int) error {
 		}
 		top = exec.Command("top", "-p", strings.Join(args, ","))
 	default:
-		return errors.Errorf("`top` command not available on platform: %s", runtime.GOOS)
+		return fmt.Errorf("`top` command not available on platform: %s", runtime.GOOS)
 	}
 
 	top.Stdin = os.Stdin

--- a/internal/local/command_services.go
+++ b/internal/local/command_services.go
@@ -336,7 +336,7 @@ func (c *command) runServicesTopCommand(_ *cobra.Command, _ []string) error {
 	}
 
 	if len(pids) == 0 {
-		return errors.New("no services running")
+		return fmt.Errorf("no services running")
 	}
 
 	return top(pids)

--- a/internal/login/command.go
+++ b/internal/login/command.go
@@ -416,7 +416,7 @@ func validateURL(url string, isCCloud bool) (string, string, error) {
 		pattern = regexp.MustCompile(`^\w+://[^/ ]+:\d+(?:\/|$)`)
 	}
 	if !pattern.MatchString(url) {
-		return "", "", errors.New(errors.InvalidLoginURLErrorMsg)
+		return "", "", fmt.Errorf(errors.InvalidLoginURLErrorMsg)
 	}
 
 	return url, strings.Join(msg, " and "), nil

--- a/internal/login/command_test.go
+++ b/internal/login/command_test.go
@@ -552,12 +552,12 @@ func TestLoginFail(t *testing.T) {
 	mockLoginCredentialsManager := &climock.LoginCredentialsManager{
 		GetCloudCredentialsFromEnvVarFunc: func(_ string) func() (*pauth.Credentials, error) {
 			return func() (*pauth.Credentials, error) {
-				return nil, errors.New("DO NOT RETURN THIS ERR")
+				return nil, fmt.Errorf("DO NOT RETURN THIS ERR")
 			}
 		},
 		GetSsoCredentialsFromConfigFunc: func(_ *config.Config, _ string) func() (*pauth.Credentials, error) {
 			return func() (*pauth.Credentials, error) {
-				return nil, errors.New("DO NOT RETURN THIS ERR")
+				return nil, fmt.Errorf("DO NOT RETURN THIS ERR")
 			}
 		},
 		GetCredentialsFromConfigFunc: func(_ *config.Config, _ netrc.NetrcMachineParams) func() (*pauth.Credentials, error) {
@@ -567,7 +567,7 @@ func TestLoginFail(t *testing.T) {
 		},
 		GetCredentialsFromNetrcFunc: func(_ netrc.NetrcMachineParams) func() (*pauth.Credentials, error) {
 			return func() (*pauth.Credentials, error) {
-				return nil, errors.New("DO NOT RETURN THIS ERR")
+				return nil, fmt.Errorf("DO NOT RETURN THIS ERR")
 			}
 		},
 		GetCloudCredentialsFromPromptFunc: func(_ string) func() (*pauth.Credentials, error) {

--- a/internal/plugin/command_install.go
+++ b/internal/plugin/command_install.go
@@ -40,7 +40,7 @@ func (c *command) install(cmd *cobra.Command, args []string) error {
 
 	installDir := filepath.Join(confluentDir, "plugins")
 	if err := os.MkdirAll(installDir, os.ModePerm); err != nil {
-		return errors.Wrapf(err, "failed to create plugin install directory %s", installDir)
+		return fmt.Errorf("failed to create plugin install directory %s: %w", installDir, err)
 	}
 
 	if _, err := clonePluginRepo(dir, cliPluginsUrl); err != nil {

--- a/internal/plugin/command_install.go
+++ b/internal/plugin/command_install.go
@@ -128,13 +128,13 @@ func installPlugin(manifest *Manifest, repositoryDir, installDir string) error {
 
 func getLanguage(manifest *Manifest) (string, *version.Version, error) {
 	if manifest == nil || len(manifest.Dependencies) == 0 {
-		return "", nil, errors.New("no language found in plugin manifest")
+		return "", nil, fmt.Errorf("no language found in plugin manifest")
 	}
 
 	language := manifest.Dependencies[0]
 	language.Name = strings.ToLower(language.Name)
 	if language.Version == "" {
-		return "", nil, errors.New(errors.NoVersionFoundErrorMsg)
+		return "", nil, fmt.Errorf(errors.NoVersionFoundErrorMsg)
 	}
 
 	ver, err := version.NewVersion(language.Version)

--- a/internal/plugin/command_install.go
+++ b/internal/plugin/command_install.go
@@ -74,7 +74,7 @@ func getPluginManifest(pluginName, dir string) (*Manifest, error) {
 
 		manifestPath := fmt.Sprintf("%s/%s/manifest.yml", dir, file.Name())
 		if !utils.DoesPathExist(manifestPath) {
-			return nil, errors.Errorf("manifest not found for plugin %s", pluginName)
+			return nil, fmt.Errorf("manifest not found for plugin %s", pluginName)
 		}
 
 		manifestFile, err := os.ReadFile(manifestPath)
@@ -91,7 +91,7 @@ func getPluginManifest(pluginName, dir string) (*Manifest, error) {
 		return manifest, nil
 	}
 
-	return nil, errors.Errorf("plugin %s not found", pluginName)
+	return nil, fmt.Errorf("plugin %s not found", pluginName)
 }
 
 func installPlugin(manifest *Manifest, repositoryDir, installDir string) error {
@@ -117,7 +117,7 @@ func installPlugin(manifest *Manifest, repositoryDir, installDir string) error {
 			InstallDir:    installDir,
 		}
 	default:
-		return errors.Errorf("installation of plugins using %s is not yet supported", language)
+		return fmt.Errorf("installation of plugins using %s is not yet supported", language)
 	}
 
 	if err := pluginInstaller.CheckVersion(ver); err != nil {

--- a/internal/schema-registry/command_cluster_update.go
+++ b/internal/schema-registry/command_cluster_update.go
@@ -1,6 +1,7 @@
 package schemaregistry
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -74,7 +75,7 @@ func (c *command) clusterUpdate(cmd *cobra.Command, _ []string) error {
 		return c.updateTopLevelMode(cmd, mode)
 	}
 
-	return errors.New(errors.CompatibilityOrModeErrorMsg)
+	return fmt.Errorf(errors.CompatibilityOrModeErrorMsg)
 }
 
 func (c *command) updateTopLevelCompatibility(cmd *cobra.Command) error {

--- a/internal/schema-registry/command_config.go
+++ b/internal/schema-registry/command_config.go
@@ -9,7 +9,6 @@ import (
 
 	pcmd "github.com/confluentinc/cli/v3/pkg/cmd"
 	"github.com/confluentinc/cli/v3/pkg/config"
-	"github.com/confluentinc/cli/v3/pkg/errors"
 )
 
 type configOut struct {
@@ -36,7 +35,7 @@ func (c *command) newConfigCommand(cfg *config.Config) *cobra.Command {
 
 func catchSubjectLevelConfigNotFoundError(err error, subject string) error {
 	if err != nil && strings.Contains(err.Error(), "Not Found") {
-		return errors.New(fmt.Sprintf(`subject "%s" does not have subject-level compatibility configured`, subject))
+		return fmt.Errorf(fmt.Sprintf(`subject "%s" does not have subject-level compatibility configured`, subject))
 	}
 
 	return err

--- a/internal/schema-registry/command_config.go
+++ b/internal/schema-registry/command_config.go
@@ -35,7 +35,7 @@ func (c *command) newConfigCommand(cfg *config.Config) *cobra.Command {
 
 func catchSubjectLevelConfigNotFoundError(err error, subject string) error {
 	if err != nil && strings.Contains(err.Error(), "Not Found") {
-		return fmt.Errorf(fmt.Sprintf(`subject "%s" does not have subject-level compatibility configured`, subject))
+		return fmt.Errorf(`subject "%s" does not have subject-level compatibility configured`, subject)
 	}
 
 	return err

--- a/internal/schema-registry/command_exporter_create.go
+++ b/internal/schema-registry/command_exporter_create.go
@@ -1,6 +1,7 @@
 package schemaregistry
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -90,7 +91,7 @@ func (c *command) exporterCreate(cmd *cobra.Command, args []string) error {
 			return err
 		}
 	} else if cmd.Flags().Changed("context-name") {
-		return errors.New(`can only set context name if context type is "custom"`)
+		return fmt.Errorf(`can only set context name if context type is "custom"`)
 	}
 
 	subjectFormat, err := cmd.Flags().GetString("subject-format")

--- a/internal/schema-registry/command_schema_delete.go
+++ b/internal/schema-registry/command_schema_delete.go
@@ -94,7 +94,7 @@ func (c *command) schemaDelete(cmd *cobra.Command, _ []string) error {
 			if _, err := client.GetSchemaByVersion(subject, checkVersion, opts); err != nil {
 				return catchSchemaNotFoundError(err, subject, checkVersion)
 			} else if _, err := client.GetSchemaByVersion(subject, checkVersion, nil); err == nil {
-				return errors.New("you must first soft delete a schema version before you can permanently delete it")
+				return fmt.Errorf("you must first soft delete a schema version before you can permanently delete it")
 			}
 		}
 	} else if _, err := client.GetSchemaByVersion(subject, checkVersion, nil); err != nil {

--- a/internal/schema-registry/command_schema_describe.go
+++ b/internal/schema-registry/command_schema_describe.go
@@ -83,9 +83,9 @@ func (c *command) schemaDescribe(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(args) > 0 && (subject != "" || version != "") {
-		return errors.New("cannot specify both schema ID and subject/version")
+		return fmt.Errorf("cannot specify both schema ID and subject/version")
 	} else if len(args) == 0 && (subject == "" || version == "") {
-		return errors.New("must specify either schema ID or subject/version")
+		return fmt.Errorf("must specify either schema ID or subject/version")
 	}
 
 	client, err := c.GetSchemaRegistryClient(cmd)

--- a/internal/schema-registry/command_subject_update.go
+++ b/internal/schema-registry/command_subject_update.go
@@ -1,6 +1,7 @@
 package schemaregistry
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -89,7 +90,7 @@ func (c *command) subjectUpdate(cmd *cobra.Command, args []string) error {
 	}
 
 	if compatibility != "" && mode != "" {
-		return errors.New(errors.CompatibilityOrModeErrorMsg)
+		return fmt.Errorf(errors.CompatibilityOrModeErrorMsg)
 	}
 
 	if compatibility != "" {
@@ -100,7 +101,7 @@ func (c *command) subjectUpdate(cmd *cobra.Command, args []string) error {
 		return c.updateMode(subject, mode, client)
 	}
 
-	return errors.New(errors.CompatibilityOrModeErrorMsg)
+	return fmt.Errorf(errors.CompatibilityOrModeErrorMsg)
 }
 
 func (c *command) updateCompatibility(cmd *cobra.Command, subject string, client *schemaregistry.Client) error {

--- a/internal/secret/command_file.go
+++ b/internal/secret/command_file.go
@@ -1,10 +1,11 @@
 package secret
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
 
 	pcmd "github.com/confluentinc/cli/v3/pkg/cmd"
-	"github.com/confluentinc/cli/v3/pkg/errors"
 )
 
 const masterKeyNotSetWarning = "This command fails if a master key has not been set in the environment variable `CONFLUENT_SECURITY_MASTER_KEY`. Create a master key using `confluent secret master-key generate`."
@@ -53,9 +54,9 @@ func (c *command) getConfigs(configSource, inputType, prompt string, secure bool
 	if err != nil {
 		switch err {
 		case pcmd.ErrNoValueSpecified:
-			return "", errors.Errorf("enter %s", inputType)
+			return "", fmt.Errorf("enter %s", inputType)
 		case pcmd.ErrNoPipe:
-			return "", errors.Errorf("pipe %s over stdin", inputType)
+			return "", fmt.Errorf("pipe %s over stdin", inputType)
 		}
 		return "", err
 	}

--- a/internal/secret/command_master_key_generate.go
+++ b/internal/secret/command_master_key_generate.go
@@ -1,6 +1,8 @@
 package secret
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
 
 	pcmd "github.com/confluentinc/cli/v3/pkg/cmd"
@@ -47,9 +49,9 @@ func (c *command) generate(cmd *cobra.Command, _ []string) error {
 		switch err {
 		case pcmd.ErrUnexpectedStdinPipe:
 			// TODO: should we require this or just assume that pipe to stdin implies '--passphrase -' ?
-			return errors.New("specify `--passphrase -` if you intend to pipe your passphrase over stdin")
+			return fmt.Errorf("specify `--passphrase -` if you intend to pipe your passphrase over stdin")
 		case pcmd.ErrNoPipe:
-			return errors.New("pipe your passphrase over stdin")
+			return fmt.Errorf("pipe your passphrase over stdin")
 		}
 		return err
 	}

--- a/internal/stream-share/utils.go
+++ b/internal/stream-share/utils.go
@@ -54,7 +54,7 @@ func confirmOptOut() (bool, error) {
 		},
 	)
 	if err := f.Prompt(form.NewPrompt()); err != nil {
-		return false, errors.New(errors.FailedToReadInputErrorMsg)
+		return false, fmt.Errorf(errors.FailedToReadInputErrorMsg)
 	}
 	return f.Responses["confirmation"].(bool), nil
 }

--- a/pkg/acl/acl.go
+++ b/pkg/acl/acl.go
@@ -174,7 +174,7 @@ func populateAclRequest(conf *AclRequestDataWithError) func(*pflag.Flag) {
 
 func setAclRequestPermission(conf *AclRequestDataWithError, permission string) {
 	if conf.Permission != "" {
-		conf.Errors = multierror.Append(conf.Errors, errors.Errorf("only `--allow` or `--deny` may be set when adding or deleting an ACL"))
+		conf.Errors = multierror.Append(conf.Errors, fmt.Errorf("only `--allow` or `--deny` may be set when adding or deleting an ACL"))
 	}
 	conf.Permission = permission
 }
@@ -235,7 +235,7 @@ func ValidateCreateDeleteAclRequestData(aclConfiguration *AclRequestDataWithErro
 	// deletion of too many acls at once. Expectation is that multi delete will be done via
 	// repeated invocation of the cli by external scripts.
 	if aclConfiguration.Permission == "" {
-		aclConfiguration.Errors = multierror.Append(aclConfiguration.Errors, errors.Errorf(errors.MustSetAllowOrDenyErrorMsg))
+		aclConfiguration.Errors = multierror.Append(aclConfiguration.Errors, fmt.Errorf(errors.MustSetAllowOrDenyErrorMsg))
 	}
 
 	if aclConfiguration.PatternType == "" {
@@ -243,7 +243,7 @@ func ValidateCreateDeleteAclRequestData(aclConfiguration *AclRequestDataWithErro
 	}
 
 	if aclConfiguration.ResourceType == "" {
-		aclConfiguration.Errors = multierror.Append(aclConfiguration.Errors, errors.Errorf(errors.MustSetResourceTypeErrorMsg,
+		aclConfiguration.Errors = multierror.Append(aclConfiguration.Errors, fmt.Errorf(errors.MustSetResourceTypeErrorMsg,
 			convertToFlags(cpkafkarestv3.ACLRESOURCETYPE_TOPIC, cpkafkarestv3.ACLRESOURCETYPE_GROUP,
 				cpkafkarestv3.ACLRESOURCETYPE_CLUSTER, cpkafkarestv3.ACLRESOURCETYPE_TRANSACTIONAL_ID)))
 	}
@@ -348,7 +348,7 @@ func PrintACLsFromKafkaRestResponse(cmd *cobra.Command, acls []cckafkarestv3.Acl
 func principalHasIntegerId(principal string) (bool, error) {
 	x := strings.Split(principal, ":")
 	if len(x) < 2 {
-		return false, errors.Errorf("unrecognized principal format %s", principal)
+		return false, fmt.Errorf("unrecognized principal format %s", principal)
 	}
 	suffix := x[1]
 

--- a/pkg/acl/acl_test.go
+++ b/pkg/acl/acl_test.go
@@ -48,7 +48,7 @@ func TestParseAclRequest(t *testing.T) {
 		{
 			args: []string{"--operation", "fake", "--principal", "User:Alice", "--cluster-scope", "--transactional-id", "123"},
 			expectedAcl: AclRequestDataWithError{
-				Errors: multierror.Append(errors.New("invalid operation value: FAKE"), fmt.Errorf("exactly one of %v must be set",
+				Errors: multierror.Append(fmt.Errorf("invalid operation value: FAKE"), fmt.Errorf("exactly one of %v must be set",
 					convertToFlags(kafkarestv3.ACLRESOURCETYPE_TOPIC, kafkarestv3.ACLRESOURCETYPE_GROUP,
 						kafkarestv3.ACLRESOURCETYPE_CLUSTER, kafkarestv3.ACLRESOURCETYPE_TRANSACTIONAL_ID))),
 			},

--- a/pkg/acl/acl_test.go
+++ b/pkg/acl/acl_test.go
@@ -56,7 +56,7 @@ func TestParseAclRequest(t *testing.T) {
 		{
 			args: []string{"--operation", "read", "--principal", "User:Alice", "--transactional-id", "123", "--allow", "--deny"},
 			expectedAcl: AclRequestDataWithError{
-				Errors: multierror.Append(errors.Errorf("only `--allow` or `--deny` may be set when adding or deleting an ACL")),
+				Errors: multierror.Append(fmt.Errorf("only `--allow` or `--deny` may be set when adding or deleting an ACL")),
 			},
 		},
 	}
@@ -95,8 +95,8 @@ func TestValidateCreateDeleteAclRequestData(t *testing.T) {
 		{
 			initialAcl: AclRequestDataWithError{Host: "*"},
 			expectedAcl: AclRequestDataWithError{Errors: multierror.Append(
-				errors.Errorf(errors.MustSetAllowOrDenyErrorMsg),
-				errors.Errorf(errors.MustSetResourceTypeErrorMsg, convertToFlags(kafkarestv3.ACLRESOURCETYPE_TOPIC, kafkarestv3.ACLRESOURCETYPE_GROUP, kafkarestv3.ACLRESOURCETYPE_CLUSTER, kafkarestv3.ACLRESOURCETYPE_TRANSACTIONAL_ID)),
+				fmt.Errorf(errors.MustSetAllowOrDenyErrorMsg),
+				fmt.Errorf(errors.MustSetResourceTypeErrorMsg, convertToFlags(kafkarestv3.ACLRESOURCETYPE_TOPIC, kafkarestv3.ACLRESOURCETYPE_GROUP, kafkarestv3.ACLRESOURCETYPE_CLUSTER, kafkarestv3.ACLRESOURCETYPE_TRANSACTIONAL_ID)),
 			)},
 		},
 	}

--- a/pkg/acl/acl_test.go
+++ b/pkg/acl/acl_test.go
@@ -5,14 +5,13 @@ import (
 	"testing"
 
 	"github.com/hashicorp/go-multierror"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
 
 	"github.com/confluentinc/kafka-rest-sdk-go/kafkarestv3"
 
 	"github.com/confluentinc/cli/v3/pkg/ccstructs"
-	errMsgs "github.com/confluentinc/cli/v3/pkg/errors"
+	"github.com/confluentinc/cli/v3/pkg/errors"
 )
 
 func TestParseAclRequest(t *testing.T) {
@@ -95,9 +94,10 @@ func TestValidateCreateDeleteAclRequestData(t *testing.T) {
 		},
 		{
 			initialAcl: AclRequestDataWithError{Host: "*"},
-			expectedAcl: AclRequestDataWithError{Errors: multierror.Append(errors.Errorf(errMsgs.MustSetAllowOrDenyErrorMsg), errors.Errorf(errMsgs.MustSetResourceTypeErrorMsg,
-				convertToFlags(kafkarestv3.ACLRESOURCETYPE_TOPIC, kafkarestv3.ACLRESOURCETYPE_GROUP,
-					kafkarestv3.ACLRESOURCETYPE_CLUSTER, kafkarestv3.ACLRESOURCETYPE_TRANSACTIONAL_ID)))},
+			expectedAcl: AclRequestDataWithError{Errors: multierror.Append(
+				errors.Errorf(errors.MustSetAllowOrDenyErrorMsg),
+				errors.Errorf(errors.MustSetResourceTypeErrorMsg, convertToFlags(kafkarestv3.ACLRESOURCETYPE_TOPIC, kafkarestv3.ACLRESOURCETYPE_GROUP, kafkarestv3.ACLRESOURCETYPE_CLUSTER, kafkarestv3.ACLRESOURCETYPE_TRANSACTIONAL_ID)),
+			)},
 		},
 	}
 	req := require.New(t)

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -215,7 +215,7 @@ func GetDataplaneToken(authenticatedState *config.ContextState, server string) (
 		return "", err
 	}
 	if res.Error != "" {
-		return "", errors.New(res.Error)
+		return "", fmt.Errorf(res.Error)
 	}
 	return res.Token, nil
 }

--- a/pkg/auth/auth_token_handler.go
+++ b/pkg/auth/auth_token_handler.go
@@ -83,10 +83,10 @@ func (a *AuthTokenHandlerImpl) getCCloudSSOToken(client *ccloudv1.Client, noBrow
 	connectionName, err := a.getSsoConnectionName(client, email, orgResourceId)
 	if err != nil {
 		log.CliLogger.Debugf("unable to obtain user SSO info: %v", err)
-		return "", "", errors.Errorf(`unable to obtain SSO info for user "%s"`, email)
+		return "", "", fmt.Errorf(`unable to obtain SSO info for user "%s"`, email)
 	}
 	if connectionName == "" {
-		return "", "", errors.Errorf(`tried to obtain SSO token for non SSO user "%s"`, email)
+		return "", "", fmt.Errorf(`tried to obtain SSO token for non SSO user "%s"`, email)
 	}
 
 	idToken, refreshToken, err := sso.Login(client.BaseURL, noBrowser, connectionName)

--- a/pkg/auth/login_credentials_manager.go
+++ b/pkg/auth/login_credentials_manager.go
@@ -257,7 +257,7 @@ func (h *LoginCredentialsManagerImpl) getNetrcMachine(filterParams netrc.NetrcMa
 		return nil, err
 	}
 	if netrcMachine == nil {
-		return nil, errors.Errorf("found no netrc machine using the filter: %+v", filterParams)
+		return nil, fmt.Errorf("found no netrc machine using the filter: %+v", filterParams)
 	}
 	return netrcMachine, err
 }

--- a/pkg/auth/login_credentials_manager.go
+++ b/pkg/auth/login_credentials_manager.go
@@ -67,7 +67,7 @@ func GetLoginCredentials(credentialsFuncs ...func() (*Credentials, error)) (*Cre
 	if err != nil {
 		return nil, err
 	}
-	return nil, errors.New(errors.NoCredentialsFoundErrorMsg)
+	return nil, fmt.Errorf(errors.NoCredentialsFoundErrorMsg)
 }
 
 type LoginCredentialsManager interface {
@@ -332,7 +332,7 @@ func (h *LoginCredentialsManagerImpl) GetOnPremPrerunCredentialsFromEnvVar() fun
 	return func() (*Credentials, error) {
 		url := GetEnvWithFallback(ConfluentPlatformMDSURL, DeprecatedConfluentPlatformMDSURL)
 		if url == "" {
-			return nil, errors.New(errors.NoUrlEnvVarErrorMsg)
+			return nil, fmt.Errorf(errors.NoUrlEnvVarErrorMsg)
 		}
 
 		envVars := environmentVariables{
@@ -344,7 +344,7 @@ func (h *LoginCredentialsManagerImpl) GetOnPremPrerunCredentialsFromEnvVar() fun
 
 		creds, _ := h.getCredentialsFromEnvVarFunc(envVars, "")()
 		if creds == nil {
-			return nil, errors.New(errors.NoCredentialsFoundErrorMsg)
+			return nil, fmt.Errorf(errors.NoCredentialsFoundErrorMsg)
 		}
 		creds.PrerunLoginURL = url
 		creds.PrerunLoginCaCertPath = GetEnvWithFallback(ConfluentPlatformCACertPath, DeprecatedConfluentPlatformCACertPath)
@@ -380,9 +380,9 @@ func (h *LoginCredentialsManagerImpl) GetCredentialsFromKeychain(cfg *config.Con
 				log.CliLogger.Debugf(`Found credentials for user "%s" from keychain (%s)`, username, stopNonInteractiveMsg)
 				return &Credentials{Username: username, Password: password}, nil
 			}
-			return nil, errors.New("no matching credentials found in keychain")
+			return nil, fmt.Errorf("no matching credentials found in keychain")
 		}
-		return nil, errors.New("keychain not available on platforms other than darwin")
+		return nil, fmt.Errorf("keychain not available on platforms other than darwin")
 	}
 }
 

--- a/pkg/auth/sso/auth_server.go
+++ b/pkg/auth/sso/auth_server.go
@@ -92,7 +92,7 @@ func (s *authServer) awaitAuthorizationCode(timeout time.Duration) error {
 func (s *authServer) callbackHandler(w http.ResponseWriter, r *http.Request) {
 	states, ok := r.URL.Query()["state"]
 	if !(ok && states[0] == s.State.SSOProviderState) {
-		s.bgErr = errors.New("authentication callback URL either did not contain a state parameter in query string, or the state parameter was invalid; login will fail")
+		s.bgErr = fmt.Errorf("authentication callback URL either did not contain a state parameter in query string, or the state parameter was invalid; login will fail")
 	}
 
 	fmt.Fprintln(w, ssoCallbackHTML)
@@ -101,7 +101,7 @@ func (s *authServer) callbackHandler(w http.ResponseWriter, r *http.Request) {
 	if ok {
 		s.State.SSOProviderAuthenticationCode = codes[0]
 	} else {
-		s.bgErr = errors.New("authentication callback URL did not contain code parameter in query string; login will fail")
+		s.bgErr = fmt.Errorf("authentication callback URL did not contain code parameter in query string; login will fail")
 	}
 
 	s.wait <- true

--- a/pkg/auth/sso/auth_sso_flow.go
+++ b/pkg/auth/sso/auth_sso_flow.go
@@ -57,7 +57,7 @@ func Login(authURL string, noBrowser bool, connectionName string) (string, strin
 			return "", "", fmt.Errorf("unable to open web browser for authorization: %w", err)
 		}
 
-		if err = server.awaitAuthorizationCode(30 * time.Second); err != nil {
+		if err := server.awaitAuthorizationCode(30 * time.Second); err != nil {
 			return "", "", err
 		}
 	}

--- a/pkg/auth/sso/auth_sso_flow.go
+++ b/pkg/auth/sso/auth_sso_flow.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/pkg/browser"
 
-	"github.com/confluentinc/cli/v3/pkg/errors"
 	"github.com/confluentinc/cli/v3/pkg/output"
 )
 
@@ -49,13 +48,13 @@ func Login(authURL string, noBrowser bool, connectionName string) (string, strin
 		// described at https://auth0.com/docs/flows/guides/auth-code-pkce/call-api-auth-code-pkce
 		server := newServer(state)
 		if err := server.startServer(); err != nil {
-			return "", "", errors.Wrap(err, "unable to start HTTP server")
+			return "", "", fmt.Errorf("unable to start HTTP server: %w", err)
 		}
 
 		// Get authorization code for making subsequent token request
 		url := state.getAuthorizationCodeUrl(connectionName, isOkta)
 		if err := browser.OpenURL(url); err != nil {
-			return "", "", errors.Wrap(err, "unable to open web browser for authorization")
+			return "", "", fmt.Errorf("unable to open web browser for authorization: %w", err)
 		}
 
 		if err = server.awaitAuthorizationCode(30 * time.Second); err != nil {

--- a/pkg/auth/sso/auth_sso_flow.go
+++ b/pkg/auth/sso/auth_sso_flow.go
@@ -2,6 +2,7 @@ package sso
 
 import (
 	"bufio"
+	"fmt"
 	"os"
 	"strings"
 	"time"
@@ -35,11 +36,11 @@ func Login(authURL string, noBrowser bool, connectionName string) (string, strin
 		input := scanner.Text()
 		split := strings.SplitAfterN(input, "/", 2)
 		if len(split) < 2 {
-			return "", "", errors.New("pasted input had invalid format")
+			return "", "", fmt.Errorf("pasted input had invalid format")
 		}
 		auth0State := strings.Replace(split[0], "/", "", 1)
 		if !(auth0State == state.SSOProviderState) {
-			return "", "", errors.New("authentication code either did not contain a state parameter or the state parameter was invalid; login will fail")
+			return "", "", fmt.Errorf("authentication code either did not contain a state parameter or the state parameter was invalid; login will fail")
 		}
 
 		state.SSOProviderAuthenticationCode = split[1]

--- a/pkg/auth/sso/auth_state.go
+++ b/pkg/auth/sso/auth_state.go
@@ -139,20 +139,20 @@ func (s *authState) generateCodes() error {
 	randomBytes := make([]byte, 32)
 
 	if _, err := rand.Read(randomBytes); err != nil {
-		return errors.Wrap(err, "unable to generate random bytes for SSO provider state")
+		return fmt.Errorf("unable to generate random bytes for SSO provider state: %w", err)
 	}
 
 	s.SSOProviderState = base64.RawURLEncoding.EncodeToString(randomBytes)
 
 	if _, err := rand.Read(randomBytes); err != nil {
-		return errors.Wrap(err, "unable to generate random bytes for code verifier")
+		return fmt.Errorf("unable to generate random bytes for code verifier: %w", err)
 	}
 
 	s.CodeVerifier = base64.RawURLEncoding.EncodeToString(randomBytes)
 
 	hasher := sha256.New()
 	if _, err := hasher.Write([]byte(s.CodeVerifier)); err != nil {
-		return errors.Wrap(err, "unable to compute hash for code challenge")
+		return fmt.Errorf("unable to compute hash for code challenge: %w", err)
 	}
 	s.CodeChallenge = base64.RawURLEncoding.EncodeToString(hasher.Sum(nil))
 
@@ -212,19 +212,19 @@ func (s *authState) getOAuthTokenResponse(payload *strings.Reader) (map[string]a
 	log.CliLogger.Debug("OAuth token request payload: ", payload)
 	req, err := http.NewRequest(http.MethodPost, url, payload)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to construct oauth token request")
+		return nil, fmt.Errorf("failed to construct oauth token re, errquest: %w", err)
 	}
 	req.Header.Add("content-type", "application/x-www-form-urlencoded")
 	res, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to get oauth token")
+		return nil, fmt.Errorf("failed to get oauth token: %w", err)
 	}
 	defer res.Body.Close()
 	errorResponseBody, _ := io.ReadAll(res.Body)
 	var data map[string]any
 	if err := json.Unmarshal(errorResponseBody, &data); err != nil {
 		log.CliLogger.Debugf("Failed oauth token response body: %s", errorResponseBody)
-		return nil, errors.Wrap(err, "failed to unmarshal response body in oauth token request")
+		return nil, fmt.Errorf("failed to unmarshal response body in oauth token request: %w", err)
 	}
 	return data, nil
 }

--- a/pkg/auth/sso/auth_state.go
+++ b/pkg/auth/sso/auth_state.go
@@ -194,13 +194,13 @@ func (s *authState) saveOAuthTokenResponse(data map[string]any) error {
 	if token, ok := data["id_token"]; ok {
 		s.SSOProviderIDToken = token.(string)
 	} else {
-		return errors.Errorf(errors.FmtMissingOauthFieldErrorMsg, "id_token")
+		return fmt.Errorf(errors.FmtMissingOauthFieldErrorMsg, "id_token")
 	}
 
 	if token, ok := data["refresh_token"]; ok {
 		s.SSOProviderRefreshToken = token.(string)
 	} else {
-		return errors.Errorf(errors.FmtMissingOauthFieldErrorMsg, "refresh_token")
+		return fmt.Errorf(errors.FmtMissingOauthFieldErrorMsg, "refresh_token")
 	}
 
 	return nil

--- a/pkg/broker/broker.go
+++ b/pkg/broker/broker.go
@@ -2,6 +2,7 @@ package broker
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"strconv"
 
@@ -9,7 +10,6 @@ import (
 
 	"github.com/confluentinc/kafka-rest-sdk-go/kafkarestv3"
 
-	"github.com/confluentinc/cli/v3/pkg/errors"
 	"github.com/confluentinc/cli/v3/pkg/kafkarest"
 )
 
@@ -35,10 +35,10 @@ func CheckAllOrIdSpecified(cmd *cobra.Command, args []string, checkAll bool) (in
 	var err error
 	if checkAll {
 		if cmd.Flags().Changed("all") && len(args) > 0 {
-			return -1, false, errors.New("only specify broker ID argument OR `--all` flag")
+			return -1, false, fmt.Errorf("only specify broker ID argument OR `--all` flag")
 		}
 		if !cmd.Flags().Changed("all") && len(args) == 0 {
-			return -1, false, errors.New("must pass broker ID argument or specify `--all` flag")
+			return -1, false, fmt.Errorf("must pass broker ID argument or specify `--all` flag")
 		}
 		all, err = cmd.Flags().GetBool("all")
 		if err != nil {

--- a/pkg/ccloudv2/connect.go
+++ b/pkg/ccloudv2/connect.go
@@ -2,6 +2,7 @@ package ccloudv2
 
 import (
 	"context"
+	"fmt"
 
 	connectv1 "github.com/confluentinc/ccloud-sdk-go-v2/connect/v1"
 
@@ -54,7 +55,7 @@ func (c *Client) GetConnectorExpansionById(connectorId, environmentId, kafkaClus
 		}
 	}
 
-	return nil, errors.Errorf(errors.UnknownConnectorIdErrorMsg, connectorId)
+	return nil, fmt.Errorf(errors.UnknownConnectorIdErrorMsg, connectorId)
 }
 
 func (c *Client) GetConnectorExpansionByName(connectorName, environmentId, kafkaClusterId string) (*connectv1.ConnectV1ConnectorExpansion, error) {
@@ -69,7 +70,7 @@ func (c *Client) GetConnectorExpansionByName(connectorName, environmentId, kafka
 		}
 	}
 
-	return nil, errors.Errorf(errors.UnknownConnectorIdErrorMsg, connectorName)
+	return nil, fmt.Errorf(errors.UnknownConnectorIdErrorMsg, connectorName)
 }
 
 func (c *Client) PauseConnector(connectorName, environmentId, kafkaClusterId string) error {

--- a/pkg/ccloudv2/flink_gateway.go
+++ b/pkg/ccloudv2/flink_gateway.go
@@ -2,7 +2,7 @@ package ccloudv2
 
 import (
 	"context"
-	"errors"
+	"fmt"
 	"net/http"
 
 	flinkgatewayv1beta1 "github.com/confluentinc/ccloud-sdk-go-v2/flink-gateway/v1beta1"
@@ -35,7 +35,7 @@ func NewFlinkGatewayClient(url, userAgent string, unsafeTrace bool, authToken st
 			// Default net/http implementation allows 10 redirects - https://go.dev/src/net/http/client.go.
 			// Lowered the redirect limit to fail fast in case of redirect cycles
 			if len(via) >= 5 {
-				return errors.New("stopped after 5 redirects")
+				return fmt.Errorf("stopped after 5 redirects")
 			}
 			log.CliLogger.Debugf("Following redirect with authorization to %s", req.URL)
 			// Customize the redirect to add authorization header on 307 Redirect.

--- a/pkg/ccloudv2/flink_gateway_test.go
+++ b/pkg/ccloudv2/flink_gateway_test.go
@@ -1,6 +1,7 @@
 package ccloudv2
 
 import (
+	"fmt"
 	"io"
 	"net/http"
 	"strings"
@@ -8,14 +9,13 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/confluentinc/cli/v3/pkg/errors"
 	"github.com/confluentinc/cli/v3/pkg/errors/flink"
 )
 
 func TestFlinkErrorCodeWhenErrors(t *testing.T) {
 	res := &http.Response{Body: io.NopCloser(strings.NewReader(`{"errors":[{"detail":"There is an error"}]}`)), StatusCode: http.StatusMethodNotAllowed}
 
-	err := flink.CatchError(errors.New("Some Error"), res)
+	err := flink.CatchError(fmt.Errorf("Some Error"), res)
 	require.Error(t, err)
 
 	flinkError, ok := err.(flink.FlinkError)
@@ -32,7 +32,7 @@ func TestFlinkErrorNil(t *testing.T) {
 }
 
 func TestFlinkErrorNilHttpRes(t *testing.T) {
-	err := flink.CatchError(errors.New("Some Error"), nil)
+	err := flink.CatchError(fmt.Errorf("Some Error"), nil)
 	require.Error(t, err)
 
 	flinkError, ok := err.(flink.FlinkError)
@@ -44,7 +44,7 @@ func TestFlinkErrorNilHttpRes(t *testing.T) {
 func TestFlinkErrorCodeWhenErrorMessage(t *testing.T) {
 	res := &http.Response{Body: io.NopCloser(strings.NewReader(`{"message":"unauthorized"}`)), StatusCode: http.StatusUnauthorized}
 
-	err := flink.CatchError(errors.New("Some Error"), res)
+	err := flink.CatchError(fmt.Errorf("Some Error"), res)
 	require.Error(t, err)
 
 	flinkError, ok := err.(flink.FlinkError)
@@ -56,7 +56,7 @@ func TestFlinkErrorCodeWhenErrorMessage(t *testing.T) {
 func TestFlinkErrorCodeWhenNestedMessage(t *testing.T) {
 	res := &http.Response{Body: io.NopCloser(strings.NewReader(`{"error":{"message":"gateway error"}}`)), StatusCode: http.StatusMethodNotAllowed}
 
-	err := flink.CatchError(errors.New("Some Error"), res)
+	err := flink.CatchError(fmt.Errorf("Some Error"), res)
 	require.Error(t, err)
 
 	flinkError, ok := err.(flink.FlinkError)
@@ -68,7 +68,7 @@ func TestFlinkErrorCodeWhenNestedMessage(t *testing.T) {
 func TestFlinkErrorOnlyStatusCode(t *testing.T) {
 	res := &http.Response{Body: io.NopCloser(strings.NewReader("")), StatusCode: http.StatusMethodNotAllowed}
 
-	err := flink.CatchError(errors.New("Some Error"), res)
+	err := flink.CatchError(fmt.Errorf("Some Error"), res)
 	require.Error(t, err)
 
 	flinkError, ok := err.(flink.FlinkError)

--- a/pkg/cmd/authenticated_cli_command.go
+++ b/pkg/cmd/authenticated_cli_command.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/http"
 	"net/url"
 	"strings"
@@ -217,7 +218,7 @@ func (c *AuthenticatedCLICommand) GetSchemaRegistryClient(cmd *cobra.Command) (*
 					return nil, err
 				}
 				if schemaRegistryEndpoint == "" {
-					return nil, errors.New(errors.SREndpointNotSpecifiedErrorMsg)
+					return nil, fmt.Errorf(errors.SREndpointNotSpecifiedErrorMsg)
 				}
 				configuration.BasePath = schemaRegistryEndpoint
 
@@ -233,7 +234,7 @@ func (c *AuthenticatedCLICommand) GetSchemaRegistryClient(cmd *cobra.Command) (*
 				c.schemaRegistryClient = schemaregistry.NewClientWithApiKey(configuration, schemaRegistryApiKey, schemaRegistryApiSecret)
 
 				if err := c.schemaRegistryClient.Get(); err != nil {
-					return nil, errors.New(errors.SRClientNotValidatedErrorMsg)
+					return nil, fmt.Errorf(errors.SRClientNotValidatedErrorMsg)
 				}
 			}
 		} else {
@@ -242,7 +243,7 @@ func (c *AuthenticatedCLICommand) GetSchemaRegistryClient(cmd *cobra.Command) (*
 				return nil, err
 			}
 			if schemaRegistryEndpoint == "" {
-				return nil, errors.New(errors.SREndpointNotSpecifiedErrorMsg)
+				return nil, fmt.Errorf(errors.SREndpointNotSpecifiedErrorMsg)
 			}
 
 			caLocation, err := cmd.Flags().GetString("ca-location")
@@ -276,7 +277,7 @@ func (c *AuthenticatedCLICommand) GetSchemaRegistryClient(cmd *cobra.Command) (*
 			}
 
 			if err := c.schemaRegistryClient.Get(); err != nil {
-				return nil, errors.New(errors.SRClientNotValidatedErrorMsg)
+				return nil, fmt.Errorf(errors.SRClientNotValidatedErrorMsg)
 			}
 		}
 	}

--- a/pkg/cmd/prerunner.go
+++ b/pkg/cmd/prerunner.go
@@ -353,7 +353,7 @@ func (r *PreRun) setCCloudClient(c *AuthenticatedCLICommand) error {
 			return nil, errors.Errorf(errors.KafkaRestProvisioningErrorMsg, lkc)
 		}
 		if restEndpoint == "" {
-			return nil, errors.New("Kafka REST is not enabled: the operation is only supported with Kafka REST proxy.")
+			return nil, fmt.Errorf("Kafka REST is not enabled: the operation is only supported with Kafka REST proxy.")
 		}
 
 		state, err := ctx.AuthenticatedState()
@@ -654,7 +654,7 @@ func resolveOnPremKafkaRestFlags(cmd *cobra.Command) (*onPremKafkaRestFlagValues
 	prompt, _ := cmd.Flags().GetBool("prompt")
 
 	if (clientCertPath == "") != (clientKeyPath == "") {
-		return nil, errors.New(errors.NeedClientCertAndKeyPathsErrorMsg)
+		return nil, fmt.Errorf(errors.NeedClientCertAndKeyPathsErrorMsg)
 	}
 
 	values := &onPremKafkaRestFlagValues{

--- a/pkg/cmd/prerunner.go
+++ b/pkg/cmd/prerunner.go
@@ -350,7 +350,7 @@ func (r *PreRun) setCCloudClient(c *AuthenticatedCLICommand) error {
 			return nil, errors.CatchKafkaNotFoundError(err, lkc, httpResp)
 		}
 		if cluster.Status.Phase == ccloudv2.StatusProvisioning {
-			return nil, errors.Errorf(errors.KafkaRestProvisioningErrorMsg, lkc)
+			return nil, fmt.Errorf(errors.KafkaRestProvisioningErrorMsg, lkc)
 		}
 		if restEndpoint == "" {
 			return nil, fmt.Errorf("Kafka REST is not enabled: the operation is only supported with Kafka REST proxy.")

--- a/pkg/cmd/prerunner_test.go
+++ b/pkg/cmd/prerunner_test.go
@@ -365,7 +365,7 @@ func TestPrerun_AutoLogin(t *testing.T) {
 		{
 			name:            "CCloud env var failed but config succeeds",
 			isCloud:         true,
-			envVarReturn:    credentialsFuncReturnValues{nil, errors.New("ENV VAR FAILED")},
+			envVarReturn:    credentialsFuncReturnValues{nil, fmt.Errorf("ENV VAR FAILED")},
 			configReturn:    credentialsFuncReturnValues{ccloudCreds, nil},
 			envVarChecked:   true,
 			keychainChecked: true,
@@ -373,7 +373,7 @@ func TestPrerun_AutoLogin(t *testing.T) {
 		},
 		{
 			name:          "Confluent env var failed but netrc succeeds",
-			envVarReturn:  credentialsFuncReturnValues{nil, errors.New("ENV VAR FAILED")},
+			envVarReturn:  credentialsFuncReturnValues{nil, fmt.Errorf("ENV VAR FAILED")},
 			netrcReturn:   credentialsFuncReturnValues{confluentCreds, nil},
 			envVarChecked: true,
 			netrcChecked:  true,
@@ -381,8 +381,8 @@ func TestPrerun_AutoLogin(t *testing.T) {
 		{
 			name:            "CCloud failed non-interactive login",
 			isCloud:         true,
-			envVarReturn:    credentialsFuncReturnValues{nil, errors.New("ENV VAR FAILED")},
-			netrcReturn:     credentialsFuncReturnValues{nil, errors.New("NETRC FAILED")},
+			envVarReturn:    credentialsFuncReturnValues{nil, fmt.Errorf("ENV VAR FAILED")},
+			netrcReturn:     credentialsFuncReturnValues{nil, fmt.Errorf("NETRC FAILED")},
 			envVarChecked:   true,
 			keychainChecked: true,
 			netrcChecked:    true,
@@ -391,8 +391,8 @@ func TestPrerun_AutoLogin(t *testing.T) {
 		},
 		{
 			name:          "Confluent failed non-interactive login",
-			envVarReturn:  credentialsFuncReturnValues{nil, errors.New("ENV VAR FAILED")},
-			configReturn:  credentialsFuncReturnValues{nil, errors.New("CONFIG FAILED")},
+			envVarReturn:  credentialsFuncReturnValues{nil, fmt.Errorf("ENV VAR FAILED")},
+			configReturn:  credentialsFuncReturnValues{nil, fmt.Errorf("CONFIG FAILED")},
 			envVarChecked: true,
 			netrcChecked:  true,
 			wantErr:       true,

--- a/pkg/cmd/token_validator.go
+++ b/pkg/cmd/token_validator.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/go-jose/go-jose/v3/jwt"
@@ -47,7 +48,7 @@ func (v *JWTValidatorImpl) Validate(context *config.Context) error {
 
 	exp, ok := claims["exp"].(float64)
 	if !ok {
-		return errors.New("malformed token: no expiration")
+		return fmt.Errorf("malformed token: no expiration")
 	}
 
 	// Add a time buffer of 1 minute to the token validator

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -189,15 +189,15 @@ func (c *Config) Load() error {
 		if os.IsNotExist(err) {
 			// Save a default version if none exists yet.
 			if err := c.Save(); err != nil {
-				return errors.Wrapf(err, "unable to save configuration file")
+				return fmt.Errorf("unable to save configuration file: %w", err)
 			}
 			return nil
 		}
-		return errors.Wrapf(err, errors.UnableToReadConfigurationFileErrorMsg, filename)
+		return fmt.Errorf(errors.UnableToReadConfigurationFileErrorMsg, filename, err)
 	}
 
 	if err := json.Unmarshal(input, c); err != nil {
-		return errors.Wrapf(err, errors.UnableToReadConfigurationFileErrorMsg, filename)
+		return fmt.Errorf(errors.UnableToReadConfigurationFileErrorMsg, filename, err)
 	}
 
 	for _, context := range c.Contexts {
@@ -264,17 +264,17 @@ func (c *Config) Save() error {
 
 	cfg, err := json.MarshalIndent(c, "", "  ")
 	if err != nil {
-		return errors.Wrapf(err, "unable to marshal config")
+		return fmt.Errorf("unable to marshal config: %w", err)
 	}
 
 	filename := c.GetFilename()
 
 	if err := os.MkdirAll(filepath.Dir(filename), 0700); err != nil {
-		return errors.Wrapf(err, "unable to create config directory: %s", filename)
+		return fmt.Errorf("unable to create config directory %s: %w", filename, err)
 	}
 
 	if err := os.WriteFile(filename, cfg, 0600); err != nil {
-		return errors.Wrapf(err, "unable to write config to file: %s", filename)
+		return fmt.Errorf("unable to write config to file %s: %w", filename, err)
 	}
 
 	c.restoreOverwrittenContext(tempContext)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -569,7 +569,7 @@ func (c *Config) UseContext(name string) error {
 
 func (c *Config) SaveCredential(credential *Credential) error {
 	if credential.Name == "" {
-		return errors.New("credential must have a name")
+		return fmt.Errorf("credential must have a name")
 	}
 	c.Credentials[credential.Name] = credential
 	return c.Save()
@@ -577,7 +577,7 @@ func (c *Config) SaveCredential(credential *Credential) error {
 
 func (c *Config) SaveLoginCredential(ctxName string, loginCredential *LoginCredential) error {
 	if ctxName == "" {
-		return errors.New("saved credential must match a context")
+		return fmt.Errorf("saved credential must match a context")
 	}
 	c.SavedCredentials[ctxName] = loginCredential
 	return c.Save()
@@ -585,7 +585,7 @@ func (c *Config) SaveLoginCredential(ctxName string, loginCredential *LoginCrede
 
 func (c *Config) SavePlatform(platform *Platform) error {
 	if platform.Name == "" {
-		return errors.New("platform must have a name")
+		return fmt.Errorf("platform must have a name")
 	}
 	c.Platforms[platform.Name] = platform
 	return c.Save()

--- a/pkg/config/context.go
+++ b/pkg/config/context.go
@@ -119,8 +119,11 @@ func (c *Context) DeleteUserAuth() error {
 	c.State.AuthToken = ""
 	c.State.AuthRefreshToken = ""
 
-	err := c.Save()
-	return errors.Wrap(err, "unable to delete user auth")
+	if err := c.Save(); err != nil {
+		return fmt.Errorf("unable to delete user auth: %w", err)
+	}
+
+	return nil
 }
 
 func (c *Context) UpdateAuthTokens(token, refreshToken string) error {

--- a/pkg/deletion/README.md
+++ b/pkg/deletion/README.md
@@ -117,7 +117,7 @@ For most resources, this is the last step and you can simply return the error to
 deleteFunc := func(id string) error {
     if err := c.V2Client.DeleteIamUser(id); err != nil {
         // You can wrap this error or process it further as needed
-        return errors.Errorf(errors.DeleteResourceErrorMsg, resource.User, id, err)
+        return fmt.Errorf(errors.DeleteResourceErrorMsg, resource.User, id, err)
     }
     return nil
 }

--- a/pkg/deletion/deletion.go
+++ b/pkg/deletion/deletion.go
@@ -57,7 +57,7 @@ func ConfirmDeletionYesNo(cmd *cobra.Command, promptMsg string) error {
 	prompt := form.NewPrompt()
 	f := form.New(form.Field{ID: "confirm", Prompt: promptMsg, IsYesOrNo: true})
 	if err := f.Prompt(prompt); err != nil {
-		return errors.New(errors.FailedToReadInputErrorMsg)
+		return fmt.Errorf(errors.FailedToReadInputErrorMsg)
 	}
 
 	if !f.Responses["confirm"].(bool) {

--- a/pkg/deletion/deletion.go
+++ b/pkg/deletion/deletion.go
@@ -93,7 +93,7 @@ func DeleteWithoutMessage(args []string, callDeleteEndpoint func(string) error) 
 	var deletedIds []string
 	for _, id := range args {
 		if err := callDeleteEndpoint(id); err != nil {
-			errs = multierror.Append(errs, errors.Wrapf(err, "failed to delete %s", id))
+			errs = multierror.Append(errs, fmt.Errorf("failed to delete %s: %w", id, err))
 		} else {
 			deletedIds = append(deletedIds, id)
 		}

--- a/pkg/dynamic-config/dynamic_context.go
+++ b/pkg/dynamic-config/dynamic_context.go
@@ -87,7 +87,7 @@ func (d *DynamicContext) GetKafkaClusterForCommand() (*config.KafkaClusterConfig
 
 	cluster, err := d.FindKafkaCluster(clusterId)
 	if presource.LookupType(clusterId) != presource.KafkaCluster && clusterId != "anonymous-id" {
-		return nil, errors.Errorf(errors.KafkaClusterMissingPrefixErrorMsg, clusterId)
+		return nil, fmt.Errorf(errors.KafkaClusterMissingPrefixErrorMsg, clusterId)
 	}
 	return cluster, errors.CatchKafkaNotFoundError(err, clusterId, nil)
 }

--- a/pkg/errors/README.md
+++ b/pkg/errors/README.md
@@ -55,7 +55,7 @@ There are four ways to create errors for the CLI.
 
 1. All basic errors will fall under this category. Use one of the error intializing functions in the errors package (errors.New, errors.Errorf, errors.Wrap, errors.Wrapf), with an error message defined in [error_message.go](error_message.go). The name of the variable must end with *ErrorMsg*.
 ```
-errors.Errorf(errors.AuthorizeAccountsErrorMsg, accountsStr)
+fmt.Errorf(errors.AuthorizeAccountsErrorMsg, accountsStr)
 ```
 2. For errors with suggestions, define the error message, and suggestions message next to each other in [error_message.go](error_message.go). The messages must have the same name with different ending following the naming convention (i.e. *ErrorMsg* and *Suggestions*). Then either `errors.NewErrorWithSuggestion` or `errors.NewWrapErrorWithSuggestion` is used to initialize the error.
 

--- a/pkg/errors/catcher.go
+++ b/pkg/errors/catcher.go
@@ -100,7 +100,7 @@ func catchMDSErrors(err error) error {
 // are supposed to be caught by more specific catchers.
 func catchCcloudV1Errors(err error) error {
 	if err, ok := err.(*ccloudv1.Error); ok {
-		return Wrap(err, "Confluent Cloud backend error")
+		return fmt.Errorf("Confluent Cloud backend error: %w", err)
 	}
 	return err
 }
@@ -177,14 +177,15 @@ func CatchCCloudV2Error(err error, r *http.Response) error {
 	}
 
 	if resBody.Message != "" {
-		return Wrap(err, strings.TrimRight(resBody.Message, "\n"))
+		message := strings.TrimRight(resBody.Message, "\n")
+		return fmt.Errorf("%s: %w", message, err)
 	}
 
 	if resBody.Error.Message != "" {
-		errorMessage := strings.TrimFunc(resBody.Error.Message, func(c rune) bool {
+		message := strings.TrimFunc(resBody.Error.Message, func(c rune) bool {
 			return c == rune('.') || c == rune('\n')
 		})
-		return Wrap(err, errorMessage)
+		return fmt.Errorf("%s: %w", message, err)
 	}
 
 	return err

--- a/pkg/errors/catcher.go
+++ b/pkg/errors/catcher.go
@@ -127,10 +127,10 @@ func catchOpenAPIError(err error) error {
 		}{}
 
 		if err := json.NewDecoder(r).Decode(formattedErr); err == nil {
-			return New(formattedErr.Message)
+			return fmt.Errorf(formattedErr.Message)
 		}
 
-		return New(body)
+		return fmt.Errorf(body)
 	}
 
 	return err
@@ -168,7 +168,7 @@ func CatchCCloudV2Error(err error, r *http.Response) error {
 			return NewErrorWithSuggestions(detail, "Look up Confluent Cloud service quota limits with `confluent service-quota list`.")
 		}
 		if detail != "" {
-			err = New(strings.TrimSuffix(detail, "\n"))
+			err = fmt.Errorf(strings.TrimSuffix(detail, "\n"))
 			if resolution := strings.TrimSuffix(resBody.Errors[0].Resolution, "\n"); resolution != "" {
 				err = NewErrorWithSuggestions(err.Error(), resolution)
 			}

--- a/pkg/errors/catcher.go
+++ b/pkg/errors/catcher.go
@@ -75,7 +75,7 @@ func parseMDSOpenAPIErrorType2(err error) (*MDSV2Alpha1ErrorType2Array, error) {
 func catchMDSErrors(err error) error {
 	switch err2 := err.(type) {
 	case mdsv1.GenericOpenAPIError:
-		return Errorf(GenericOpenApiErrorMsg, err.Error(), string(err2.Body()))
+		return fmt.Errorf(GenericOpenApiErrorMsg, err.Error(), string(err2.Body()))
 	case mdsv2alpha1.GenericOpenAPIError:
 		if strings.Contains(err.Error(), "Forbidden Access") {
 			return NewErrorWithSuggestions("user is unauthorized to perform this action", "Check the user's privileges by running `confluent iam rbac role-binding list`.\nGive the user the appropriate permissions using `confluent iam rbac role-binding create`.")
@@ -88,7 +88,7 @@ func catchMDSErrors(err error) error {
 			if parseErr2 == nil {
 				return openAPIErrorType2.UserFacingError()
 			} else {
-				return Errorf(GenericOpenApiErrorMsg, err.Error(), string(err2.Body()))
+				return fmt.Errorf(GenericOpenApiErrorMsg, err.Error(), string(err2.Body()))
 			}
 		}
 	}

--- a/pkg/errors/catcher.go
+++ b/pkg/errors/catcher.go
@@ -9,8 +9,6 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/pkg/errors"
-
 	ccloudv1 "github.com/confluentinc/ccloud-sdk-go-v1-public"
 	"github.com/confluentinc/mds-sdk-go-public/mdsv1"
 	"github.com/confluentinc/mds-sdk-go-public/mdsv2alpha1"
@@ -170,7 +168,7 @@ func CatchCCloudV2Error(err error, r *http.Response) error {
 			return NewErrorWithSuggestions(detail, "Look up Confluent Cloud service quota limits with `confluent service-quota list`.")
 		}
 		if detail != "" {
-			err = errors.New(strings.TrimSuffix(detail, "\n"))
+			err = New(strings.TrimSuffix(detail, "\n"))
 			if resolution := strings.TrimSuffix(resBody.Errors[0].Resolution, "\n"); resolution != "" {
 				err = NewErrorWithSuggestions(err.Error(), resolution)
 			}

--- a/pkg/errors/catcher_test.go
+++ b/pkg/errors/catcher_test.go
@@ -1,6 +1,7 @@
 package errors
 
 import (
+	"fmt"
 	"io"
 	"net/http"
 	"strings"
@@ -12,7 +13,7 @@ import (
 func TestCatchServiceAccountExceedError(t *testing.T) {
 	res := &http.Response{Body: io.NopCloser(strings.NewReader(`{"errors":[{"detail":"Your environment is currently limited to 1000 service accounts"}]}`))}
 
-	err := CatchServiceNameInUseError(New("402 Payment Required"), res, "")
+	err := CatchServiceNameInUseError(fmt.Errorf("402 Payment Required"), res, "")
 	require.Error(t, err)
 	require.Equal(t, "Your environment is currently limited to 1000 service accounts", err.Error())
 }

--- a/pkg/errors/error_message.go
+++ b/pkg/errors/error_message.go
@@ -8,7 +8,7 @@ const (
 	ApiKeyNotFoundSuggestions         = "Ensure the API key exists and has not been deleted, or create a new API key via `confluent api-key create`."
 	BadServiceAccountIdErrorMsg       = `failed to parse service account id: ensure service account id begins with "sa-"`
 	ByokKeyNotFoundSuggestions        = "Ensure the self-managed key exists and has not been deleted, or register a new key via `confluent byok register`."
-	DeleteResourceErrorMsg            = `failed to delete %s "%s": %v`
+	DeleteResourceErrorMsg            = `failed to delete %s "%s": %w`
 	EndOfFreeTrialErrorMsg            = `organization "%s" has been suspended because your free trial has ended`
 	EndOfFreeTrialSuggestions         = "To continue using Confluent Cloud, please enter a credit card with `confluent admin payment update` or claim a promo code with `confluent admin promo add`. To enter payment via the UI, please go to https://confluent.cloud/login."
 	EnsureCpSixPlusSuggestions        = "Ensure that you are running against MDS with CP 6.0+."
@@ -33,9 +33,9 @@ const (
 	KafkaClusterMissingPrefixErrorMsg = `Kafka cluster "%s" is missing required prefix "lkc-"`
 
 	// kafka topic commands
-	FailedToCreateProducerErrorMsg    = "failed to create producer: %v"
-	FailedToCreateConsumerErrorMsg    = "failed to create consumer: %v"
-	FailedToCreateAdminClientErrorMsg = "failed to create confluent-kafka-go admin client: %v"
+	FailedToCreateProducerErrorMsg    = "failed to create producer: %w"
+	FailedToCreateConsumerErrorMsg    = "failed to create consumer: %w"
+	FailedToCreateAdminClientErrorMsg = "failed to create confluent-kafka-go admin client: %w"
 	FailedToProduceErrorMsg           = "failed to produce offset %d: %s\n"
 	UnknownValueFormatErrorMsg        = "unknown value schema format"
 	ExceedPartitionLimitSuggestions   = "The total partition limit for a dedicated cluster may be increased by expanding its CKU count using `confluent kafka cluster update <id> --cku <count>`."
@@ -58,11 +58,9 @@ const (
 	CompatibilityOrModeErrorMsg = "must pass either `--compatibility` or `--mode` flag"
 
 	// auth package
-	WriteToNetrcFileErrorMsg         = `unable to write to netrc file "%s"`
-	NetrcCredentialsNotFoundErrorMsg = `login credentials not found in netrc file "%s"`
-	NoCredentialsFoundErrorMsg       = "no credentials found"
-	NoUrlEnvVarErrorMsg              = "no URL env var"
-	InvalidInputFormatErrorMsg       = `"%s" is not of valid format for field "%s"`
+	NoCredentialsFoundErrorMsg = "no credentials found"
+	NoUrlEnvVarErrorMsg        = "no URL env var"
+	InvalidInputFormatErrorMsg = `"%s" is not of valid format for field "%s"`
 
 	// config package
 	UnableToReadConfigurationFileErrorMsg = `unable to read configuration file "%s"`

--- a/pkg/errors/error_message.go
+++ b/pkg/errors/error_message.go
@@ -63,7 +63,7 @@ const (
 	InvalidInputFormatErrorMsg = `"%s" is not of valid format for field "%s"`
 
 	// config package
-	UnableToReadConfigurationFileErrorMsg = `unable to read configuration file "%s"`
+	UnableToReadConfigurationFileErrorMsg = `unable to read configuration file "%s": %w`
 	NoNameContextErrorMsg                 = "one of the existing contexts has no name"
 	ContextDoesNotExistErrorMsg           = `context "%s" does not exist`
 	ContextAlreadyExistsErrorMsg          = `context "%s" already exists`

--- a/pkg/errors/error_message.go
+++ b/pkg/errors/error_message.go
@@ -156,6 +156,5 @@ const (
 	FailedToReadInputErrorMsg        = "failed to read input"
 
 	// Special error types
-	GenericOpenApiErrorMsg       = "metadata service backend error: %s: %s"
-	ParsedGenericOpenApiErrorMsg = "metadata service backend error: %s"
+	GenericOpenApiErrorMsg = "metadata service backend error: %s: %s"
 )

--- a/pkg/errors/error_with_suggestions.go
+++ b/pkg/errors/error_with_suggestions.go
@@ -29,7 +29,7 @@ func NewErrorWithSuggestions(errorMsg, suggestionsMsg string) ErrorWithSuggestio
 
 func NewWrapErrorWithSuggestions(err error, errorMsg, suggestionsMsg string) ErrorWithSuggestions {
 	return &ErrorWithSuggestionsImpl{
-		errorMsg:       Wrap(err, errorMsg).Error(),
+		errorMsg:       fmt.Sprintf("%s: %v", errorMsg, err),
 		suggestionsMsg: suggestionsMsg,
 	}
 }

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -2,24 +2,22 @@ package errors
 
 import (
 	"fmt"
-
-	"github.com/pkg/errors"
 )
 
 func New(msg string) error {
-	return errors.New(msg)
+	return fmt.Errorf(msg)
 }
 
 func Wrap(err error, msg string) error {
-	return errors.Wrap(err, msg)
+	return fmt.Errorf("%s: %w", msg, err)
 }
 
-func Wrapf(err error, fmt string, args ...any) error {
-	return errors.Wrapf(err, fmt, args...)
+func Wrapf(err error, format string, args ...any) error {
+	return fmt.Errorf("%s: %w", fmt.Sprintf(format, args...), err)
 }
 
-func Errorf(fmt string, args ...any) error {
-	return errors.Errorf(fmt, args...)
+func Errorf(format string, args ...any) error {
+	return fmt.Errorf(format, args...)
 }
 
 func CustomMultierrorList(errors []error) string {

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -4,10 +4,6 @@ import (
 	"fmt"
 )
 
-func New(msg string) error {
-	return fmt.Errorf(msg)
-}
-
 func Wrap(err error, msg string) error {
 	if err == nil {
 		return nil

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -9,10 +9,18 @@ func New(msg string) error {
 }
 
 func Wrap(err error, msg string) error {
+	if err == nil {
+		return nil
+	}
+
 	return fmt.Errorf("%s: %w", msg, err)
 }
 
 func Wrapf(err error, format string, args ...any) error {
+	if err == nil {
+		return nil
+	}
+
 	return fmt.Errorf("%s: %w", fmt.Sprintf(format, args...), err)
 }
 

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -12,10 +12,6 @@ func Wrapf(err error, format string, args ...any) error {
 	return fmt.Errorf("%s: %w", fmt.Sprintf(format, args...), err)
 }
 
-func Errorf(format string, args ...any) error {
-	return fmt.Errorf(format, args...)
-}
-
 func CustomMultierrorList(errors []error) string {
 	if len(errors) == 1 {
 		return errors[0].Error()

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -4,14 +4,6 @@ import (
 	"fmt"
 )
 
-func Wrap(err error, msg string) error {
-	if err == nil {
-		return nil
-	}
-
-	return fmt.Errorf("%s: %w", msg, err)
-}
-
 func Wrapf(err error, format string, args ...any) error {
 	if err == nil {
 		return nil

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -4,14 +4,6 @@ import (
 	"fmt"
 )
 
-func Wrapf(err error, format string, args ...any) error {
-	if err == nil {
-		return nil
-	}
-
-	return fmt.Errorf("%s: %w", fmt.Sprintf(format, args...), err)
-}
-
 func CustomMultierrorList(errors []error) string {
 	if len(errors) == 1 {
 		return errors[0].Error()

--- a/pkg/errors/handle_test.go
+++ b/pkg/errors/handle_test.go
@@ -52,8 +52,8 @@ func TestHandleError(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			var err error
-			if err = HandleCommon(test.err); (err != nil) != test.wantErr {
+			err := HandleCommon(test.err)
+			if (err != nil) != test.wantErr {
 				t.Errorf("HandleCommon()\nerror: %v\nwantErr: %v", err, test.wantErr)
 			}
 			if err.Error() != test.want {

--- a/pkg/errors/typed.go
+++ b/pkg/errors/typed.go
@@ -6,6 +6,8 @@ import (
 	"github.com/confluentinc/cli/v3/pkg/log"
 )
 
+const parsedGenericOpenApiErrorMsg = "metadata service backend error: %s"
+
 type CLITypedError interface {
 	error
 	UserFacingError() error
@@ -118,9 +120,9 @@ func (e *UnconfiguredAPISecretError) UserFacingError() error {
 func NewCorruptedConfigError(format, contextName, configFile string) CLITypedError {
 	var errorWithStackTrace error
 	if contextName != "" {
-		errorWithStackTrace = Errorf(format, contextName)
+		errorWithStackTrace = fmt.Errorf(format, contextName)
 	} else {
-		errorWithStackTrace = Errorf(format)
+		errorWithStackTrace = fmt.Errorf(format)
 	}
 	// logging stack trace of the error use pkg/errors error type
 	log.CliLogger.Debugf("%+v", errorWithStackTrace)
@@ -160,10 +162,10 @@ func (e *UpdateClientError) Error() string {
 }
 
 func (e *UpdateClientError) UserFacingError() error {
-	errMsg := fmt.Sprintf("update client failure: %s", e.errorMsg)
-	return NewErrorWithSuggestions(errMsg, "Please submit a support ticket.\n"+
-		"In the meantime, see link for other ways to download the latest CLI version:\n"+
-		"https://docs.confluent.io/current/cli/installing.html")
+	return NewErrorWithSuggestions(
+		fmt.Sprintf("update client failure: %s", e.errorMsg),
+		"Please submit a support ticket.\nIn the meantime, see link for other ways to download the latest CLI version:\nhttps://docs.confluent.io/current/cli/installing.html",
+	)
 }
 
 type MDSV2Alpha1ErrorType1 struct {
@@ -176,7 +178,7 @@ type MDSV2Alpha1ErrorType1 struct {
 func (e *MDSV2Alpha1ErrorType1) Error() string { return e.Message }
 
 func (e *MDSV2Alpha1ErrorType1) UserFacingError() error {
-	return Errorf(ParsedGenericOpenApiErrorMsg, e.Message)
+	return fmt.Errorf(parsedGenericOpenApiErrorMsg, e.Message)
 }
 
 type MDSV2Alpha1ErrorType2 struct {
@@ -198,11 +200,11 @@ type MDSV2Alpha1ErrorType2Array struct {
 func (e *MDSV2Alpha1ErrorType2Array) Error() string {
 	errorMessage := ""
 	for _, error := range e.Errors {
-		errorMessage = fmt.Sprintf("%s ", error.Error()) + errorMessage
+		errorMessage = fmt.Sprintf("%s %s", error.Error(), errorMessage)
 	}
 	return errorMessage
 }
 
 func (e *MDSV2Alpha1ErrorType2Array) UserFacingError() error {
-	return Errorf(ParsedGenericOpenApiErrorMsg, e.Error())
+	return fmt.Errorf(parsedGenericOpenApiErrorMsg, e.Error())
 }

--- a/pkg/errors/typed.go
+++ b/pkg/errors/typed.go
@@ -148,7 +148,7 @@ func (e *CorruptedConfigError) UserFacingError() error {
 }
 
 func NewUpdateClientWrapError(err error, errorMsg string) CLITypedError {
-	return &UpdateClientError{errorMsg: Wrap(err, errorMsg).Error()}
+	return &UpdateClientError{errorMsg: fmt.Sprintf("%s: %v", errorMsg, err)}
 }
 
 type UpdateClientError struct {

--- a/pkg/flink/app/application_test.go
+++ b/pkg/flink/app/application_test.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"fmt"
 	"sync"
 	"testing"
 
@@ -9,7 +10,6 @@ import (
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/mock/gomock"
 
-	"github.com/confluentinc/cli/v3/pkg/errors"
 	"github.com/confluentinc/cli/v3/pkg/flink/internal/controller"
 	"github.com/confluentinc/cli/v3/pkg/flink/internal/history"
 	"github.com/confluentinc/cli/v3/pkg/flink/test"
@@ -63,7 +63,7 @@ func authenticated() error {
 }
 
 func unauthenticated() error {
-	return errors.New("401 unauthorized")
+	return fmt.Errorf("401 unauthorized")
 }
 
 func (s *ApplicationTestSuite) TestReplDoesNotRunWhenUnauthenticated() {

--- a/pkg/flink/internal/controller/input_controller.go
+++ b/pkg/flink/internal/controller/input_controller.go
@@ -1,7 +1,7 @@
 package controller
 
 import (
-	"errors"
+	"fmt"
 	"reflect"
 	"strings"
 
@@ -80,21 +80,21 @@ func (c *InputController) getMaxCol() (int, error) {
 	p := c.prompt
 	v := reflect.ValueOf(p)
 	if v.Kind() != reflect.Pointer {
-		return -1, errors.New("could not reflect prompt")
+		return -1, fmt.Errorf("could not reflect prompt")
 	} else {
 		v = v.Elem()
 	}
 
 	v = v.FieldByName("renderer")
 	if v.Kind() != reflect.Pointer {
-		return -1, errors.New("could not reflect prompt.renderer")
+		return -1, fmt.Errorf("could not reflect prompt.renderer")
 	} else {
 		v = v.Elem()
 	}
 
 	v = v.FieldByName("col")
 	if v.Kind() != reflect.Uint16 {
-		return -1, errors.New("could not reflect prompt.renderer.col")
+		return -1, fmt.Errorf("could not reflect prompt.renderer.col")
 	}
 
 	maxCol := v.Uint()

--- a/pkg/flink/internal/results/result_converter.go
+++ b/pkg/flink/internal/results/result_converter.go
@@ -1,7 +1,7 @@
 package results
 
 import (
-	"errors"
+	"fmt"
 
 	flinkgatewayv1beta1 "github.com/confluentinc/ccloud-sdk-go-v2/flink-gateway/v1beta1"
 
@@ -30,12 +30,12 @@ func ConvertToInternalResults(results []any, resultSchema flinkgatewayv1beta1.Sq
 	for rowIdx, result := range results {
 		resultItem, ok := result.(map[string]any)
 		if !ok {
-			return nil, errors.New("given result item does not match op/row schema")
+			return nil, fmt.Errorf("given result item does not match op/row schema")
 		}
 
 		items, _ := resultItem["row"].([]any)
 		if len(items) != len(resultSchema.GetColumns()) {
-			return nil, errors.New("given result row does not match the provided schema")
+			return nil, fmt.Errorf("given result row does not match the provided schema")
 		}
 
 		convertedFields := make([]types.StatementResultField, len(items))

--- a/pkg/flink/internal/store/store_test.go
+++ b/pkg/flink/internal/store/store_test.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -758,7 +757,7 @@ func (s *StoreTestSuite) TestProcessHttpErrors() {
 	assert.Nil(s.T(), err)
 
 	// given
-	err = errors.New("some error")
+	err = fmt.Errorf("some error")
 
 	// when
 	err = processHttpErrors(nil, err)
@@ -1223,7 +1222,7 @@ func (s *StoreTestSuite) TestProcessStatementFailsOnError() {
 			Statement:     &statement,
 		},
 	}
-	returnedError := errors.New("test error")
+	returnedError := fmt.Errorf("test error")
 
 	client.EXPECT().CreateStatement(SqlV1beta1StatementMatcher{statementObj}, serviceAccountId, appOptions.EnvironmentId, appOptions.OrgResourceId).
 		Return(statementObj, returnedError)
@@ -1363,7 +1362,7 @@ func (s *StoreTestSuite) TestWaitPendingStatementFailsOnWaitError() {
 			Detail: &statusDetailMessage,
 		},
 	}
-	returnedErr := errors.New("test error")
+	returnedErr := fmt.Errorf("test error")
 	client.EXPECT().GetStatement("envId", statementName, "orgId").Return(statementObj, returnedErr)
 	expectedError := &types.StatementError{
 		Message:        returnedErr.Error(),
@@ -1748,7 +1747,7 @@ func TestWaitForTerminalStateStopsOnError(t *testing.T) {
 			Detail: flinkgatewayv1beta1.PtrString("Test status detail message"),
 		},
 	}
-	client.EXPECT().GetStatement("envId", statementObj.GetName(), "orgId").Return(statementObj, errors.New("error"))
+	client.EXPECT().GetStatement("envId", statementObj.GetName(), "orgId").Return(statementObj, fmt.Errorf("error"))
 
 	_, err := s.WaitForTerminalStatementState(context.Background(), *types.NewProcessedStatement(statementObj))
 

--- a/pkg/hub/manifest.go
+++ b/pkg/hub/manifest.go
@@ -16,7 +16,7 @@ const clientNotInitializedErrorMsg = "Hub client not initialized"
 
 func (c *Client) GetRemoteManifest(owner, name, version string) (*cpstructs.Manifest, error) {
 	if c == nil {
-		return nil, errors.New(clientNotInitializedErrorMsg)
+		return nil, fmt.Errorf(clientNotInitializedErrorMsg)
 	}
 
 	manifestUrl := fmt.Sprintf("%s/api/plugins/%s/%s", c.URL, owner, name)
@@ -76,7 +76,7 @@ func (c *Client) GetRemoteManifest(owner, name, version string) (*cpstructs.Mani
 
 func (c *Client) GetRemoteArchive(pluginManifest *cpstructs.Manifest) ([]byte, error) {
 	if c == nil {
-		return nil, errors.New(clientNotInitializedErrorMsg)
+		return nil, fmt.Errorf(clientNotInitializedErrorMsg)
 	}
 
 	req, err := http.NewRequest(http.MethodGet, pluginManifest.Archive.Url, nil)
@@ -100,7 +100,7 @@ func (c *Client) GetRemoteArchive(pluginManifest *cpstructs.Manifest) ([]byte, e
 	defer r.Body.Close()
 
 	if r.StatusCode != http.StatusOK {
-		return nil, errors.New("failed to retrieve archive from Confuent Hub")
+		return nil, fmt.Errorf("failed to retrieve archive from Confuent Hub")
 	}
 
 	return io.ReadAll(r.Body)

--- a/pkg/hub/manifest.go
+++ b/pkg/hub/manifest.go
@@ -8,7 +8,6 @@ import (
 	"net/http/httputil"
 
 	"github.com/confluentinc/cli/v3/pkg/cpstructs"
-	"github.com/confluentinc/cli/v3/pkg/errors"
 	"github.com/confluentinc/cli/v3/pkg/log"
 )
 
@@ -61,9 +60,9 @@ func (c *Client) GetRemoteManifest(owner, name, version string) (*cpstructs.Mani
 		response := make(map[string]interface{})
 		_ = json.Unmarshal(body, &response)
 		if errorMessage, ok := response["message"]; ok {
-			return nil, errors.Errorf("failed to read manifest file from Confluent Hub: %s", errorMessage)
+			return nil, fmt.Errorf("failed to read manifest file from Confluent Hub: %s", errorMessage)
 		}
-		return nil, errors.Errorf("failed to read manifest file from Confluent Hub")
+		return nil, fmt.Errorf("failed to read manifest file from Confluent Hub")
 	}
 
 	pluginManifest := new(cpstructs.Manifest)

--- a/pkg/kafkarest/kafkarest.go
+++ b/pkg/kafkarest/kafkarest.go
@@ -29,7 +29,7 @@ func NewError(url string, err error, httpResp *http.Response) error {
 		if strings.Contains(e.Error(), SelfSignedCertError) || strings.Contains(e.Error(), UnauthorizedCertError) {
 			return errors.NewErrorWithSuggestions(fmt.Sprintf(errors.KafkaRestConnectionErrorMsg, url, e.Err), errors.KafkaRestCertErrorSuggestions)
 		}
-		return errors.Errorf(errors.KafkaRestConnectionErrorMsg, url, e.Err)
+		return fmt.Errorf(errors.KafkaRestConnectionErrorMsg, url, e.Err)
 	case cckafkarestv3.GenericOpenAPIError:
 		openAPIError, parseErr := ParseOpenAPIErrorCloud(err)
 		if parseErr == nil {

--- a/pkg/kafkarest/kafkarest.go
+++ b/pkg/kafkarest/kafkarest.go
@@ -36,7 +36,7 @@ func NewError(url string, err error, httpResp *http.Response) error {
 			if strings.Contains(openAPIError.Message, "invalid_token") {
 				return errors.NewErrorWithSuggestions(errors.InvalidMDSTokenErrorMsg, errors.InvalidMDSTokenSuggestions)
 			}
-			return fmt.Errorf("REST request failed: %v (%v)", openAPIError.Message, openAPIError.Code)
+			return fmt.Errorf("REST request failed: %s", openAPIError.Message)
 		}
 		if httpResp != nil && httpResp.StatusCode >= 400 {
 			return kafkaRestHttpError(httpResp)
@@ -48,7 +48,7 @@ func NewError(url string, err error, httpResp *http.Response) error {
 			if strings.Contains(openAPIError.Message, "invalid_token") {
 				return errors.NewErrorWithSuggestions(errors.InvalidMDSTokenErrorMsg, errors.InvalidMDSTokenSuggestions)
 			}
-			return fmt.Errorf("REST request failed: %v (%v)", openAPIError.Message, openAPIError.Code)
+			return fmt.Errorf("REST request failed: %s", openAPIError.Message)
 		}
 		if httpResp != nil && httpResp.StatusCode >= 400 {
 			return kafkaRestHttpError(httpResp)

--- a/pkg/keychain/keychain_darwin.go
+++ b/pkg/keychain/keychain_darwin.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/keybase/go-keychain"
 
-	"github.com/confluentinc/cli/v3/pkg/errors"
 	"github.com/confluentinc/cli/v3/pkg/log"
 	"github.com/confluentinc/cli/v3/pkg/netrc"
 )
@@ -86,7 +85,7 @@ func Read(isCloud bool, ctxName, url string) (string, string, error) {
 func parseCredentialsFromKeychain(data []byte) (string, string, error) {
 	substrings := strings.Split(string(data), separator)
 	if len(substrings) < 2 {
-		return "", "", errors.New("unable to parse credentials in keychain access")
+		return "", "", fmt.Errorf("unable to parse credentials in keychain access")
 	}
 	return substrings[0], substrings[1], nil
 }

--- a/pkg/local/confluent_home.go
+++ b/pkg/local/confluent_home.go
@@ -10,8 +10,6 @@ import (
 	"strings"
 
 	"github.com/hashicorp/go-version"
-
-	"github.com/confluentinc/cli/v3/pkg/errors"
 )
 
 /*
@@ -234,7 +232,7 @@ func (ch *ConfluentHomeManager) GetVersion(service string) (string, error) {
 		return "", err
 	}
 	if len(matches) == 0 {
-		return "", errors.Errorf("could not find %s in CONFLUENT_HOME", pattern)
+		return "", fmt.Errorf("could not find %s in CONFLUENT_HOME", pattern)
 	}
 
 	versionFile := matches[0]
@@ -260,7 +258,7 @@ func (ch *ConfluentHomeManager) GetKafkaScript(format, mode string) (string, err
 	case "protobuf":
 		script = fmt.Sprintf("kafka-protobuf-console-%s", mode)
 	default:
-		return "", errors.Errorf("invalid format: %s", format)
+		return "", fmt.Errorf("invalid format: %s", format)
 	}
 
 	return ch.GetFile("bin", script)

--- a/pkg/local/confluent_home.go
+++ b/pkg/local/confluent_home.go
@@ -98,7 +98,7 @@ func (ch *ConfluentHomeManager) getRootDir() (string, error) {
 		return dir, nil
 	}
 
-	return "", errors.New("set environment variable CONFLUENT_HOME")
+	return "", fmt.Errorf("set environment variable CONFLUENT_HOME")
 }
 
 func (ch *ConfluentHomeManager) GetFile(path ...string) (string, error) {

--- a/pkg/netrc/netrc_handler.go
+++ b/pkg/netrc/netrc_handler.go
@@ -76,7 +76,7 @@ func (n *NetrcHandlerImpl) RemoveNetrcCredentials(isCloud bool, ctxName string) 
 		}
 		return machine.Login, nil
 	} else {
-		err = errors.New(errors.NetrcCredentialsNotFoundErrorMsg)
+		err = fmt.Errorf(errors.NetrcCredentialsNotFoundErrorMsg)
 		return "", err
 	}
 }

--- a/pkg/netrc/utils.go
+++ b/pkg/netrc/utils.go
@@ -1,9 +1,8 @@
 package netrc
 
 import (
+	"fmt"
 	"strings"
-
-	"github.com/confluentinc/cli/v3/pkg/errors"
 )
 
 type MachineContextInfo struct {
@@ -15,7 +14,7 @@ type MachineContextInfo struct {
 
 func ParseNetrcMachineName(machineName string) (*MachineContextInfo, error) {
 	if !strings.HasPrefix(machineName, localCredentialsPrefix) {
-		return nil, errors.New("Incorrect machine name format")
+		return nil, fmt.Errorf("Incorrect machine name format")
 	}
 
 	// example: machinename = confluent-cli:ccloud-username-password:login-caas-team+integ-cli@confluent.io-https://devel.cpdev.cloud
@@ -50,7 +49,7 @@ func extractCredentialType(nameSubstring string) (string, string, error) {
 	} else if strings.HasPrefix(nameSubstring, ccloudUsernamePasswordString) {
 		credType = ccloudUsernamePasswordString
 	} else {
-		return "", "", errors.New("incorrect machine name format")
+		return "", "", fmt.Errorf("incorrect machine name format")
 	}
 	// +1 to remove the character ":"
 	rest := suffixFromIndex(nameSubstring, len(credType)+1)
@@ -60,7 +59,7 @@ func extractCredentialType(nameSubstring string) (string, string, error) {
 func parseContextName(nameSubstring string) (string, string, string, error) {
 	contextNamePrefix := "login-"
 	if !strings.HasPrefix(nameSubstring, contextNamePrefix) {
-		return "", "", "", errors.New("incorrect context name format")
+		return "", "", "", fmt.Errorf("incorrect context name format")
 	}
 
 	contextName := suffixFromIndex(nameSubstring, len(contextNamePrefix))

--- a/pkg/plugin/bash_plugin_installer.go
+++ b/pkg/plugin/bash_plugin_installer.go
@@ -36,10 +36,10 @@ func (b *BashPluginInstaller) CheckVersion(ver *version.Version) error {
 			parenthesisIdx := strings.Index(word, "(")
 			installedVer, err := version.NewVersion(word[:parenthesisIdx])
 			if err != nil {
-				return errors.Errorf(unableToParseVersionErrorMsg, "bash")
+				return fmt.Errorf(unableToParseVersionErrorMsg, "bash")
 			}
 			if installedVer.GreaterThan(ver) {
-				return errors.Errorf(insufficientVersionErrorMsg, "bash", installedVer, ver)
+				return fmt.Errorf(insufficientVersionErrorMsg, "bash", installedVer, ver)
 			}
 		}
 	}

--- a/pkg/plugin/go_plugin_installer.go
+++ b/pkg/plugin/go_plugin_installer.go
@@ -33,10 +33,10 @@ func (g *GoPluginInstaller) CheckVersion(ver *version.Version) error {
 		if g.IsVersion(word) {
 			installedVer, err := version.NewVersion(strings.TrimPrefix(word, "go"))
 			if err != nil {
-				return errors.Errorf(unableToParseVersionErrorMsg, "go")
+				return fmt.Errorf(unableToParseVersionErrorMsg, "go")
 			}
 			if installedVer.LessThan(ver) {
-				return errors.Errorf(insufficientVersionErrorMsg, "go", installedVer, ver)
+				return fmt.Errorf(insufficientVersionErrorMsg, "go", installedVer, ver)
 			}
 		}
 	}

--- a/pkg/plugin/go_plugin_installer.go
+++ b/pkg/plugin/go_plugin_installer.go
@@ -49,7 +49,7 @@ func (g *GoPluginInstaller) Install() error {
 	installCmd := exec.NewCommand("go", "install", packageName)
 
 	if _, err := installCmd.Output(); err != nil {
-		return errors.Wrap(err, "failed to run `go install`")
+		return fmt.Errorf("failed to run `go install`: %w", err)
 	}
 
 	return nil

--- a/pkg/plugin/plugin_installer.go
+++ b/pkg/plugin/plugin_installer.go
@@ -5,8 +5,6 @@ import (
 	"os"
 
 	"github.com/hashicorp/go-version"
-
-	"github.com/confluentinc/cli/v3/pkg/errors"
 )
 
 const (
@@ -46,7 +44,7 @@ func installSimplePlugin(name, repositoryDir, installDir, language string) error
 	}
 
 	if !found {
-		return errors.Errorf("unable to find %s file for plugin %s", language, name)
+		return fmt.Errorf("unable to find %s file for plugin %s", language, name)
 	}
 	return nil
 }

--- a/pkg/plugin/python_plugin_installer.go
+++ b/pkg/plugin/python_plugin_installer.go
@@ -29,7 +29,7 @@ func (p *PythonPluginInstaller) CheckVersion(ver *version.Version) error {
 
 	versionSegments := ver.Segments()
 	if len(versionSegments) == 0 {
-		return errors.New(errors.NoVersionFoundErrorMsg)
+		return fmt.Errorf(errors.NoVersionFoundErrorMsg)
 	}
 	majorVer := versionSegments[0]
 

--- a/pkg/plugin/python_plugin_installer.go
+++ b/pkg/plugin/python_plugin_installer.go
@@ -49,10 +49,10 @@ func (p *PythonPluginInstaller) CheckVersion(ver *version.Version) error {
 		if p.IsVersion(word) {
 			installedVer, err := version.NewVersion(strings.TrimSpace(word))
 			if err != nil {
-				return errors.Errorf(unableToParseVersionErrorMsg, "python")
+				return fmt.Errorf(unableToParseVersionErrorMsg, "python")
 			}
 			if installedVer.LessThan(ver) {
-				return errors.Errorf(insufficientVersionErrorMsg, "python", installedVer, ver)
+				return fmt.Errorf(insufficientVersionErrorMsg, "python", installedVer, ver)
 			}
 		}
 	}

--- a/pkg/resource/resource.go
+++ b/pkg/resource/resource.go
@@ -109,9 +109,9 @@ func ValidatePrefixes(resourceType string, args []string) error {
 	}
 
 	if len(malformed) == 1 {
-		return errors.Errorf(`failed parsing resource ID %s: missing prefix "%s-"`, malformed[0], prefix)
+		return fmt.Errorf(`failed parsing resource ID %s: missing prefix "%s-"`, malformed[0], prefix)
 	} else if len(malformed) > 1 {
-		return errors.Errorf(`failed parsing resource IDs %s: missing prefix "%s-"`, utils.ArrayToCommaDelimitedString(malformed, "and"), prefix)
+		return fmt.Errorf(`failed parsing resource IDs %s: missing prefix "%s-"`, utils.ArrayToCommaDelimitedString(malformed, "and"), prefix)
 	}
 
 	return nil

--- a/pkg/retry/retry_test.go
+++ b/pkg/retry/retry_test.go
@@ -1,7 +1,7 @@
 package retry
 
 import (
-	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -10,7 +10,7 @@ import (
 
 func TestRetry(t *testing.T) {
 	require.Error(t, Retry(time.Nanosecond, 2*time.Nanosecond, func() error {
-		return errors.New("error")
+		return fmt.Errorf("error")
 	}))
 	require.NoError(t, Retry(time.Nanosecond, 2*time.Nanosecond, func() error {
 		return nil

--- a/pkg/secret/encryption_engine.go
+++ b/pkg/secret/encryption_engine.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rand"
 	"crypto/sha512"
 	"encoding/base64"
+	"fmt"
 
 	"golang.org/x/crypto/pbkdf2"
 
@@ -196,7 +197,7 @@ func (c *EncryptEngineImpl) pkcs5Trimming(encrypt []byte) ([]byte, error) {
 	padding := encrypt[len(encrypt)-1]
 	length := len(encrypt) - int(padding)
 	if length < 0 || length > len(encrypt) {
-		return nil, errors.New("failed to decrypt the cipher: data is corrupted")
+		return nil, fmt.Errorf("failed to decrypt the cipher: data is corrupted")
 	}
 	return encrypt[:len(encrypt)-int(padding)], nil
 }

--- a/pkg/secret/encryption_engine.go
+++ b/pkg/secret/encryption_engine.go
@@ -10,7 +10,6 @@ import (
 
 	"golang.org/x/crypto/pbkdf2"
 
-	"github.com/confluentinc/cli/v3/pkg/errors"
 	"github.com/confluentinc/cli/v3/pkg/log"
 )
 
@@ -189,7 +188,7 @@ func (c *EncryptEngineImpl) decrypt(crypt, key, iv []byte, algo string) ([]byte,
 		}
 		return decrypted, nil
 	} else {
-		return []byte{}, errors.Errorf(`invalid algorithm "%s"`, algo)
+		return []byte{}, fmt.Errorf(`invalid algorithm "%s"`, algo)
 	}
 }
 

--- a/pkg/secret/encryption_other.go
+++ b/pkg/secret/encryption_other.go
@@ -66,7 +66,7 @@ func Encrypt(username, password string, salt, nonce []byte) (string, error) {
 	}
 
 	if len(nonce) != NonceLength {
-		return "", errors.New(errors.IncorrectNonceLengthErrorMsg)
+		return "", fmt.Errorf(errors.IncorrectNonceLengthErrorMsg)
 	}
 	encryptedPassword := aesgcm.Seal(nil, nonce, []byte(password), []byte(username))
 
@@ -97,7 +97,7 @@ func Decrypt(username, encrypted string, salt, nonce []byte) (string, error) {
 	}
 
 	if len(nonce) != NonceLength {
-		return "", errors.New(errors.IncorrectNonceLengthErrorMsg)
+		return "", fmt.Errorf(errors.IncorrectNonceLengthErrorMsg)
 	}
 	decryptedPassword, err := aesgcm.Open(nil, nonce, cipherText, []byte(username))
 	if err != nil {

--- a/pkg/secret/encryption_other.go
+++ b/pkg/secret/encryption_other.go
@@ -93,7 +93,7 @@ func Decrypt(username, encrypted string, salt, nonce []byte) (string, error) {
 
 	cipherText, err := base64.RawStdEncoding.DecodeString(encrypted)
 	if err != nil {
-		return "", fmt.Errorf("failed to decode base64: %v", err)
+		return "", fmt.Errorf("failed to decode base64: %w", err)
 	}
 
 	if len(nonce) != NonceLength {

--- a/pkg/secret/jaas_config_parser.go
+++ b/pkg/secret/jaas_config_parser.go
@@ -44,7 +44,7 @@ func (j *JAASParser) updateJAASConfig(op, key, value, config string) (string, er
 		if pattern.MatchString(config) {
 			matched := pattern.FindString(config)
 			if matched == "" {
-				return "", errors.Errorf(errors.ConfigNotInJaasErrorMsg, config)
+				return "", fmt.Errorf(errors.ConfigNotInJaasErrorMsg, config)
 			}
 			config = pattern.ReplaceAllString(config, del)
 			if strings.HasSuffix(matched, ";") {
@@ -55,7 +55,7 @@ func (j *JAASParser) updateJAASConfig(op, key, value, config string) (string, er
 			pattern := regexp.MustCompile(keyValuePattern)
 			matched := pattern.FindString(config)
 			if matched == "" {
-				return "", errors.Errorf(errors.ConfigNotInJaasErrorMsg, key)
+				return "", fmt.Errorf(errors.ConfigNotInJaasErrorMsg, key)
 			}
 			config = pattern.ReplaceAllString(config, del)
 		}
@@ -74,7 +74,7 @@ func (j *JAASParser) updateJAASConfig(op, key, value, config string) (string, er
 			config = strings.TrimSuffix(config, ";") + add + ";"
 		}
 	default:
-		return "", errors.Errorf(`the operation "%s" is not supported`, op)
+		return "", fmt.Errorf(`the operation "%s" is not supported`, op)
 	}
 
 	return config, nil
@@ -104,7 +104,7 @@ func (j *JAASParser) parseConfig(specialChar rune) (string, int, error) {
 
 func validateConfig(config string) error {
 	if config == "}" || config == "{" || config == ";" || config == "=" || config == "};" || config == "" || config == " " {
-		return errors.Errorf(errors.InvalidJaasConfigErrorMsg, fmt.Sprintf(errors.ExpectedConfigNameErrorMsg, config))
+		return fmt.Errorf(errors.InvalidJaasConfigErrorMsg, fmt.Sprintf(errors.ExpectedConfigNameErrorMsg, config))
 	}
 
 	return nil
@@ -126,7 +126,7 @@ func (j *JAASParser) parseControlFlag() error {
 		j.ignoreBackslash()
 		return nil
 	default:
-		return errors.Errorf(errors.InvalidJaasConfigErrorMsg, errors.LoginModuleControlFlagErrorMsg)
+		return fmt.Errorf(errors.InvalidJaasConfigErrorMsg, errors.LoginModuleControlFlagErrorMsg)
 	}
 }
 
@@ -203,7 +203,7 @@ func (j *JAASParser) parseConfigurationEntry(prefixKey string) (int, int, *prope
 
 		// Parse =
 		if j.tokenizer.Peek() == scanner.EOF || j.tokenizer.Scan() != '=' || j.tokenizer.TokenText() == "" {
-			return 0, 0, nil, "", errors.Errorf(errors.InvalidJaasConfigErrorMsg, fmt.Sprintf(`value is not specified for the key "%s"`, key))
+			return 0, 0, nil, "", fmt.Errorf(errors.InvalidJaasConfigErrorMsg, fmt.Sprintf(`value is not specified for the key "%s"`, key))
 		}
 
 		// Parse Value
@@ -219,7 +219,7 @@ func (j *JAASParser) parseConfigurationEntry(prefixKey string) (int, int, *prope
 		j.ignoreBackslash()
 	}
 	if j.tokenizer.Scan() != ';' {
-		return 0, 0, nil, "", errors.Errorf(errors.InvalidJaasConfigErrorMsg, "configuration not terminated with a ';'")
+		return 0, 0, nil, "", fmt.Errorf(errors.InvalidJaasConfigErrorMsg, "configuration not terminated with a ';'")
 	}
 	endIndex := j.tokenizer.Pos().Offset
 

--- a/pkg/secret/jaas_config_parser.go
+++ b/pkg/secret/jaas_config_parser.go
@@ -158,7 +158,7 @@ func (j *JAASParser) ConvertPropertiesToJAAS(props *properties.Properties, op st
 		configKey = keys[ClassId] + KeySeparator + keys[ParentId]
 		jaas, ok := j.JaasOriginalConfigKeys.Get(configKey)
 		if !ok {
-			return nil, errors.New("failed to convert the properties to a JAAS configuration")
+			return nil, fmt.Errorf("failed to convert the properties to a JAAS configuration")
 		}
 		jaas, err := j.updateJAASConfig(op, keys[KeyId], value, jaas)
 		if err != nil {

--- a/pkg/secret/password_protection_plugin.go
+++ b/pkg/secret/password_protection_plugin.go
@@ -47,7 +47,7 @@ func NewPasswordProtectionPlugin() *PasswordProtectionSuite {
 func (c *PasswordProtectionSuite) CreateMasterKey(passphrase, localSecureConfigPath string) (string, error) {
 	passphrase = strings.TrimSuffix(passphrase, "\n")
 	if strings.TrimSpace(passphrase) == "" {
-		return "", errors.New(errors.EmptyPassphraseErrorMsg)
+		return "", fmt.Errorf(errors.EmptyPassphraseErrorMsg)
 	}
 
 	secureConfigProps := properties.NewProperties()
@@ -183,7 +183,7 @@ func (c *PasswordProtectionSuite) DecryptConfigFileSecrets(configFilePath, local
 	dataKey, err := c.unwrapDataKey(cipherSuite.EncryptedDataKey, engine)
 	if err != nil {
 		log.CliLogger.Debug(err)
-		return errors.New(errors.UnwrapDataKeyErrorMsg)
+		return fmt.Errorf(errors.UnwrapDataKeyErrorMsg)
 	}
 
 	for key, value := range configProps.Map() {
@@ -217,7 +217,7 @@ func (c *PasswordProtectionSuite) DecryptConfigFileSecrets(configFilePath, local
 func (c *PasswordProtectionSuite) RotateDataKey(masterPassphrase, localSecureConfigPath string) error {
 	masterPassphrase = strings.TrimSuffix(masterPassphrase, "\n")
 	if strings.TrimSpace(masterPassphrase) == "" {
-		return errors.New(errors.EmptyPassphraseErrorMsg)
+		return fmt.Errorf(errors.EmptyPassphraseErrorMsg)
 	}
 	cipherSuite, err := c.loadCipherSuiteFromLocalFile(localSecureConfigPath)
 	if err != nil {
@@ -240,7 +240,7 @@ func (c *PasswordProtectionSuite) RotateDataKey(masterPassphrase, localSecureCon
 
 	// Verify master key passphrase
 	if masterKey != userMasterKey {
-		return errors.New(errors.IncorrectPassphraseErrorMsg)
+		return fmt.Errorf(errors.IncorrectPassphraseErrorMsg)
 	}
 
 	secureConfigProps, err := utils.LoadPropertiesFile(localSecureConfigPath)
@@ -252,7 +252,7 @@ func (c *PasswordProtectionSuite) RotateDataKey(masterPassphrase, localSecureCon
 	dataKey, err := c.unwrapDataKey(cipherSuite.EncryptedDataKey, engine)
 	if err != nil {
 		log.CliLogger.Debug(err)
-		return errors.New(errors.UnwrapDataKeyErrorMsg)
+		return fmt.Errorf(errors.UnwrapDataKeyErrorMsg)
 	}
 
 	// Generate a new DEK
@@ -309,11 +309,11 @@ func (c *PasswordProtectionSuite) RotateMasterKey(oldPassphrase, newPassphrase, 
 	oldPassphrase = strings.TrimSuffix(oldPassphrase, "\n")
 	newPassphrase = strings.TrimSuffix(newPassphrase, "\n")
 	if strings.TrimSpace(oldPassphrase) == "" || strings.TrimSpace(newPassphrase) == "" {
-		return "", errors.New(errors.EmptyPassphraseErrorMsg)
+		return "", fmt.Errorf(errors.EmptyPassphraseErrorMsg)
 	}
 
 	if oldPassphrase == newPassphrase {
-		return "", errors.New(errors.SamePassphraseErrorMsg)
+		return "", fmt.Errorf(errors.SamePassphraseErrorMsg)
 	}
 
 	cipherSuite, err := c.loadCipherSuiteFromLocalFile(localSecureConfigPath)
@@ -337,14 +337,14 @@ func (c *PasswordProtectionSuite) RotateMasterKey(oldPassphrase, newPassphrase, 
 
 	// Verify master key passphrase
 	if masterKey != userMasterKey {
-		return "", errors.New(errors.IncorrectPassphraseErrorMsg)
+		return "", fmt.Errorf(errors.IncorrectPassphraseErrorMsg)
 	}
 
 	// Unwrap DEK using the MEK
 	dataKey, err := c.unwrapDataKey(cipherSuite.EncryptedDataKey, engine)
 	if err != nil {
 		log.CliLogger.Debug(err)
-		return "", errors.New(errors.UnwrapDataKeyErrorMsg)
+		return "", fmt.Errorf(errors.UnwrapDataKeyErrorMsg)
 	}
 
 	newMasterKey, salt, err := engine.GenerateMasterKey(newPassphrase, "")
@@ -397,7 +397,7 @@ func (c *PasswordProtectionSuite) AddEncryptedPasswords(configFilePath, localSec
 	}
 
 	if newConfigProps.Len() == 0 {
-		return errors.New("add failed: empty list of new configs")
+		return fmt.Errorf("add failed: empty list of new configs")
 	}
 
 	return c.encryptConfigValues(newConfigProps, localSecureConfigPath, configFilePath, remoteSecureConfigPath)
@@ -415,7 +415,7 @@ func (c *PasswordProtectionSuite) UpdateEncryptedPasswords(configFilePath, local
 	}
 
 	if newConfigProps.Len() == 0 {
-		return errors.New("update failed: empty list of update configs")
+		return fmt.Errorf("update failed: empty list of update configs")
 	}
 
 	configProps, err := LoadConfiguration(configFilePath, newConfigProps.Keys(), true)
@@ -622,7 +622,7 @@ func (c *PasswordProtectionSuite) encryptConfigValues(matchProps *properties.Pro
 	dataKey, err := c.unwrapDataKey(cipherSuite.EncryptedDataKey, engine)
 	if err != nil {
 		log.CliLogger.Debug(err)
-		return errors.New(errors.UnwrapDataKeyErrorMsg)
+		return fmt.Errorf(errors.UnwrapDataKeyErrorMsg)
 	}
 
 	configProps := properties.NewProperties()

--- a/pkg/secret/password_protection_plugin.go
+++ b/pkg/secret/password_protection_plugin.go
@@ -125,7 +125,7 @@ func (c *PasswordProtectionSuite) generateNewDataKey(masterKey string) (*Cipher,
 func (c *PasswordProtectionSuite) EncryptConfigFileSecrets(configFilePath, localSecureConfigPath, remoteSecureConfigPath, encryptConfigKeys string) error {
 	// Check if config file path is valid.
 	if !utils.DoesPathExist(configFilePath) {
-		return errors.Errorf(errors.InvalidConfigFilePathErrorMsg, configFilePath)
+		return fmt.Errorf(errors.InvalidConfigFilePathErrorMsg, configFilePath)
 	}
 	var configs []string
 	// Load the configs.
@@ -148,12 +148,12 @@ func (c *PasswordProtectionSuite) EncryptConfigFileSecrets(configFilePath, local
 func (c *PasswordProtectionSuite) DecryptConfigFileSecrets(configFilePath, localSecureConfigPath, outputFilePath, configs string) error {
 	// Check if config file path is valid
 	if !utils.DoesPathExist(configFilePath) {
-		return errors.Errorf(errors.InvalidConfigFilePathErrorMsg, configFilePath)
+		return fmt.Errorf(errors.InvalidConfigFilePathErrorMsg, configFilePath)
 	}
 
 	// Check if secure config file path is valid
 	if !utils.DoesPathExist(localSecureConfigPath) {
-		return errors.Errorf(`invalid secrets file path "%s"`, localSecureConfigPath)
+		return fmt.Errorf(`invalid secrets file path "%s"`, localSecureConfigPath)
 	}
 
 	var configKeys []string
@@ -196,13 +196,13 @@ func (c *PasswordProtectionSuite) DecryptConfigFileSecrets(configFilePath, local
 				plainSecret, err := engine.Decrypt(data, iv, algo, dataKey)
 				if err != nil {
 					log.CliLogger.Debug(err)
-					return errors.Errorf(errors.DecryptConfigErrorMsg, key)
+					return fmt.Errorf(errors.DecryptConfigErrorMsg, key)
 				}
 				if _, _, err := configProps.Set(key, plainSecret); err != nil {
 					return err
 				}
 			} else {
-				return errors.Errorf(`missing config key "%s" in secret config file`, key)
+				return fmt.Errorf(`missing config key "%s" in secret config file`, key)
 			}
 		} else {
 			configProps.Delete(key)
@@ -449,7 +449,7 @@ func (c *PasswordProtectionSuite) RemoveEncryptedPasswords(configFilePath, local
 		}
 		// Check if config is removed from secrets files
 		if _, ok := secureConfigProps.Get(pathKey); !ok {
-			return errors.Errorf(errors.ConfigKeyNotEncryptedErrorMsg, key)
+			return fmt.Errorf(errors.ConfigKeyNotEncryptedErrorMsg, key)
 		}
 		secureConfigProps.Delete(pathKey)
 	}
@@ -461,7 +461,7 @@ func (c *PasswordProtectionSuite) RemoveEncryptedPasswords(configFilePath, local
 	case ".json":
 		err = c.removeJsonConfig(configFilePath, configs)
 	default:
-		err = errors.Errorf(`file type "%s" currently not supported`, fileType)
+		err = fmt.Errorf(`file type "%s" currently not supported`, fileType)
 	}
 	if err != nil {
 		return err
@@ -487,7 +487,7 @@ func (c *PasswordProtectionSuite) removeJsonConfig(configFilePath string, config
 				return err
 			}
 		} else {
-			return errors.Errorf(errors.ConfigKeyNotInJsonErrorMsg, key)
+			return fmt.Errorf(errors.ConfigKeyNotInJsonErrorMsg, key)
 		}
 	}
 	return WriteFile(configFilePath, []byte(jsonConfig))

--- a/pkg/secret/utils.go
+++ b/pkg/secret/utils.go
@@ -2,6 +2,7 @@ package secret
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -225,7 +226,7 @@ func LoadJSONFile(path string) (string, error) {
 
 	jsonConfig := string(jsonByteArr)
 	if !gjson.Valid(jsonConfig) {
-		return "", errors.New(errors.InvalidJsonFileFormatErrorMsg)
+		return "", fmt.Errorf(errors.InvalidJsonFileFormatErrorMsg)
 	}
 
 	return jsonConfig, nil

--- a/pkg/secret/utils.go
+++ b/pkg/secret/utils.go
@@ -54,7 +54,7 @@ func SaveConfiguration(path string, configuration *properties.Properties, addSec
 	case ".json":
 		return writeJSONConfig(path, configuration, addSecureConfig)
 	default:
-		return errors.Errorf(errors.UnsupportedFileFormatErrorMsg, path)
+		return fmt.Errorf(errors.UnsupportedFileFormatErrorMsg, path)
 	}
 }
 
@@ -93,7 +93,7 @@ func addSecureConfigProviderProperty(property *properties.Properties) (*properti
 
 func LoadConfiguration(path string, configKeys []string, filter bool) (*properties.Properties, error) {
 	if !utils.DoesPathExist(path) {
-		return nil, errors.Errorf(errors.InvalidFilePathErrorMsg, path)
+		return nil, fmt.Errorf(errors.InvalidFilePathErrorMsg, path)
 	}
 	fileType := filepath.Ext(path)
 	switch fileType {
@@ -102,7 +102,7 @@ func LoadConfiguration(path string, configKeys []string, filter bool) (*properti
 	case ".json":
 		return loadJSONConfig(path, configKeys)
 	default:
-		return nil, errors.Errorf(errors.UnsupportedFileFormatErrorMsg, path)
+		return nil, fmt.Errorf(errors.UnsupportedFileFormatErrorMsg, path)
 	}
 }
 
@@ -120,7 +120,7 @@ func filterProperties(configProps *properties.Properties, configKeys []string, f
 					return nil, err
 				}
 			} else {
-				return nil, errors.Errorf(errors.ConfigKeyNotPresentErrorMsg, key)
+				return nil, fmt.Errorf(errors.ConfigKeyNotPresentErrorMsg, key)
 			}
 		}
 		return matchProps, nil
@@ -249,7 +249,7 @@ func loadJSONConfig(path string, configKeys []string) (*properties.Properties, e
 				return nil, err
 			}
 		} else {
-			return nil, errors.Errorf(errors.ConfigKeyNotInJsonErrorMsg, key)
+			return nil, fmt.Errorf(errors.ConfigKeyNotInJsonErrorMsg, key)
 		}
 	}
 
@@ -300,7 +300,7 @@ func RemovePropertiesConfig(removeConfigs []string, path string) error {
 			}
 		} else {
 			if _, ok := configProps.Get(key); !ok {
-				return errors.Errorf(errors.ConfigKeyNotPresentErrorMsg, key)
+				return fmt.Errorf(errors.ConfigKeyNotPresentErrorMsg, key)
 			}
 			configProps.Delete(key)
 		}

--- a/pkg/serdes/avro_deserialization_provider.go
+++ b/pkg/serdes/avro_deserialization_provider.go
@@ -1,6 +1,7 @@
 package serdes
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/linkedin/goavro/v2"
@@ -14,7 +15,7 @@ type AvroDeserializationProvider struct {
 
 func (a *AvroDeserializationProvider) LoadSchema(schemaPath string, referencePathMap map[string]string) error {
 	if len(referencePathMap) > 0 {
-		return errors.New(errors.AvroReferenceNotSupportedErrorMsg)
+		return fmt.Errorf(errors.AvroReferenceNotSupportedErrorMsg)
 	}
 
 	schema, err := os.ReadFile(schemaPath)

--- a/pkg/serdes/avro_serialization_provider.go
+++ b/pkg/serdes/avro_serialization_provider.go
@@ -1,6 +1,7 @@
 package serdes
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/linkedin/goavro/v2"
@@ -14,7 +15,7 @@ type AvroSerializationProvider struct {
 
 func (a *AvroSerializationProvider) LoadSchema(schemaPath string, referencePathMap map[string]string) error {
 	if len(referencePathMap) > 0 {
-		return errors.New(errors.AvroReferenceNotSupportedErrorMsg)
+		return fmt.Errorf(errors.AvroReferenceNotSupportedErrorMsg)
 	}
 
 	schema, err := os.ReadFile(schemaPath)

--- a/pkg/serdes/json_deserialization_provider.go
+++ b/pkg/serdes/json_deserialization_provider.go
@@ -3,6 +3,7 @@ package serdes
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 
 	"github.com/xeipuuv/gojsonschema"
 
@@ -34,7 +35,7 @@ func (j *JsonSchemaDeserializationProvider) Deserialize(data []byte) (string, er
 	}
 
 	if !result.Valid() {
-		return "", errors.New(errors.JsonDocumentInvalidErrorMsg)
+		return "", fmt.Errorf(errors.JsonDocumentInvalidErrorMsg)
 	}
 
 	data = []byte(str)

--- a/pkg/serdes/json_serialization_provider.go
+++ b/pkg/serdes/json_serialization_provider.go
@@ -3,6 +3,7 @@ package serdes
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"os"
 
 	"github.com/xeipuuv/gojsonschema"
@@ -37,7 +38,7 @@ func (j *JsonSerializationProvider) Serialize(str string) ([]byte, error) {
 	}
 
 	if !result.Valid() {
-		return nil, errors.New(errors.JsonDocumentInvalidErrorMsg)
+		return nil, fmt.Errorf(errors.JsonDocumentInvalidErrorMsg)
 	}
 
 	data := []byte(str)
@@ -65,7 +66,7 @@ func parseSchema(schemaPath string, referencePathMap map[string]string) (*gojson
 
 	schema, err := os.ReadFile(schemaPath)
 	if err != nil {
-		return nil, errors.New("the JSON schema is invalid")
+		return nil, fmt.Errorf("the JSON schema is invalid")
 	}
 
 	return sl.Compile(gojsonschema.NewStringLoader(string(schema)))

--- a/pkg/serdes/protobuf_deserialization_provider.go
+++ b/pkg/serdes/protobuf_deserialization_provider.go
@@ -1,6 +1,8 @@
 package serdes
 
 import (
+	"fmt"
+
 	"github.com/golang/protobuf/jsonpb" //nolint:staticcheck // deprecated module cannot be removed due to https://github.com/jhump/protoreflect/issues/301
 	"github.com/golang/protobuf/proto"  //nolint:staticcheck // deprecated module cannot be removed due to https://github.com/jhump/protoreflect/issues/301
 
@@ -27,7 +29,7 @@ func (p *ProtobufDeserializationProvider) Deserialize(data []byte) (string, erro
 
 	// Convert from binary format to proto message type.
 	if err := proto.Unmarshal(data, p.message); err != nil {
-		return "", errors.New(errors.ProtoDocumentInvalidErrorMsg)
+		return "", fmt.Errorf(errors.ProtoDocumentInvalidErrorMsg)
 	}
 
 	// Convert from proto message type to JSON string.

--- a/pkg/serdes/protobuf_serialization_provider.go
+++ b/pkg/serdes/protobuf_serialization_provider.go
@@ -1,6 +1,7 @@
 package serdes
 
 import (
+	"fmt"
 	"path/filepath"
 	"strings"
 
@@ -36,7 +37,7 @@ func (p *ProtobufSerializationProvider) Serialize(str string) ([]byte, error) {
 
 	// Convert from JSON string to proto message type.
 	if err := jsonpb.UnmarshalString(str, p.message); err != nil {
-		return nil, errors.New(errors.ProtoDocumentInvalidErrorMsg)
+		return nil, fmt.Errorf(errors.ProtoDocumentInvalidErrorMsg)
 	}
 
 	// Serialize proto message type to binary format.
@@ -59,13 +60,13 @@ func parseMessage(schemaPath string, referencePathMap map[string]string) (proto.
 		return nil, errors.Wrap(err, errors.ProtoSchemaInvalidErrorMsg)
 	}
 	if len(fileDescriptors) == 0 {
-		return nil, errors.New(errors.ProtoSchemaInvalidErrorMsg)
+		return nil, fmt.Errorf(errors.ProtoSchemaInvalidErrorMsg)
 	}
 	fileDescriptor := fileDescriptors[0]
 
 	messageDescriptors := fileDescriptor.GetMessageTypes()
 	if len(messageDescriptors) == 0 {
-		return nil, errors.New(errors.ProtoSchemaInvalidErrorMsg)
+		return nil, fmt.Errorf(errors.ProtoSchemaInvalidErrorMsg)
 	}
 	// We're always using the outermost first message.
 	messageDescriptor := messageDescriptors[0]

--- a/pkg/serdes/protobuf_serialization_provider.go
+++ b/pkg/serdes/protobuf_serialization_provider.go
@@ -57,7 +57,7 @@ func parseMessage(schemaPath string, referencePathMap map[string]string) (proto.
 	parser := parse.Parser{ImportPaths: importPaths}
 	fileDescriptors, err := parser.ParseFiles(filepath.Base(schemaPath))
 	if err != nil {
-		return nil, errors.Wrap(err, errors.ProtoSchemaInvalidErrorMsg)
+		return nil, fmt.Errorf("%s: %w", errors.ProtoSchemaInvalidErrorMsg, err)
 	}
 	if len(fileDescriptors) == 0 {
 		return nil, fmt.Errorf(errors.ProtoSchemaInvalidErrorMsg)

--- a/pkg/serdes/serdes.go
+++ b/pkg/serdes/serdes.go
@@ -1,6 +1,10 @@
 package serdes
 
-import "github.com/confluentinc/cli/v3/pkg/errors"
+import (
+	"fmt"
+
+	"github.com/confluentinc/cli/v3/pkg/errors"
+)
 
 const (
 	AvroSchemaName     string = "avro"
@@ -39,7 +43,7 @@ func FormatTranslation(backendValueFormat string) (string, error) {
 	case JsonSchemaBackendName:
 		cliValueFormat = JsonSchemaName
 	default:
-		return "", errors.New(errors.UnknownValueFormatErrorMsg)
+		return "", fmt.Errorf(errors.UnknownValueFormatErrorMsg)
 	}
 	return cliValueFormat, nil
 }
@@ -57,7 +61,7 @@ func GetSerializationProvider(valueFormat string) (SerializationProvider, error)
 	case StringSchemaName:
 		return new(StringSerializationProvider), nil
 	default:
-		return nil, errors.New(errors.UnknownValueFormatErrorMsg)
+		return nil, fmt.Errorf(errors.UnknownValueFormatErrorMsg)
 	}
 }
 
@@ -74,6 +78,6 @@ func GetDeserializationProvider(valueFormat string) (DeserializationProvider, er
 	case StringSchemaName:
 		return new(StringDeserializationProvider), nil
 	default:
-		return nil, errors.New(errors.UnknownValueFormatErrorMsg)
+		return nil, fmt.Errorf(errors.UnknownValueFormatErrorMsg)
 	}
 }

--- a/pkg/update/client.go
+++ b/pkg/update/client.go
@@ -102,7 +102,7 @@ func (c *client) CheckForUpdates(cliName, currentVersion string, forceCheck bool
 
 	// After fetching the latest version, we touch the file so that we don't make the request again for 24hrs.
 	if err := c.touchCheckFile(); err != nil {
-		return "", "", errors.Wrap(err, "unable to touch last check file")
+		return "", "", fmt.Errorf("unable to touch last check file: %w", err)
 	}
 
 	var major, minor string

--- a/pkg/update/client.go
+++ b/pkg/update/client.go
@@ -84,7 +84,8 @@ func (c *client) CheckForUpdates(cliName, currentVersion string, forceCheck bool
 
 	currVersion, err := version.NewVersion(currentVersion)
 	if err != nil {
-		return "", "", errors.Wrapf(err, errors.ParseVersionErrorMsg, cliName, currentVersion)
+		message := fmt.Sprintf(errors.ParseVersionErrorMsg, cliName, currentVersion)
+		return "", "", fmt.Errorf("%s: %w", message, err)
 	}
 
 	latestMajorVersion, latestMinorVersion, err := c.Repository.GetLatestMajorAndMinorVersion(cliName, currVersion)
@@ -200,7 +201,7 @@ func (c *client) PromptToDownload(cliName, currVersion, latestVersion, releaseNo
 func (c *client) UpdateBinary(cliName, version, path string, noVerify bool) error {
 	downloadDir, err := c.fs.MkdirTemp("", cliName)
 	if err != nil {
-		return errors.Wrapf(err, "unable to get temp dir for %s", cliName)
+		return fmt.Errorf("unable to get temporary directory for %s: %w", cliName, err)
 	}
 	defer func() {
 		if err := c.fs.RemoveAll(downloadDir); err != nil {
@@ -213,7 +214,7 @@ func (c *client) UpdateBinary(cliName, version, path string, noVerify bool) erro
 
 	payload, err := c.Repository.DownloadVersion(cliName, version, downloadDir)
 	if err != nil {
-		return errors.Wrapf(err, "unable to download %s version %s to %s", cliName, version, downloadDir)
+		return fmt.Errorf("unable to download %s version %s to %s: %w", cliName, version, downloadDir, err)
 	}
 
 	mb := float64(len(payload)) / 1024.0 / 1024.0
@@ -224,7 +225,7 @@ func (c *client) UpdateBinary(cliName, version, path string, noVerify bool) erro
 	if !noVerify {
 		content, err := c.Repository.DownloadChecksums(cliName, version)
 		if err != nil {
-			return errors.Wrapf(err, "failed to download checksums file")
+			return fmt.Errorf("failed to download checksums file: %w", err)
 		}
 
 		binary := getBinaryName(version, c.OS, runtime.GOARCH)

--- a/pkg/update/client_test.go
+++ b/pkg/update/client_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/confluentinc/cli/v3/pkg/errors"
 	pio "github.com/confluentinc/cli/v3/pkg/io"
 	"github.com/confluentinc/cli/v3/pkg/mock"
 	updateMock "github.com/confluentinc/cli/v3/pkg/update/mock"
@@ -100,7 +99,7 @@ func TestCheckForUpdates(t *testing.T) {
 			client: NewClient(&ClientParams{
 				Repository: &updateMock.Repository{
 					GetLatestMajorAndMinorVersionFunc: func(name string, current *version.Version) (*version.Version, *version.Version, error) {
-						return nil, nil, errors.New("zap")
+						return nil, nil, fmt.Errorf("zap")
 					},
 				},
 			}),
@@ -148,7 +147,7 @@ func TestCheckForUpdates(t *testing.T) {
 				Repository: &updateMock.Repository{
 					GetLatestMajorAndMinorVersionFunc: func(name string, current *version.Version) (*version.Version, *version.Version, error) {
 						require.Fail(t, "Shouldn't be called")
-						return nil, nil, errors.New("whoops")
+						return nil, nil, fmt.Errorf("whoops")
 					},
 				},
 				// This check file was created by the TmpFile process, modtime is current, so should skip check
@@ -220,7 +219,7 @@ func TestCheckForUpdates(t *testing.T) {
 				Repository: &updateMock.Repository{
 					GetLatestMajorAndMinorVersionFunc: func(name string, current *version.Version) (*version.Version, *version.Version, error) {
 						require.Fail(t, "Shouldn't be called")
-						return nil, nil, errors.New("whoops")
+						return nil, nil, fmt.Errorf("whoops")
 					},
 				},
 				DisableCheck: true,
@@ -235,7 +234,7 @@ func TestCheckForUpdates(t *testing.T) {
 			client: NewClient(&ClientParams{
 				Repository: &updateMock.Repository{
 					GetLatestMajorAndMinorVersionFunc: func(name string, current *version.Version) (*version.Version, *version.Version, error) {
-						return nil, nil, errors.New("whoops")
+						return nil, nil, fmt.Errorf("whoops")
 					},
 				},
 			}),
@@ -465,7 +464,7 @@ func TestVerifyChecksum(t *testing.T) {
 			if version == "2.5.1" {
 				return checksums, nil
 			} else {
-				return "", errors.New("No checksums for given version")
+				return "", fmt.Errorf("No checksums for given version")
 			}
 		},
 	}
@@ -475,7 +474,7 @@ func TestVerifyChecksum(t *testing.T) {
 			if strings.Contains(checksums, newBin) {
 				return nil
 			}
-			return errors.New("checksum verification failed")
+			return fmt.Errorf("checksum verification failed")
 		},
 	}
 
@@ -561,7 +560,7 @@ func TestGetLatestReleaseNotes(t *testing.T) {
 			client: NewClient(&ClientParams{
 				Repository: &updateMock.Repository{
 					GetLatestReleaseNotesVersionsFunc: func(_, _ string) (version.Collection, error) {
-						return nil, errors.New("whoops")
+						return nil, fmt.Errorf("whoops")
 					},
 					DownloadReleaseNotesFunc: func(_, _ string) (string, error) {
 						return "", nil
@@ -579,7 +578,7 @@ func TestGetLatestReleaseNotes(t *testing.T) {
 						return version.Collection{v1}, nil
 					},
 					DownloadReleaseNotesFunc: func(_, _ string) (string, error) {
-						return "", errors.New("whoops")
+						return "", fmt.Errorf("whoops")
 					},
 				},
 			}),
@@ -654,7 +653,7 @@ func TestUpdateBinary(t *testing.T) {
 				ClientParams: &ClientParams{
 					Repository: &updateMock.Repository{
 						DownloadVersionFunc: func(name, version, downloadDir string) ([]byte, error) {
-							return nil, errors.New("out of disk!")
+							return nil, fmt.Errorf("out of disk!")
 						},
 					},
 				},
@@ -687,7 +686,7 @@ func TestUpdateBinary(t *testing.T) {
 				fs: &mock.PassThroughFileSystem{
 					Mock: &mock.FileSystem{
 						MoveFunc: func(src, dst string) error {
-							return errors.New("move func intentionally failed")
+							return fmt.Errorf("move func intentionally failed")
 						},
 					},
 					FS: &pio.RealFileSystem{},

--- a/pkg/update/s3/object_key.go
+++ b/pkg/update/s3/object_key.go
@@ -41,7 +41,7 @@ type PrefixedKey struct {
 // Prefix may be an empty string. An error will be returned if sep is empty or a space.
 func NewPrefixedKey(prefix, sep string, prefixVersion bool) (*PrefixedKey, error) {
 	if sep == "" || sep == " " {
-		return nil, errors.New("sep must be a non-empty string")
+		return nil, fmt.Errorf("sep must be a non-empty string")
 	}
 	return &PrefixedKey{
 		Prefix:        prefix,

--- a/pkg/update/s3/object_key.go
+++ b/pkg/update/s3/object_key.go
@@ -119,7 +119,7 @@ func (p *PrefixedKey) ParseVersion(key, name string) (bool, *version.Version, er
 
 	ver, err := version.NewSemver(split[1])
 	if err != nil {
-		return false, nil, errors.Errorf(errors.ParseVersionErrorMsg, name, split[1])
+		return false, nil, fmt.Errorf(errors.ParseVersionErrorMsg, name, split[1])
 	}
 	return true, ver, nil
 }

--- a/pkg/update/s3/public.go
+++ b/pkg/update/s3/public.go
@@ -292,7 +292,7 @@ func (r *PublicRepo) getHttpResponse(url string) (*http.Response, error) {
 		if err == nil {
 			log.CliLogger.Tracef("Response from AWS: %s", string(body))
 		}
-		return nil, errors.Errorf("received unexpected response from S3: %s", resp.Status)
+		return nil, fmt.Errorf("received unexpected response from S3: %s", resp.Status)
 	}
 	return resp, nil
 }

--- a/pkg/update/s3/public.go
+++ b/pkg/update/s3/public.go
@@ -73,7 +73,7 @@ func (r *PublicRepo) GetLatestMajorAndMinorVersion(name string, current *version
 	// The index of the largest available version. This may be a major version update.
 	majorIdx := len(versions) - 1
 	if majorIdx < 0 {
-		return nil, nil, errors.New(errors.GetBinaryVersionsErrorMsg)
+		return nil, nil, fmt.Errorf(errors.GetBinaryVersionsErrorMsg)
 	}
 	major := versions[majorIdx]
 	if current.Segments()[0] == major.Segments()[0] {
@@ -90,7 +90,7 @@ func (r *PublicRepo) GetLatestMajorAndMinorVersion(name string, current *version
 	}) - 1
 
 	if minorIdx < 0 {
-		return nil, nil, errors.New(errors.GetBinaryVersionsErrorMsg)
+		return nil, nil, fmt.Errorf(errors.GetBinaryVersionsErrorMsg)
 	}
 	minor := versions[minorIdx]
 
@@ -107,7 +107,7 @@ func (r *PublicRepo) GetAvailableBinaryVersions(name string) (version.Collection
 		return nil, err
 	}
 	if len(availableVersions) == 0 {
-		return nil, errors.New(errors.NoVersionsErrorMsg)
+		return nil, fmt.Errorf(errors.NoVersionsErrorMsg)
 	}
 	return availableVersions, nil
 }
@@ -197,7 +197,7 @@ func (r *PublicRepo) GetAvailableReleaseNotesVersions(name string) (version.Coll
 	}
 	availableVersions := r.getMatchedReleaseNotesVersionsFromListBucketResult(name, listBucketResult)
 	if len(availableVersions) == 0 {
-		return nil, errors.New(errors.NoVersionsErrorMsg)
+		return nil, fmt.Errorf(errors.NoVersionsErrorMsg)
 	}
 	return availableVersions, nil
 }

--- a/pkg/update/s3/public.go
+++ b/pkg/update/s3/public.go
@@ -67,7 +67,7 @@ func NewPublicRepo(params *PublicRepoParams) *PublicRepo {
 func (r *PublicRepo) GetLatestMajorAndMinorVersion(name string, current *version.Version) (*version.Version, *version.Version, error) {
 	versions, err := r.GetAvailableBinaryVersions(name)
 	if err != nil {
-		return nil, nil, errors.Wrapf(err, errors.GetBinaryVersionsErrorMsg)
+		return nil, nil, fmt.Errorf("%s: %w", errors.GetBinaryVersionsErrorMsg, err)
 	}
 
 	// The index of the largest available version. This may be a major version update.
@@ -177,7 +177,7 @@ func (r *PublicRepo) getMatchedBinaryVersionsFromListBucketResult(result *ListBu
 func (r *PublicRepo) GetLatestReleaseNotesVersions(name, currentVersion string) (version.Collection, error) {
 	versions, err := r.GetAvailableReleaseNotesVersions(name)
 	if err != nil {
-		return nil, errors.Wrapf(err, "unable to get available release notes versions")
+		return nil, fmt.Errorf("unable to get available release notes versions: %w", err)
 	}
 
 	current, err := version.NewVersion(currentVersion)

--- a/pkg/utils/cert_utils.go
+++ b/pkg/utils/cert_utils.go
@@ -102,7 +102,7 @@ func SelfSignedCertClient(caCertReader io.Reader, clientCert tls.Certificate) (*
 		// read custom certs
 		caCerts, err := io.ReadAll(caCertReader)
 		if err != nil {
-			return nil, errors.Wrap(err, "failed to read certificate")
+			return nil, fmt.Errorf("failed to read certificate: %w", err)
 		}
 		log.CliLogger.Tracef("Specified CA certificate has been read")
 

--- a/pkg/utils/cert_utils.go
+++ b/pkg/utils/cert_utils.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"crypto/tls"
 	"crypto/x509"
+	"fmt"
 	"io"
 	"net"
 	"net/http"
@@ -82,7 +83,7 @@ func CustomCAAndClientCertClient(caCertPath, clientCertPath, clientKeyPath strin
 
 func SelfSignedCertClient(caCertReader io.Reader, clientCert tls.Certificate) (*http.Client, error) {
 	if caCertReader == nil && isEmptyClientCert(clientCert) {
-		return nil, errors.New("no reader specified for reading custom certificates")
+		return nil, fmt.Errorf("no reader specified for reading custom certificates")
 	}
 	transport := DefaultTransport()
 
@@ -107,7 +108,7 @@ func SelfSignedCertClient(caCertReader io.Reader, clientCert tls.Certificate) (*
 
 		// Append custom certs to the system pool
 		if ok := caCertPool.AppendCertsFromPEM(caCerts); !ok {
-			return nil, errors.New("no certs appended, using system certs only")
+			return nil, fmt.Errorf("no certs appended, using system certs only")
 		}
 		log.CliLogger.Tracef("Successfully appended new certificate to the pool")
 		// Trust the updated cert pool in our client

--- a/pkg/utils/stripe_utils.go
+++ b/pkg/utils/stripe_utils.go
@@ -1,7 +1,7 @@
 package utils
 
 import (
-	"errors"
+	"fmt"
 	"strings"
 
 	"github.com/stripe/stripe-go"
@@ -40,7 +40,7 @@ func NewStripeToken(cardNumber, expiration, cvc, name string, isTest bool) (*str
 	stripeToken, err := token.New(params)
 	if err != nil {
 		if stripeErr, ok := err.(*stripe.Error); ok {
-			return nil, errors.New(stripeErr.Msg)
+			return nil, fmt.Errorf(stripeErr.Msg)
 		}
 		return nil, err
 	}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -31,7 +31,7 @@ func FileExists(filename string) bool {
 
 func LoadPropertiesFile(path string) (*properties.Properties, error) {
 	if !DoesPathExist(path) {
-		return nil, errors.Errorf(errors.InvalidFilePathErrorMsg, path)
+		return nil, fmt.Errorf(errors.InvalidFilePathErrorMsg, path)
 	}
 
 	loader := new(properties.Loader)

--- a/test/fixtures/output/kafka/consumer/group/describe-dne.golden
+++ b/test/fixtures/output/kafka/consumer/group/describe-dne.golden
@@ -1,1 +1,1 @@
-Error: REST request failed: This server does not host this consumer group. (40403)
+Error: REST request failed: This server does not host this consumer group.

--- a/test/fixtures/output/kafka/consumer/group/describe-onprem-dne.golden
+++ b/test/fixtures/output/kafka/consumer/group/describe-onprem-dne.golden
@@ -1,1 +1,1 @@
-Error: REST request failed: This server does not host this consumer group. (40403)
+Error: REST request failed: This server does not host this consumer group.

--- a/test/kafka_test.go
+++ b/test/kafka_test.go
@@ -393,11 +393,11 @@ func (s *CLITestSuite) TestKafkaTopicCreate() {
 		// --partitions errors
 		{args: fmt.Sprintf("kafka topic create topic-X --url %s --partitions -2 --no-authentication", kafkaRestURL), exitCode: 1, name: "creating topic with negative partitions name should fail", fixture: "kafka/topic/create-negative-partitions.golden"},
 		// --replication-factor errors
-		{args: fmt.Sprintf("kafka topic create topic-X --url %s --replication-factor 4 --no-authentication", kafkaRestURL), contains: "Error: REST request failed: Replication factor: 4 larger than available brokers: 3. (40002)\n", exitCode: 1, name: "creating topic with larger replication factor than num. brokers should fail"},
+		{args: fmt.Sprintf("kafka topic create topic-X --url %s --replication-factor 4 --no-authentication", kafkaRestURL), contains: "Error: REST request failed: Replication factor: 4 larger than available brokers: 3.\n", exitCode: 1, name: "creating topic with larger replication factor than num. brokers should fail"},
 		{args: fmt.Sprintf("kafka topic create topic-X --url %s --replication-factor -2 --no-authentication", kafkaRestURL), exitCode: 1, name: "creating topic with negative replication factor should fail", fixture: "kafka/topic/create-negative-replication-factor.golden"},
 		// --config errors
-		{args: fmt.Sprintf("kafka topic create topic-X --url %s --config asdf=1 --no-authentication", kafkaRestURL), contains: "Error: REST request failed: Unknown topic config name: asdf (40002)\n", exitCode: 1, name: "creating topic with incorrect config name should fail"},
-		{args: fmt.Sprintf("kafka topic create topic-X --url %s --config retention.ms=as --no-authentication", kafkaRestURL), contains: "Error: REST request failed: Invalid value as for configuration retention.ms: Not a number of type LONG (40002)\n", exitCode: 1, name: "creating topic with correct key incorrect config value should fail"},
+		{args: fmt.Sprintf("kafka topic create topic-X --url %s --config asdf=1 --no-authentication", kafkaRestURL), contains: "Error: REST request failed: Unknown topic config name: asdf\n", exitCode: 1, name: "creating topic with incorrect config name should fail"},
+		{args: fmt.Sprintf("kafka topic create topic-X --url %s --config retention.ms=as --no-authentication", kafkaRestURL), contains: "Error: REST request failed: Invalid value as for configuration retention.ms: Not a number of type LONG\n", exitCode: 1, name: "creating topic with correct key incorrect config value should fail"},
 		// Success
 		{args: fmt.Sprintf("kafka topic create topic-X --url %s --no-authentication", kafkaRestURL), fixture: "kafka/topic/create-topic-success.golden", name: "correct URL with default params (part 6, repl 3, no configs) should create successfully"},
 		{args: fmt.Sprintf("kafka topic create topic-X --url %s --partitions 7 --replication-factor 2 --config retention.ms=100000,compression.type=gzip --no-authentication", kafkaRestURL), fixture: "kafka/topic/create-topic-success.golden", name: "correct URL with valid optional params should create successfully"},
@@ -432,10 +432,10 @@ func (s *CLITestSuite) TestKafkaTopicUpdate() {
 	tests := []CLITest{
 		// Topic name errors
 		{args: fmt.Sprintf("kafka topic update --url %s --no-authentication", kafkaRestURL), contains: "Error: accepts 1 arg(s), received 0", exitCode: 1, name: "missing topic-name should return error"},
-		{args: fmt.Sprintf("kafka topic update topic-not-exist --url %s --no-authentication", kafkaRestURL), contains: "Error: REST request failed: This server does not host this topic-partition. (40403)\n", exitCode: 1, name: "update config of a non-existent topic should fail"},
+		{args: fmt.Sprintf("kafka topic update topic-not-exist --url %s --no-authentication", kafkaRestURL), contains: "Error: REST request failed: This server does not host this topic-partition.\n", exitCode: 1, name: "update config of a non-existent topic should fail"},
 		// --config errors
-		{args: fmt.Sprintf("kafka topic update topic-exist --url %s --config asdf=1 --no-authentication", kafkaRestURL), contains: "Error: REST request failed: Config asdf cannot be found for TOPIC topic-exist in cluster cluster-1. (404)\n", exitCode: 1, name: "incorrect config name should fail"},
-		{args: fmt.Sprintf("kafka topic update topic-exist --url %s --config retention.ms=as --no-authentication", kafkaRestURL), contains: "Error: REST request failed: Invalid config value for resource ConfigResource(type=TOPIC, name='topic-exist'): Invalid value as for configuration retention.ms: Not a number of type LONG (40002)\n", exitCode: 1, name: "correct key incorrect config value should fail"},
+		{args: fmt.Sprintf("kafka topic update topic-exist --url %s --config asdf=1 --no-authentication", kafkaRestURL), contains: "Error: REST request failed: Config asdf cannot be found for TOPIC topic-exist in cluster cluster-1.\n", exitCode: 1, name: "incorrect config name should fail"},
+		{args: fmt.Sprintf("kafka topic update topic-exist --url %s --config retention.ms=as --no-authentication", kafkaRestURL), contains: "Error: REST request failed: Invalid config value for resource ConfigResource(type=TOPIC, name='topic-exist'): Invalid value as for configuration retention.ms: Not a number of type LONG\n", exitCode: 1, name: "correct key incorrect config value should fail"},
 		// Success cases
 		{args: fmt.Sprintf("kafka topic update topic-exist --url %s --config retention.ms=1,compression.type=gzip --no-authentication", kafkaRestURL), fixture: "kafka/topic/update-topic-config-success", name: "valid config updates should succeed with configs printed sorted"},
 		{args: fmt.Sprintf("kafka topic update topic-exist --url %s --config retention.ms=1000,retention.ms=1 --no-authentication", kafkaRestURL), fixture: "kafka/topic/update-topic-config-duplicate-success", name: "valid duplicate config should succeed with the later config value kept"},
@@ -453,7 +453,7 @@ func (s *CLITestSuite) TestKafkaTopicDescribe() {
 	tests := []CLITest{
 		// Topic name errors
 		{args: fmt.Sprintf("kafka topic describe --url %s --no-authentication", kafkaRestURL), contains: "Error: accepts 1 arg(s), received 0", exitCode: 1, name: "<topic> arg missing should lead to error"},
-		{args: fmt.Sprintf("kafka topic describe topic-not-exist --url %s --no-authentication", kafkaRestURL), contains: "Error: REST request failed: This server does not host this topic-partition. (40403)\n", exitCode: 1, name: "describing a non-existent topic should lead to error"},
+		{args: fmt.Sprintf("kafka topic describe topic-not-exist --url %s --no-authentication", kafkaRestURL), contains: "Error: REST request failed: This server does not host this topic-partition.\n", exitCode: 1, name: "describing a non-existent topic should lead to error"},
 		// Success cases
 		{args: fmt.Sprintf("kafka topic describe topic-exist --url %s --no-authentication", kafkaRestURL), fixture: "kafka/topic/describe-topic-success.golden", name: "topic that exists & correct format arg should lead to success"},
 		{args: fmt.Sprintf("kafka topic describe topic-exist --url %s -o human --no-authentication", kafkaRestURL), fixture: "kafka/topic/describe-topic-success.golden", name: "topic that exist & human arg should lead to success"},


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
The errors package is deprecated and can be replaced with standard library functions as of Go 2. Prefer `fmt.Errorf()` over `errors.*`.

Test & Review
-------------
Tests still pass