### PR TITLE
[CLI-1913] Refresh auth token on HTTP retry

### DIFF
--- a/internal/command.go
+++ b/internal/command.go
@@ -44,6 +44,7 @@ import (
 	"github.com/confluentinc/cli/v3/internal/update"
 	"github.com/confluentinc/cli/v3/internal/version"
 	pauth "github.com/confluentinc/cli/v3/pkg/auth"
+	"github.com/confluentinc/cli/v3/pkg/ccloudv2"
 	pcmd "github.com/confluentinc/cli/v3/pkg/cmd"
 	"github.com/confluentinc/cli/v3/pkg/config"
 	dynamicconfig "github.com/confluentinc/cli/v3/pkg/dynamic-config"
@@ -192,7 +193,7 @@ func reportUsage(cmd *cobra.Command, cfg *config.Config, u *usage.Usage) error {
 		if err != nil {
 			return err
 		}
-		u.Report(cfg.GetCloudClientV2(unsafeTrace))
+		u.Report(ccloudv2.NewClient(cfg, unsafeTrace))
 	}
 	return nil
 }

--- a/internal/flink/command_shell.go
+++ b/internal/flink/command_shell.go
@@ -4,6 +4,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/confluentinc/cli/v3/pkg/auth"
+	"github.com/confluentinc/cli/v3/pkg/ccloudv2"
 	pcmd "github.com/confluentinc/cli/v3/pkg/cmd"
 	"github.com/confluentinc/cli/v3/pkg/config"
 	"github.com/confluentinc/cli/v3/pkg/errors"
@@ -165,6 +166,6 @@ func (c *command) startFlinkSqlClient(prerunner pcmd.PreRunner, cmd *cobra.Comma
 func reportUsage(cmd *cobra.Command, cfg *config.Config, unsafeTrace bool) func() {
 	return func() {
 		u := ppanic.CollectPanic(cmd, nil, cfg)
-		u.Report(cfg.GetCloudClientV2(unsafeTrace))
+		u.Report(ccloudv2.NewClient(cfg, unsafeTrace))
 	}
 }

--- a/pkg/auth/login_credentials_manager.go
+++ b/pkg/auth/login_credentials_manager.go
@@ -202,7 +202,7 @@ func (h *LoginCredentialsManagerImpl) GetSsoCredentialsFromConfig(cfg *config.Co
 		}
 
 		credentials := &Credentials{
-			IsSSO:            ctx.GetUser().GetAuthType() == ccloudv1.AuthType_AUTH_TYPE_SSO || ctx.GetUser().GetSocialConnection() != "",
+			IsSSO:            ctx.IsSso(),
 			Username:         ctx.GetUser().GetEmail(),
 			AuthToken:        ctx.GetAuthToken(),
 			AuthRefreshToken: ctx.GetAuthRefreshToken(),

--- a/pkg/ccloudv2/api_keys.go
+++ b/pkg/ccloudv2/api_keys.go
@@ -21,7 +21,7 @@ func newApiKeysClient(url, userAgent string, unsafeTrace bool) *apikeysv2.APICli
 }
 
 func (c *Client) apiKeysApiContext() context.Context {
-	return context.WithValue(context.Background(), apikeysv2.ContextAccessToken, c.AuthToken)
+	return context.WithValue(context.Background(), apikeysv2.ContextAccessToken, c.cfg.Context().GetAuthToken())
 }
 
 func (c *Client) CreateApiKey(iamV2ApiKey apikeysv2.IamV2ApiKey) (apikeysv2.IamV2ApiKey, *http.Response, error) {

--- a/pkg/ccloudv2/apikeys.go
+++ b/pkg/ccloudv2/apikeys.go
@@ -10,10 +10,10 @@ import (
 	"github.com/confluentinc/cli/v3/pkg/errors"
 )
 
-func newApiKeysClient(url, userAgent string, unsafeTrace bool) *apikeysv2.APIClient {
+func newApiKeysClient(httpClient *http.Client, url, userAgent string, unsafeTrace bool) *apikeysv2.APIClient {
 	cfg := apikeysv2.NewConfiguration()
 	cfg.Debug = unsafeTrace
-	cfg.HTTPClient = NewRetryableHttpClient(unsafeTrace)
+	cfg.HTTPClient = httpClient
 	cfg.Servers = apikeysv2.ServerConfigurations{{URL: url}}
 	cfg.UserAgent = userAgent
 

--- a/pkg/ccloudv2/billing.go
+++ b/pkg/ccloudv2/billing.go
@@ -9,10 +9,10 @@ import (
 	"github.com/confluentinc/cli/v3/pkg/errors"
 )
 
-func newBillingClient(url, userAgent string, unsafeTrace bool) *billingv1.APIClient {
+func newBillingClient(httpClient *http.Client, url, userAgent string, unsafeTrace bool) *billingv1.APIClient {
 	cfg := billingv1.NewConfiguration()
 	cfg.Debug = unsafeTrace
-	cfg.HTTPClient = NewRetryableHttpClient(unsafeTrace)
+	cfg.HTTPClient = httpClient
 	cfg.Servers = billingv1.ServerConfigurations{{URL: url}}
 	cfg.UserAgent = userAgent
 

--- a/pkg/ccloudv2/billing.go
+++ b/pkg/ccloudv2/billing.go
@@ -20,7 +20,7 @@ func newBillingClient(url, userAgent string, unsafeTrace bool) *billingv1.APICli
 }
 
 func (c *Client) billingApiContext() context.Context {
-	return context.WithValue(context.Background(), billingv1.ContextAccessToken, c.AuthToken)
+	return context.WithValue(context.Background(), billingv1.ContextAccessToken, c.cfg.Context().GetAuthToken())
 }
 
 func (c *Client) ListBillingCosts(startDate, endDate string) ([]billingv1.BillingV1Cost, error) {

--- a/pkg/ccloudv2/byok.go
+++ b/pkg/ccloudv2/byok.go
@@ -9,10 +9,10 @@ import (
 	"github.com/confluentinc/cli/v3/pkg/errors"
 )
 
-func newByokV1Client(url, userAgent string, unsafeTrace bool) *byokv1.APIClient {
+func newByokV1Client(httpClient *http.Client, url, userAgent string, unsafeTrace bool) *byokv1.APIClient {
 	cfg := byokv1.NewConfiguration()
 	cfg.Debug = unsafeTrace
-	cfg.HTTPClient = NewRetryableHttpClient(unsafeTrace)
+	cfg.HTTPClient = httpClient
 	cfg.Servers = byokv1.ServerConfigurations{{URL: url}}
 	cfg.UserAgent = userAgent
 

--- a/pkg/ccloudv2/byok.go
+++ b/pkg/ccloudv2/byok.go
@@ -20,7 +20,7 @@ func newByokV1Client(url, userAgent string, unsafeTrace bool) *byokv1.APIClient 
 }
 
 func (c *Client) byokApiContext() context.Context {
-	return context.WithValue(context.Background(), byokv1.ContextAccessToken, c.AuthToken)
+	return context.WithValue(context.Background(), byokv1.ContextAccessToken, c.cfg.Context().GetAuthToken())
 }
 
 func (c *Client) CreateByokKey(key byokv1.ByokV1Key) (byokv1.ByokV1Key, *http.Response, error) {

--- a/pkg/ccloudv2/cdx.go
+++ b/pkg/ccloudv2/cdx.go
@@ -20,7 +20,7 @@ func newCdxClient(url, userAgent string, unsafeTrace bool) *cdxv1.APIClient {
 }
 
 func (c *Client) cdxApiContext() context.Context {
-	return context.WithValue(context.Background(), cdxv1.ContextAccessToken, c.AuthToken)
+	return context.WithValue(context.Background(), cdxv1.ContextAccessToken, c.cfg.Context().GetAuthToken())
 }
 
 func (c *Client) ResendInvite(shareId string) error {

--- a/pkg/ccloudv2/cdx.go
+++ b/pkg/ccloudv2/cdx.go
@@ -9,10 +9,10 @@ import (
 	"github.com/confluentinc/cli/v3/pkg/errors"
 )
 
-func newCdxClient(url, userAgent string, unsafeTrace bool) *cdxv1.APIClient {
+func newCdxClient(httpClient *http.Client, url, userAgent string, unsafeTrace bool) *cdxv1.APIClient {
 	cfg := cdxv1.NewConfiguration()
 	cfg.Debug = unsafeTrace
-	cfg.HTTPClient = NewRetryableHttpClient(unsafeTrace)
+	cfg.HTTPClient = httpClient
 	cfg.Servers = cdxv1.ServerConfigurations{{URL: url}}
 	cfg.UserAgent = userAgent
 

--- a/pkg/ccloudv2/cli.go
+++ b/pkg/ccloudv2/cli.go
@@ -24,7 +24,7 @@ func newCliClient(url, userAgent string, unsafeTrace bool) *cliv1.APIClient {
 }
 
 func (c *Client) cliApiContext() context.Context {
-	return context.WithValue(context.Background(), cliv1.ContextAccessToken, c.AuthToken)
+	return context.WithValue(context.Background(), cliv1.ContextAccessToken, c.cfg.Context().GetAuthToken())
 }
 
 func (c *Client) CreateCliFeedback(feedback cliv1.CliV1Feedback) error {

--- a/pkg/ccloudv2/client.go
+++ b/pkg/ccloudv2/client.go
@@ -51,6 +51,8 @@ type Client struct {
 }
 
 func NewClient(cfg *config.Config, unsafeTrace bool) *Client {
+	httpClient := NewRetryableHttpClient(cfg, unsafeTrace)
+
 	url := getServerUrl(cfg.Context().GetPlatformServer())
 	if cfg.IsTest {
 		url = testserver.TestV2CloudUrl.String()
@@ -61,24 +63,24 @@ func NewClient(cfg *config.Config, unsafeTrace bool) *Client {
 	return &Client{
 		cfg: cfg,
 
-		ApiKeysClient:             newApiKeysClient(url, userAgent, unsafeTrace),
-		BillingClient:             newBillingClient(url, userAgent, unsafeTrace),
-		ByokClient:                newByokV1Client(url, userAgent, unsafeTrace),
-		CdxClient:                 newCdxClient(url, userAgent, unsafeTrace),
+		ApiKeysClient:             newApiKeysClient(httpClient, url, userAgent, unsafeTrace),
+		BillingClient:             newBillingClient(httpClient, url, userAgent, unsafeTrace),
+		ByokClient:                newByokV1Client(httpClient, url, userAgent, unsafeTrace),
+		CdxClient:                 newCdxClient(httpClient, url, userAgent, unsafeTrace),
 		CliClient:                 newCliClient(url, userAgent, unsafeTrace),
-		CmkClient:                 newCmkClient(url, userAgent, unsafeTrace),
-		ConnectClient:             newConnectClient(url, userAgent, unsafeTrace),
-		ConnectCustomPluginClient: newConnectCustomPluginClient(url, userAgent, unsafeTrace),
-		FlinkClient:               newFlinkClient(url, userAgent, unsafeTrace),
-		IamClient:                 newIamClient(url, userAgent, unsafeTrace),
-		IdentityProviderClient:    newIdentityProviderClient(url, userAgent, unsafeTrace),
-		KafkaQuotasClient:         newKafkaQuotasClient(url, userAgent, unsafeTrace),
-		KsqlClient:                newKsqlClient(url, userAgent, unsafeTrace),
-		MdsClient:                 newMdsClient(url, userAgent, unsafeTrace),
-		OrgClient:                 newOrgClient(url, userAgent, unsafeTrace),
-		ServiceQuotaClient:        newServiceQuotaClient(url, userAgent, unsafeTrace),
-		SrcmClient:                newSrcmClient(url, userAgent, unsafeTrace),
-		SsoClient:                 newSsoClient(url, userAgent, unsafeTrace),
-		StreamDesignerClient:      newStreamDesignerClient(url, userAgent, unsafeTrace),
+		CmkClient:                 newCmkClient(httpClient, url, userAgent, unsafeTrace),
+		ConnectClient:             newConnectClient(httpClient, url, userAgent, unsafeTrace),
+		ConnectCustomPluginClient: newConnectCustomPluginClient(httpClient, url, userAgent, unsafeTrace),
+		FlinkClient:               newFlinkClient(httpClient, url, userAgent, unsafeTrace),
+		IamClient:                 newIamClient(httpClient, url, userAgent, unsafeTrace),
+		IdentityProviderClient:    newIdentityProviderClient(httpClient, url, userAgent, unsafeTrace),
+		KafkaQuotasClient:         newKafkaQuotasClient(httpClient, url, userAgent, unsafeTrace),
+		KsqlClient:                newKsqlClient(httpClient, url, userAgent, unsafeTrace),
+		MdsClient:                 newMdsClient(httpClient, url, userAgent, unsafeTrace),
+		OrgClient:                 newOrgClient(httpClient, url, userAgent, unsafeTrace),
+		ServiceQuotaClient:        newServiceQuotaClient(httpClient, url, userAgent, unsafeTrace),
+		SrcmClient:                newSrcmClient(httpClient, url, userAgent, unsafeTrace),
+		SsoClient:                 newSsoClient(httpClient, url, userAgent, unsafeTrace),
+		StreamDesignerClient:      newStreamDesignerClient(httpClient, url, userAgent, unsafeTrace),
 	}
 }

--- a/pkg/ccloudv2/client.go
+++ b/pkg/ccloudv2/client.go
@@ -21,21 +21,22 @@ import (
 	ssov2 "github.com/confluentinc/ccloud-sdk-go-v2/sso/v2"
 	streamdesignerv1 "github.com/confluentinc/ccloud-sdk-go-v2/stream-designer/v1"
 
+	"github.com/confluentinc/cli/v3/pkg/config"
 	testserver "github.com/confluentinc/cli/v3/test/test-server"
 )
 
 // Client represents a Confluent Cloud Client as defined by ccloud-sdk-go-v2
 type Client struct {
-	AuthToken string
+	cfg *config.Config
 
 	ApiKeysClient             *apikeysv2.APIClient
 	BillingClient             *billingv1.APIClient
 	ByokClient                *byokv1.APIClient
-	ConnectCustomPluginClient *connectcustompluginv1.APIClient
 	CdxClient                 *cdxv1.APIClient
 	CliClient                 *cliv1.APIClient
 	CmkClient                 *cmkv2.APIClient
 	ConnectClient             *connectv1.APIClient
+	ConnectCustomPluginClient *connectcustompluginv1.APIClient
 	FlinkClient               *flinkv2.APIClient
 	IamClient                 *iamv2.APIClient
 	IdentityProviderClient    *identityproviderv2.APIClient
@@ -43,29 +44,31 @@ type Client struct {
 	KsqlClient                *ksqlv2.APIClient
 	MdsClient                 *mdsv2.APIClient
 	OrgClient                 *orgv2.APIClient
-	SrcmClient                *srcmv2.APIClient
 	ServiceQuotaClient        *servicequotav1.APIClient
+	SrcmClient                *srcmv2.APIClient
 	SsoClient                 *ssov2.APIClient
 	StreamDesignerClient      *streamdesignerv1.APIClient
 }
 
-func NewClient(baseUrl string, isTest bool, authToken, userAgent string, unsafeTrace bool) *Client {
-	url := getServerUrl(baseUrl)
-	if isTest {
+func NewClient(cfg *config.Config, unsafeTrace bool) *Client {
+	url := getServerUrl(cfg.Context().GetPlatformServer())
+	if cfg.IsTest {
 		url = testserver.TestV2CloudUrl.String()
 	}
 
+	userAgent := cfg.Version.UserAgent
+
 	return &Client{
-		AuthToken: authToken,
+		cfg: cfg,
 
 		ApiKeysClient:             newApiKeysClient(url, userAgent, unsafeTrace),
 		BillingClient:             newBillingClient(url, userAgent, unsafeTrace),
 		ByokClient:                newByokV1Client(url, userAgent, unsafeTrace),
-		ConnectCustomPluginClient: newConnectCustomPluginClient(url, userAgent, unsafeTrace),
 		CdxClient:                 newCdxClient(url, userAgent, unsafeTrace),
 		CliClient:                 newCliClient(url, userAgent, unsafeTrace),
 		CmkClient:                 newCmkClient(url, userAgent, unsafeTrace),
 		ConnectClient:             newConnectClient(url, userAgent, unsafeTrace),
+		ConnectCustomPluginClient: newConnectCustomPluginClient(url, userAgent, unsafeTrace),
 		FlinkClient:               newFlinkClient(url, userAgent, unsafeTrace),
 		IamClient:                 newIamClient(url, userAgent, unsafeTrace),
 		IdentityProviderClient:    newIdentityProviderClient(url, userAgent, unsafeTrace),
@@ -73,8 +76,8 @@ func NewClient(baseUrl string, isTest bool, authToken, userAgent string, unsafeT
 		KsqlClient:                newKsqlClient(url, userAgent, unsafeTrace),
 		MdsClient:                 newMdsClient(url, userAgent, unsafeTrace),
 		OrgClient:                 newOrgClient(url, userAgent, unsafeTrace),
-		SrcmClient:                newSrcmClient(url, userAgent, unsafeTrace),
 		ServiceQuotaClient:        newServiceQuotaClient(url, userAgent, unsafeTrace),
+		SrcmClient:                newSrcmClient(url, userAgent, unsafeTrace),
 		SsoClient:                 newSsoClient(url, userAgent, unsafeTrace),
 		StreamDesignerClient:      newStreamDesignerClient(url, userAgent, unsafeTrace),
 	}

--- a/pkg/ccloudv2/cmk.go
+++ b/pkg/ccloudv2/cmk.go
@@ -11,10 +11,10 @@ import (
 
 const StatusProvisioning = "PROVISIONING"
 
-func newCmkClient(url, userAgent string, unsafeTrace bool) *cmkv2.APIClient {
+func newCmkClient(httpClient *http.Client, url, userAgent string, unsafeTrace bool) *cmkv2.APIClient {
 	cfg := cmkv2.NewConfiguration()
 	cfg.Debug = unsafeTrace
-	cfg.HTTPClient = NewRetryableHttpClient(unsafeTrace)
+	cfg.HTTPClient = httpClient
 	cfg.Servers = cmkv2.ServerConfigurations{{URL: url}}
 	cfg.UserAgent = userAgent
 

--- a/pkg/ccloudv2/cmk.go
+++ b/pkg/ccloudv2/cmk.go
@@ -22,7 +22,7 @@ func newCmkClient(url, userAgent string, unsafeTrace bool) *cmkv2.APIClient {
 }
 
 func (c *Client) cmkApiContext() context.Context {
-	return context.WithValue(context.Background(), cmkv2.ContextAccessToken, c.AuthToken)
+	return context.WithValue(context.Background(), cmkv2.ContextAccessToken, c.cfg.Context().GetAuthToken())
 }
 
 func (c *Client) CreateKafkaCluster(cluster cmkv2.CmkV2Cluster) (cmkv2.CmkV2Cluster, *http.Response, error) {

--- a/pkg/ccloudv2/connect.go
+++ b/pkg/ccloudv2/connect.go
@@ -20,7 +20,7 @@ func newConnectClient(url, userAgent string, unsafeTrace bool) *connectv1.APICli
 }
 
 func (c *Client) connectApiContext() context.Context {
-	return context.WithValue(context.Background(), connectv1.ContextAccessToken, c.AuthToken)
+	return context.WithValue(context.Background(), connectv1.ContextAccessToken, c.cfg.Context().GetAuthToken())
 }
 
 func (c *Client) CreateConnector(environmentId, kafkaClusterId string, connect connectv1.InlineObject) (connectv1.ConnectV1Connector, error) {

--- a/pkg/ccloudv2/connect.go
+++ b/pkg/ccloudv2/connect.go
@@ -3,16 +3,17 @@ package ccloudv2
 import (
 	"context"
 	"fmt"
+	"net/http"
 
 	connectv1 "github.com/confluentinc/ccloud-sdk-go-v2/connect/v1"
 
 	"github.com/confluentinc/cli/v3/pkg/errors"
 )
 
-func newConnectClient(url, userAgent string, unsafeTrace bool) *connectv1.APIClient {
+func newConnectClient(httpClient *http.Client, url, userAgent string, unsafeTrace bool) *connectv1.APIClient {
 	cfg := connectv1.NewConfiguration()
 	cfg.Debug = unsafeTrace
-	cfg.HTTPClient = NewRetryableHttpClient(unsafeTrace)
+	cfg.HTTPClient = httpClient
 	cfg.Servers = connectv1.ServerConfigurations{{URL: url}}
 	cfg.UserAgent = userAgent
 

--- a/pkg/ccloudv2/connect_custom_plugin.go
+++ b/pkg/ccloudv2/connect_custom_plugin.go
@@ -9,10 +9,10 @@ import (
 	"github.com/confluentinc/cli/v3/pkg/errors"
 )
 
-func newConnectCustomPluginClient(url, userAgent string, unsafeTrace bool) *connectcustompluginv1.APIClient {
+func newConnectCustomPluginClient(httpClient *http.Client, url, userAgent string, unsafeTrace bool) *connectcustompluginv1.APIClient {
 	cfg := connectcustompluginv1.NewConfiguration()
 	cfg.Debug = unsafeTrace
-	cfg.HTTPClient = NewRetryableHttpClient(unsafeTrace)
+	cfg.HTTPClient = httpClient
 	cfg.Servers = connectcustompluginv1.ServerConfigurations{{URL: url}}
 	cfg.UserAgent = userAgent
 

--- a/pkg/ccloudv2/connect_custom_plugin.go
+++ b/pkg/ccloudv2/connect_custom_plugin.go
@@ -20,7 +20,7 @@ func newConnectCustomPluginClient(url, userAgent string, unsafeTrace bool) *conn
 }
 
 func (c *Client) connectCustomPluginApiContext() context.Context {
-	return context.WithValue(context.Background(), connectcustompluginv1.ContextAccessToken, c.AuthToken)
+	return context.WithValue(context.Background(), connectcustompluginv1.ContextAccessToken, c.cfg.Context().GetAuthToken())
 }
 
 func (c *Client) GetPresignedUrl(request connectcustompluginv1.ConnectV1PresignedUrlRequest) (connectcustompluginv1.ConnectV1PresignedUrl, error) {

--- a/pkg/ccloudv2/flink.go
+++ b/pkg/ccloudv2/flink.go
@@ -2,6 +2,7 @@ package ccloudv2
 
 import (
 	"context"
+	"net/http"
 
 	flinkv2 "github.com/confluentinc/ccloud-sdk-go-v2/flink/v2"
 
@@ -9,10 +10,10 @@ import (
 	"github.com/confluentinc/cli/v3/pkg/resource"
 )
 
-func newFlinkClient(url, userAgent string, unsafeTrace bool) *flinkv2.APIClient {
+func newFlinkClient(httpClient *http.Client, url, userAgent string, unsafeTrace bool) *flinkv2.APIClient {
 	cfg := flinkv2.NewConfiguration()
 	cfg.Debug = unsafeTrace
-	cfg.HTTPClient = NewRetryableHttpClient(unsafeTrace)
+	cfg.HTTPClient = httpClient
 	cfg.Servers = flinkv2.ServerConfigurations{{URL: url}}
 	cfg.UserAgent = userAgent
 

--- a/pkg/ccloudv2/flink.go
+++ b/pkg/ccloudv2/flink.go
@@ -20,7 +20,7 @@ func newFlinkClient(url, userAgent string, unsafeTrace bool) *flinkv2.APIClient 
 }
 
 func (c *Client) flinkApiContext() context.Context {
-	return context.WithValue(context.Background(), flinkv2.ContextAccessToken, c.AuthToken)
+	return context.WithValue(context.Background(), flinkv2.ContextAccessToken, c.cfg.Context().GetAuthToken())
 }
 
 func (c *Client) CreateFlinkComputePool(computePool flinkv2.FcpmV2ComputePool) (flinkv2.FcpmV2ComputePool, error) {

--- a/pkg/ccloudv2/iam.go
+++ b/pkg/ccloudv2/iam.go
@@ -10,10 +10,10 @@ import (
 	"github.com/confluentinc/cli/v3/pkg/errors"
 )
 
-func newIamClient(url, userAgent string, unsafeTrace bool) *iamv2.APIClient {
+func newIamClient(httpClient *http.Client, url, userAgent string, unsafeTrace bool) *iamv2.APIClient {
 	cfg := iamv2.NewConfiguration()
 	cfg.Debug = unsafeTrace
-	cfg.HTTPClient = NewRetryableHttpClient(unsafeTrace)
+	cfg.HTTPClient = httpClient
 	cfg.Servers = iamv2.ServerConfigurations{{URL: url}}
 	cfg.UserAgent = userAgent
 

--- a/pkg/ccloudv2/iam.go
+++ b/pkg/ccloudv2/iam.go
@@ -21,7 +21,7 @@ func newIamClient(url, userAgent string, unsafeTrace bool) *iamv2.APIClient {
 }
 
 func (c *Client) iamApiContext() context.Context {
-	return context.WithValue(context.Background(), iamv2.ContextAccessToken, c.AuthToken)
+	return context.WithValue(context.Background(), iamv2.ContextAccessToken, c.cfg.Context().GetAuthToken())
 }
 
 // iam service-account api calls

--- a/pkg/ccloudv2/identity_provider.go
+++ b/pkg/ccloudv2/identity_provider.go
@@ -9,10 +9,10 @@ import (
 	"github.com/confluentinc/cli/v3/pkg/errors"
 )
 
-func newIdentityProviderClient(url, userAgent string, unsafeTrace bool) *identityproviderv2.APIClient {
+func newIdentityProviderClient(httpClient *http.Client, url, userAgent string, unsafeTrace bool) *identityproviderv2.APIClient {
 	cfg := identityproviderv2.NewConfiguration()
 	cfg.Debug = unsafeTrace
-	cfg.HTTPClient = NewRetryableHttpClient(unsafeTrace)
+	cfg.HTTPClient = httpClient
 	cfg.Servers = identityproviderv2.ServerConfigurations{{URL: url}}
 	cfg.UserAgent = userAgent
 

--- a/pkg/ccloudv2/identity_provider.go
+++ b/pkg/ccloudv2/identity_provider.go
@@ -20,11 +20,11 @@ func newIdentityProviderClient(url, userAgent string, unsafeTrace bool) *identit
 }
 
 func (c *Client) identityProviderApiContext() context.Context {
-	return context.WithValue(context.Background(), identityproviderv2.ContextAccessToken, c.AuthToken)
+	return context.WithValue(context.Background(), identityproviderv2.ContextAccessToken, c.cfg.Context().GetAuthToken())
 }
 
 func (c *Client) identityPoolApiContext() context.Context {
-	return context.WithValue(context.Background(), identityproviderv2.ContextAccessToken, c.AuthToken)
+	return context.WithValue(context.Background(), identityproviderv2.ContextAccessToken, c.cfg.Context().GetAuthToken())
 }
 
 func (c *Client) CreateIdentityProvider(identityProvider identityproviderv2.IamV2IdentityProvider) (identityproviderv2.IamV2IdentityProvider, error) {

--- a/pkg/ccloudv2/kafka_quota.go
+++ b/pkg/ccloudv2/kafka_quota.go
@@ -20,7 +20,7 @@ func newKafkaQuotasClient(url, userAgent string, unsafeTrace bool) *kafkaquotasv
 }
 
 func (c *Client) quotaContext() context.Context {
-	return context.WithValue(context.Background(), kafkaquotasv1.ContextAccessToken, c.AuthToken)
+	return context.WithValue(context.Background(), kafkaquotasv1.ContextAccessToken, c.cfg.Context().GetAuthToken())
 }
 
 func (c *Client) ListKafkaQuotas(clusterId, envId string) ([]kafkaquotasv1.KafkaQuotasV1ClientQuota, error) {

--- a/pkg/ccloudv2/kafka_quotas.go
+++ b/pkg/ccloudv2/kafka_quotas.go
@@ -9,10 +9,10 @@ import (
 	"github.com/confluentinc/cli/v3/pkg/errors"
 )
 
-func newKafkaQuotasClient(url, userAgent string, unsafeTrace bool) *kafkaquotasv1.APIClient {
+func newKafkaQuotasClient(httpClient *http.Client, url, userAgent string, unsafeTrace bool) *kafkaquotasv1.APIClient {
 	cfg := kafkaquotasv1.NewConfiguration()
 	cfg.Debug = unsafeTrace
-	cfg.HTTPClient = NewRetryableHttpClient(unsafeTrace)
+	cfg.HTTPClient = httpClient
 	cfg.Servers = kafkaquotasv1.ServerConfigurations{{URL: url}}
 	cfg.UserAgent = userAgent
 

--- a/pkg/ccloudv2/kafkarest.go
+++ b/pkg/ccloudv2/kafkarest.go
@@ -26,7 +26,7 @@ type KafkaRestClient struct {
 func NewKafkaRestClient(url, clusterId, userAgent, authToken string, unsafeTrace bool) *KafkaRestClient {
 	cfg := kafkarestv3.NewConfiguration()
 	cfg.Debug = unsafeTrace
-	cfg.HTTPClient = NewRetryableHttpClient(unsafeTrace)
+	cfg.HTTPClient = NewRetryableHttpClient(nil, unsafeTrace)
 	cfg.Servers = kafkarestv3.ServerConfigurations{{URL: url}}
 	cfg.UserAgent = userAgent
 

--- a/pkg/ccloudv2/ksql.go
+++ b/pkg/ccloudv2/ksql.go
@@ -20,7 +20,7 @@ func newKsqlClient(url, userAgent string, unsafeTrace bool) *ksqlv2.APIClient {
 }
 
 func (c *Client) ksqlApiContext() context.Context {
-	return context.WithValue(context.Background(), ksqlv2.ContextAccessToken, c.AuthToken)
+	return context.WithValue(context.Background(), ksqlv2.ContextAccessToken, c.cfg.Context().GetAuthToken())
 }
 
 func (c *Client) ListKsqlClusters(environmentId string) ([]ksqlv2.KsqldbcmV2Cluster, error) {

--- a/pkg/ccloudv2/ksql.go
+++ b/pkg/ccloudv2/ksql.go
@@ -9,10 +9,10 @@ import (
 	"github.com/confluentinc/cli/v3/pkg/errors"
 )
 
-func newKsqlClient(url, userAgent string, unsafeTrace bool) *ksqlv2.APIClient {
+func newKsqlClient(httpClient *http.Client, url, userAgent string, unsafeTrace bool) *ksqlv2.APIClient {
 	cfg := ksqlv2.NewConfiguration()
 	cfg.Debug = unsafeTrace
-	cfg.HTTPClient = NewRetryableHttpClient(unsafeTrace)
+	cfg.HTTPClient = httpClient
 	cfg.Servers = ksqlv2.ServerConfigurations{{URL: url}}
 	cfg.UserAgent = userAgent
 

--- a/pkg/ccloudv2/mds.go
+++ b/pkg/ccloudv2/mds.go
@@ -9,10 +9,10 @@ import (
 	"github.com/confluentinc/cli/v3/pkg/errors"
 )
 
-func newMdsClient(url, userAgent string, unsafeTrace bool) *mdsv2.APIClient {
+func newMdsClient(httpClient *http.Client, url, userAgent string, unsafeTrace bool) *mdsv2.APIClient {
 	cfg := mdsv2.NewConfiguration()
 	cfg.Debug = unsafeTrace
-	cfg.HTTPClient = NewRetryableHttpClient(unsafeTrace)
+	cfg.HTTPClient = httpClient
 	cfg.Servers = mdsv2.ServerConfigurations{{URL: url}}
 	cfg.UserAgent = userAgent
 

--- a/pkg/ccloudv2/mds.go
+++ b/pkg/ccloudv2/mds.go
@@ -20,7 +20,7 @@ func newMdsClient(url, userAgent string, unsafeTrace bool) *mdsv2.APIClient {
 }
 
 func (c *Client) mdsApiContext() context.Context {
-	return context.WithValue(context.Background(), mdsv2.ContextAccessToken, c.AuthToken)
+	return context.WithValue(context.Background(), mdsv2.ContextAccessToken, c.cfg.Context().GetAuthToken())
 }
 
 func (c *Client) CreateIamRoleBinding(iamV2RoleBinding *mdsv2.IamV2RoleBinding) (mdsv2.IamV2RoleBinding, error) {

--- a/pkg/ccloudv2/metrics.go
+++ b/pkg/ccloudv2/metrics.go
@@ -27,7 +27,7 @@ type MetricsClient struct {
 func NewMetricsClient(url, userAgent string, unsafeTrace bool, authToken string) *MetricsClient {
 	cfg := metricsv2.NewConfiguration()
 	cfg.Debug = unsafeTrace
-	cfg.HTTPClient = NewRetryableHttpClient(unsafeTrace)
+	cfg.HTTPClient = NewRetryableHttpClient(nil, unsafeTrace)
 	cfg.Servers = metricsv2.ServerConfigurations{{URL: url}}
 	cfg.UserAgent = userAgent
 

--- a/pkg/ccloudv2/org.go
+++ b/pkg/ccloudv2/org.go
@@ -9,10 +9,10 @@ import (
 	"github.com/confluentinc/cli/v3/pkg/errors"
 )
 
-func newOrgClient(url, userAgent string, unsafeTrace bool) *orgv2.APIClient {
+func newOrgClient(httpClient *http.Client, url, userAgent string, unsafeTrace bool) *orgv2.APIClient {
 	cfg := orgv2.NewConfiguration()
 	cfg.Debug = unsafeTrace
-	cfg.HTTPClient = NewRetryableHttpClient(unsafeTrace)
+	cfg.HTTPClient = httpClient
 	cfg.Servers = orgv2.ServerConfigurations{{URL: url}}
 	cfg.UserAgent = userAgent
 

--- a/pkg/ccloudv2/org.go
+++ b/pkg/ccloudv2/org.go
@@ -20,7 +20,7 @@ func newOrgClient(url, userAgent string, unsafeTrace bool) *orgv2.APIClient {
 }
 
 func (c *Client) orgApiContext() context.Context {
-	return context.WithValue(context.Background(), orgv2.ContextAccessToken, c.AuthToken)
+	return context.WithValue(context.Background(), orgv2.ContextAccessToken, c.cfg.Context().GetAuthToken())
 }
 
 func (c *Client) CreateOrgEnvironment(environment orgv2.OrgV2Environment) (orgv2.OrgV2Environment, error) {

--- a/pkg/ccloudv2/schema_registry.go
+++ b/pkg/ccloudv2/schema_registry.go
@@ -20,7 +20,7 @@ func newSrcmClient(url, userAgent string, unsafeTrace bool) *srcmv2.APIClient {
 }
 
 func (c *Client) SrcmApiContext() context.Context {
-	return context.WithValue(context.Background(), srcmv2.ContextAccessToken, c.AuthToken)
+	return context.WithValue(context.Background(), srcmv2.ContextAccessToken, c.cfg.Context().GetAuthToken())
 }
 
 func (c *Client) GetStreamGovernanceRegionById(regionId string) (srcmv2.SrcmV2Region, error) {

--- a/pkg/ccloudv2/service_quota.go
+++ b/pkg/ccloudv2/service_quota.go
@@ -9,10 +9,10 @@ import (
 	"github.com/confluentinc/cli/v3/pkg/errors"
 )
 
-func newServiceQuotaClient(url, userAgent string, unsafeTrace bool) *servicequotav1.APIClient {
+func newServiceQuotaClient(httpClient *http.Client, url, userAgent string, unsafeTrace bool) *servicequotav1.APIClient {
 	cfg := servicequotav1.NewConfiguration()
 	cfg.Debug = unsafeTrace
-	cfg.HTTPClient = NewRetryableHttpClient(unsafeTrace)
+	cfg.HTTPClient = httpClient
 	cfg.Servers = servicequotav1.ServerConfigurations{{URL: url}}
 	cfg.UserAgent = userAgent
 

--- a/pkg/ccloudv2/service_quota.go
+++ b/pkg/ccloudv2/service_quota.go
@@ -20,7 +20,7 @@ func newServiceQuotaClient(url, userAgent string, unsafeTrace bool) *servicequot
 }
 
 func (c *Client) serviceQuotasApiContext() context.Context {
-	return context.WithValue(context.Background(), servicequotav1.ContextAccessToken, c.AuthToken)
+	return context.WithValue(context.Background(), servicequotav1.ContextAccessToken, c.cfg.Context().GetAuthToken())
 }
 
 func (c *Client) ListServiceQuotas(quotaScope, kafkaCluster, environment, network, quotaCode string) ([]servicequotav1.ServiceQuotaV1AppliedQuota, error) {

--- a/pkg/ccloudv2/srcm.go
+++ b/pkg/ccloudv2/srcm.go
@@ -9,10 +9,10 @@ import (
 	"github.com/confluentinc/cli/v3/pkg/errors"
 )
 
-func newSrcmClient(url, userAgent string, unsafeTrace bool) *srcmv2.APIClient {
+func newSrcmClient(httpClient *http.Client, url, userAgent string, unsafeTrace bool) *srcmv2.APIClient {
 	cfg := srcmv2.NewConfiguration()
 	cfg.Debug = unsafeTrace
-	cfg.HTTPClient = NewRetryableHttpClient(unsafeTrace)
+	cfg.HTTPClient = httpClient
 	cfg.Servers = srcmv2.ServerConfigurations{{URL: url}}
 	cfg.UserAgent = userAgent
 

--- a/pkg/ccloudv2/sso.go
+++ b/pkg/ccloudv2/sso.go
@@ -20,7 +20,7 @@ func newSsoClient(url, userAgent string, unsafeTrace bool) *ssov2.APIClient {
 }
 
 func (c *Client) groupMappingApiContext() context.Context {
-	return context.WithValue(context.Background(), ssov2.ContextAccessToken, c.AuthToken)
+	return context.WithValue(context.Background(), ssov2.ContextAccessToken, c.cfg.Context().GetAuthToken())
 }
 
 func (c *Client) CreateGroupMapping(groupMapping ssov2.IamV2SsoGroupMapping) (ssov2.IamV2SsoGroupMapping, error) {

--- a/pkg/ccloudv2/sso.go
+++ b/pkg/ccloudv2/sso.go
@@ -9,10 +9,10 @@ import (
 	"github.com/confluentinc/cli/v3/pkg/errors"
 )
 
-func newSsoClient(url, userAgent string, unsafeTrace bool) *ssov2.APIClient {
+func newSsoClient(httpClient *http.Client, url, userAgent string, unsafeTrace bool) *ssov2.APIClient {
 	cfg := ssov2.NewConfiguration()
 	cfg.Debug = unsafeTrace
-	cfg.HTTPClient = NewRetryableHttpClient(unsafeTrace)
+	cfg.HTTPClient = httpClient
 	cfg.Servers = ssov2.ServerConfigurations{{URL: url}}
 	cfg.UserAgent = userAgent
 

--- a/pkg/ccloudv2/stream_designer.go
+++ b/pkg/ccloudv2/stream_designer.go
@@ -2,16 +2,17 @@ package ccloudv2
 
 import (
 	"context"
+	"net/http"
 
 	streamdesignerv1 "github.com/confluentinc/ccloud-sdk-go-v2/stream-designer/v1"
 
 	"github.com/confluentinc/cli/v3/pkg/errors"
 )
 
-func newStreamDesignerClient(url, userAgent string, unsafeTrace bool) *streamdesignerv1.APIClient {
+func newStreamDesignerClient(httpClient *http.Client, url, userAgent string, unsafeTrace bool) *streamdesignerv1.APIClient {
 	cfg := streamdesignerv1.NewConfiguration()
 	cfg.Debug = unsafeTrace
-	cfg.HTTPClient = NewRetryableHttpClient(unsafeTrace)
+	cfg.HTTPClient = httpClient
 	cfg.Servers = streamdesignerv1.ServerConfigurations{{URL: url}}
 	cfg.UserAgent = userAgent
 

--- a/pkg/ccloudv2/stream_designer.go
+++ b/pkg/ccloudv2/stream_designer.go
@@ -19,7 +19,7 @@ func newStreamDesignerClient(url, userAgent string, unsafeTrace bool) *streamdes
 }
 
 func (c *Client) sdApiContext() context.Context {
-	return context.WithValue(context.Background(), streamdesignerv1.ContextAccessToken, c.AuthToken)
+	return context.WithValue(context.Background(), streamdesignerv1.ContextAccessToken, c.cfg.Context().GetAuthToken())
 }
 
 func (c *Client) ListPipelines(envId, clusterId string) ([]streamdesignerv1.SdV1Pipeline, error) {

--- a/pkg/ccloudv2/utils.go
+++ b/pkg/ccloudv2/utils.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/hashicorp/go-retryablehttp"
 
+	"github.com/confluentinc/cli/v3/pkg/config"
 	plog "github.com/confluentinc/cli/v3/pkg/log"
 	testserver "github.com/confluentinc/cli/v3/test/test-server"
 )
@@ -43,13 +44,18 @@ func IsCCloudURL(url string, isTest bool) bool {
 	return false
 }
 
-func NewRetryableHttpClient(unsafeTrace bool) *http.Client {
+func NewRetryableHttpClient(cfg *config.Config, unsafeTrace bool) *http.Client {
 	client := retryablehttp.NewClient()
 	client.Logger = plog.NewLeveledLogger(unsafeTrace)
 	client.CheckRetry = func(ctx context.Context, resp *http.Response, err error) (bool, error) {
 		if resp == nil {
 			return false, err
 		}
+
+		if cfg != nil && resp.StatusCode == http.StatusUnauthorized {
+			// TODO: Refresh
+		}
+
 		return resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode >= 500, err
 	}
 	return client.StandardClient()

--- a/pkg/cmd/authenticated_cli_command.go
+++ b/pkg/cmd/authenticated_cli_command.go
@@ -186,7 +186,7 @@ func (c *AuthenticatedCLICommand) GetSchemaRegistryClient(cmd *cobra.Command) (*
 			configuration := srsdk.NewConfiguration()
 			configuration.UserAgent = c.Config.Version.UserAgent
 			configuration.Debug = unsafeTrace
-			configuration.HTTPClient = ccloudv2.NewRetryableHttpClient(unsafeTrace)
+			configuration.HTTPClient = ccloudv2.NewRetryableHttpClient(nil, unsafeTrace)
 
 			if c.Context.GetState() != nil {
 				clusters, err := c.V2Client.GetSchemaRegistryClustersByEnvironment(c.Context.GetCurrentEnvironment())
@@ -255,7 +255,7 @@ func (c *AuthenticatedCLICommand) GetSchemaRegistryClient(cmd *cobra.Command) (*
 					return nil, err
 				}
 			} else {
-				client = ccloudv2.NewRetryableHttpClient(unsafeTrace)
+				client = ccloudv2.NewRetryableHttpClient(nil, unsafeTrace)
 			}
 
 			configuration := srsdk.NewConfiguration()

--- a/pkg/cmd/prerunner.go
+++ b/pkg/cmd/prerunner.go
@@ -221,7 +221,7 @@ func (r *PreRun) Authenticated(command *AuthenticatedCLICommand) func(*cobra.Com
 			return err
 		}
 
-		command.V2Client = command.Config.GetCloudClientV2(unsafeTrace)
+		command.V2Client = ccloudv2.NewClient(command.Config.Config, unsafeTrace)
 
 		return nil
 	}

--- a/pkg/cmd/token_validator.go
+++ b/pkg/cmd/token_validator.go
@@ -32,16 +32,12 @@ func NewJWTValidator() *JWTValidatorImpl {
 // Validate returns an error if the JWT in the specified context is invalid.
 // The JWT is invalid if it's not parsable or expired.
 func (v *JWTValidatorImpl) Validate(context *config.Context) error {
-	var authToken string
-	if context != nil {
-		authToken = context.State.AuthToken
-	}
-
-	var claims map[string]any
-	token, err := jwt.ParseSigned(authToken)
+	token, err := jwt.ParseSigned(context.GetAuthToken())
 	if err != nil {
 		return new(ccloudv1.InvalidTokenError)
 	}
+
+	var claims map[string]any
 	if err := token.UnsafeClaimsWithoutVerification(&claims); err != nil {
 		return err
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -11,7 +11,6 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/confluentinc/cli/v3/pkg/ccloudv2"
 	"github.com/confluentinc/cli/v3/pkg/errors"
 	"github.com/confluentinc/cli/v3/pkg/log"
 	"github.com/confluentinc/cli/v3/pkg/secret"
@@ -766,9 +765,4 @@ func (c *Config) isOrgSuspended() bool {
 
 func (c *Config) isLoginBlockedByOrgSuspension() bool {
 	return utils.IsLoginBlockedByOrgSuspension(c.Context().GetSuspensionStatus())
-}
-
-func (c *Config) GetCloudClientV2(unsafeTrace bool) *ccloudv2.Client {
-	ctx := c.Context()
-	return ccloudv2.NewClient(ctx.GetPlatformServer(), c.IsTest, ctx.GetAuthToken(), c.Version.UserAgent, unsafeTrace)
 }

--- a/pkg/config/context.go
+++ b/pkg/config/context.go
@@ -6,7 +6,6 @@ import (
 
 	ccloudv1 "github.com/confluentinc/ccloud-sdk-go-v1-public"
 
-	"github.com/confluentinc/cli/v3/pkg/ccloudv2"
 	"github.com/confluentinc/cli/v3/pkg/errors"
 	"github.com/confluentinc/cli/v3/pkg/output"
 	testserver "github.com/confluentinc/cli/v3/test/test-server"
@@ -137,7 +136,7 @@ func (c *Context) IsCloud(isTest bool) bool {
 		return true
 	}
 
-	for _, hostname := range ccloudv2.Hostnames {
+	for _, hostname := range []string{"confluent.cloud", "confluentgov-internal.com", "confluentgov.com", "cpdev.cloud"} {
 		if strings.Contains(c.PlatformName, hostname) {
 			return true
 		}

--- a/pkg/config/context.go
+++ b/pkg/config/context.go
@@ -6,6 +6,7 @@ import (
 
 	ccloudv1 "github.com/confluentinc/ccloud-sdk-go-v1-public"
 
+	"github.com/confluentinc/cli/v3/pkg/auth/sso"
 	"github.com/confluentinc/cli/v3/pkg/errors"
 	"github.com/confluentinc/cli/v3/pkg/output"
 	testserver "github.com/confluentinc/cli/v3/test/test-server"
@@ -386,6 +387,52 @@ func (c *Context) GetNetrcMachineName() string {
 		return c.NetrcMachineName
 	}
 	return ""
+}
+
+func (c *Context) RefreshSession(client *ccloudv1.Client) error {
+	if c.IsSso() {
+		idToken, refreshToken, err := sso.RefreshTokens(client.BaseURL, c.GetAuthRefreshToken())
+		if err != nil {
+			return err
+		}
+
+		req := &ccloudv1.AuthenticateRequest{
+			IdToken:       idToken,
+			OrgResourceId: c.GetCurrentOrganization(),
+		}
+
+		var res *ccloudv1.AuthenticateReply
+		if sso.IsOkta(client.BaseURL) {
+			res, err = client.Auth.OktaLogin(req)
+		} else {
+			res, err = client.Auth.Login(req)
+		}
+		if err != nil {
+			return err
+		}
+
+		c.State.AuthToken = res.GetToken()
+		c.State.AuthRefreshToken = refreshToken
+	} else {
+		req := &ccloudv1.AuthenticateRequest{
+			RefreshToken:  c.GetAuthRefreshToken(),
+			OrgResourceId: c.GetCurrentOrganization(),
+		}
+
+		res, err := client.Auth.Login(req)
+		if err != nil {
+			return err
+		}
+
+		c.State.AuthToken = res.GetToken()
+		c.State.AuthRefreshToken = res.GetRefreshToken()
+	}
+
+	return nil
+}
+
+func (c *Context) IsSso() bool {
+	return c.GetUser().GetAuthType() == ccloudv1.AuthType_AUTH_TYPE_SSO || c.GetUser().GetSocialConnection() != ""
 }
 
 func printApiKeysDictErrorMessage(missingKey, mismatchKey, missingSecret bool, cluster *KafkaClusterConfig, contextName string) {

--- a/pkg/config/context_state.go
+++ b/pkg/config/context_state.go
@@ -3,6 +3,9 @@ package config
 import (
 	"regexp"
 	"runtime"
+	"time"
+
+	"github.com/go-jose/go-jose/v3/jwt"
 
 	"github.com/confluentinc/cli/v3/pkg/secret"
 )
@@ -46,4 +49,23 @@ func (c *ContextState) DecryptContextStateAuthRefreshToken(ctxName string) error
 	}
 
 	return nil
+}
+
+func (c *ContextState) IsExpired() bool {
+	token, err := jwt.ParseSigned(c.AuthToken)
+	if err != nil {
+		return false
+	}
+
+	var claims map[string]any
+	if err := token.UnsafeClaimsWithoutVerification(&claims); err != nil {
+		return false
+	}
+
+	exp, ok := claims["exp"].(float64)
+	if !ok {
+		return false
+	}
+
+	return float64(time.Now().Unix()) > exp
 }


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- PLACEHOLDER

New Features
- PLACEHOLDER

Bug Fixes
- Refresh authentication token on HTTP retry, if needed

Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   - [x] yes: ok
   - [ ] no: DO NOT MERGE until the required features are live in prod  

What
----
The auth token can sometimes time out during HTTP retry if a rate limit is hit. Refactor code to allow refreshing the auth token. This requires passing the complete configuration into the ccloudv2 package.

References
----------
https://confluentinc.atlassian.net/browse/CLI-1913

Test & Review
-------------
TODO

Open Questions / Follow-ups
---------------------------
Will support Kafka REST, Schema Registry, metrics, and Flink in separate PRs
