### PR TITLE
feat: add retry when GW returns 409 for GetStatementResults

### DIFF
--- a/pkg/flink/internal/store/store.go
+++ b/pkg/flink/internal/store/store.go
@@ -169,7 +169,7 @@ func (s *Store) FetchStatementResults(statement types.ProcessedStatement) (*type
 	return &statement, nil
 }
 
-// TODO: remove this when backend fixes latency problem/the RUNNING state is set with the ResultsSchema
+// TODO: https://confluentinc.atlassian.net/browse/KFS-1211 remove this when backend fixes latency problem/the RUNNING state is set with the ResultsSchema
 // This is to work around a problem where the CLI fetches results to fast, leading to the backend returning a 409.
 // In this case we should retry a set amount of times to check if results can now be fetched.
 func (s *Store) getStatementResultsWithRetryOn409(statementName, pageToken string, maxRetries int) (flinkgatewayv1beta1.SqlV1beta1StatementResult, error) {
@@ -244,7 +244,7 @@ func (s *Store) waitForPendingStatement(ctx context.Context, statementName strin
 				return nil, types.NewStatementErrorFailureMsg(err, statusDetail)
 			}
 
-			// TODO: remove this when backend fixes latency problem/the RUNNING state is set with the ResultsSchema
+			// TODO: https://confluentinc.atlassian.net/browse/KFS-1211 remove this when backend fixes latency problem/the RUNNING state is set with the ResultsSchema
 			if statementObj.Status.ResultSchema != nil {
 				processedStatement := types.NewProcessedStatement(statementObj)
 				// if it's a SELECT statement we manually set the status to RUNNING, otherwise COMPLETED


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   - [x] yes: ok

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->
The CLI recently introduced a change to improve latency by not waiting for the statement phase to be in the RUNNING state as designed initially but rather to try and optimistically fetch results as soon as the status.result_schema is available. 
This has resulted in a race with 500s returned earlier(replaced by 409 now) as the backend was not ready to return results. 

This PR introduces a simple retry for this case. We retry 10 times in 100ms interval (so we wait for 1s in total) and stop the retry when the GetStatementResults endpoint either returns success or an error that is not 409.