### PR TITLE
Fix Flink autocomplete and statement name generation bugs

### DIFF
--- a/internal/flink/command_statement.go
+++ b/internal/flink/command_statement.go
@@ -54,11 +54,10 @@ func (c *command) validStatementArgsMultiple(cmd *cobra.Command, args []string) 
 		return nil
 	}
 
-	listStatementsResponse, err := client.ListStatements(environmentId, c.Context.GetCurrentOrganization(), "", "")
+	statements, err := client.ListStatements(environmentId, c.Context.GetCurrentOrganization(), c.Context.GetCurrentFlinkComputePool())
 	if err != nil {
 		return nil
 	}
-	statements := listStatementsResponse.GetData()
 
 	suggestions := make([]string, len(statements))
 	for i, statement := range statements {

--- a/internal/flink/command_statement_create.go
+++ b/internal/flink/command_statement_create.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/spf13/cobra"
 
 	flinkgatewayv1beta1 "github.com/confluentinc/ccloud-sdk-go-v2/flink-gateway/v1beta1"
@@ -13,6 +12,7 @@ import (
 	"github.com/confluentinc/cli/v3/pkg/errors"
 	"github.com/confluentinc/cli/v3/pkg/examples"
 	"github.com/confluentinc/cli/v3/pkg/flink/config"
+	"github.com/confluentinc/cli/v3/pkg/flink/types"
 	"github.com/confluentinc/cli/v3/pkg/output"
 	"github.com/confluentinc/cli/v3/pkg/retry"
 )
@@ -68,7 +68,7 @@ func (c *command) statementCreate(cmd *cobra.Command, args []string) error {
 		)
 	}
 
-	name := uuid.New().String()
+	name := types.GenerateStatementName()
 	if len(args) == 1 {
 		name = args[0]
 	}

--- a/internal/flink/command_statement_list.go
+++ b/internal/flink/command_statement_list.go
@@ -73,12 +73,10 @@ func (c *command) statementList(cmd *cobra.Command, _ []string) error {
 		log.CliLogger.Warnf(`Invalid status "%s". Valid statuses are %s.`, status, utils.ArrayToCommaDelimitedString(allowedStatuses, "and"))
 	}
 
-	statements, err := client.ListAllStatements(environmentId, c.Context.GetCurrentOrganization(), c.Context.GetCurrentFlinkComputePool())
+	statements, err := client.ListStatements(environmentId, c.Context.GetCurrentOrganization(), c.Context.GetCurrentFlinkComputePool())
 	if err != nil {
 		return err
 	}
-
-	list := output.NewList(cmd)
 
 	if status != "" {
 		statements = lo.Filter(statements, func(statement v1beta1.SqlV1beta1Statement, _ int) bool {
@@ -86,6 +84,7 @@ func (c *command) statementList(cmd *cobra.Command, _ []string) error {
 		})
 	}
 
+	list := output.NewList(cmd)
 	for _, statement := range statements {
 		list.Add(&statementOut{
 			CreationDate: statement.Metadata.GetCreatedAt(),

--- a/pkg/ccloudv2/flink_gateway.go
+++ b/pkg/ccloudv2/flink_gateway.go
@@ -14,7 +14,7 @@ import (
 
 type GatewayClientInterface interface {
 	GetStatement(environmentId, statementName, orgId string) (flinkgatewayv1beta1.SqlV1beta1Statement, error)
-	ListStatements(environmentId, orgId, pageToken, computePoolId string) (flinkgatewayv1beta1.SqlV1beta1StatementList, error)
+	ListStatements(environmentId, orgId, computePoolId string) ([]flinkgatewayv1beta1.SqlV1beta1Statement, error)
 	CreateStatement(statement flinkgatewayv1beta1.SqlV1beta1Statement, principal, environmentId, orgId string) (flinkgatewayv1beta1.SqlV1beta1Statement, error)
 	GetStatementResults(environmentId, statementId, orgId, pageToken string) (flinkgatewayv1beta1.SqlV1beta1StatementResult, error)
 	GetExceptions(environmentId, statementId, orgId string) (flinkgatewayv1beta1.SqlV1beta1StatementExceptionList, error)
@@ -30,25 +30,7 @@ type FlinkGatewayClient struct {
 func NewFlinkGatewayClient(url, userAgent string, unsafeTrace bool, authToken string) *FlinkGatewayClient {
 	cfg := flinkgatewayv1beta1.NewConfiguration()
 	cfg.Debug = unsafeTrace
-	cfg.HTTPClient = NewRetryableHttpClientWithRedirect(unsafeTrace,
-		func(req *http.Request, via []*http.Request) error {
-			// Default net/http implementation allows 10 redirects - https://go.dev/src/net/http/client.go.
-			// Lowered the redirect limit to fail fast in case of redirect cycles
-			if len(via) >= 5 {
-				return fmt.Errorf("stopped after 5 redirects")
-			}
-			if len(via) > 0 {
-				if authHeader := via[len(via)-1].Header.Get("Authorization"); authHeader != "" {
-					log.CliLogger.Debugf("Following redirect with authorization to %s", req.URL)
-					// Copy Authorization header from previous request as the location returned by
-					// Flink GW on a redirect won't be a subdomain or exact match of initial domain
-					// to be copied automatically.
-					req.Header.Add("Authorization", authHeader)
-				}
-			}
-
-			return nil
-		})
+	cfg.HTTPClient = NewRetryableHttpClientWithRedirect(unsafeTrace, checkRedirect)
 	cfg.Servers = flinkgatewayv1beta1.ServerConfigurations{{URL: url}}
 	cfg.UserAgent = userAgent
 
@@ -56,6 +38,28 @@ func NewFlinkGatewayClient(url, userAgent string, unsafeTrace bool, authToken st
 		APIClient: flinkgatewayv1beta1.NewAPIClient(cfg),
 		AuthToken: authToken,
 	}
+}
+
+func checkRedirect(req *http.Request, via []*http.Request) error {
+	// Default net/http implementation allows 10 redirects - https://go.dev/src/net/http/client.go.
+	// Lowered the redirect limit to fail fast in case of redirect cycles
+	const maxRedirects = 5
+
+	if len(via) >= maxRedirects {
+		return fmt.Errorf("stopped after %d redirects", maxRedirects)
+	}
+
+	if len(via) > 0 {
+		if authorization := via[len(via)-1].Header.Get("Authorization"); authorization != "" {
+			log.CliLogger.Debugf("Following redirect with authorization to %s", req.URL)
+			// Copy Authorization header from previous request as the location returned by
+			// Flink GW on a redirect won't be a subdomain or exact match of initial domain
+			// to be copied automatically.
+			req.Header.Add("Authorization", authorization)
+		}
+	}
+
+	return nil
 }
 
 func (c *FlinkGatewayClient) flinkGatewayApiContext() context.Context {
@@ -72,26 +76,12 @@ func (c *FlinkGatewayClient) GetStatement(environmentId, statementName, orgId st
 	return resp, flinkerror.CatchError(err, httpResp)
 }
 
-func (c *FlinkGatewayClient) ListStatements(environmentId, orgId, pageToken, computePoolId string) (flinkgatewayv1beta1.SqlV1beta1StatementList, error) {
-	req := c.StatementsSqlV1beta1Api.ListSqlv1beta1Statements(c.flinkGatewayApiContext(), orgId, environmentId).PageSize(ccloudV2ListPageSize)
-
-	if computePoolId != "" {
-		req = req.SpecComputePoolId(computePoolId)
-	}
-
-	if pageToken != "" {
-		req = req.PageToken(pageToken)
-	}
-	resp, httpResp, err := req.Execute()
-	return resp, flinkerror.CatchError(err, httpResp)
-}
-
-func (c *FlinkGatewayClient) ListAllStatements(environmentId, orgId, computePoolId string) ([]flinkgatewayv1beta1.SqlV1beta1Statement, error) {
+func (c *FlinkGatewayClient) ListStatements(environmentId, orgId, computePoolId string) ([]flinkgatewayv1beta1.SqlV1beta1Statement, error) {
 	var allStatements []flinkgatewayv1beta1.SqlV1beta1Statement
 	pageToken := ""
 	done := false
 	for !done {
-		statementListResponse, err := c.ListStatements(environmentId, orgId, pageToken, computePoolId)
+		statementListResponse, err := c.executeListStatements(environmentId, orgId, pageToken, computePoolId)
 		if err != nil {
 			return nil, err
 		}
@@ -103,6 +93,20 @@ func (c *FlinkGatewayClient) ListAllStatements(environmentId, orgId, computePool
 		}
 	}
 	return allStatements, nil
+}
+
+func (c *FlinkGatewayClient) executeListStatements(environmentId, orgId, pageToken, computePoolId string) (flinkgatewayv1beta1.SqlV1beta1StatementList, error) {
+	req := c.StatementsSqlV1beta1Api.ListSqlv1beta1Statements(c.flinkGatewayApiContext(), orgId, environmentId).PageSize(ccloudV2ListPageSize)
+
+	if computePoolId != "" {
+		req = req.SpecComputePoolId(computePoolId)
+	}
+
+	if pageToken != "" {
+		req = req.PageToken(pageToken)
+	}
+	resp, httpResp, err := req.Execute()
+	return resp, flinkerror.CatchError(err, httpResp)
 }
 
 func (c *FlinkGatewayClient) CreateStatement(statement flinkgatewayv1beta1.SqlV1beta1Statement, principal, environmentId, orgId string) (flinkgatewayv1beta1.SqlV1beta1Statement, error) {

--- a/pkg/flink/internal/store/store.go
+++ b/pkg/flink/internal/store/store.go
@@ -8,8 +8,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/uuid"
-
 	flinkgatewayv1beta1 "github.com/confluentinc/ccloud-sdk-go-v2/flink-gateway/v1beta1"
 
 	"github.com/confluentinc/cli/v3/pkg/ccloudv2"
@@ -78,7 +76,7 @@ func (s *Store) ProcessStatement(statement string) (*types.ProcessedStatement, *
 		return result, sErr
 	}
 
-	statementName := s.Properties.GetOrDefault(config.KeyStatementName, uuid.New().String()[:18])
+	statementName := s.Properties.GetOrDefault(config.KeyStatementName, types.GenerateStatementName())
 	defer s.Properties.Delete(config.KeyStatementName)
 
 	// Process remote statements

--- a/pkg/flink/test/mock/gateway_client_fake.go
+++ b/pkg/flink/test/mock/gateway_client_fake.go
@@ -46,8 +46,8 @@ func (c *FakeFlinkGatewayClient) GetStatement(_, _, _ string) (flinkgatewayv1bet
 	return c.statement, nil
 }
 
-func (c *FakeFlinkGatewayClient) ListStatements(_, _, _, _ string) (flinkgatewayv1beta1.SqlV1beta1StatementList, error) {
-	return flinkgatewayv1beta1.SqlV1beta1StatementList{Data: c.statements}, nil
+func (c *FakeFlinkGatewayClient) ListStatements(_, _, _ string) ([]flinkgatewayv1beta1.SqlV1beta1Statement, error) {
+	return c.statements, nil
 }
 
 func (c *FakeFlinkGatewayClient) CreateStatement(statement flinkgatewayv1beta1.SqlV1beta1Statement, _, _, _ string) (flinkgatewayv1beta1.SqlV1beta1Statement, error) {

--- a/pkg/flink/test/mock/gateway_client_mock.go
+++ b/pkg/flink/test/mock/gateway_client_mock.go
@@ -113,18 +113,18 @@ func (mr *MockGatewayClientInterfaceMockRecorder) GetStatementResults(arg0, arg1
 }
 
 // ListStatements mocks base method.
-func (m *MockGatewayClientInterface) ListStatements(arg0, arg1, arg2, arg3 string) (v1beta1.SqlV1beta1StatementList, error) {
+func (m *MockGatewayClientInterface) ListStatements(arg0, arg1, arg2 string) ([]v1beta1.SqlV1beta1Statement, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListStatements", arg0, arg1, arg2, arg3)
-	ret0, _ := ret[0].(v1beta1.SqlV1beta1StatementList)
+	ret := m.ctrl.Call(m, "ListStatements", arg0, arg1, arg2)
+	ret0, _ := ret[0].([]v1beta1.SqlV1beta1Statement)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListStatements indicates an expected call of ListStatements.
-func (mr *MockGatewayClientInterfaceMockRecorder) ListStatements(arg0, arg1, arg2, arg3 any) *gomock.Call {
+func (mr *MockGatewayClientInterfaceMockRecorder) ListStatements(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListStatements", reflect.TypeOf((*MockGatewayClientInterface)(nil).ListStatements), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListStatements", reflect.TypeOf((*MockGatewayClientInterface)(nil).ListStatements), arg0, arg1, arg2)
 }
 
 // UpdateStatement mocks base method.

--- a/pkg/flink/types/statement.go
+++ b/pkg/flink/types/statement.go
@@ -1,0 +1,7 @@
+package types
+
+import "github.com/google/uuid"
+
+func GenerateStatementName() string {
+	return uuid.New().String()[:18]
+}

--- a/test/fixtures/output/flink/statement/create-no-name-yaml.golden
+++ b/test/fixtures/output/flink/statement/create-no-name-yaml.golden
@@ -1,5 +1,5 @@
 creation_date: 2023-01-01T00:00:00Z
-name: [0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}
+name: [0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}
 statement: INSERT \* INTO table;
 compute_pool: lfcp-123456
 status: PENDING


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   - [x] yes: ok
   - [ ] no: DO NOT MERGE until the required features are live in prod  

What
----
* Filter statements by compute pool while autocompleting
* Generate statement names with the same function (previously was generating statement names with different length)