### PR TITLE
Suggest using `--prompt` on invalid login

### DIFF
--- a/pkg/errors/error_message.go
+++ b/pkg/errors/error_message.go
@@ -153,6 +153,7 @@ const (
 	InvalidLoginURLErrorMsg      = "invalid URL value, see structure: http(s)://<domain/hostname/ip>:<port>/"
 	InvalidLoginErrorMsg         = "incorrect email, password, or organization ID"
 	InvalidLoginErrorSuggestions = "To log into an organization other than the default organization, use the `--organization-id` flag.\n" +
+		"To skip auto-login and force a username and password prompt, use the `--prompt` flag.\n" + // TODO: Remove in V4
 		AvoidTimeoutSuggestions
 	SuspendedOrganizationSuggestions = "Your organization has been suspended, please contact support if you want to unsuspend it."
 	FailedToReadInputErrorMsg        = "failed to read input"


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- PLACEHOLDER

New Features
- PLACEHOLDER

Bug Fixes
- PLACEHOLDER

Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   - [x] yes: ok
   - [ ] no: DO NOT MERGE until the required features are live in prod  

What
----
The CLI can put a user in a state where auto-login incorrectly and automatically tries to log them in:
```
% confluent login --save --url devel.cpdev.cloud --organization-id e9eb4f2c-ef73-475c-ba7f-6b37a4ff00e5
Assuming https protocol.
Error: incorrect email, password, or organization ID

Suggestions:
    To log into an organization other than the default organization, use the `--organization-id` flag.
    To avoid session timeouts, non-SSO users can save their credentials with `confluent login --save`.
```

The fix here is to use `--prompt`, so this should be a suggestion. Note that this bad UX will be removed in V4 and this suggestion can be deleted at that time.

Test & Review
-------------
Tests still pass