### PR TITLE
STORAGE-434 Add GCP BYOK CLI

### DIFF
--- a/internal/byok/command_create_test.go
+++ b/internal/byok/command_create_test.go
@@ -3,6 +3,7 @@ package byok
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -40,4 +41,33 @@ func TestRemoveKeyVersionFromAzureKeyId(t *testing.T) {
 			require.Equal(t, test.expected, actual)
 		})
 	}
+}
+
+func TestGcpMetadataCustomRoleName(t *testing.T) {
+	t.Run("success, custom role name generated", func(t *testing.T) {
+		metadata := gcpPolicyMetadata{
+			keyRing: "testKeyRing",
+			key:     "testKey",
+		}
+		customRoleName := metadata.getCustomRoleName()
+		assert.Equal(t, "testKeyRing_testKey_custom_kms_role", customRoleName)
+	})
+
+	t.Run("success, hyphens replaced", func(t *testing.T) {
+		metadata := gcpPolicyMetadata{
+			keyRing: "test-key-ring",
+			key:     "test-key",
+		}
+		customRoleName := metadata.getCustomRoleName()
+		assert.Equal(t, "test_key_ring_test_key_custom_kms_role", customRoleName)
+	})
+
+	t.Run("failure, default role name returned", func(t *testing.T) {
+		metadata := gcpPolicyMetadata{
+			keyRing: "test&key&ring",
+			key:     "test&key",
+		}
+		customRoleName := metadata.getCustomRoleName()
+		assert.Equal(t, "custom_kms_role", customRoleName)
+	})
 }

--- a/internal/byok/command_describe.go
+++ b/internal/byok/command_describe.go
@@ -47,6 +47,9 @@ func (c *command) outputByokKeyDescription(cmd *cobra.Command, key byokv1.ByokV1
 	case key.Key.ByokV1AzureKey != nil:
 		keyString = key.Key.ByokV1AzureKey.KeyId
 		roles = append(roles, key.Key.ByokV1AzureKey.GetApplicationId())
+	case key.Key.ByokV1GcpKey != nil:
+		roles = append(roles, key.Key.ByokV1GcpKey.GetSecurityGroup())
+
 	default:
 		return fmt.Errorf(byokUnknownKeyTypeErrorMsg)
 	}


### PR DESCRIPTION
# DRAFT: API & SDK RELEASE PENDING
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- PLACEHOLDER

New Features
- PLACEHOLDER

Bug Fixes
- PLACEHOLDER

Checklist
---------
- [ ] Leave this box unchecked if features are not yet available in production

What
----
This PR adds the capability to create GCP BYOK objects via the CLI. There is work being done to migrate the GCP bucket creation and BYOK flow from the old bucket service to the new bucket service API. Consequently, CLI support is required.

References
----------
[STORAGE-434](https://confluentinc.atlassian.net/browse/STORAGE-434)

Test & Review
-------------
Unit tests

[STORAGE-434]: https://confluentinc.atlassian.net/browse/STORAGE-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ