### PR TITLE
Remove "ID" from `flink region list`

### DIFF
--- a/internal/flink/command_region_list.go
+++ b/internal/flink/command_region_list.go
@@ -11,10 +11,10 @@ import (
 )
 
 type regionOut struct {
-	Id         string `human:"ID" serialized:"id"`
-	Name       string `human:"Name" serialized:"name"`
-	Cloud      string `human:"Cloud" serialized:"cloud"`
-	RegionName string `human:"Region Name" serialized:"region_name"`
+	IsCurrent bool   `human:"Current" serialized:"is_current"`
+	Name      string `human:"Name" serialized:"name"`
+	Cloud     string `human:"Cloud" serialized:"cloud"`
+	Region    string `human:"Region" serialized:"region"`
 }
 
 func (c *command) newRegionListCommand() *cobra.Command {
@@ -51,12 +51,17 @@ func (c *command) regionList(cmd *cobra.Command, _ []string) error {
 
 	list := output.NewList(cmd)
 	for _, region := range regions {
-		list.Add(&regionOut{
-			Id:         region.GetId(),
-			Name:       region.GetDisplayName(),
-			Cloud:      region.GetCloud(),
-			RegionName: region.GetRegionName(),
-		})
+		out := &regionOut{
+			Cloud:  region.GetCloud(),
+			Region: region.GetRegionName(),
+			Name:   region.GetDisplayName(),
+		}
+
+		if x := strings.SplitN(region.GetId(), ".", 2); len(x) == 2 {
+			out.IsCurrent = x[0] == c.Context.GetCurrentFlinkCloudProvider() && x[1] == c.Context.GetCurrentFlinkRegion()
+		}
+
+		list.Add(out)
 	}
 	return list.Print()
 }

--- a/internal/flink/command_region_use.go
+++ b/internal/flink/command_region_use.go
@@ -23,7 +23,7 @@ func (c *command) newRegionUseCommand() *cobra.Command {
 		RunE:  c.regionUse,
 		Example: examples.BuildExampleString(
 			examples.Example{
-				Text: "Select the N. Virginia (us-east-1) region for use in subsequent Flink commands.",
+				Text: `Select region "N. Virginia (us-east-1)" for use in subsequent Flink commands.`,
 				Code: "confluent flink region use --cloud aws --region us-east-1",
 			},
 		),

--- a/test/fixtures/output/flink/region/list-cloud.golden
+++ b/test/fixtures/output/flink/region/list-cloud.golden
@@ -1,3 +1,3 @@
-       ID       |        Name        | Cloud | Region Name  
-----------------+--------------------+-------+--------------
-  aws.eu-west-1 | Europe (eu-west-1) | AWS   | eu-west-1    
+  Current |        Name        | Cloud |  Region    
+----------+--------------------+-------+------------
+  *       | Europe (eu-west-1) | AWS   | eu-west-1  

--- a/test/fixtures/output/flink/region/list-json.golden
+++ b/test/fixtures/output/flink/region/list-json.golden
@@ -1,14 +1,14 @@
 [
   {
-    "id": "aws.eu-west-1",
+    "is_current": true,
     "name": "Europe (eu-west-1)",
     "cloud": "AWS",
-    "region_name": "eu-west-1"
+    "region": "eu-west-1"
   },
   {
-    "id": "gcp.europe-west3-a",
+    "is_current": false,
     "name": "Frankfurt (europe-west3-a)",
     "cloud": "GCP",
-    "region_name": "europe-west3-a"
+    "region": "europe-west3-a"
   }
 ]

--- a/test/fixtures/output/flink/region/list.golden
+++ b/test/fixtures/output/flink/region/list.golden
@@ -1,4 +1,4 @@
-          ID         |            Name            | Cloud |  Region Name    
----------------------+----------------------------+-------+-----------------
-  aws.eu-west-1      | Europe (eu-west-1)         | AWS   | eu-west-1       
-  gcp.europe-west3-a | Frankfurt (europe-west3-a) | GCP   | europe-west3-a  
+  Current |            Name            | Cloud |     Region      
+----------+----------------------------+-------+-----------------
+  *       | Europe (eu-west-1)         | AWS   | eu-west-1       
+          | Frankfurt (europe-west3-a) | GCP   | europe-west3-a  

--- a/test/fixtures/output/flink/region/use-autocomplete.golden
+++ b/test/fixtures/output/flink/region/use-autocomplete.golden
@@ -1,4 +1,0 @@
-aws.eu-west-1	Europe (eu-west-1)
-gcp.europe-west3-a	Frankfurt (europe-west3-a)
-:4
-Completion ended with directive: ShellCompDirectiveNoFileComp

--- a/test/fixtures/output/flink/region/use-help.golden
+++ b/test/fixtures/output/flink/region/use-help.golden
@@ -1,9 +1,16 @@
 Choose a Flink compute pool to be used in subsequent commands which support passing a compute pool with the `--compute-pool` flag.
 
 Usage:
-  confluent flink region use <id> [flags]
+  confluent flink region use [flags]
+
+Examples:
+Select region "N. Virginia (us-east-1)" for use in subsequent Flink commands.
+
+  $ confluent flink region use --cloud aws --region us-east-1
 
 Flags:
+      --cloud string         REQUIRED: Specify the cloud provider as "aws", "azure", or "gcp".
+      --region string        REQUIRED: Cloud region for compute pool (use "confluent flink region list" to see all).
       --environment string   Environment ID.
       --context string       CLI context name.
 

--- a/test/fixtures/output/flink/region/use-missing-cloud.golden
+++ b/test/fixtures/output/flink/region/use-missing-cloud.golden
@@ -1,4 +1,0 @@
-Error: Flink region "eu-west-2" is invalid
-
-Suggestions:
-    Run `confluent flink region list` to see available regions.

--- a/test/fixtures/output/flink/region/use-missing-region.golden
+++ b/test/fixtures/output/flink/region/use-missing-region.golden
@@ -1,4 +1,0 @@
-Error: Flink region "aws" is invalid
-
-Suggestions:
-    Run `confluent flink region list` to see available regions.

--- a/test/fixtures/output/flink/region/use.golden
+++ b/test/fixtures/output/flink/region/use.golden
@@ -1,1 +1,1 @@
-Using Flink region "aws.eu-west-1".
+Using Flink region "Europe (eu-west-1)".

--- a/test/flink_test.go
+++ b/test/flink_test.go
@@ -112,7 +112,6 @@ func (s *CLITestSuite) TestFlink_Autocomplete() {
 		{args: `__complete flink compute-pool create my-compute-pool --cloud aws --region ""`, fixture: "flink/compute-pool/create-region-autocomplete.golden"},
 		{args: `__complete flink compute-pool delete ""`, fixture: "flink/compute-pool/delete-autocomplete.golden"},
 		{args: `__complete flink compute-pool list --region ""`, fixture: "flink/compute-pool/list-region-autocomplete.golden"},
-		{args: `__complete flink region use ""`, fixture: "flink/region/use-autocomplete.golden"},
 		{args: `__complete flink statement create my-statement --database ""`, fixture: "flink/statement/create-database-autocomplete.golden"},
 	}
 

--- a/test/flink_test.go
+++ b/test/flink_test.go
@@ -59,16 +59,15 @@ func (s *CLITestSuite) TestFlinkComputePoolUse() {
 
 func (s *CLITestSuite) TestFlinkRegion() {
 	tests := []CLITest{
+		{args: "flink region use --cloud aws --region eu-west-1", fixture: "flink/region/use.golden"},
 		{args: "flink region list", fixture: "flink/region/list.golden"},
-		{args: "flink region use aws.eu-west-1", fixture: "flink/region/use.golden"},
-		{args: "flink region use aws", fixture: "flink/region/use-missing-region.golden", exitCode: 1},
-		{args: "flink region use eu-west-2", fixture: "flink/region/use-missing-cloud.golden", exitCode: 1},
 		{args: "flink region list -o json", fixture: "flink/region/list-json.golden"},
 		{args: "flink region list --cloud aws", fixture: "flink/region/list-cloud.golden"},
 	}
 
 	for _, test := range tests {
 		test.login = "cloud"
+		test.workflow = true
 		s.runIntegrationTest(test)
 	}
 }


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   - [x] yes: ok
   - [ ] no: DO NOT MERGE until the required features are live in prod  

What
----
The ID is only used in the backend and causes confusion in the frontend. Require `--cloud` and `--region` flags instead of concatenated region ID.

Test & Review
-------------
Updated integration tests