### PR TITLE
Fix `release-docs-main` and `release-docs-staging`

### DIFF
--- a/mk-files/docs.mk
+++ b/mk-files/docs.mk
@@ -1,5 +1,7 @@
 STAGING_BRANCH_REGEX="s/\([0-9]*\.[0-9]*\.\)[0-9]*/\1x/"
+STAGING_BRANCH_REGEX_DASH="s/\([0-9]*\)\.\([0-9]*\)\.[0-9]*/\1-\2-x/"
 STAGING_BRANCH=$(shell echo $(CLEAN_VERSION) | sed $(STAGING_BRANCH_REGEX))
+STAGING_BRANCH_DASH=$(shell echo $(CLEAN_VERSION) | sed $(STAGING_BRANCH_REGEX_DASH))
 
 ifeq ($(shell uname),Darwin)
 SED ?= gsed
@@ -10,6 +12,7 @@ endif
 NEXT_MINOR_VERSION = $(word 1,$(split_version)).$(shell expr $(word 2,$(split_version)) + 1).0
 SHORT_NEXT_MINOR_VERSION = $(word 1,$(split_version)).$(shell expr $(word 2,$(split_version)) + 1)
 CURRENT_SHORT_MINOR_VERSION = $(word 1,$(split_version)).$(word 2,$(split_version))
+CURRENT_SHORT_MINOR_VERSION_DASH = $(word 1,$(split_version))-$(word 2,$(split_version))
 NEXT_PATCH_VERSION = $(word 1,$(split_version)).$(word 2,$(split_version)).$(shell expr $(word 3,$(split_version)) + 1)
 
 .PHONY: docs
@@ -87,22 +90,22 @@ release-docs-staging:
 	git clone git@github.com:confluentinc/docs-confluent-cli.git $(DOCS_CONFLUENT_CLI) && \
 	cd $(DOCS_CONFLUENT_CLI) && \
 	git fetch && \
-	git checkout -b release-docs-staging-v$(CURRENT_SHORT_MINOR_VERSION) origin/$(CURRENT_SHORT_MINOR_VERSION)-post && \
+	git checkout -b release-docs-staging-v$(CURRENT_SHORT_MINOR_VERSION_DASH) origin/$(CURRENT_SHORT_MINOR_VERSION)-post && \
 	$(SED) -i 's/export RELEASE_VERSION=.*/export RELEASE_VERSION=$(CLEAN_VERSION)/g' settings.sh && \
 	$(SED) -i 's/export PUBLIC_VERSION=.*/export PUBLIC_VERSION=$(CURRENT_SHORT_MINOR_VERSION)/g' settings.sh && \
 	$(SED) -i "s/^version = '.*'/version = \'$(CURRENT_SHORT_MINOR_VERSION)\'/g" conf.py && \
 	$(SED) -i "s/^release = '.*'/release = \'$(CLEAN_VERSION)\'/g" conf.py && \
 	git commit -am "[ci skip] chore: update settings.sh and conf.py due to $(CLEAN_VERSION) release" && \
-	$(call dry-run,git push origin release-docs-staging-v$(CURRENT_SHORT_MINOR_VERSION)) && \
-	$(call dry-run,gh pr create --base $(CURRENT_SHORT_MINOR_VERSION)-post --title "[ci skip] update settings.sh and conf.py due to $(CLEAN_VERSION) release" --body "") && \
-	git checkout -b release-docs-staging-v$(STAGING_BRANCH) origin/$(STAGING_BRANCH) && \
+	$(call dry-run,git push origin release-docs-staging-v$(CURRENT_SHORT_MINOR_VERSION_DASH)) && \
+	$(call dry-run,gh pr create --base $(CURRENT_SHORT_MINOR_VERSION)-post --title "[ci skip] Release docs to staging for v$(CLEAN_VERSION) release" --body "") && \
+	git checkout -b release-docs-staging-v$(STAGING_BRANCH_DASH) origin/$(STAGING_BRANCH) && \
 	$(SED) -i 's/export RELEASE_VERSION=.*/export RELEASE_VERSION=$(NEXT_PATCH_VERSION)-SNAPSHOT/g' settings.sh && \
 	$(SED) -i 's/export PUBLIC_VERSION=.*/export PUBLIC_VERSION=$(CURRENT_SHORT_MINOR_VERSION)/g' settings.sh && \
 	$(SED) -i "s/^version = '.*'/version = \'$(CURRENT_SHORT_MINOR_VERSION)\'/g" conf.py && \
 	$(SED) -i "s/^release = '.*'/release = \'$(NEXT_PATCH_VERSION)-SNAPSHOT\'/g" conf.py && \
 	git commit -am "[ci skip] chore: update settings.sh and conf.py due to $(CLEAN_VERSION) release" && \
-	git merge -s ours -m "Merge branch 'release-docs-staging-v$(CURRENT_SHORT_MINOR_VERSION)' into release-docs-staging-v$(STAGING_BRANCH)" release-docs-staging-v$(CURRENT_SHORT_MINOR_VERSION) && \
-	$(call dry-run,git push origin release-docs-staging-v$(STAGING_BRANCH)) && \
-	$(call dry-run,gh pr create --base $(STAGING_BRANCH) --title "[ci skip] update settings.sh and conf.py due to $(CLEAN_VERSION) release" --body "")
+	git merge -s ours -m "Merge branch 'release-docs-staging-v$(CURRENT_SHORT_MINOR_VERSION_DASH)' into release-docs-staging-v$(STAGING_BRANCH_DASH)" release-docs-staging-v$(CURRENT_SHORT_MINOR_VERSION_DASH) && \
+	$(call dry-run,git push origin release-docs-staging-v$(STAGING_BRANCH_DASH)) && \
+	$(call dry-run,gh pr create --base $(STAGING_BRANCH) --title "[ci skip] Release docs to staging for v$(CLEAN_VERSION) release" --body "")
 
 	rm -rf $(DIR)

--- a/mk-files/docs.mk
+++ b/mk-files/docs.mk
@@ -87,13 +87,13 @@ release-docs-staging:
 	git clone git@github.com:confluentinc/docs-confluent-cli.git $(DOCS_CONFLUENT_CLI) && \
 	cd $(DOCS_CONFLUENT_CLI) && \
 	git fetch && \
-	git checkout -b release-docs-staging-v$(CURRENT_SHORT_MINOR_VERSION)-post origin/$(CURRENT_SHORT_MINOR_VERSION)-post && \
+	git checkout -b release-docs-staging-v$(CURRENT_SHORT_MINOR_VERSION) origin/$(CURRENT_SHORT_MINOR_VERSION)-post && \
 	$(SED) -i 's/export RELEASE_VERSION=.*/export RELEASE_VERSION=$(CLEAN_VERSION)/g' settings.sh && \
 	$(SED) -i 's/export PUBLIC_VERSION=.*/export PUBLIC_VERSION=$(CURRENT_SHORT_MINOR_VERSION)/g' settings.sh && \
 	$(SED) -i "s/^version = '.*'/version = \'$(CURRENT_SHORT_MINOR_VERSION)\'/g" conf.py && \
 	$(SED) -i "s/^release = '.*'/release = \'$(CLEAN_VERSION)\'/g" conf.py && \
 	git commit -am "[ci skip] chore: update settings.sh and conf.py due to $(CLEAN_VERSION) release" && \
-	$(call dry-run,git push origin release-docs-staging-v$(CURRENT_SHORT_MINOR_VERSION)-post) && \
+	$(call dry-run,git push origin release-docs-staging-v$(CURRENT_SHORT_MINOR_VERSION)) && \
 	$(call dry-run,gh pr create --base $(CURRENT_SHORT_MINOR_VERSION)-post --title "update settings.sh and conf.py due to $(CLEAN_VERSION) release" --body "") && \
 	git checkout -b release-docs-staging-v$(STAGING_BRANCH) origin/$(STAGING_BRANCH) && \
 	$(SED) -i 's/export RELEASE_VERSION=.*/export RELEASE_VERSION=$(NEXT_PATCH_VERSION)-SNAPSHOT/g' settings.sh && \
@@ -101,7 +101,7 @@ release-docs-staging:
 	$(SED) -i "s/^version = '.*'/version = \'$(CURRENT_SHORT_MINOR_VERSION)\'/g" conf.py && \
 	$(SED) -i "s/^release = '.*'/release = \'$(NEXT_PATCH_VERSION)-SNAPSHOT\'/g" conf.py && \
 	git commit -am "[ci skip] chore: update settings.sh and conf.py due to $(CLEAN_VERSION) release" && \
-	git merge -s ours -m "Merge branch 'release-docs-staging-v$(CURRENT_SHORT_MINOR_VERSION)-post' into release-docs-staging-v$(STAGING_BRANCH)" release-docs-staging-v$(CURRENT_SHORT_MINOR_VERSION)-post && \
+	git merge -s ours -m "Merge branch 'release-docs-staging-v$(CURRENT_SHORT_MINOR_VERSION)' into release-docs-staging-v$(STAGING_BRANCH)" release-docs-staging-v$(CURRENT_SHORT_MINOR_VERSION) && \
 	$(call dry-run,git push origin release-docs-staging-v$(STAGING_BRANCH)) && \
 	$(call dry-run,gh pr create --base $(STAGING_BRANCH) --title "update settings.sh and conf.py due to $(CLEAN_VERSION) release" --body "")
 

--- a/mk-files/docs.mk
+++ b/mk-files/docs.mk
@@ -87,22 +87,22 @@ release-docs-staging:
 	git clone git@github.com:confluentinc/docs-confluent-cli.git $(DOCS_CONFLUENT_CLI) && \
 	cd $(DOCS_CONFLUENT_CLI) && \
 	git fetch && \
-	git checkout -b release-docs-staging-$(CURRENT_SHORT_MINOR_VERSION)-post origin/$(CURRENT_SHORT_MINOR_VERSION)-post && \
+	git checkout -b release-docs-staging-v$(CURRENT_SHORT_MINOR_VERSION)-post origin/$(CURRENT_SHORT_MINOR_VERSION)-post && \
 	$(SED) -i 's/export RELEASE_VERSION=.*/export RELEASE_VERSION=$(CLEAN_VERSION)/g' settings.sh && \
 	$(SED) -i 's/export PUBLIC_VERSION=.*/export PUBLIC_VERSION=$(CURRENT_SHORT_MINOR_VERSION)/g' settings.sh && \
 	$(SED) -i "s/^version = '.*'/version = \'$(CURRENT_SHORT_MINOR_VERSION)\'/g" conf.py && \
 	$(SED) -i "s/^release = '.*'/release = \'$(CLEAN_VERSION)\'/g" conf.py && \
 	git commit -am "[ci skip] chore: update settings.sh and conf.py due to $(CLEAN_VERSION) release" && \
-	$(call dry-run,git push origin release-docs-staging-$(CURRENT_SHORT_MINOR_VERSION)-post) && \
+	$(call dry-run,git push origin release-docs-staging-v$(CURRENT_SHORT_MINOR_VERSION)-post) && \
 	$(call dry-run,gh pr create --base $(CURRENT_SHORT_MINOR_VERSION)-post --title "update settings.sh and conf.py due to $(CLEAN_VERSION) release" --body "") && \
-	git checkout -b release-docs-staging-$(STAGING_BRANCH) origin/$(STAGING_BRANCH) && \
+	git checkout -b release-docs-staging-v$(STAGING_BRANCH) origin/$(STAGING_BRANCH) && \
 	$(SED) -i 's/export RELEASE_VERSION=.*/export RELEASE_VERSION=$(NEXT_PATCH_VERSION)-SNAPSHOT/g' settings.sh && \
 	$(SED) -i 's/export PUBLIC_VERSION=.*/export PUBLIC_VERSION=$(CURRENT_SHORT_MINOR_VERSION)/g' settings.sh && \
 	$(SED) -i "s/^version = '.*'/version = \'$(CURRENT_SHORT_MINOR_VERSION)\'/g" conf.py && \
 	$(SED) -i "s/^release = '.*'/release = \'$(NEXT_PATCH_VERSION)-SNAPSHOT\'/g" conf.py && \
 	git commit -am "[ci skip] chore: update settings.sh and conf.py due to $(CLEAN_VERSION) release" && \
-	git merge -s ours -m "Merge branch 'release-docs-staging-$(CURRENT_SHORT_MINOR_VERSION)-post' into release-docs-staging-$(STAGING_BRANCH)" release-docs-staging-$(CURRENT_SHORT_MINOR_VERSION)-post && \
-	$(call dry-run,git push origin release-docs-staging-$(STAGING_BRANCH)) && \
+	git merge -s ours -m "Merge branch 'release-docs-staging-v$(CURRENT_SHORT_MINOR_VERSION)-post' into release-docs-staging-v$(STAGING_BRANCH)" release-docs-staging-v$(CURRENT_SHORT_MINOR_VERSION)-post && \
+	$(call dry-run,git push origin release-docs-staging-v$(STAGING_BRANCH)) && \
 	$(call dry-run,gh pr create --base $(STAGING_BRANCH) --title "update settings.sh and conf.py due to $(CLEAN_VERSION) release" --body "")
 
 	rm -rf $(DIR)

--- a/mk-files/docs.mk
+++ b/mk-files/docs.mk
@@ -94,7 +94,7 @@ release-docs-staging:
 	$(SED) -i "s/^release = '.*'/release = \'$(CLEAN_VERSION)\'/g" conf.py && \
 	git commit -am "[ci skip] chore: update settings.sh and conf.py due to $(CLEAN_VERSION) release" && \
 	$(call dry-run,git push origin release-docs-staging-v$(CURRENT_SHORT_MINOR_VERSION)) && \
-	$(call dry-run,gh pr create --base $(CURRENT_SHORT_MINOR_VERSION)-post --title "update settings.sh and conf.py due to $(CLEAN_VERSION) release" --body "") && \
+	$(call dry-run,gh pr create --base $(CURRENT_SHORT_MINOR_VERSION)-post --title "[ci skip] update settings.sh and conf.py due to $(CLEAN_VERSION) release" --body "") && \
 	git checkout -b release-docs-staging-v$(STAGING_BRANCH) origin/$(STAGING_BRANCH) && \
 	$(SED) -i 's/export RELEASE_VERSION=.*/export RELEASE_VERSION=$(NEXT_PATCH_VERSION)-SNAPSHOT/g' settings.sh && \
 	$(SED) -i 's/export PUBLIC_VERSION=.*/export PUBLIC_VERSION=$(CURRENT_SHORT_MINOR_VERSION)/g' settings.sh && \
@@ -103,6 +103,6 @@ release-docs-staging:
 	git commit -am "[ci skip] chore: update settings.sh and conf.py due to $(CLEAN_VERSION) release" && \
 	git merge -s ours -m "Merge branch 'release-docs-staging-v$(CURRENT_SHORT_MINOR_VERSION)' into release-docs-staging-v$(STAGING_BRANCH)" release-docs-staging-v$(CURRENT_SHORT_MINOR_VERSION) && \
 	$(call dry-run,git push origin release-docs-staging-v$(STAGING_BRANCH)) && \
-	$(call dry-run,gh pr create --base $(STAGING_BRANCH) --title "update settings.sh and conf.py due to $(CLEAN_VERSION) release" --body "")
+	$(call dry-run,gh pr create --base $(STAGING_BRANCH) --title "[ci skip] update settings.sh and conf.py due to $(CLEAN_VERSION) release" --body "")
 
 	rm -rf $(DIR)

--- a/mk-files/docs.mk
+++ b/mk-files/docs.mk
@@ -86,20 +86,22 @@ release-docs-staging:
 
 	git clone git@github.com:confluentinc/docs-confluent-cli.git $(DOCS_CONFLUENT_CLI) && \
 	cd $(DOCS_CONFLUENT_CLI) && \
-	git checkout $(STAGING_BRANCH) && \
+	git fetch && \
+	git checkout -b update-settings-$(STAGING_BRANCH) origin/$(STAGING_BRANCH) && \
 	$(SED) -i 's/export RELEASE_VERSION=.*/export RELEASE_VERSION=$(NEXT_PATCH_VERSION)-SNAPSHOT/g' settings.sh && \
 	$(SED) -i 's/export PUBLIC_VERSION=.*/export PUBLIC_VERSION=$(CURRENT_SHORT_MINOR_VERSION)/g' settings.sh && \
 	$(SED) -i "s/^version = '.*'/version = \'$(CURRENT_SHORT_MINOR_VERSION)\'/g" conf.py && \
 	$(SED) -i "s/^release = '.*'/release = \'$(NEXT_PATCH_VERSION)-SNAPSHOT\'/g" conf.py && \
 	git commit -am "[ci skip] chore: update settings.sh and conf.py due to $(CLEAN_VERSION) release" && \
-	git checkout $(CURRENT_SHORT_MINOR_VERSION)-post && \
+	git checkout -b update-settings-$(CURRENT_SHORT_MINOR_VERSION)-post origin/$(CURRENT_SHORT_MINOR_VERSION)-post && \
 	$(SED) -i 's/export RELEASE_VERSION=.*/export RELEASE_VERSION=$(CLEAN_VERSION)/g' settings.sh && \
 	$(SED) -i 's/export PUBLIC_VERSION=.*/export PUBLIC_VERSION=$(CURRENT_SHORT_MINOR_VERSION)/g' settings.sh && \
 	$(SED) -i "s/^version = '.*'/version = \'$(CURRENT_SHORT_MINOR_VERSION)\'/g" conf.py && \
 	$(SED) -i "s/^release = '.*'/release = \'$(CLEAN_VERSION)\'/g" conf.py && \
 	git commit -am "[ci skip] chore: update settings.sh and conf.py due to $(CLEAN_VERSION) release" && \
-	git checkout $(STAGING_BRANCH) && \
-	git merge -s ours -m "Merge branch '$(CURRENT_SHORT_MINOR_VERSION)-post' into $(STAGING_BRANCH)" $(CURRENT_SHORT_MINOR_VERSION)-post && \
-	$(call dry-run,git push origin "$(CURRENT_SHORT_MINOR_VERSION)-post:$(CURRENT_SHORT_MINOR_VERSION)-post" "$(STAGING_BRANCH):$(STAGING_BRANCH)")
+	$(call dry-run,gh pr create --base $(CURRENT_SHORT_MINOR_VERSION)-post --title "update settings.sh and conf.py due to $(CLEAN_VERSION) release" --body "") && \
+	git checkout update-settings-$(STAGING_BRANCH) && \
+	git merge -s ours -m "Merge branch 'update-settings-$(CURRENT_SHORT_MINOR_VERSION)-post' into update-settings-$(STAGING_BRANCH)" update-settings-$(CURRENT_SHORT_MINOR_VERSION)-post && \
+	$(call dry-run,gh pr create --base $(STAGING_BRANCH) --title "update settings.sh and conf.py due to $(CLEAN_VERSION) release" --body "")
 
 	rm -rf $(DIR)

--- a/mk-files/docs.mk
+++ b/mk-files/docs.mk
@@ -90,22 +90,22 @@ release-docs-staging:
 	git clone git@github.com:confluentinc/docs-confluent-cli.git $(DOCS_CONFLUENT_CLI) && \
 	cd $(DOCS_CONFLUENT_CLI) && \
 	git fetch && \
-	git checkout -b release-docs-staging-v$(CURRENT_SHORT_MINOR_VERSION_DASH) origin/$(CURRENT_SHORT_MINOR_VERSION)-post && \
+	git checkout -b release-docs-staging-$(CURRENT_SHORT_MINOR_VERSION_DASH) origin/$(CURRENT_SHORT_MINOR_VERSION)-post && \
 	$(SED) -i 's/export RELEASE_VERSION=.*/export RELEASE_VERSION=$(CLEAN_VERSION)/g' settings.sh && \
 	$(SED) -i 's/export PUBLIC_VERSION=.*/export PUBLIC_VERSION=$(CURRENT_SHORT_MINOR_VERSION)/g' settings.sh && \
 	$(SED) -i "s/^version = '.*'/version = \'$(CURRENT_SHORT_MINOR_VERSION)\'/g" conf.py && \
 	$(SED) -i "s/^release = '.*'/release = \'$(CLEAN_VERSION)\'/g" conf.py && \
 	git commit -am "[ci skip] chore: update settings.sh and conf.py due to $(CLEAN_VERSION) release" && \
-	$(call dry-run,git push origin release-docs-staging-v$(CURRENT_SHORT_MINOR_VERSION_DASH)) && \
+	$(call dry-run,git push origin release-docs-staging-$(CURRENT_SHORT_MINOR_VERSION_DASH)) && \
 	$(call dry-run,gh pr create --base $(CURRENT_SHORT_MINOR_VERSION)-post --title "[ci skip] Release docs to staging for v$(CLEAN_VERSION) release" --body "") && \
-	git checkout -b release-docs-staging-v$(STAGING_BRANCH_DASH) origin/$(STAGING_BRANCH) && \
+	git checkout -b release-docs-staging-$(STAGING_BRANCH_DASH) origin/$(STAGING_BRANCH) && \
 	$(SED) -i 's/export RELEASE_VERSION=.*/export RELEASE_VERSION=$(NEXT_PATCH_VERSION)-SNAPSHOT/g' settings.sh && \
 	$(SED) -i 's/export PUBLIC_VERSION=.*/export PUBLIC_VERSION=$(CURRENT_SHORT_MINOR_VERSION)/g' settings.sh && \
 	$(SED) -i "s/^version = '.*'/version = \'$(CURRENT_SHORT_MINOR_VERSION)\'/g" conf.py && \
 	$(SED) -i "s/^release = '.*'/release = \'$(NEXT_PATCH_VERSION)-SNAPSHOT\'/g" conf.py && \
 	git commit -am "[ci skip] chore: update settings.sh and conf.py due to $(CLEAN_VERSION) release" && \
-	git merge -s ours -m "Merge branch 'release-docs-staging-v$(CURRENT_SHORT_MINOR_VERSION_DASH)' into release-docs-staging-v$(STAGING_BRANCH_DASH)" release-docs-staging-v$(CURRENT_SHORT_MINOR_VERSION_DASH) && \
-	$(call dry-run,git push origin release-docs-staging-v$(STAGING_BRANCH_DASH)) && \
+	git merge -s ours -m "Merge branch 'release-docs-staging-$(CURRENT_SHORT_MINOR_VERSION_DASH)' into release-docs-staging-$(STAGING_BRANCH_DASH)" release-docs-staging-$(CURRENT_SHORT_MINOR_VERSION_DASH) && \
+	$(call dry-run,git push origin release-docs-staging-$(STAGING_BRANCH_DASH)) && \
 	$(call dry-run,gh pr create --base $(STAGING_BRANCH) --title "[ci skip] Release docs to staging for v$(CLEAN_VERSION) release" --body "")
 
 	rm -rf $(DIR)

--- a/mk-files/docs.mk
+++ b/mk-files/docs.mk
@@ -73,6 +73,7 @@ release-docs-main:
 		$(SED) -i "s/^version = '.*'/version = \'$(SHORT_NEXT_MINOR_VERSION)\'/g" conf.py && \
 		$(SED) -i "s/^release = '.*'/release = \'$(NEXT_MINOR_VERSION)-SNAPSHOT\'/g" conf.py && \
 		git commit -am "[ci skip] chore: update settings.sh and conf.py due to $(CLEAN_VERSION) release" && \
+		$(call dry-run,git push origin update-settings-v$(CLEAN_VERSION)) && \
 		$(call dry-run,gh pr create --base master --title "update settings.sh and conf.py due to $(CLEAN_VERSION) release"); \
 	fi
 

--- a/mk-files/docs.mk
+++ b/mk-files/docs.mk
@@ -74,7 +74,7 @@ release-docs-main:
 		$(SED) -i "s/^release = '.*'/release = \'$(NEXT_MINOR_VERSION)-SNAPSHOT\'/g" conf.py && \
 		git commit -am "[ci skip] chore: update settings.sh and conf.py due to $(CLEAN_VERSION) release" && \
 		$(call dry-run,git push origin update-settings-v$(CLEAN_VERSION)) && \
-		$(call dry-run,gh pr create --base master --title "update settings.sh and conf.py due to $(CLEAN_VERSION) release"); \
+		$(call dry-run,gh pr create --base master --title "update settings.sh and conf.py due to $(CLEAN_VERSION) release" --body ""); \
 	fi
 
 	rm -rf $(DIR)

--- a/mk-files/docs.mk
+++ b/mk-files/docs.mk
@@ -74,7 +74,7 @@ release-docs:
 		$(SED) -i "s/^release = '.*'/release = \'$(NEXT_MINOR_VERSION)-SNAPSHOT\'/g" conf.py && \
 		git commit -am "[ci skip] chore: update settings.sh and conf.py due to $(CLEAN_VERSION) release" && \
 		$(call dry-run,git push origin release-docs-$(CLEAN_VERSION)) && \
-		$(call dry-run,gh pr create --base master --title "update settings.sh and conf.py due to $(CLEAN_VERSION) release" --body ""); \
+		$(call dry-run,gh pr create --base master --title "Release docs for v$(CLEAN_VERSION)" --body ""); \
 	fi
 
 	rm -rf $(DIR)

--- a/mk-files/docs.mk
+++ b/mk-files/docs.mk
@@ -87,21 +87,22 @@ release-docs-staging:
 	git clone git@github.com:confluentinc/docs-confluent-cli.git $(DOCS_CONFLUENT_CLI) && \
 	cd $(DOCS_CONFLUENT_CLI) && \
 	git fetch && \
-	git checkout -b update-settings-$(STAGING_BRANCH) origin/$(STAGING_BRANCH) && \
-	$(SED) -i 's/export RELEASE_VERSION=.*/export RELEASE_VERSION=$(NEXT_PATCH_VERSION)-SNAPSHOT/g' settings.sh && \
-	$(SED) -i 's/export PUBLIC_VERSION=.*/export PUBLIC_VERSION=$(CURRENT_SHORT_MINOR_VERSION)/g' settings.sh && \
-	$(SED) -i "s/^version = '.*'/version = \'$(CURRENT_SHORT_MINOR_VERSION)\'/g" conf.py && \
-	$(SED) -i "s/^release = '.*'/release = \'$(NEXT_PATCH_VERSION)-SNAPSHOT\'/g" conf.py && \
-	git commit -am "[ci skip] chore: update settings.sh and conf.py due to $(CLEAN_VERSION) release" && \
 	git checkout -b update-settings-$(CURRENT_SHORT_MINOR_VERSION)-post origin/$(CURRENT_SHORT_MINOR_VERSION)-post && \
 	$(SED) -i 's/export RELEASE_VERSION=.*/export RELEASE_VERSION=$(CLEAN_VERSION)/g' settings.sh && \
 	$(SED) -i 's/export PUBLIC_VERSION=.*/export PUBLIC_VERSION=$(CURRENT_SHORT_MINOR_VERSION)/g' settings.sh && \
 	$(SED) -i "s/^version = '.*'/version = \'$(CURRENT_SHORT_MINOR_VERSION)\'/g" conf.py && \
 	$(SED) -i "s/^release = '.*'/release = \'$(CLEAN_VERSION)\'/g" conf.py && \
 	git commit -am "[ci skip] chore: update settings.sh and conf.py due to $(CLEAN_VERSION) release" && \
+	$(call dry-run,git push origin update-settings-$(CURRENT_SHORT_MINOR_VERSION)-post) && \
 	$(call dry-run,gh pr create --base $(CURRENT_SHORT_MINOR_VERSION)-post --title "update settings.sh and conf.py due to $(CLEAN_VERSION) release" --body "") && \
-	git checkout update-settings-$(STAGING_BRANCH) && \
+	git checkout -b update-settings-$(STAGING_BRANCH) origin/$(STAGING_BRANCH) && \
+	$(SED) -i 's/export RELEASE_VERSION=.*/export RELEASE_VERSION=$(NEXT_PATCH_VERSION)-SNAPSHOT/g' settings.sh && \
+	$(SED) -i 's/export PUBLIC_VERSION=.*/export PUBLIC_VERSION=$(CURRENT_SHORT_MINOR_VERSION)/g' settings.sh && \
+	$(SED) -i "s/^version = '.*'/version = \'$(CURRENT_SHORT_MINOR_VERSION)\'/g" conf.py && \
+	$(SED) -i "s/^release = '.*'/release = \'$(NEXT_PATCH_VERSION)-SNAPSHOT\'/g" conf.py && \
+	git commit -am "[ci skip] chore: update settings.sh and conf.py due to $(CLEAN_VERSION) release" && \
 	git merge -s ours -m "Merge branch 'update-settings-$(CURRENT_SHORT_MINOR_VERSION)-post' into update-settings-$(STAGING_BRANCH)" update-settings-$(CURRENT_SHORT_MINOR_VERSION)-post && \
+	$(call dry-run,git push origin update-settings-$(STAGING_BRANCH)) && \
 	$(call dry-run,gh pr create --base $(STAGING_BRANCH) --title "update settings.sh and conf.py due to $(CLEAN_VERSION) release" --body "")
 
 	rm -rf $(DIR)

--- a/mk-files/docs.mk
+++ b/mk-files/docs.mk
@@ -50,8 +50,8 @@ publish-docs: docs
 # The .x branch has been updated to ignore [ci skip] for minor branches since it is a pure upstream branch of minor branches.
 # To ensure pint merge will work correctly, we will manually merge the -post branch into the .x branch using `-s ours`. Then, these
 # branches will be pushed at the same time. This ensure there are no errors with pint merge.
-.PHONY: release-docs-main
-release-docs-main:
+.PHONY: release-docs
+release-docs:
 	$(eval DIR=$(shell mktemp -d))
 	$(eval DOCS_CONFLUENT_CLI=$(DIR)/docs-confluent-cli)
 
@@ -67,13 +67,13 @@ release-docs-main:
 	$(call dry-run,git push -u origin $(CURRENT_SHORT_MINOR_VERSION)-post) && \
 	if [[ $(CLEAN_VERSION) == *.0 ]]; then \
 		git checkout master && \
-		git checkout -b release-docs-main-v$(CLEAN_VERSION) && \
+		git checkout -b release-docs-$(CLEAN_VERSION) && \
 		$(SED) -i 's/export RELEASE_VERSION=.*/export RELEASE_VERSION=$(NEXT_MINOR_VERSION)-SNAPSHOT/g' settings.sh && \
 		$(SED) -i 's/export PUBLIC_VERSION=.*/export PUBLIC_VERSION=$(SHORT_NEXT_MINOR_VERSION)/g' settings.sh && \
 		$(SED) -i "s/^version = '.*'/version = \'$(SHORT_NEXT_MINOR_VERSION)\'/g" conf.py && \
 		$(SED) -i "s/^release = '.*'/release = \'$(NEXT_MINOR_VERSION)-SNAPSHOT\'/g" conf.py && \
 		git commit -am "[ci skip] chore: update settings.sh and conf.py due to $(CLEAN_VERSION) release" && \
-		$(call dry-run,git push origin release-docs-main-v$(CLEAN_VERSION)) && \
+		$(call dry-run,git push origin release-docs-$(CLEAN_VERSION)) && \
 		$(call dry-run,gh pr create --base master --title "update settings.sh and conf.py due to $(CLEAN_VERSION) release" --body ""); \
 	fi
 

--- a/mk-files/docs.mk
+++ b/mk-files/docs.mk
@@ -67,13 +67,13 @@ release-docs-main:
 	$(call dry-run,git push -u origin $(CURRENT_SHORT_MINOR_VERSION)-post) && \
 	if [[ $(CLEAN_VERSION) == *.0 ]]; then \
 		git checkout master && \
-		git checkout -b update-settings-v$(CLEAN_VERSION) && \
+		git checkout -b release-docs-main-v$(CLEAN_VERSION) && \
 		$(SED) -i 's/export RELEASE_VERSION=.*/export RELEASE_VERSION=$(NEXT_MINOR_VERSION)-SNAPSHOT/g' settings.sh && \
 		$(SED) -i 's/export PUBLIC_VERSION=.*/export PUBLIC_VERSION=$(SHORT_NEXT_MINOR_VERSION)/g' settings.sh && \
 		$(SED) -i "s/^version = '.*'/version = \'$(SHORT_NEXT_MINOR_VERSION)\'/g" conf.py && \
 		$(SED) -i "s/^release = '.*'/release = \'$(NEXT_MINOR_VERSION)-SNAPSHOT\'/g" conf.py && \
 		git commit -am "[ci skip] chore: update settings.sh and conf.py due to $(CLEAN_VERSION) release" && \
-		$(call dry-run,git push origin update-settings-v$(CLEAN_VERSION)) && \
+		$(call dry-run,git push origin release-docs-main-v$(CLEAN_VERSION)) && \
 		$(call dry-run,gh pr create --base master --title "update settings.sh and conf.py due to $(CLEAN_VERSION) release" --body ""); \
 	fi
 
@@ -87,22 +87,22 @@ release-docs-staging:
 	git clone git@github.com:confluentinc/docs-confluent-cli.git $(DOCS_CONFLUENT_CLI) && \
 	cd $(DOCS_CONFLUENT_CLI) && \
 	git fetch && \
-	git checkout -b update-settings-$(CURRENT_SHORT_MINOR_VERSION)-post origin/$(CURRENT_SHORT_MINOR_VERSION)-post && \
+	git checkout -b release-docs-staging-$(CURRENT_SHORT_MINOR_VERSION)-post origin/$(CURRENT_SHORT_MINOR_VERSION)-post && \
 	$(SED) -i 's/export RELEASE_VERSION=.*/export RELEASE_VERSION=$(CLEAN_VERSION)/g' settings.sh && \
 	$(SED) -i 's/export PUBLIC_VERSION=.*/export PUBLIC_VERSION=$(CURRENT_SHORT_MINOR_VERSION)/g' settings.sh && \
 	$(SED) -i "s/^version = '.*'/version = \'$(CURRENT_SHORT_MINOR_VERSION)\'/g" conf.py && \
 	$(SED) -i "s/^release = '.*'/release = \'$(CLEAN_VERSION)\'/g" conf.py && \
 	git commit -am "[ci skip] chore: update settings.sh and conf.py due to $(CLEAN_VERSION) release" && \
-	$(call dry-run,git push origin update-settings-$(CURRENT_SHORT_MINOR_VERSION)-post) && \
+	$(call dry-run,git push origin release-docs-staging-$(CURRENT_SHORT_MINOR_VERSION)-post) && \
 	$(call dry-run,gh pr create --base $(CURRENT_SHORT_MINOR_VERSION)-post --title "update settings.sh and conf.py due to $(CLEAN_VERSION) release" --body "") && \
-	git checkout -b update-settings-$(STAGING_BRANCH) origin/$(STAGING_BRANCH) && \
+	git checkout -b release-docs-staging-$(STAGING_BRANCH) origin/$(STAGING_BRANCH) && \
 	$(SED) -i 's/export RELEASE_VERSION=.*/export RELEASE_VERSION=$(NEXT_PATCH_VERSION)-SNAPSHOT/g' settings.sh && \
 	$(SED) -i 's/export PUBLIC_VERSION=.*/export PUBLIC_VERSION=$(CURRENT_SHORT_MINOR_VERSION)/g' settings.sh && \
 	$(SED) -i "s/^version = '.*'/version = \'$(CURRENT_SHORT_MINOR_VERSION)\'/g" conf.py && \
 	$(SED) -i "s/^release = '.*'/release = \'$(NEXT_PATCH_VERSION)-SNAPSHOT\'/g" conf.py && \
 	git commit -am "[ci skip] chore: update settings.sh and conf.py due to $(CLEAN_VERSION) release" && \
-	git merge -s ours -m "Merge branch 'update-settings-$(CURRENT_SHORT_MINOR_VERSION)-post' into update-settings-$(STAGING_BRANCH)" update-settings-$(CURRENT_SHORT_MINOR_VERSION)-post && \
-	$(call dry-run,git push origin update-settings-$(STAGING_BRANCH)) && \
+	git merge -s ours -m "Merge branch 'release-docs-staging-$(CURRENT_SHORT_MINOR_VERSION)-post' into release-docs-staging-$(STAGING_BRANCH)" release-docs-staging-$(CURRENT_SHORT_MINOR_VERSION)-post && \
+	$(call dry-run,git push origin release-docs-staging-$(STAGING_BRANCH)) && \
 	$(call dry-run,gh pr create --base $(STAGING_BRANCH) --title "update settings.sh and conf.py due to $(CLEAN_VERSION) release" --body "")
 
 	rm -rf $(DIR)

--- a/mk-files/docs.mk
+++ b/mk-files/docs.mk
@@ -67,6 +67,7 @@ release-docs-main:
 	$(call dry-run,git push -u origin $(CURRENT_SHORT_MINOR_VERSION)-post) && \
 	if [[ $(CLEAN_VERSION) == *.0 ]]; then \
 		git checkout master && \
+		git checkout -b update-settings-v$(CLEAN_VERSION) && \
 		$(SED) -i 's/export RELEASE_VERSION=.*/export RELEASE_VERSION=$(NEXT_MINOR_VERSION)-SNAPSHOT/g' settings.sh && \
 		$(SED) -i 's/export PUBLIC_VERSION=.*/export PUBLIC_VERSION=$(SHORT_NEXT_MINOR_VERSION)/g' settings.sh && \
 		$(SED) -i "s/^version = '.*'/version = \'$(SHORT_NEXT_MINOR_VERSION)\'/g" conf.py && \


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- PLACEHOLDER

New Features
- PLACEHOLDER

Bug Fixes
- PLACEHOLDER

Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   - [x] yes: ok
   - [ ] no: DO NOT MERGE until the required features are live in prod  

What
----
Fix mistakes from my last PR.

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
Ran without `DRY_RUN` and created the PRs successfully (both targets)

Edit: We've already merged these PRs so DRY_RUN doesn't fully succeed, but here's the list of commands w/ actual version numbers on a current DRY_RUN with the most recent changes:
```
git clone git@github.com:confluentinc/docs-confluent-cli.git /var/folders/xc/09xynw81209b2w17t9d7r5s40000gp/T/tmp.KcAV6D13/docs-confluent-cli && \
cd /var/folders/xc/09xynw81209b2w17t9d7r5s40000gp/T/tmp.KcAV6D13/docs-confluent-cli && \
git fetch && \
git checkout -b release-docs-staging-3-40 origin/3.40-post && \
gsed -i 's/export RELEASE_VERSION=.*/export RELEASE_VERSION=3.40.0/g' settings.sh && \
gsed -i 's/export PUBLIC_VERSION=.*/export PUBLIC_VERSION=3.40/g' settings.sh && \
gsed -i "s/^version = '.*'/version = \'3.40\'/g" conf.py && \
gsed -i "s/^release = '.*'/release = \'3.40.0\'/g" conf.py && \
git commit -am "[ci skip] chore: update settings.sh and conf.py due to 3.40.0 release" && \
echo [DRY RUN] git push origin release-docs-staging-3-40 && \
echo [DRY RUN] gh pr create --base 3.40-post --title "[ci skip] Release docs to staging for v3.40.0 release" --body "" && \
git checkout -b release-docs-staging-3-40-x origin/3.40.x && \
gsed -i 's/export RELEASE_VERSION=.*/export RELEASE_VERSION=3.40.1-SNAPSHOT/g' settings.sh && \
gsed -i 's/export PUBLIC_VERSION=.*/export PUBLIC_VERSION=3.40/g' settings.sh && \
gsed -i "s/^version = '.*'/version = \'3.40\'/g" conf.py && \
gsed -i "s/^release = '.*'/release = \'3.40.1-SNAPSHOT\'/g" conf.py && \
git commit -am "[ci skip] chore: update settings.sh and conf.py due to 3.40.0 release" && \
git merge -s ours -m "Merge branch 'release-docs-staging-3-40' into release-docs-staging-3-40-x" release-docs-staging-3-40 && \
echo [DRY RUN] git push origin release-docs-staging-3-40-x && \
echo [DRY RUN] gh pr create --base 3.40.x --title "[ci skip] Release docs to staging for v3.40.0 release" --body ""
```

Open Questions / Follow-ups
---------------------------
<!--
Optional: Anything open to discussion for the reviewer, out of scope of this PR, or follow-ups.
-->
