### PR TITLE
[FCP-1283] fix: bug where expired token was used on redirect

### DIFF
--- a/pkg/ccloudv2/flink_gateway.go
+++ b/pkg/ccloudv2/flink_gateway.go
@@ -28,10 +28,6 @@ type FlinkGatewayClient struct {
 }
 
 func NewFlinkGatewayClient(url, userAgent string, unsafeTrace bool, authToken string) *FlinkGatewayClient {
-	client := &FlinkGatewayClient{
-		AuthToken: authToken,
-	}
-
 	cfg := flinkgatewayv1beta1.NewConfiguration()
 	cfg.Debug = unsafeTrace
 	cfg.HTTPClient = NewRetryableHttpClientWithRedirect(unsafeTrace,
@@ -41,22 +37,25 @@ func NewFlinkGatewayClient(url, userAgent string, unsafeTrace bool, authToken st
 			if len(via) >= 5 {
 				return fmt.Errorf("stopped after 5 redirects")
 			}
-			log.CliLogger.Debugf("Following redirect with authorization to %s", req.URL)
-			// Customize the redirect to add authorization header on 307 Redirect.
-			// This is required as the Location header returned by the gateway may not be an exact subdomain and Authorization
-			// header is copied only when the hostname is exactly the same or an exact subdomain of the hostname
-			// Ideally, we should check the status code returned in via[0].Response. However, via[0].Response is nil in underlying
-			// retryable http implementation
-			// To ensure we have a fresh token, we need to use client.AuthToken and NOT the local authToken
-			req.Header.Add("Authorization", "Bearer "+client.AuthToken)
+			if len(via) > 0 {
+				if authHeader := via[len(via)-1].Header.Get("Authorization"); authHeader != "" {
+					log.CliLogger.Debugf("Following redirect with authorization to %s", req.URL)
+					// Copy Authorization header from previous request as the location returned by
+					// Flink GW on a redirect won't be a subdomain or exact match of initial domain
+					// to be copied automatically.
+					req.Header.Add("Authorization", authHeader)
+				}
+			}
 
 			return nil
 		})
 	cfg.Servers = flinkgatewayv1beta1.ServerConfigurations{{URL: url}}
 	cfg.UserAgent = userAgent
 
-	client.APIClient = flinkgatewayv1beta1.NewAPIClient(cfg)
-	return client
+	return &FlinkGatewayClient{
+		APIClient: flinkgatewayv1beta1.NewAPIClient(cfg),
+		AuthToken: authToken,
+	}
 }
 
 func (c *FlinkGatewayClient) flinkGatewayApiContext() context.Context {


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   - [x] yes: ok 

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->
PR #2231 introduced client redirection, which also sets the Authorization header when redirects happen. The problem is that the token used for the header, is actually the local variable that's passed to the GatewayClient constructor. This will lead to the token never being refreshed and thus to 401s after the initial token has expired. 

Instead we need to either use the token inside the GW client struct `client.AuthToken`, which gets refreshed by the flink shell or copy over the authorization header from the previous request.
