### PR TITLE
Remove double-collected AsyncAPI metrics

### DIFF
--- a/internal/asyncapi/account_details.go
+++ b/internal/asyncapi/account_details.go
@@ -119,13 +119,6 @@ func (d *accountDetails) getTopicDescription() error {
 	return nil
 }
 
-func (c *command) countAsyncApiUsage(details *accountDetails) error {
-	if err := details.srClient.AsyncapiPut(); err != nil {
-		return fmt.Errorf("failed to access AsyncAPI metric endpoint: %w", err)
-	}
-	return nil
-}
-
 func (d *accountDetails) buildMessageEntity() *spec.MessageEntity {
 	entityProducer := new(spec.MessageEntity)
 	entityProducer.WithContentType(d.channelDetails.contentType)

--- a/internal/asyncapi/command_export.go
+++ b/internal/asyncapi/command_export.go
@@ -166,9 +166,6 @@ func (c *command) export(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return err
 	}
-	if err := c.countAsyncApiUsage(accountDetails); err != nil {
-		log.CliLogger.Debug(err)
-	}
 	output.Printf(c.Config.EnableColor, "AsyncAPI specification written to \"%s\".\n", flags.file)
 	return os.WriteFile(flags.file, yaml, 0644)
 }

--- a/pkg/schema-registry/client.go
+++ b/pkg/schema-registry/client.go
@@ -206,8 +206,3 @@ func (c *Client) GetByUniqueAttributes(typeName, qualifiedName string) (srsdk.At
 	res, _, err := c.DefaultApi.GetByUniqueAttributes(c.context, typeName, qualifiedName, nil)
 	return res, err
 }
-
-func (c *Client) AsyncapiPut() error {
-	_, err := c.DefaultApi.AsyncapiPut(c.context)
-	return err
-}


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   - [x] yes: ok
   - [ ] no: DO NOT MERGE until the required features are live in prod  

What
----
We already collect metrics on all Confluent Cloud commands, so we do not need to separately collect metrics for AsyncAPI commands

Test & Review
-------------
Tests still pass