### PR TITLE
Remove Flink from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,1 @@
-*                   @confluentinc/cli
-pkg/flink/ @confluentinc/cloud-surfaces
-pkg/ccloudv2/flink.go @confluentinc/cli @confluentinc/cloud-surfaces
-pkg/ccloudv2/flink_gateway.go @confluentinc/cli @confluentinc/cloud-surfaces
-go.mod @confluentinc/cli @confluentinc/cloud-surfaces
-go.sum @confluentinc/cli @confluentinc/cloud-surfaces
+* @confluentinc/cli


### PR DESCRIPTION
Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   - [ ] yes: ok
   - [ ] no: DO NOT MERGE until the required features are live in prod  

What
----
According to https://confluent.slack.com/archives/C038ZJ00P/p1698776762773139?thread_ts=1692295006.029139&cid=C038ZJ00P, we will no longer be able to force merge in a week or two from today. Since `flink shell` development has decreased to < 1 PR/week and we are not releasing faster than once per week, we should remove the Flink team from the CODEOWNERS file, so a review is not required from the Flink team for changes to the go.mod file and global edits that happen to touch Flink-related files.