### PR TITLE
Support for `--value-format double`

### DIFF
--- a/internal/asyncapi/command_export.go
+++ b/internal/asyncapi/command_export.go
@@ -60,8 +60,8 @@ type flags struct {
 }
 
 // messageOffset is 5, as the schema ID is stored at the [1:5] bytes of a message as meta info (when valid)
-const messageOffset int = 5
-const protobufErrorMessage string = "protobuf is not supported"
+const messageOffset = 5
+const protobufErrorMessage = "protobuf is not supported"
 
 func (c *command) newExportCommand() *cobra.Command {
 	cmd := &cobra.Command{

--- a/internal/asyncapi/command_import.go
+++ b/internal/asyncapi/command_import.go
@@ -30,7 +30,7 @@ import (
 	"github.com/confluentinc/cli/v3/pkg/utils"
 )
 
-const parseErrorMessage string = "topic is already present and `--overwrite` is not set"
+const parseErrorMessage = "topic is already present and `--overwrite` is not set"
 
 type flagsImport struct {
 	file                    string

--- a/pkg/cmd/flags.go
+++ b/pkg/cmd/flags.go
@@ -11,11 +11,10 @@ import (
 	"github.com/confluentinc/cli/v3/pkg/config"
 	"github.com/confluentinc/cli/v3/pkg/kafka"
 	"github.com/confluentinc/cli/v3/pkg/output"
+	"github.com/confluentinc/cli/v3/pkg/serdes"
 	"github.com/confluentinc/cli/v3/pkg/types"
 	"github.com/confluentinc/cli/v3/pkg/utils"
 )
-
-var serializationFormats = []string{"string", "avro", "integer", "jsonschema", "protobuf"}
 
 func AddApiKeyFlag(cmd *cobra.Command, c *AuthenticatedCLICommand) {
 	cmd.Flags().String("api-key", "", "API key.")
@@ -410,13 +409,13 @@ func AddTypeFlag(cmd *cobra.Command) {
 }
 
 func AddKeyFormatFlag(cmd *cobra.Command) {
-	cmd.Flags().String("key-format", "string", fmt.Sprintf("Format of message key as %s. Note that schema references are not supported for Avro.", utils.ArrayToCommaDelimitedString(serializationFormats, "or")))
-	RegisterFlagCompletionFunc(cmd, "key-format", func(_ *cobra.Command, _ []string) []string { return serializationFormats })
+	cmd.Flags().String("key-format", "string", fmt.Sprintf("Format of message key as %s. Note that schema references are not supported for Avro.", utils.ArrayToCommaDelimitedString(serdes.Formats, "or")))
+	RegisterFlagCompletionFunc(cmd, "key-format", func(_ *cobra.Command, _ []string) []string { return serdes.Formats })
 }
 
 func AddValueFormatFlag(cmd *cobra.Command) {
-	cmd.Flags().String("value-format", "string", fmt.Sprintf("Format message value as %s. Note that schema references are not supported for Avro.", utils.ArrayToCommaDelimitedString(serializationFormats, "or")))
-	RegisterFlagCompletionFunc(cmd, "value-format", func(_ *cobra.Command, _ []string) []string { return serializationFormats })
+	cmd.Flags().String("value-format", "string", fmt.Sprintf("Format message value as %s. Note that schema references are not supported for Avro.", utils.ArrayToCommaDelimitedString(serdes.Formats, "or")))
+	RegisterFlagCompletionFunc(cmd, "value-format", func(_ *cobra.Command, _ []string) []string { return serdes.Formats })
 }
 
 func AddLinkFlag(cmd *cobra.Command, command *AuthenticatedCLICommand) {

--- a/pkg/flink/components/table_view.go
+++ b/pkg/flink/components/table_view.go
@@ -32,13 +32,13 @@ type TableView struct {
 }
 
 const (
-	numPaddingRows              = 1
-	minColumnWidth          int = 4 // min characters displayed in a column
-	ExitTableViewShortcut       = "Q"
-	ToggleRefreshShortcut       = "P"
-	ToggleTableModeShortcut     = "M"
-	JumpUpShortcut              = "U"
-	JumpDownShortcut            = "D"
+	numPaddingRows          = 1
+	minColumnWidth          = 4 // min characters displayed in a column
+	ExitTableViewShortcut   = "Q"
+	ToggleRefreshShortcut   = "P"
+	ToggleTableModeShortcut = "M"
+	JumpUpShortcut          = "U"
+	JumpDownShortcut        = "D"
 )
 
 func NewTableView() TableViewInterface {

--- a/pkg/serdes/avro_serialization_provider.go
+++ b/pkg/serdes/avro_serialization_provider.go
@@ -32,7 +32,7 @@ func (a *AvroSerializationProvider) LoadSchema(schemaPath string, referencePathM
 }
 
 func (a *AvroSerializationProvider) GetSchemaName() string {
-	return AvroSchemaBackendName
+	return avroSchemaBackendName
 }
 
 func (a *AvroSerializationProvider) Serialize(str string) ([]byte, error) {

--- a/pkg/serdes/double_deserialization_provider.go
+++ b/pkg/serdes/double_deserialization_provider.go
@@ -1,0 +1,21 @@
+package serdes
+
+import (
+	"encoding/binary"
+	"fmt"
+	"math"
+)
+
+type DoubleDeserializationProvider struct{}
+
+func (DoubleDeserializationProvider) LoadSchema(_ string, _ map[string]string) error {
+	return nil
+}
+
+func (DoubleDeserializationProvider) Deserialize(data []byte) (string, error) {
+	if len(data) == 0 {
+		return "", nil
+	}
+
+	return fmt.Sprintf("%f", math.Float64frombits(binary.LittleEndian.Uint64(data))), nil
+}

--- a/pkg/serdes/double_serialization_provider.go
+++ b/pkg/serdes/double_serialization_provider.go
@@ -1,0 +1,29 @@
+package serdes
+
+import (
+	"encoding/binary"
+	"math"
+	"strconv"
+)
+
+type DoubleSerializationProvider struct{}
+
+func (DoubleSerializationProvider) LoadSchema(_ string, _ map[string]string) error {
+	return nil
+}
+
+func (DoubleSerializationProvider) Serialize(str string) ([]byte, error) {
+	f, err := strconv.ParseFloat(str, 64)
+	if err != nil {
+		return nil, err
+	}
+
+	buf := make([]byte, 8)
+	binary.LittleEndian.PutUint64(buf, math.Float64bits(f))
+
+	return buf, nil
+}
+
+func (DoubleSerializationProvider) GetSchemaName() string {
+	return ""
+}

--- a/pkg/serdes/integer_deserialization_provider.go
+++ b/pkg/serdes/integer_deserialization_provider.go
@@ -7,11 +7,11 @@ import (
 
 type IntegerDeserializationProvider struct{}
 
-func (s *IntegerDeserializationProvider) LoadSchema(_ string, _ map[string]string) error {
+func (IntegerDeserializationProvider) LoadSchema(_ string, _ map[string]string) error {
 	return nil
 }
 
-func (s *IntegerDeserializationProvider) Deserialize(data []byte) (string, error) {
+func (IntegerDeserializationProvider) Deserialize(data []byte) (string, error) {
 	if len(data) == 0 {
 		return "", nil
 	}

--- a/pkg/serdes/integer_serialization_provider.go
+++ b/pkg/serdes/integer_serialization_provider.go
@@ -7,11 +7,11 @@ import (
 
 type IntegerSerializationProvider struct{}
 
-func (s *IntegerSerializationProvider) LoadSchema(_ string, _ map[string]string) error {
+func (IntegerSerializationProvider) LoadSchema(_ string, _ map[string]string) error {
 	return nil
 }
 
-func (s *IntegerSerializationProvider) Serialize(str string) ([]byte, error) {
+func (IntegerSerializationProvider) Serialize(str string) ([]byte, error) {
 	i, err := strconv.ParseUint(str, 10, 32)
 	if err != nil {
 		return nil, err
@@ -23,6 +23,6 @@ func (s *IntegerSerializationProvider) Serialize(str string) ([]byte, error) {
 	return buf, nil
 }
 
-func (s *IntegerSerializationProvider) GetSchemaName() string {
+func (IntegerSerializationProvider) GetSchemaName() string {
 	return ""
 }

--- a/pkg/serdes/json_serialization_provider.go
+++ b/pkg/serdes/json_serialization_provider.go
@@ -25,7 +25,7 @@ func (j *JsonSerializationProvider) LoadSchema(schemaPath string, referencePathM
 }
 
 func (j *JsonSerializationProvider) GetSchemaName() string {
-	return JsonSchemaBackendName
+	return jsonSchemaBackendName
 }
 
 func (j *JsonSerializationProvider) Serialize(str string) ([]byte, error) {

--- a/pkg/serdes/protobuf_serialization_provider.go
+++ b/pkg/serdes/protobuf_serialization_provider.go
@@ -27,7 +27,7 @@ func (p *ProtobufSerializationProvider) LoadSchema(schemaPath string, referenceP
 }
 
 func (p *ProtobufSerializationProvider) GetSchemaName() string {
-	return ProtobufSchemaBackendName
+	return protobufSchemaBackendName
 }
 
 func (p *ProtobufSerializationProvider) Serialize(str string) ([]byte, error) {

--- a/pkg/serdes/serdes.go
+++ b/pkg/serdes/serdes.go
@@ -7,21 +7,34 @@ import (
 )
 
 const (
-	AvroSchemaName     = "avro"
-	DoubleSchemaName   = "double"
-	IntegerSchemaName  = "integer"
-	JsonSchemaName     = "jsonschema"
-	ProtobufSchemaName = "protobuf"
-	StringSchemaName   = "string"
+	avroSchemaName     = "avro"
+	doubleSchemaName   = "double"
+	integerSchemaName  = "integer"
+	jsonSchemaName     = "jsonschema"
+	protobufSchemaName = "protobuf"
+	stringSchemaName   = "string"
 )
+
+var Formats = []string{
+	stringSchemaName,
+	avroSchemaName,
+	doubleSchemaName,
+	integerSchemaName,
+	jsonSchemaName,
+	protobufSchemaName,
+}
+
+var SchemaBasedFormats = []string{
+	avroSchemaName,
+	jsonSchemaName,
+	protobufSchemaName,
+}
 
 const (
-	AvroSchemaBackendName     = "AVRO"
-	JsonSchemaBackendName     = "JSON"
-	ProtobufSchemaBackendName = "PROTOBUF"
+	avroSchemaBackendName     = "AVRO"
+	jsonSchemaBackendName     = "JSON"
+	protobufSchemaBackendName = "PROTOBUF"
 )
-
-var SchemaBasedFormats = []string{"avro", "jsonschema", "protobuf"}
 
 type SerializationProvider interface {
 	LoadSchema(string, map[string]string) error
@@ -37,12 +50,12 @@ type DeserializationProvider interface {
 func FormatTranslation(backendValueFormat string) (string, error) {
 	var cliValueFormat string
 	switch backendValueFormat {
-	case "", AvroSchemaBackendName:
-		cliValueFormat = AvroSchemaName
-	case ProtobufSchemaBackendName:
-		cliValueFormat = ProtobufSchemaName
-	case JsonSchemaBackendName:
-		cliValueFormat = JsonSchemaName
+	case "", avroSchemaBackendName:
+		cliValueFormat = avroSchemaName
+	case protobufSchemaBackendName:
+		cliValueFormat = protobufSchemaName
+	case jsonSchemaBackendName:
+		cliValueFormat = jsonSchemaName
 	default:
 		return "", fmt.Errorf(errors.UnknownValueFormatErrorMsg)
 	}
@@ -51,17 +64,17 @@ func FormatTranslation(backendValueFormat string) (string, error) {
 
 func GetSerializationProvider(valueFormat string) (SerializationProvider, error) {
 	switch valueFormat {
-	case AvroSchemaName:
+	case avroSchemaName:
 		return new(AvroSerializationProvider), nil
-	case DoubleSchemaName:
+	case doubleSchemaName:
 		return new(DoubleSerializationProvider), nil
-	case IntegerSchemaName:
+	case integerSchemaName:
 		return new(IntegerSerializationProvider), nil
-	case JsonSchemaName:
+	case jsonSchemaName:
 		return new(JsonSerializationProvider), nil
-	case ProtobufSchemaName:
+	case protobufSchemaName:
 		return new(ProtobufSerializationProvider), nil
-	case StringSchemaName:
+	case stringSchemaName:
 		return new(StringSerializationProvider), nil
 	default:
 		return nil, fmt.Errorf(errors.UnknownValueFormatErrorMsg)
@@ -70,17 +83,17 @@ func GetSerializationProvider(valueFormat string) (SerializationProvider, error)
 
 func GetDeserializationProvider(valueFormat string) (DeserializationProvider, error) {
 	switch valueFormat {
-	case AvroSchemaName:
+	case avroSchemaName:
 		return new(AvroDeserializationProvider), nil
-	case DoubleSchemaName:
+	case doubleSchemaName:
 		return new(DoubleDeserializationProvider), nil
-	case IntegerSchemaName:
+	case integerSchemaName:
 		return new(IntegerDeserializationProvider), nil
-	case JsonSchemaName:
+	case jsonSchemaName:
 		return new(JsonSchemaDeserializationProvider), nil
-	case ProtobufSchemaName:
+	case protobufSchemaName:
 		return new(ProtobufDeserializationProvider), nil
-	case StringSchemaName:
+	case stringSchemaName:
 		return new(StringDeserializationProvider), nil
 	default:
 		return nil, fmt.Errorf(errors.UnknownValueFormatErrorMsg)

--- a/pkg/serdes/serdes.go
+++ b/pkg/serdes/serdes.go
@@ -7,17 +7,18 @@ import (
 )
 
 const (
-	AvroSchemaName     string = "avro"
-	IntegerSchemaName  string = "integer"
-	JsonSchemaName     string = "jsonschema"
-	ProtobufSchemaName string = "protobuf"
-	StringSchemaName   string = "string"
+	AvroSchemaName     = "avro"
+	DoubleSchemaName   = "double"
+	IntegerSchemaName  = "integer"
+	JsonSchemaName     = "jsonschema"
+	ProtobufSchemaName = "protobuf"
+	StringSchemaName   = "string"
 )
 
 const (
-	AvroSchemaBackendName     string = "AVRO"
-	JsonSchemaBackendName     string = "JSON"
-	ProtobufSchemaBackendName string = "PROTOBUF"
+	AvroSchemaBackendName     = "AVRO"
+	JsonSchemaBackendName     = "JSON"
+	ProtobufSchemaBackendName = "PROTOBUF"
 )
 
 var SchemaBasedFormats = []string{"avro", "jsonschema", "protobuf"}
@@ -52,6 +53,8 @@ func GetSerializationProvider(valueFormat string) (SerializationProvider, error)
 	switch valueFormat {
 	case AvroSchemaName:
 		return new(AvroSerializationProvider), nil
+	case DoubleSchemaName:
+		return new(DoubleSerializationProvider), nil
 	case IntegerSchemaName:
 		return new(IntegerSerializationProvider), nil
 	case JsonSchemaName:
@@ -69,6 +72,8 @@ func GetDeserializationProvider(valueFormat string) (DeserializationProvider, er
 	switch valueFormat {
 	case AvroSchemaName:
 		return new(AvroDeserializationProvider), nil
+	case DoubleSchemaName:
+		return new(DoubleDeserializationProvider), nil
 	case IntegerSchemaName:
 		return new(IntegerDeserializationProvider), nil
 	case JsonSchemaName:

--- a/pkg/serdes/serdes_test.go
+++ b/pkg/serdes/serdes_test.go
@@ -7,14 +7,12 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-
-	sr "github.com/confluentinc/cli/v3/internal/schema-registry"
 )
 
 func TestGetSerializationProvider(t *testing.T) {
 	req := require.New(t)
-	valueFormats := []string{AvroSchemaName, JsonSchemaName, ProtobufSchemaName}
-	schemaNames := []string{AvroSchemaBackendName, JsonSchemaBackendName, ProtobufSchemaBackendName}
+	valueFormats := []string{avroSchemaName, jsonSchemaName, protobufSchemaName}
+	schemaNames := []string{avroSchemaBackendName, jsonSchemaBackendName, protobufSchemaBackendName}
 
 	for idx, valueFormat := range valueFormats {
 		provider, err := GetSerializationProvider(valueFormat)
@@ -28,7 +26,7 @@ func TestGetSerializationProvider(t *testing.T) {
 }
 
 func TestGetDeserializationProvider(t *testing.T) {
-	valueFormats := []string{AvroSchemaName, ProtobufSchemaName, JsonSchemaName, StringSchemaName}
+	valueFormats := []string{avroSchemaName, protobufSchemaName, jsonSchemaName, stringSchemaName}
 
 	for _, valueFormat := range valueFormats {
 		_, err := GetDeserializationProvider(valueFormat)
@@ -42,14 +40,14 @@ func TestGetDeserializationProvider(t *testing.T) {
 func TestStringSerdes(t *testing.T) {
 	req := require.New(t)
 
-	serializationProvider, _ := GetSerializationProvider(StringSchemaName)
+	serializationProvider, _ := GetSerializationProvider(stringSchemaName)
 	expectedBytes := []byte{115, 111, 109, 101, 115, 116, 114, 105, 110, 103}
 	data, err := serializationProvider.Serialize("somestring")
 	req.Nil(err)
 	result := bytes.Compare(data, expectedBytes)
 	req.Zero(result)
 
-	deserializationProvider, _ := GetDeserializationProvider(StringSchemaName)
+	deserializationProvider, _ := GetDeserializationProvider(stringSchemaName)
 	data = []byte{115, 111, 109, 101, 115, 116, 114, 105, 110, 103}
 	str, err := deserializationProvider.Deserialize(data)
 	req.Nil(err)
@@ -59,7 +57,7 @@ func TestStringSerdes(t *testing.T) {
 func TestAvroSerdesValid(t *testing.T) {
 	req := require.New(t)
 
-	dir, err := sr.CreateTempDir()
+	dir, err := createTempDir()
 	req.Nil(err)
 
 	schemaString := `{"type":"record","name":"myrecord","fields":[{"name":"f1","type":"string"}]}`
@@ -69,7 +67,7 @@ func TestAvroSerdesValid(t *testing.T) {
 	expectedString := `{"f1":"asd"}`
 	expectedBytes := []byte{6, 97, 115, 100}
 
-	serializationProvider, _ := GetSerializationProvider(AvroSchemaName)
+	serializationProvider, _ := GetSerializationProvider(avroSchemaName)
 	err = serializationProvider.LoadSchema(schemaPath, map[string]string{})
 	req.Nil(err)
 	data, err := serializationProvider.Serialize(expectedString)
@@ -80,7 +78,7 @@ func TestAvroSerdesValid(t *testing.T) {
 
 	data = []byte{6, 97, 115, 100}
 
-	deserializationProvider, _ := GetDeserializationProvider(AvroSchemaName)
+	deserializationProvider, _ := GetDeserializationProvider(avroSchemaName)
 	err = deserializationProvider.LoadSchema(schemaPath, map[string]string{})
 	req.Nil(err)
 	str, err := deserializationProvider.Deserialize(data)
@@ -93,17 +91,17 @@ func TestAvroSerdesValid(t *testing.T) {
 func TestAvroSerdesInvalid(t *testing.T) {
 	req := require.New(t)
 
-	dir, err := sr.CreateTempDir()
+	dir, err := createTempDir()
 	req.Nil(err)
 
 	schemaString := `{"type":"record","name":"myrecord","fields":[{"name":"f1","type":"string"}]}`
 	schemaPath := filepath.Join(dir, "avro-schema.txt")
 	req.NoError(os.WriteFile(schemaPath, []byte(schemaString), 0644))
 
-	serializationProvider, _ := GetSerializationProvider(AvroSchemaName)
+	serializationProvider, _ := GetSerializationProvider(avroSchemaName)
 	err = serializationProvider.LoadSchema(schemaPath, map[string]string{})
 	req.Nil(err)
-	deserializationProvider, _ := GetDeserializationProvider(AvroSchemaName)
+	deserializationProvider, _ := GetDeserializationProvider(avroSchemaName)
 	err = deserializationProvider.LoadSchema(schemaPath, map[string]string{})
 	req.Nil(err)
 
@@ -127,7 +125,7 @@ func TestAvroSerdesInvalid(t *testing.T) {
 func TestJsonSerdesValid(t *testing.T) {
 	req := require.New(t)
 
-	dir, err := sr.CreateTempDir()
+	dir, err := createTempDir()
 	req.Nil(err)
 
 	schemaString := `{"type":"object","properties":{"f1":{"type":"string"}},"required":["f1"]}`
@@ -137,7 +135,7 @@ func TestJsonSerdesValid(t *testing.T) {
 	expectedString := `{"f1":"asd"}`
 	expectedBytes := []byte{123, 34, 102, 49, 34, 58, 34, 97, 115, 100, 34, 125}
 
-	serializationProvider, _ := GetSerializationProvider(JsonSchemaName)
+	serializationProvider, _ := GetSerializationProvider(jsonSchemaName)
 	err = serializationProvider.LoadSchema(schemaPath, map[string]string{})
 	req.Nil(err)
 	data, err := serializationProvider.Serialize(expectedString)
@@ -147,7 +145,7 @@ func TestJsonSerdesValid(t *testing.T) {
 	req.Zero(result)
 
 	data = expectedBytes
-	deserializationProvider, _ := GetDeserializationProvider(JsonSchemaName)
+	deserializationProvider, _ := GetDeserializationProvider(jsonSchemaName)
 	err = deserializationProvider.LoadSchema(schemaPath, map[string]string{})
 	req.Nil(err)
 	str, err := deserializationProvider.Deserialize(data)
@@ -160,7 +158,7 @@ func TestJsonSerdesValid(t *testing.T) {
 func TestJsonSerdesReference(t *testing.T) {
 	req := require.New(t)
 
-	dir, err := sr.CreateTempDir()
+	dir, err := createTempDir()
 	req.Nil(err)
 
 	referenceString := `{"type": "string"}`
@@ -174,7 +172,7 @@ func TestJsonSerdesReference(t *testing.T) {
 	expectedString := `{"f1":"asd"}`
 	expectedBytes := []byte{123, 34, 102, 49, 34, 58, 34, 97, 115, 100, 34, 125}
 
-	serializationProvider, _ := GetSerializationProvider(JsonSchemaName)
+	serializationProvider, _ := GetSerializationProvider(jsonSchemaName)
 	err = serializationProvider.LoadSchema(schemaPath, map[string]string{"json-reference.json": referencePath})
 	req.Nil(err)
 	data, err := serializationProvider.Serialize(expectedString)
@@ -184,7 +182,7 @@ func TestJsonSerdesReference(t *testing.T) {
 	req.Zero(result)
 
 	data = expectedBytes
-	deserializationProvider, _ := GetDeserializationProvider(JsonSchemaName)
+	deserializationProvider, _ := GetDeserializationProvider(jsonSchemaName)
 	err = deserializationProvider.LoadSchema(schemaPath, map[string]string{"json-reference.json": referencePath})
 	req.Nil(err)
 	str, err := deserializationProvider.Deserialize(data)
@@ -197,17 +195,17 @@ func TestJsonSerdesReference(t *testing.T) {
 func TestJsonSerdesInvalid(t *testing.T) {
 	req := require.New(t)
 
-	dir, err := sr.CreateTempDir()
+	dir, err := createTempDir()
 	req.Nil(err)
 
 	schemaString := `{"type":"object","properties":{"f1":{"type":"string"}},"required":["f1"]}`
 	schemaPath := filepath.Join(dir, "json-demo.json")
 	req.NoError(os.WriteFile(schemaPath, []byte(schemaString), 0644))
 
-	serializationProvider, _ := GetSerializationProvider(JsonSchemaName)
+	serializationProvider, _ := GetSerializationProvider(jsonSchemaName)
 	err = serializationProvider.LoadSchema(schemaPath, map[string]string{})
 	req.Nil(err)
-	deserializationProvider, _ := GetDeserializationProvider(JsonSchemaName)
+	deserializationProvider, _ := GetDeserializationProvider(jsonSchemaName)
 	err = deserializationProvider.LoadSchema(schemaPath, map[string]string{})
 	req.Nil(err)
 
@@ -237,7 +235,7 @@ func TestJsonSerdesInvalid(t *testing.T) {
 func TestProtobufSerdesValid(t *testing.T) {
 	req := require.New(t)
 
-	dir, err := sr.CreateTempDir()
+	dir, err := createTempDir()
 	req.Nil(err)
 
 	schemaString := `
@@ -253,7 +251,7 @@ func TestProtobufSerdesValid(t *testing.T) {
 	expectedString := `{"name":"abc","page":1,"result":2}`
 	expectedBytes := []byte{0, 10, 3, 97, 98, 99, 16, 1, 24, 2}
 
-	serializationProvider, _ := GetSerializationProvider(ProtobufSchemaName)
+	serializationProvider, _ := GetSerializationProvider(protobufSchemaName)
 	err = serializationProvider.LoadSchema(schemaPath, map[string]string{})
 	req.Nil(err)
 	data, err := serializationProvider.Serialize(expectedString)
@@ -263,7 +261,7 @@ func TestProtobufSerdesValid(t *testing.T) {
 	req.Zero(result)
 
 	data = expectedBytes
-	deserializationProvider, _ := GetDeserializationProvider(ProtobufSchemaName)
+	deserializationProvider, _ := GetDeserializationProvider(protobufSchemaName)
 	err = deserializationProvider.LoadSchema(schemaPath, map[string]string{})
 	req.Nil(err)
 	str, err := deserializationProvider.Deserialize(data)
@@ -276,7 +274,7 @@ func TestProtobufSerdesValid(t *testing.T) {
 func TestProtobufSerdesReference(t *testing.T) {
 	req := require.New(t)
 
-	dir, err := sr.CreateTempDir()
+	dir, err := createTempDir()
 	req.Nil(err)
 
 	referenceString := `
@@ -304,7 +302,7 @@ func TestProtobufSerdesReference(t *testing.T) {
 	expectedString := `{"name":"abc","address":{"city":"LA"},"result":2}`
 	expectedBytes := []byte{0, 10, 3, 97, 98, 99, 18, 4, 10, 2, 76, 65, 24, 2}
 
-	serializationProvider, _ := GetSerializationProvider(ProtobufSchemaName)
+	serializationProvider, _ := GetSerializationProvider(protobufSchemaName)
 	err = serializationProvider.LoadSchema(schemaPath, map[string]string{"address.proto": referencePath})
 	req.Nil(err)
 	data, err := serializationProvider.Serialize(expectedString)
@@ -315,7 +313,7 @@ func TestProtobufSerdesReference(t *testing.T) {
 	req.Zero(result)
 
 	data = expectedBytes
-	deserializationProvider, _ := GetDeserializationProvider(ProtobufSchemaName)
+	deserializationProvider, _ := GetDeserializationProvider(protobufSchemaName)
 	err = deserializationProvider.LoadSchema(schemaPath, map[string]string{"address.proto": referencePath})
 	req.Nil(err)
 	str, err := deserializationProvider.Deserialize(data)
@@ -328,7 +326,7 @@ func TestProtobufSerdesReference(t *testing.T) {
 func TestProtobufSerdesInvalid(t *testing.T) {
 	req := require.New(t)
 
-	dir, err := sr.CreateTempDir()
+	dir, err := createTempDir()
 	req.Nil(err)
 
 	schemaString := `
@@ -341,10 +339,10 @@ func TestProtobufSerdesInvalid(t *testing.T) {
 	schemaPath := filepath.Join(dir, "person.proto")
 	req.NoError(os.WriteFile(schemaPath, []byte(schemaString), 0644))
 
-	serializationProvider, _ := GetSerializationProvider(ProtobufSchemaName)
+	serializationProvider, _ := GetSerializationProvider(protobufSchemaName)
 	err = serializationProvider.LoadSchema(schemaPath, map[string]string{})
 	req.Nil(err)
-	deserializationProvider, _ := GetDeserializationProvider(ProtobufSchemaName)
+	deserializationProvider, _ := GetDeserializationProvider(protobufSchemaName)
 	err = deserializationProvider.LoadSchema(schemaPath, map[string]string{})
 	req.Nil(err)
 
@@ -374,7 +372,7 @@ func TestProtobufSerdesInvalid(t *testing.T) {
 func TestProtobufSerdesNestedValid(t *testing.T) {
 	req := require.New(t)
 
-	dir, err := sr.CreateTempDir()
+	dir, err := createTempDir()
 	req.Nil(err)
 
 	schemaString := `
@@ -402,7 +400,7 @@ func TestProtobufSerdesNestedValid(t *testing.T) {
 		49, 50, 51, 18, 3, 100, 101, 102, 34, 5, 10, 3, 50, 51, 52,
 	}
 
-	serializationProvider, _ := GetSerializationProvider(ProtobufSchemaName)
+	serializationProvider, _ := GetSerializationProvider(protobufSchemaName)
 	err = serializationProvider.LoadSchema(schemaPath, map[string]string{})
 	req.Nil(err)
 	data, err := serializationProvider.Serialize(expectedString)
@@ -413,7 +411,7 @@ func TestProtobufSerdesNestedValid(t *testing.T) {
 
 	data = expectedBytes
 
-	deserializationProvider, _ := GetDeserializationProvider(ProtobufSchemaName)
+	deserializationProvider, _ := GetDeserializationProvider(protobufSchemaName)
 	err = deserializationProvider.LoadSchema(schemaPath, map[string]string{})
 	req.Nil(err)
 	str, err := deserializationProvider.Deserialize(data)
@@ -421,4 +419,10 @@ func TestProtobufSerdesNestedValid(t *testing.T) {
 	req.Equal(str, expectedString)
 
 	req.NoError(os.RemoveAll(dir))
+}
+
+func createTempDir() (string, error) {
+	dir := filepath.Join(os.TempDir(), "ccloud-schema")
+	err := os.MkdirAll(dir, 0755)
+	return dir, err
 }

--- a/test/fixtures/output/asyncapi/export-help.golden
+++ b/test/fixtures/output/asyncapi/export-help.golden
@@ -16,7 +16,7 @@ Flags:
       --kafka-api-key string    Kafka cluster API key.
       --schema-context string   Use a specific schema context. (default "default")
       --topics strings          A comma-separated list of topics to export. Supports prefixes ending with a wildcard (*).
-      --value-format string     Format message value as "string", "avro", "integer", "jsonschema", or "protobuf". Note that schema references are not supported for Avro. (default "string")
+      --value-format string     Format message value as "string", "avro", "double", "integer", "jsonschema", or "protobuf". Note that schema references are not supported for Avro. (default "string")
       --cluster string          Kafka cluster ID.
       --environment string      Environment ID.
 

--- a/test/fixtures/output/kafka/topic/consume-help-onprem.golden
+++ b/test/fixtures/output/kafka/topic/consume-help-onprem.golden
@@ -28,8 +28,8 @@ Flags:
   -b, --from-beginning                    Consume from beginning of the topic.
       --offset int                        The offset from the beginning to consume from.
       --partition int32                   The partition to consume from. (default -1)
-      --key-format string                 Format of message key as "string", "avro", "integer", "jsonschema", or "protobuf". Note that schema references are not supported for Avro. (default "string")
-      --value-format string               Format message value as "string", "avro", "integer", "jsonschema", or "protobuf". Note that schema references are not supported for Avro. (default "string")
+      --key-format string                 Format of message key as "string", "avro", "double", "integer", "jsonschema", or "protobuf". Note that schema references are not supported for Avro. (default "string")
+      --value-format string               Format message value as "string", "avro", "double", "integer", "jsonschema", or "protobuf". Note that schema references are not supported for Avro. (default "string")
       --print-key                         Print key of the message.
       --full-header                       Print complete content of message headers.
       --timestamp                         Print message timestamp in milliseconds.

--- a/test/fixtures/output/kafka/topic/consume-help.golden
+++ b/test/fixtures/output/kafka/topic/consume-help.golden
@@ -15,8 +15,8 @@ Flags:
   -b, --from-beginning                      Consume from beginning of the topic.
       --offset int                          The offset from the beginning to consume from.
       --partition int32                     The partition to consume from. (default -1)
-      --key-format string                   Format of message key as "string", "avro", "integer", "jsonschema", or "protobuf". Note that schema references are not supported for Avro. (default "string")
-      --value-format string                 Format message value as "string", "avro", "integer", "jsonschema", or "protobuf". Note that schema references are not supported for Avro. (default "string")
+      --key-format string                   Format of message key as "string", "avro", "double", "integer", "jsonschema", or "protobuf". Note that schema references are not supported for Avro. (default "string")
+      --value-format string                 Format message value as "string", "avro", "double", "integer", "jsonschema", or "protobuf". Note that schema references are not supported for Avro. (default "string")
       --print-key                           Print key of the message.
       --print-offset                        Print partition number and offset of the message.
       --full-header                         Print complete content of message headers.

--- a/test/fixtures/output/kafka/topic/produce-help-onprem.golden
+++ b/test/fixtures/output/kafka/topic/produce-help-onprem.golden
@@ -26,8 +26,8 @@ Flags:
       --sasl-mechanism string             SASL_SSL mechanism used for authentication. (default "PLAIN")
       --key-schema string                 The filepath of the message key schema.
       --schema string                     The filepath of the message value schema.
-      --key-format string                 Format of message key as "string", "avro", "integer", "jsonschema", or "protobuf". Note that schema references are not supported for Avro. (default "string")
-      --value-format string               Format message value as "string", "avro", "integer", "jsonschema", or "protobuf". Note that schema references are not supported for Avro. (default "string")
+      --key-format string                 Format of message key as "string", "avro", "double", "integer", "jsonschema", or "protobuf". Note that schema references are not supported for Avro. (default "string")
+      --value-format string               Format message value as "string", "avro", "double", "integer", "jsonschema", or "protobuf". Note that schema references are not supported for Avro. (default "string")
       --references string                 The path to the references file.
       --parse-key                         Parse key from the message.
       --delimiter string                  The delimiter separating each key and value. (default ":")

--- a/test/fixtures/output/kafka/topic/produce-help.golden
+++ b/test/fixtures/output/kafka/topic/produce-help.golden
@@ -8,8 +8,8 @@ Usage:
 Flags:
       --key-schema string                   The ID or filepath of the message key schema.
       --schema string                       The ID or filepath of the message value schema.
-      --key-format string                   Format of message key as "string", "avro", "integer", "jsonschema", or "protobuf". Note that schema references are not supported for Avro. (default "string")
-      --value-format string                 Format message value as "string", "avro", "integer", "jsonschema", or "protobuf". Note that schema references are not supported for Avro. (default "string")
+      --key-format string                   Format of message key as "string", "avro", "double", "integer", "jsonschema", or "protobuf". Note that schema references are not supported for Avro. (default "string")
+      --value-format string                 Format message value as "string", "avro", "double", "integer", "jsonschema", or "protobuf". Note that schema references are not supported for Avro. (default "string")
       --key-references string               The path to the message key schema references file.
       --references string                   The path to the message value schema references file.
       --parse-key                           Parse key from the message.


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- PLACEHOLDER

New Features
- Support `--value-format double` in `confluent kafka topic produce` and `confluent kafka topic consume`

Bug Fixes
- PLACEHOLDER

Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   - [x] yes: ok
   - [ ] no: DO NOT MERGE until the required features are live in prod  

What
----
Added support for integers in #2163. Adding support for doubles.

Test & Review
-------------
Manually tested:
```
% confluent kafka topic produce test-double --value-format double
Starting Kafka Producer. Use Ctrl-C or Ctrl-D to exit.
1.1
3.14159265358979
% confluent kafka topic consume test-double --value-format double --from-beginning 
Starting Kafka Consumer. Use Ctrl-C to exit.
1.100000
3.141593
^CStopping Consumer.
```