### PR TITLE
[CLI-2831] Allow api-key authenticated produce and consume in cloud

### DIFF
--- a/internal/kafka/command_topic.go
+++ b/internal/kafka/command_topic.go
@@ -25,6 +25,8 @@ const EOF = "\u0004"
 
 const numPartitionsKey = "num.partitions"
 
+var adminClientTimeout = 10 * time.Second
+
 type command struct {
 	*pcmd.AuthenticatedCLICommand
 	clientID string
@@ -39,16 +41,23 @@ func newTopicCommand(cfg *config.Config, prerunner pcmd.PreRunner) *cobra.Comman
 	c := &command{clientID: cfg.Version.ClientID}
 
 	if cfg.IsCloudLogin() {
-		c.AuthenticatedCLICommand = pcmd.NewAuthenticatedCLICommand(cmd, prerunner)
+		if cfg.Context().GetOrganization() != nil {
+			fmt.Println("i'm actually logged in.")
+			c.AuthenticatedCLICommand = pcmd.NewAuthenticatedCLICommand(cmd, prerunner)
+			cmd.AddCommand(c.newCreateCommand())
+			cmd.AddCommand(c.newDeleteCommand())
+			cmd.AddCommand(c.newDescribeCommand())
+			cmd.AddCommand(c.newUpdateCommand())
+		} else {
+			fmt.Println("i'm using context")
+			c.AuthenticatedCLICommand = pcmd.NewAnonymousAuthenticatedCLICommand(cmd, prerunner)
+		}
 
 		cmd.AddCommand(c.newConsumeCommand())
-		cmd.AddCommand(c.newCreateCommand())
-		cmd.AddCommand(c.newDeleteCommand())
-		cmd.AddCommand(c.newDescribeCommand())
 		cmd.AddCommand(c.newListCommand())
 		cmd.AddCommand(c.newProduceCommand())
-		cmd.AddCommand(c.newUpdateCommand())
 	} else {
+		fmt.Println("no it's not cloud.")
 		c.AuthenticatedCLICommand = pcmd.NewAuthenticatedWithMDSCLICommand(cmd, prerunner)
 		c.PersistentPreRunE = prerunner.InitializeOnPremKafkaRest(c.AuthenticatedCLICommand)
 
@@ -99,8 +108,7 @@ func (c *command) autocompleteTopics() []string {
 
 // validate that a topic exists before attempting to produce/consume messages
 func (c *command) validateTopic(client *ckafka.AdminClient, topic string, cluster *config.KafkaClusterConfig) error {
-	timeout := 10 * time.Second
-	metadata, err := client.GetMetadata(nil, true, int(timeout.Milliseconds()))
+	metadata, err := client.GetMetadata(nil, true, int(adminClientTimeout.Milliseconds()))
 	if err != nil {
 		if err.Error() == ckafka.ErrTransport.String() {
 			err = fmt.Errorf("API key may not be provisioned yet")

--- a/internal/kafka/command_topic.go
+++ b/internal/kafka/command_topic.go
@@ -42,22 +42,19 @@ func newTopicCommand(cfg *config.Config, prerunner pcmd.PreRunner) *cobra.Comman
 
 	if cfg.IsCloudLogin() {
 		if cfg.Context().GetOrganization() != nil {
-			fmt.Println("i'm actually logged in.")
 			c.AuthenticatedCLICommand = pcmd.NewAuthenticatedCLICommand(cmd, prerunner)
 			cmd.AddCommand(c.newCreateCommand())
 			cmd.AddCommand(c.newDeleteCommand())
 			cmd.AddCommand(c.newDescribeCommand())
 			cmd.AddCommand(c.newUpdateCommand())
 		} else {
-			fmt.Println("i'm using context")
-			c.AuthenticatedCLICommand = pcmd.NewAnonymousAuthenticatedCLICommand(cmd, prerunner)
+			c.AuthenticatedCLICommand = pcmd.NewAuthenticatedWithAPIKeyCLICommand(cmd, prerunner)
 		}
 
 		cmd.AddCommand(c.newConsumeCommand())
 		cmd.AddCommand(c.newListCommand())
 		cmd.AddCommand(c.newProduceCommand())
 	} else {
-		fmt.Println("no it's not cloud.")
 		c.AuthenticatedCLICommand = pcmd.NewAuthenticatedWithMDSCLICommand(cmd, prerunner)
 		c.PersistentPreRunE = prerunner.InitializeOnPremKafkaRest(c.AuthenticatedCLICommand)
 

--- a/internal/kafka/command_topic_consume.go
+++ b/internal/kafka/command_topic_consume.go
@@ -28,7 +28,6 @@ func (c *command) newConsumeCommand() *cobra.Command {
 		Args:              cobra.ExactArgs(1),
 		ValidArgsFunction: pcmd.NewValidArgsFunction(c.validArgs),
 		RunE:              c.consume,
-		Annotations:       map[string]string{pcmd.RunRequirement: pcmd.RequireCloudLogin},
 		Example: examples.BuildExampleString(
 			examples.Example{
 				Text: `Consume items from topic "my-topic" and press "Ctrl-C" to exit.`,
@@ -44,7 +43,7 @@ func (c *command) newConsumeCommand() *cobra.Command {
 	pcmd.AddKeyFormatFlag(cmd)
 	pcmd.AddValueFormatFlag(cmd)
 	cmd.Flags().Bool("print-key", false, "Print key of the message.")
-	cmd.Flags().Bool("print-offset", false, "Print partition number and offset of the message.")
+	cmd.Flags().Bool("print-offset", false, "Print the partition number and offset of the message.")
 	cmd.Flags().Bool("full-header", false, "Print complete content of message headers.")
 	cmd.Flags().String("delimiter", "\t", "The delimiter separating each key and value.")
 	cmd.Flags().Bool("timestamp", false, "Print message timestamp in milliseconds.")

--- a/internal/kafka/command_topic_list.go
+++ b/internal/kafka/command_topic_list.go
@@ -1,11 +1,15 @@
 package kafka
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
 
 	kafkarestv3 "github.com/confluentinc/ccloud-sdk-go-v2/kafkarest/v3"
+	ckafka "github.com/confluentinc/confluent-kafka-go/kafka"
 
 	pcmd "github.com/confluentinc/cli/v3/pkg/cmd"
+	"github.com/confluentinc/cli/v3/pkg/errors"
 	"github.com/confluentinc/cli/v3/pkg/output"
 )
 
@@ -22,6 +26,8 @@ func (c *command) newListCommand() *cobra.Command {
 		Annotations: map[string]string{pcmd.RunRequirement: pcmd.RequireNonAPIKeyCloudLogin},
 	}
 
+	pcmd.AddApiKeyFlag(cmd, c.AuthenticatedCLICommand)
+	pcmd.AddApiSecretFlag(cmd)
 	pcmd.AddClusterFlag(cmd, c.AuthenticatedCLICommand)
 	pcmd.AddContextFlag(cmd, c.CLICommand)
 	pcmd.AddEnvironmentFlag(cmd, c.AuthenticatedCLICommand)
@@ -31,16 +37,20 @@ func (c *command) newListCommand() *cobra.Command {
 }
 
 func (c *command) list(cmd *cobra.Command, _ []string) error {
-	topics, err := c.getTopics()
-	if err != nil {
-		return err
+	if c.V2Client != nil {
+		topics, err := c.getTopics()
+		if err != nil {
+			return err
+		}
+
+		list := output.NewList(cmd)
+		for _, topic := range topics {
+			list.Add(&topicOut{Name: topic.GetTopicName()})
+		}
+		return list.Print()
 	}
 
-	list := output.NewList(cmd)
-	for _, topic := range topics {
-		list.Add(&topicOut{Name: topic.GetTopicName()})
-	}
-	return list.Print()
+	return c.getTopicsWithConfluentKafka(cmd)
 }
 
 func (c *command) getTopics() ([]kafkarestv3.TopicData, error) {
@@ -59,4 +69,40 @@ func (c *command) getTopics() ([]kafkarestv3.TopicData, error) {
 	}
 
 	return topics.Data, nil
+}
+
+func (c *command) getTopicsWithConfluentKafka(cmd *cobra.Command) error {
+	cluster, err := c.Context.GetKafkaClusterForCommand(nil)
+	if err != nil {
+		return err
+	}
+
+	if err := addApiKeyToCluster(cmd, cluster); err != nil {
+		return err
+	}
+
+	producer, err := newProducer(cluster, c.clientID, "", nil)
+	if err != nil {
+		return err
+	}
+
+	adminClient, err := ckafka.NewAdminClientFromProducer(producer)
+	if err != nil {
+		return fmt.Errorf(errors.FailedToCreateAdminClientErrorMsg, err)
+	}
+	defer adminClient.Close()
+
+	metadata, err := adminClient.GetMetadata(nil, true, int(adminClientTimeout.Milliseconds()))
+	if err != nil {
+		if err.Error() == ckafka.ErrTransport.String() {
+			err = fmt.Errorf("API key may not be provisioned yet")
+		}
+		return fmt.Errorf("failed to obtain topics from client: %w", err)
+	}
+
+	list := output.NewList(cmd)
+	for _, topic := range metadata.Topics {
+		list.Add(&topicOut{Name: topic.Topic})
+	}
+	return list.Print()
 }

--- a/internal/kafka/command_topic_produce.go
+++ b/internal/kafka/command_topic_produce.go
@@ -33,7 +33,6 @@ func (c *command) newProduceCommand() *cobra.Command {
 		Args:              cobra.ExactArgs(1),
 		ValidArgsFunction: pcmd.NewValidArgsFunction(c.validArgs),
 		RunE:              c.produce,
-		Annotations:       map[string]string{pcmd.RunRequirement: pcmd.RequireCloudLogin},
 	}
 
 	cmd.Flags().String("key-schema", "", "The ID or filepath of the message key schema.")

--- a/internal/kafka/metrics_utils.go
+++ b/internal/kafka/metrics_utils.go
@@ -81,7 +81,7 @@ func (c *clusterCommand) validateClusterLoad(clusterId string, isLatestMetric bo
 
 	maxClusterLoad := maxApiDataValue(clusterLoadResponse.FlatQueryResponse.GetData())
 	if maxClusterLoad.Value >= 0.7 {
-		return fmt.Errorf("Cluster Load was %f percent at %s.\nRecommended cluster load should be less than 70 percent", maxClusterLoad.Value*100, maxClusterLoad.Timestamp.In(time.Local))
+		return fmt.Errorf("cluster Load was %f percent at %s.\nRecommended cluster load should be less than 70 percent", maxClusterLoad.Value*100, maxClusterLoad.Timestamp.In(time.Local))
 	}
 
 	return nil

--- a/pkg/cmd/authenticated_cli_command.go
+++ b/pkg/cmd/authenticated_cli_command.go
@@ -46,9 +46,9 @@ func NewAuthenticatedCLICommand(cmd *cobra.Command, prerunner PreRunner) *Authen
 	return c
 }
 
-func NewAnonymousAuthenticatedCLICommand(cmd *cobra.Command, prerunner PreRunner) *AuthenticatedCLICommand { // ?
+func NewAuthenticatedWithAPIKeyCLICommand(cmd *cobra.Command, prerunner PreRunner) *AuthenticatedCLICommand {
 	c := &AuthenticatedCLICommand{CLICommand: NewCLICommand(cmd)}
-	cmd.PersistentPreRunE = chain(prerunner.AnonymousAuthenticated(c), prerunner.ParseFlagsIntoContext(c.CLICommand))
+	cmd.PersistentPreRunE = chain(prerunner.AuthenticatedWithAPIKey(c), prerunner.ParseFlagsIntoContext(c.CLICommand))
 	return c
 }
 
@@ -194,7 +194,7 @@ func (c *AuthenticatedCLICommand) GetSchemaRegistryClient(cmd *cobra.Command) (*
 			configuration.Debug = unsafeTrace
 			configuration.HTTPClient = ccloudv2.NewRetryableHttpClient(unsafeTrace)
 
-			if c.Context.GetState() != nil {
+			if c.Context.GetState() != nil && c.V2Client != nil {
 				clusters, err := c.V2Client.GetSchemaRegistryClustersByEnvironment(c.Context.GetCurrentEnvironment())
 				if err != nil {
 					return nil, err

--- a/pkg/cmd/authenticated_cli_command.go
+++ b/pkg/cmd/authenticated_cli_command.go
@@ -46,6 +46,12 @@ func NewAuthenticatedCLICommand(cmd *cobra.Command, prerunner PreRunner) *Authen
 	return c
 }
 
+func NewAnonymousAuthenticatedCLICommand(cmd *cobra.Command, prerunner PreRunner) *AuthenticatedCLICommand { // ?
+	c := &AuthenticatedCLICommand{CLICommand: NewCLICommand(cmd)}
+	cmd.PersistentPreRunE = chain(prerunner.AnonymousAuthenticated(c), prerunner.ParseFlagsIntoContext(c.CLICommand))
+	return c
+}
+
 func NewAuthenticatedWithMDSCLICommand(cmd *cobra.Command, prerunner PreRunner) *AuthenticatedCLICommand {
 	c := &AuthenticatedCLICommand{CLICommand: NewCLICommand(cmd)}
 	cmd.PersistentPreRunE = chain(prerunner.AuthenticatedWithMDS(c), prerunner.ParseFlagsIntoContext(c.CLICommand))

--- a/pkg/cmd/flags.go
+++ b/pkg/cmd/flags.go
@@ -20,13 +20,15 @@ var serializationFormats = []string{"string", "avro", "integer", "jsonschema", "
 func AddApiKeyFlag(cmd *cobra.Command, c *AuthenticatedCLICommand) {
 	cmd.Flags().String("api-key", "", "API key.")
 
-	RegisterFlagCompletionFunc(cmd, "api-key", func(cmd *cobra.Command, args []string) []string {
-		if err := c.PersistentPreRunE(cmd, args); err != nil {
-			return nil
-		}
+	if c.V2Client != nil {
+		RegisterFlagCompletionFunc(cmd, "api-key", func(cmd *cobra.Command, args []string) []string {
+			if err := c.PersistentPreRunE(cmd, args); err != nil {
+				return nil
+			}
 
-		return AutocompleteApiKeys(c.V2Client)
-	})
+			return AutocompleteApiKeys(c.V2Client)
+		})
+	}
 }
 
 func AddApiSecretFlag(cmd *cobra.Command) {
@@ -96,17 +98,20 @@ func AddCloudFlag(cmd *cobra.Command) {
 
 func AddClusterFlag(cmd *cobra.Command, c *AuthenticatedCLICommand) {
 	cmd.Flags().String("cluster", "", "Kafka cluster ID.")
-	RegisterFlagCompletionFunc(cmd, "cluster", func(cmd *cobra.Command, args []string) []string {
-		if err := c.PersistentPreRunE(cmd, args); err != nil {
-			return nil
-		}
 
-		environmentId, err := c.Context.EnvironmentId()
-		if err != nil {
-			return nil
-		}
-		return AutocompleteClusters(environmentId, c.V2Client)
-	})
+	if c.V2Client != nil {
+		RegisterFlagCompletionFunc(cmd, "cluster", func(cmd *cobra.Command, args []string) []string {
+			if err := c.PersistentPreRunE(cmd, args); err != nil {
+				return nil
+			}
+
+			environmentId, err := c.Context.EnvironmentId()
+			if err != nil {
+				return nil
+			}
+			return AutocompleteClusters(environmentId, c.V2Client)
+		})
+	}
 }
 
 func AutocompleteClusters(environmentId string, client *ccloudv2.Client) []string {
@@ -144,13 +149,16 @@ func AutocompleteContexts(cfg *config.Config) []string {
 
 func AddEnvironmentFlag(cmd *cobra.Command, command *AuthenticatedCLICommand) {
 	cmd.Flags().String("environment", "", "Environment ID.")
-	RegisterFlagCompletionFunc(cmd, "environment", func(cmd *cobra.Command, args []string) []string {
-		if err := command.PersistentPreRunE(cmd, args); err != nil {
-			return nil
-		}
 
-		return AutocompleteEnvironments(command.Client, command.V2Client)
-	})
+	if command.V2Client != nil {
+		RegisterFlagCompletionFunc(cmd, "environment", func(cmd *cobra.Command, args []string) []string {
+			if err := command.PersistentPreRunE(cmd, args); err != nil {
+				return nil
+			}
+
+			return AutocompleteEnvironments(command.Client, command.V2Client)
+		})
+	}
 }
 
 func AutocompleteEnvironments(v1Client *ccloudv1.Client, v2Client *ccloudv2.Client) []string {

--- a/pkg/cmd/prerunner.go
+++ b/pkg/cmd/prerunner.go
@@ -172,14 +172,15 @@ func (r *PreRun) AuthenticatedWithAPIKey(command *AuthenticatedCLICommand) func(
 			return err
 		}
 
-		if r.Config.Context().GetCredentialType() != config.APIKey {
-			return errors.NewErrorWithSuggestions("hmm, i need apikeys", "Hello.")
-		}
-
 		ctx := command.Config.Context()
 		if ctx == nil {
-			return errors.NewErrorWithSuggestions("hmm, context is not here...", "Hello.")
+			return errors.NewErrorWithSuggestions("no context found", "Create a context with `confluent context create --bootstrap <bootstrap-server> --api-key <api-key> --api-secret <api-secret>`.")
 		}
+
+		if r.Config.Context().GetCredentialType() != config.APIKey {
+			return errors.NewErrorWithSuggestions("you must authenticate the context with API key", "Create a context with `confluent context create --bootstrap <bootstrap-server> --api-key <api-key> --api-secret <api-secret>`.")
+		}
+
 		command.Context = ctx
 		return nil
 	}

--- a/pkg/cmd/prerunner.go
+++ b/pkg/cmd/prerunner.go
@@ -38,8 +38,8 @@ var wrongLoginCommandsMap = map[string]string{
 // PreRun is a helper class for automatically setting up Cobra PersistentPreRun commands
 type PreRunner interface {
 	Anonymous(command *CLICommand, willAuthenticate bool) func(*cobra.Command, []string) error
-	AnonymousAuthenticated(command *AuthenticatedCLICommand) func(*cobra.Command, []string) error
 	Authenticated(command *AuthenticatedCLICommand) func(*cobra.Command, []string) error
+	AuthenticatedWithAPIKey(command *AuthenticatedCLICommand) func(*cobra.Command, []string) error
 	AuthenticatedWithMDS(command *AuthenticatedCLICommand) func(*cobra.Command, []string) error
 	InitializeOnPremKafkaRest(command *AuthenticatedCLICommand) func(*cobra.Command, []string) error
 	ParseFlagsIntoContext(command *CLICommand) func(*cobra.Command, []string) error
@@ -166,7 +166,7 @@ func IsFlagRequired(flag *pflag.Flag) bool {
 }
 
 // Authenticated provides PreRun operations for commands that require a logged-in Confluent Cloud user.
-func (r *PreRun) AnonymousAuthenticated(command *AuthenticatedCLICommand) func(*cobra.Command, []string) error {
+func (r *PreRun) AuthenticatedWithAPIKey(command *AuthenticatedCLICommand) func(*cobra.Command, []string) error {
 	return func(cmd *cobra.Command, args []string) error {
 		if err := r.Anonymous(command.CLICommand, true)(cmd, args); err != nil {
 			return err
@@ -174,10 +174,6 @@ func (r *PreRun) AnonymousAuthenticated(command *AuthenticatedCLICommand) func(*
 
 		if r.Config.Context().GetCredentialType() != config.APIKey {
 			return errors.NewErrorWithSuggestions("hmm, i need apikeys", "Hello.")
-		}
-
-		if err := r.Config.DecryptContextStates(); err != nil {
-			return err
 		}
 
 		ctx := command.Config.Context()

--- a/pkg/dynamic-config/dynamic_context.go
+++ b/pkg/dynamic-config/dynamic_context.go
@@ -110,6 +110,9 @@ func (d *DynamicContext) FindKafkaCluster(client *ccloudv2.Client, clusterId str
 		return nil, err
 	}
 
+	if client == nil {
+		return nil, fmt.Errorf("no kafka cluster context found, and not logged in to cloud")
+	}
 	cluster, httpResp, err := client.DescribeKafkaCluster(clusterId, environmentId)
 	if err != nil {
 		return nil, errors.CatchKafkaNotFoundError(err, clusterId, httpResp)


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- PLACEHOLDER

New Features
- Allow `confluent kafka topic list/produce/consume` in Confluent Cloud without login, when using a context of Kafka cluster bootstrap, Kafka API key

Bug Fixes
- PLACEHOLDER

Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   - [ ] yes: ok

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->
Create a pair of kafka cluster api key, and discover the endpoint of the cluster. Create a new context:
```
confluent context create test --bootstrap <cluster-endpoint> --api-key <kafka-api-key> --api-secret <kafka-api-secret>
```
use that context, you can then list topics:
```
confluent kafka topic list
```
then produce and consume. if use schema, provide schema endpoint and api key.
```
confluent kafka topic produce hello --value-format avro --schema ~/test.json --schema-registry-endpoint https://psrc-mw731.us-east-2.aws.confluent.cloud --schema-registry-api-key xxx --schema-registry-api-secret xxx
```

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
<!--
Has it been tested? How?
Copy and paste any instructions or steps that can save the reviewer time.
-->
manual tests

Open Questions / Follow-ups
---------------------------
<!--
Optional: Anything open to discussion for the reviewer, out of scope of this PR, or follow-ups.
-->
