### PR TITLE
Feat/statement list with cp or cloudregion

### DIFF
--- a/internal/flink/command_statement_list.go
+++ b/internal/flink/command_statement_list.go
@@ -25,7 +25,13 @@ func (c *command) newStatementListCommand() *cobra.Command {
 }
 
 func (c *command) statementList(cmd *cobra.Command, args []string) error {
-	client, err := c.GetFlinkGatewayClient(false)
+	computePoolOnly := false
+
+	if c.Context.GetCurrentFlinkComputePool() != "" {
+		computePoolOnly = true
+	}
+
+	client, err := c.GetFlinkGatewayClient(computePoolOnly)
 	if err != nil {
 		return err
 	}

--- a/test/fixtures/output/flink/statement/list-compute-pool-yaml.golden
+++ b/test/fixtures/output/flink/statement/list-compute-pool-yaml.golden
@@ -1,0 +1,12 @@
+- creation_date: 2022-01-01T00:00:00Z
+  name: 22222222-2222-2222-2
+  statement: CREATE TABLE test;
+  compute_pool: lfcp-123456
+  status: COMPLETED
+  status_detail: SQL statement is completed
+- creation_date: 2023-01-01T00:00:00Z
+  name: 11111111-1111-1111-1
+  statement: CREATE TABLE test;
+  compute_pool: lfcp-123456
+  status: COMPLETED
+  status_detail: SQL statement is completed

--- a/test/fixtures/output/flink/statement/list-compute-pool.golden
+++ b/test/fixtures/output/flink/statement/list-compute-pool.golden
@@ -1,0 +1,4 @@
+          Creation Date         |         Name         |     Statement      | Compute Pool |  Status   |       Status Detail         
+--------------------------------+----------------------+--------------------+--------------+-----------+-----------------------------
+  2022-01-01 00:00:00 +0000 UTC | 22222222-2222-2222-2 | CREATE TABLE test; | lfcp-123456  | COMPLETED | SQL statement is completed  
+  2023-01-01 00:00:00 +0000 UTC | 11111111-1111-1111-1 | CREATE TABLE test; | lfcp-123456  | COMPLETED | SQL statement is completed  

--- a/test/flink_test.go
+++ b/test/flink_test.go
@@ -65,6 +65,8 @@ func (s *CLITestSuite) TestFlinkStatement() {
 		{args: "flink statement delete my-statement --force --cloud aws --region eu-west-1", fixture: "flink/statement/delete.golden"},
 		{args: "flink statement list --cloud aws --region eu-west-1", fixture: "flink/statement/list.golden"},
 		{args: "flink statement list --cloud aws --region eu-west-1 -o yaml", fixture: "flink/statement/list-yaml.golden"},
+		{args: "flink statement list --compute-pool lfcp-123456", fixture: "flink/statement/list-compute-pool.golden"},
+		{args: "flink statement list --compute-pool lfcp-123456 -o yaml", fixture: "flink/statement/list-compute-pool-yaml.golden"},
 		{args: "flink statement describe my-statement --cloud aws --region eu-west-1", fixture: "flink/statement/describe.golden"},
 		{args: "flink statement describe my-statement --cloud aws --region eu-west-1 -o yaml", fixture: "flink/statement/describe-yaml.golden"},
 		{args: "flink statement stop my-statement --region eu-west-1 --cloud aws", fixture: "flink/statement/stop.golden"},


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

New Features
- `confluent flink statement list` now supports either only providing the `--compute-pool` flag or a `--cloud --region`
 pair.
 
Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok


What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->

Requiring the --cloud and --region flag even if you provide --compute-pool was confusing for users, since the --compute-pool exists inside one cloud and one region. Experience is more consistent now, since you list the statements for a compute-pool without having to also provide the region and cloud provider for it.

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
<!--
Has it been tested? How?
Copy and paste any instructions or steps that can save the reviewer time.
-->

golden tests

Open Questions / Follow-ups
---------------------------
<!--
Optional: Anything open to discussion for the reviewer, out of scope of this PR, or follow-ups.
-->
