### PR TITLE
[CLI-2860] Fix panic in HTTP retry

### DIFF
--- a/pkg/config/context_state.go
+++ b/pkg/config/context_state.go
@@ -52,6 +52,10 @@ func (c *ContextState) DecryptContextStateAuthRefreshToken(ctxName string) error
 }
 
 func (c *ContextState) IsExpired() bool {
+	if c == nil {
+		return false
+	}
+
 	token, err := jwt.ParseSigned(c.AuthToken)
 	if err != nil {
 		return false


### PR DESCRIPTION
Release Notes
-------------
Bug Fixes
- Fix panic during HTTP retry

Checklist
---------
1. [CRUCIAL] Is the change for features that are already live in prod?
   - [x] yes: ok
   - [ ] no: DO NOT MERGE until the required features are live in prod  

What
----
The context state (session) might be `nil`, in which case accessing the auth token on line 55 results in an NPE

References
----------
https://confluentinc.atlassian.net/browse/CLI-2860