### PR TITLE
Use comma delimited string for human BYOK role output

### DIFF
--- a/internal/byok/command.go
+++ b/internal/byok/command.go
@@ -12,6 +12,24 @@ type command struct {
 	*pcmd.AuthenticatedCLICommand
 }
 
+type humanOut struct {
+	Id        string `human:"ID"`
+	Key       string `human:"Key"`
+	Roles     string `human:"Roles"`
+	Provider  string `human:"Provider"`
+	State     string `human:"State"`
+	CreatedAt string `human:"Created At"`
+}
+
+type serializedOut struct {
+	Id        string   `serialized:"id"`
+	Key       string   `serialized:"key"`
+	Roles     []string `serialized:"roles"`
+	Provider  string   `serialized:"provider"`
+	State     string   `serialized:"state"`
+	CreatedAt string   `serialized:"created_at"`
+}
+
 func New(prerunner pcmd.PreRunner) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:         "byok",

--- a/internal/byok/command_describe.go
+++ b/internal/byok/command_describe.go
@@ -2,6 +2,7 @@ package byok
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -11,17 +12,6 @@ import (
 	"github.com/confluentinc/cli/v3/pkg/errors"
 	"github.com/confluentinc/cli/v3/pkg/output"
 )
-
-type describeStruct struct {
-	Id        string   `human:"ID" serialized:"id"`
-	Key       string   `human:"Key" serialized:"key"`
-	Roles     []string `human:"Roles" serialized:"roles"`
-	Provider  string   `human:"Provider" serialized:"provider"`
-	State     string   `human:"State" serialized:"state"`
-	CreatedAt string   `human:"Created At" serialized:"created_at"`
-	UpdatedAt string   `human:"Updated At" serialized:"updated_at"`
-	DeletedAt string   `human:"Deleted At" serialized:"deleted_at"`
-}
 
 func (c *command) newDescribeCommand() *cobra.Command {
 	cmd := &cobra.Command{
@@ -43,37 +33,10 @@ func (c *command) describe(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return errors.CatchByokKeyNotFoundError(err, httpResp)
 	}
-
-	return c.outputByokKeyDescription(cmd, &key)
+	return c.outputByokKeyDescription(cmd, key)
 }
 
-func (c *command) outputByokKeyDescription(cmd *cobra.Command, key *byokv1.ByokV1Key) error {
-	postCreationStepInstructions, err := getPolicyCommand(key)
-	if err != nil {
-		return err
-	}
-
-	out, err := c.convertByokKeyToDescribeStruct(key)
-	if err != nil {
-		return err
-	}
-
-	table := output.NewTable(cmd)
-	table.Add(out)
-	table.Filter([]string{"Id", "Key", "Roles", "Provider", "State", "CreatedAt"})
-	table.Print()
-
-	if output.GetFormat(cmd) == output.Human {
-		output.ErrPrintln(c.Config.EnableColor, "")
-		output.ErrPrintf(c.Config.EnableColor, "%s\n", getPostCreateStepInstruction(key))
-		output.ErrPrintln(c.Config.EnableColor, "")
-		output.ErrPrintln(c.Config.EnableColor, postCreationStepInstructions)
-	}
-
-	return nil
-}
-
-func (c *command) convertByokKeyToDescribeStruct(key *byokv1.ByokV1Key) (*describeStruct, error) {
+func (c *command) outputByokKeyDescription(cmd *cobra.Command, key byokv1.ByokV1Key) error {
 	var keyString string
 	var roles []string
 
@@ -85,29 +48,42 @@ func (c *command) convertByokKeyToDescribeStruct(key *byokv1.ByokV1Key) (*descri
 		keyString = key.Key.ByokV1AzureKey.KeyId
 		roles = append(roles, key.Key.ByokV1AzureKey.GetApplicationId())
 	default:
-		return nil, fmt.Errorf(byokUnknownKeyTypeErrorMsg)
+		return fmt.Errorf(byokUnknownKeyTypeErrorMsg)
 	}
 
-	updatedAt := ""
-	if !key.Metadata.GetUpdatedAt().IsZero() {
-		updatedAt = key.Metadata.GetUpdatedAt().String()
+	table := output.NewTable(cmd)
+	if output.GetFormat(cmd) == output.Human {
+		table.Add(&humanOut{
+			Id:        key.GetId(),
+			Key:       keyString,
+			Roles:     strings.Join(roles, ", "),
+			Provider:  key.GetProvider(),
+			State:     key.GetState(),
+			CreatedAt: key.Metadata.CreatedAt.String(),
+		})
+	} else {
+		table.Add(&serializedOut{
+			Id:        key.GetId(),
+			Key:       keyString,
+			Roles:     roles,
+			Provider:  key.GetProvider(),
+			State:     key.GetState(),
+			CreatedAt: key.Metadata.CreatedAt.String(),
+		})
+	}
+	table.Print()
+
+	if output.GetFormat(cmd) == output.Human {
+		postCreationStepInstructions, err := getPolicyCommand(key)
+		if err != nil {
+			return err
+		}
+
+		output.ErrPrintln(c.Config.EnableColor, "")
+		output.ErrPrintln(c.Config.EnableColor, getPostCreateStepInstruction(key))
+		output.ErrPrintln(c.Config.EnableColor, "")
+		output.ErrPrintln(c.Config.EnableColor, postCreationStepInstructions)
 	}
 
-	deletedAt := ""
-	if !key.Metadata.GetDeletedAt().IsZero() {
-		deletedAt = key.Metadata.GetDeletedAt().String()
-	}
-
-	describeKey := &describeStruct{
-		Id:        key.GetId(),
-		Key:       keyString,
-		Roles:     roles,
-		Provider:  key.GetProvider(),
-		State:     key.GetState(),
-		CreatedAt: key.Metadata.CreatedAt.String(),
-		UpdatedAt: updatedAt,
-		DeletedAt: deletedAt,
-	}
-
-	return describeKey, nil
+	return nil
 }

--- a/test/fixtures/output/byok/create_1.golden
+++ b/test/fixtures/output/byok/create_1.golden
@@ -1,8 +1,8 @@
 +------------+-----------------------------------------------------------------------------+
 | ID         | cck-004                                                                     |
 | Key        | arn:aws:kms:us-west-2:037803949979:key/0e2609e3-a0bf-4f39-aedf-8b1f63b16d81 |
-| Roles      | [arn:aws:iam::123456789012:role/role1                                       |
-|            | arn:aws:iam::123456789012:role/role2]                                       |
+| Roles      | arn:aws:iam::123456789012:role/role1,                                       |
+|            | arn:aws:iam::123456789012:role/role2                                        |
 | Provider   | AWS                                                                         |
 | State      | AVAILABLE                                                                   |
 | Created At | 2022-12-24 00:00:00 +0000 UTC                                               |

--- a/test/fixtures/output/byok/create_2.golden
+++ b/test/fixtures/output/byok/create_2.golden
@@ -1,7 +1,7 @@
 +------------+--------------------------------------------+
 | ID         | cck-004                                    |
 | Key        | https://a-vault.vault.azure.net/keys/a-key |
-| Roles      | [12345678-1234-1234-1234-123456789012]     |
+| Roles      | 12345678-1234-1234-1234-123456789012       |
 | Provider   | AZURE                                      |
 | State      | AVAILABLE                                  |
 | Created At | 2022-12-24 00:00:00 +0000 UTC              |

--- a/test/fixtures/output/byok/describe-aws.golden
+++ b/test/fixtures/output/byok/describe-aws.golden
@@ -1,8 +1,8 @@
 +------------+-----------------------------------------------------------------------------+
 | ID         | cck-001                                                                     |
 | Key        | arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012 |
-| Roles      | [arn:aws:iam::123456789012:role/role1                                       |
-|            | arn:aws:iam::123456789012:role/role2]                                       |
+| Roles      | arn:aws:iam::123456789012:role/role1,                                       |
+|            | arn:aws:iam::123456789012:role/role2                                        |
 | Provider   | AWS                                                                         |
 | State      | IN_USE                                                                      |
 | Created At | 2022-11-12 08:24:00 +0000 UTC                                               |

--- a/test/fixtures/output/byok/describe-azure.golden
+++ b/test/fixtures/output/byok/describe-azure.golden
@@ -1,7 +1,7 @@
 +------------+--------------------------------------------+
 | ID         | cck-003                                    |
 | Key        | https://a-vault.vault.azure.net/keys/a-key |
-| Roles      | [00000000-0000-0000-0000-000000000000]     |
+| Roles      | 00000000-0000-0000-0000-000000000000       |
 | Provider   | Azure                                      |
 | State      | AVAILABLE                                  |
 | Created At | 2023-01-01 12:00:30 +0000 UTC              |


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   * yes: ok

What
----
For `confluent byok [create|describe|list]` commands, instead of `[a b c]`, print `a, b, c`. The same problem exists for at least 4 other commands, will create a few more follow-up PRs.

Test & Review
-------------
Update integration tests