### PR TITLE
Do not require `--ca-location` in `kafka topic produce`

### DIFF
--- a/internal/kafka/command_topic_consume_onprem.go
+++ b/internal/kafka/command_topic_consume_onprem.go
@@ -56,6 +56,7 @@ func (c *command) newConsumeCommandOnPrem() *cobra.Command {
 	cmd.Flags().String("schema-registry-endpoint", "", "The URL of the Schema Registry cluster.")
 
 	cobra.CheckErr(cmd.MarkFlagFilename("config-file", "avsc", "json"))
+
 	cobra.CheckErr(cmd.MarkFlagRequired("bootstrap"))
 
 	cmd.MarkFlagsMutuallyExclusive("config", "config-file")

--- a/internal/kafka/command_topic_produce_onprem.go
+++ b/internal/kafka/command_topic_produce_onprem.go
@@ -56,7 +56,6 @@ func (c *command) newProduceCommandOnPrem() *cobra.Command {
 	cobra.CheckErr(cmd.MarkFlagFilename("config-file", "avsc", "json"))
 
 	cobra.CheckErr(cmd.MarkFlagRequired("bootstrap"))
-	cobra.CheckErr(cmd.MarkFlagRequired("ca-location"))
 
 	cmd.MarkFlagsMutuallyExclusive("config-file", "config")
 

--- a/test/fixtures/output/kafka/topic/produce-help-onprem.golden
+++ b/test/fixtures/output/kafka/topic/produce-help-onprem.golden
@@ -16,7 +16,7 @@ Produce message to topic "my_topic" with SSL protocol, and SSL verification enab
 
 Flags:
       --bootstrap string                  REQUIRED: Comma-separated list of broker hosts, each formatted as "host" or "host:port".
-      --ca-location string                REQUIRED: File or directory path to one or more CA certificates for verifying the broker's key with SSL.
+      --ca-location string                File or directory path to one or more CA certificates for verifying the broker's key with SSL.
       --username string                   SASL_SSL username for use with PLAIN mechanism.
       --password string                   SASL_SSL password for use with PLAIN mechanism.
       --cert-location string              Path to client's public key (PEM) used for SSL authentication.


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- PLACEHOLDER

New Features
- PLACEHOLDER

Bug Fixes
- In on-premises `confluent kafka topic produce`, the `--ca-location` flag is no longer required

Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   - [x] yes: ok
   - [ ] no: DO NOT MERGE until the required features are live in prod  

What
----
Since plaintext mode is supported, `--ca-location` should not be required.

References
----------
Closes #2364

Test & Review
-------------
Updated integration tests