### PR TITLE
[TRAFFIC-9338] Add `confluent network network-link service describe` command

### DIFF
--- a/internal/network/command.go
+++ b/internal/network/command.go
@@ -85,6 +85,7 @@ func New(prerunner pcmd.PreRunner) *cobra.Command {
 	cmd.AddCommand(c.newPeeringCommand())
 	cmd.AddCommand(c.newPrivateLinkCommand())
 	cmd.AddCommand(c.newTransitGatewayAttachmentCommand())
+	cmd.AddCommand(c.newNetworkLinkCommand())
 	cmd.AddCommand(c.newUpdateCommand())
 
 	return cmd

--- a/internal/network/command.go
+++ b/internal/network/command.go
@@ -82,10 +82,10 @@ func New(prerunner pcmd.PreRunner) *cobra.Command {
 	cmd.AddCommand(c.newDescribeCommand())
 	cmd.AddCommand(c.newIpAddressCommand())
 	cmd.AddCommand(c.newListCommand())
+	cmd.AddCommand(c.newNetworkLinkCommand())
 	cmd.AddCommand(c.newPeeringCommand())
 	cmd.AddCommand(c.newPrivateLinkCommand())
 	cmd.AddCommand(c.newTransitGatewayAttachmentCommand())
-	cmd.AddCommand(c.newNetworkLinkCommand())
 	cmd.AddCommand(c.newUpdateCommand())
 
 	return cmd

--- a/internal/network/command_network_link.go
+++ b/internal/network/command_network_link.go
@@ -1,0 +1,17 @@
+package network
+
+import (
+	"github.com/spf13/cobra"
+)
+
+func (c *command) newNetworkLinkCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "network-link",
+		Short:   "Manage network links.",
+		Aliases: []string{"nl"},
+	}
+
+	cmd.AddCommand(c.newNetworkLinkServiceCommand())
+
+	return cmd
+}

--- a/internal/network/command_network_link_service.go
+++ b/internal/network/command_network_link_service.go
@@ -1,0 +1,121 @@
+package network
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	networkingv1 "github.com/confluentinc/ccloud-sdk-go-v2/networking/v1"
+
+	"github.com/confluentinc/cli/v3/pkg/errors"
+	"github.com/confluentinc/cli/v3/pkg/output"
+)
+
+type networkLinkServiceHumanOut struct {
+	Id                   string `human:"ID"`
+	Name                 string `human:"Name"`
+	NetworkId            string `human:"Network ID"`
+	Environment          string `human:"Environment"`
+	Description          string `human:"Description,omitempty"`
+	AcceptedEnvironments string `human:"Accepted Environments,omitempty"`
+	AcceptedNetworks     string `human:"Accepted Networks,omitempty"`
+	Phase                string `human:"Phase"`
+}
+
+type networkLinkServiceSerializedOut struct {
+	Id                   string   `serialized:"id"`
+	Name                 string   `serialized:"name"`
+	NetworkId            string   `serialized:"network_id"`
+	Environment          string   `serialized:"environment_id"`
+	Description          string   `serialized:"description,omitempty"`
+	AcceptedEnvironments []string `serialized:"accepted_environments,omitempty"`
+	AcceptedNetworks     []string `serialized:"accepted_networks,omitempty"`
+	Phase                string   `serialized:"phase"`
+}
+
+func (c *command) newNetworkLinkServiceCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "service",
+		Short: "Manage network link services.",
+		Args:  cobra.NoArgs,
+	}
+
+	cmd.AddCommand(c.newNetworkLinkServiceDescribeCommand())
+
+	return cmd
+}
+
+func (c *command) getNetworkLinkServices() ([]networkingv1.NetworkingV1NetworkLinkService, error) {
+	environmentId, err := c.Context.EnvironmentId()
+	if err != nil {
+		return nil, err
+	}
+
+	return c.V2Client.ListNetworkLinkServices(environmentId)
+}
+
+func (c *command) validNetworkLinkServiceArgs(cmd *cobra.Command, args []string) []string {
+	if len(args) > 0 {
+		return nil
+	}
+	return c.validNetworkLinkServicesArgsMultiple(cmd, args)
+}
+
+func (c *command) validNetworkLinkServicesArgsMultiple(cmd *cobra.Command, args []string) []string {
+	if err := c.PersistentPreRunE(cmd, args); err != nil {
+		return nil
+	}
+
+	return c.autocompleteNetworkLinkServices()
+}
+
+func (c *command) autocompleteNetworkLinkServices() []string {
+	services, err := c.getNetworkLinkServices()
+	if err != nil {
+		return nil
+	}
+
+	suggestions := make([]string, len(services))
+	for i, service := range services {
+		suggestions[i] = fmt.Sprintf("%s\t%s", service.GetId(), service.Spec.GetDisplayName())
+	}
+	return suggestions
+}
+
+func printNetworkLinkServiceTable(cmd *cobra.Command, service networkingv1.NetworkingV1NetworkLinkService) error {
+	if service.Spec == nil {
+		return fmt.Errorf(errors.CorruptedNetworkResponseErrorMsg, "spec")
+	}
+	if service.Status == nil {
+		return fmt.Errorf(errors.CorruptedNetworkResponseErrorMsg, "status")
+	}
+
+	table := output.NewTable(cmd)
+
+	if output.GetFormat(cmd) == output.Human {
+		table.Add(&networkLinkServiceHumanOut{
+			Id:                   service.GetId(),
+			Name:                 service.Spec.GetDisplayName(),
+			NetworkId:            service.Spec.Network.GetId(),
+			Environment:          service.Spec.Environment.GetId(),
+			Description:          service.Spec.GetDescription(),
+			AcceptedEnvironments: strings.Join(service.Spec.Accept.GetEnvironments(), ", "),
+			AcceptedNetworks:     strings.Join(service.Spec.Accept.GetNetworks(), ", "),
+			Phase:                service.Status.GetPhase(),
+		})
+	} else {
+		table.Add(&networkLinkServiceSerializedOut{
+			Id:                   service.GetId(),
+			Name:                 service.Spec.GetDisplayName(),
+			NetworkId:            service.Spec.Network.GetId(),
+			Environment:          service.Spec.Environment.GetId(),
+			Description:          service.Spec.GetDescription(),
+			AcceptedEnvironments: service.Spec.Accept.GetEnvironments(),
+			AcceptedNetworks:     service.Spec.Accept.GetNetworks(),
+			Phase:                service.Status.GetPhase(),
+		})
+	}
+
+	return table.PrintWithAutoWrap(false)
+}

--- a/internal/network/command_network_link_service.go
+++ b/internal/network/command_network_link_service.go
@@ -15,7 +15,7 @@ import (
 type networkLinkServiceHumanOut struct {
 	Id                   string `human:"ID"`
 	Name                 string `human:"Name"`
-	NetworkId            string `human:"Network ID"`
+	Network              string `human:"Network"`
 	Environment          string `human:"Environment"`
 	Description          string `human:"Description,omitempty"`
 	AcceptedEnvironments string `human:"Accepted Environments,omitempty"`
@@ -26,8 +26,8 @@ type networkLinkServiceHumanOut struct {
 type networkLinkServiceSerializedOut struct {
 	Id                   string   `serialized:"id"`
 	Name                 string   `serialized:"name"`
-	NetworkId            string   `serialized:"network_id"`
-	Environment          string   `serialized:"environment_id"`
+	Network              string   `serialized:"network"`
+	Environment          string   `serialized:"environment"`
 	Description          string   `serialized:"description,omitempty"`
 	AcceptedEnvironments []string `serialized:"accepted_environments,omitempty"`
 	AcceptedNetworks     []string `serialized:"accepted_networks,omitempty"`
@@ -97,7 +97,7 @@ func printNetworkLinkServiceTable(cmd *cobra.Command, service networkingv1.Netwo
 		table.Add(&networkLinkServiceHumanOut{
 			Id:                   service.GetId(),
 			Name:                 service.Spec.GetDisplayName(),
-			NetworkId:            service.Spec.Network.GetId(),
+			Network:              service.Spec.Network.GetId(),
 			Environment:          service.Spec.Environment.GetId(),
 			Description:          service.Spec.GetDescription(),
 			AcceptedEnvironments: strings.Join(service.Spec.Accept.GetEnvironments(), ", "),
@@ -108,7 +108,7 @@ func printNetworkLinkServiceTable(cmd *cobra.Command, service networkingv1.Netwo
 		table.Add(&networkLinkServiceSerializedOut{
 			Id:                   service.GetId(),
 			Name:                 service.Spec.GetDisplayName(),
-			NetworkId:            service.Spec.Network.GetId(),
+			Network:              service.Spec.Network.GetId(),
 			Environment:          service.Spec.Environment.GetId(),
 			Description:          service.Spec.GetDescription(),
 			AcceptedEnvironments: service.Spec.Accept.GetEnvironments(),

--- a/internal/network/command_network_link_service_describe.go
+++ b/internal/network/command_network_link_service_describe.go
@@ -1,0 +1,45 @@
+package network
+
+import (
+	"github.com/spf13/cobra"
+
+	pcmd "github.com/confluentinc/cli/v3/pkg/cmd"
+	"github.com/confluentinc/cli/v3/pkg/examples"
+)
+
+func (c *command) newNetworkLinkServiceDescribeCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:               "describe <id>",
+		Short:             "Describe a network link service.",
+		Args:              cobra.ExactArgs(1),
+		ValidArgsFunction: pcmd.NewValidArgsFunction(c.validNetworkLinkServiceArgs),
+		RunE:              c.networkLinkServiceDescribe,
+
+		Example: examples.BuildExampleString(
+			examples.Example{
+				Text: `Describe network link service "nls-123456".`,
+				Code: "confluent network network-link service describe nls-123456",
+			},
+		),
+	}
+
+	pcmd.AddContextFlag(cmd, c.CLICommand)
+	pcmd.AddEnvironmentFlag(cmd, c.AuthenticatedCLICommand)
+	pcmd.AddOutputFlag(cmd)
+
+	return cmd
+}
+
+func (c *command) networkLinkServiceDescribe(cmd *cobra.Command, args []string) error {
+	environmentId, err := c.Context.EnvironmentId()
+	if err != nil {
+		return err
+	}
+
+	service, err := c.V2Client.GetNetworkLinkService(environmentId, args[0])
+	if err != nil {
+		return err
+	}
+
+	return printNetworkLinkServiceTable(cmd, service)
+}

--- a/internal/network/command_network_link_service_describe.go
+++ b/internal/network/command_network_link_service_describe.go
@@ -14,7 +14,6 @@ func (c *command) newNetworkLinkServiceDescribeCommand() *cobra.Command {
 		Args:              cobra.ExactArgs(1),
 		ValidArgsFunction: pcmd.NewValidArgsFunction(c.validNetworkLinkServiceArgs),
 		RunE:              c.networkLinkServiceDescribe,
-
 		Example: examples.BuildExampleString(
 			examples.Example{
 				Text: `Describe network link service "nls-123456".`,

--- a/internal/network/command_network_link_service_list.go
+++ b/internal/network/command_network_link_service_list.go
@@ -1,0 +1,1 @@
+package network

--- a/internal/network/command_network_link_service_list.go
+++ b/internal/network/command_network_link_service_list.go
@@ -1,1 +1,0 @@
-package network

--- a/pkg/ccloudv2/networking.go
+++ b/pkg/ccloudv2/networking.go
@@ -221,3 +221,38 @@ func (c *Client) CreatePrivateLinkAccess(access networkingv1.NetworkingV1Private
 	resp, httpResp, err := c.NetworkingClient.PrivateLinkAccessesNetworkingV1Api.CreateNetworkingV1PrivateLinkAccess(c.networkingApiContext()).NetworkingV1PrivateLinkAccess(access).Execute()
 	return resp, errors.CatchCCloudV2Error(err, httpResp)
 }
+
+func (c *Client) ListNetworkLinkServices(environment string) ([]networkingv1.NetworkingV1NetworkLinkService, error) {
+	var list []networkingv1.NetworkingV1NetworkLinkService
+
+	done := false
+	pageToken := ""
+	for !done {
+		page, err := c.executeListNetworkLinkServices(environment, pageToken)
+		if err != nil {
+			return nil, err
+		}
+		list = append(list, page.GetData()...)
+
+		pageToken, done, err = extractNextPageToken(page.GetMetadata().Next)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return list, nil
+}
+
+func (c *Client) executeListNetworkLinkServices(environment, pageToken string) (networkingv1.NetworkingV1NetworkLinkServiceList, error) {
+	req := c.NetworkingClient.NetworkLinkServicesNetworkingV1Api.ListNetworkingV1NetworkLinkServices(c.networkingApiContext()).Environment(environment).PageSize(ccloudV2ListPageSize)
+	if pageToken != "" {
+		req = req.PageToken(pageToken)
+	}
+
+	resp, httpResp, err := req.Execute()
+	return resp, errors.CatchCCloudV2Error(err, httpResp)
+}
+
+func (c *Client) GetNetworkLinkService(environment, id string) (networkingv1.NetworkingV1NetworkLinkService, error) {
+	resp, httpResp, err := c.NetworkingClient.NetworkLinkServicesNetworkingV1Api.GetNetworkingV1NetworkLinkService(c.networkingApiContext(), id).Environment(environment).Execute()
+	return resp, errors.CatchCCloudV2Error(err, httpResp)
+}

--- a/test/fixtures/output/network/help.golden
+++ b/test/fixtures/output/network/help.golden
@@ -9,9 +9,9 @@ Available Commands:
   describe                   Describe a network.
   ip-address                 List Confluent Cloud egress public IP addresses.
   list                       List networks.
+  network-link               Manage network links.
   peering                    Manage peerings.
   private-link               Manage private links.
-  network-link               Manage network links.
   transit-gateway-attachment Manage transit gateway attachments.
   update                     Update an existing network.
 

--- a/test/fixtures/output/network/help.golden
+++ b/test/fixtures/output/network/help.golden
@@ -11,6 +11,7 @@ Available Commands:
   list                       List networks.
   peering                    Manage peerings.
   private-link               Manage private links.
+  network-link               Manage network links.
   transit-gateway-attachment Manage transit gateway attachments.
   update                     Update an existing network.
 

--- a/test/fixtures/output/network/network-link/help.golden
+++ b/test/fixtures/output/network/network-link/help.golden
@@ -7,8 +7,7 @@ Aliases:
   network-link, nl
 
 Available Commands:
-  service    Manage network link services.
-  endpoint   Manage network link endpoints.
+  service     Manage network link services.
 
 Global Flags:
   -h, --help            Show help for this command.

--- a/test/fixtures/output/network/network-link/help.golden
+++ b/test/fixtures/output/network/network-link/help.golden
@@ -1,0 +1,18 @@
+Manage network links.
+
+Usage:
+  confluent network network-link [command]
+
+Aliases:
+  network-link, nl
+
+Available Commands:
+  service    Manage network link services.
+  endpoint   Manage network link endpoints.
+
+Global Flags:
+  -h, --help            Show help for this command.
+      --unsafe-trace    Equivalent to -vvvv, but also log HTTP requests and responses which might contain plaintext secrets.
+  -v, --verbose count   Increase verbosity (-v for warn, -vv for info, -vvv for debug, -vvvv for trace).
+
+Use "confluent network network-link [command] --help" for more information about a command.

--- a/test/fixtures/output/network/network-link/service/describe-help.golden
+++ b/test/fixtures/output/network/network-link/service/describe-help.golden
@@ -1,0 +1,19 @@
+Describe a network link service.
+
+Usage:
+  confluent network network-link service describe <id> [flags]
+
+Examples:
+Describe network link service "nls-123456".
+
+  $ confluent network network-link service describe nls-123456
+
+Flags:
+      --context string       CLI context name.
+      --environment string   Environment ID.
+  -o, --output string        Specify the output format as "human", "json", or "yaml". (default "human")
+
+Global Flags:
+  -h, --help            Show help for this command.
+      --unsafe-trace    Equivalent to -vvvv, but also log HTTP requests and responses which might contain plaintext secrets.
+  -v, --verbose count   Increase verbosity (-v for warn, -vv for info, -vvv for debug, -vvvv for trace).

--- a/test/fixtures/output/network/network-link/service/describe-invalid.golden
+++ b/test/fixtures/output/network/network-link/service/describe-invalid.golden
@@ -1,0 +1,1 @@
+Error: The network-link-service nls-invalid was not found.: 404 Not Found

--- a/test/fixtures/output/network/network-link/service/describe-json.golden
+++ b/test/fixtures/output/network/network-link/service/describe-json.golden
@@ -1,8 +1,8 @@
 {
   "id": "nls-123456",
   "name": "test-nls",
-  "network_id": "n-abcde1",
-  "environment_id": "env-00000",
+  "network": "n-abcde1",
+  "environment": "env-00000",
   "description": "test nls",
   "accepted_environments": ["env-11111", "env-22222"],
   "accepted_networks": ["n-abcde2", "n-abcde3"],

--- a/test/fixtures/output/network/network-link/service/describe-json.golden
+++ b/test/fixtures/output/network/network-link/service/describe-json.golden
@@ -1,0 +1,10 @@
+{
+  "id": "nls-123456",
+  "name": "test-nls",
+  "network_id": "n-abcde1",
+  "environment_id": "env-00000",
+  "description": "test nls",
+  "accepted_environments": ["env-11111", "env-22222"],
+  "accepted_networks": ["n-abcde2", "n-abcde3"],
+  "phase": "READY"
+}

--- a/test/fixtures/output/network/network-link/service/describe-missing-id.golden
+++ b/test/fixtures/output/network/network-link/service/describe-missing-id.golden
@@ -1,0 +1,19 @@
+Error: accepts 1 arg(s), received 0
+Usage:
+  confluent network network-link service describe <id> [flags]
+
+Examples:
+Describe network link service "nls-123456".
+
+  $ confluent network network-link service describe nls-123456
+
+Flags:
+      --context string       CLI context name.
+      --environment string   Environment ID.
+  -o, --output string        Specify the output format as "human", "json", or "yaml". (default "human")
+
+Global Flags:
+  -h, --help            Show help for this command.
+      --unsafe-trace    Equivalent to -vvvv, but also log HTTP requests and responses which might contain plaintext secrets.
+  -v, --verbose count   Increase verbosity (-v for warn, -vv for info, -vvv for debug, -vvvv for trace).
+

--- a/test/fixtures/output/network/network-link/service/describe.golden
+++ b/test/fixtures/output/network/network-link/service/describe.golden
@@ -1,0 +1,10 @@
++-----------------------+----------------------+
+| ID                    | nls-123456           |
+| Name                  | test-nls             |
+| Network ID            | n-abcde1             |
+| Environment           | env-00000            |
+| Description           | test nls             |
+| Accepted Environments | env-11111, env-22222 |
+| Accepted Networks     | n-abcde2, n-abcde3   |
+| Phase                 | READY                |
++-----------------------+----------------------+

--- a/test/fixtures/output/network/network-link/service/describe.golden
+++ b/test/fixtures/output/network/network-link/service/describe.golden
@@ -1,7 +1,7 @@
 +-----------------------+----------------------+
 | ID                    | nls-123456           |
 | Name                  | test-nls             |
-| Network ID            | n-abcde1             |
+| Network               | n-abcde1             |
 | Environment           | env-00000            |
 | Description           | test nls             |
 | Accepted Environments | env-11111, env-22222 |

--- a/test/fixtures/output/network/network-link/service/help.golden
+++ b/test/fixtures/output/network/network-link/service/help.golden
@@ -4,11 +4,7 @@ Usage:
   confluent network network-link service [command]
 
 Available Commands:
-  create      Create a network link service.
-  delete      Delete one or more network link services.
   describe    Describe a network link service.
-  list        List network link services.
-  update      Update an existing network link service.
 
 Global Flags:
   -h, --help            Show help for this command.

--- a/test/fixtures/output/network/network-link/service/help.golden
+++ b/test/fixtures/output/network/network-link/service/help.golden
@@ -1,0 +1,18 @@
+Manage network link services.
+
+Usage:
+  confluent network network-link service [command]
+
+Available Commands:
+  create      Create a network link service.
+  delete      Delete one or more network link services.
+  describe    Describe a network link service.
+  list        List network link services.
+  update      Update an existing network link service.
+
+Global Flags:
+  -h, --help            Show help for this command.
+      --unsafe-trace    Equivalent to -vvvv, but also log HTTP requests and responses which might contain plaintext secrets.
+  -v, --verbose count   Increase verbosity (-v for warn, -vv for info, -vvv for debug, -vvvv for trace).
+
+Use "confluent network network-link service [command] --help" for more information about a command.

--- a/test/network_test.go
+++ b/test/network_test.go
@@ -545,6 +545,21 @@ func (s *CLITestSuite) TestNetworkPrivateLinkAttachmentConnection_Autocomplete()
 	}
 }
 
+func (s *CLITestSuite) TestNetworkNetworkLinkServiceDescribe() {
+	tests := []CLITest{
+		{args: "network nl service describe nls-123456", fixture: "network/network-link/service/describe.golden"},
+		{args: "network network-link service describe nls-123456", fixture: "network/network-link/service/describe.golden"},
+		{args: "network network-link service describe nls-123456 --output json", fixture: "network/network-link/service/describe-json.golden"},
+		{args: "network network-link service describe", fixture: "network/network-link/service/describe-missing-id.golden", exitCode: 1},
+		{args: "network network-link service describe nls-invalid", fixture: "network/network-link/service/describe-invalid.golden", exitCode: 1},
+	}
+
+	for _, test := range tests {
+		test.login = "cloud"
+		s.runIntegrationTest(test)
+	}
+}
+
 func (s *CLITestSuite) TestNetworkIpAddressList() {
 	tests := []CLITest{
 		{args: "network ip-address list", fixture: "network/ip-address/list.golden"},

--- a/test/test-server/ccloudv2_router.go
+++ b/test/test-server/ccloudv2_router.go
@@ -72,6 +72,7 @@ var ccloudV2Routes = []route{
 	{"/networking/v1/private-link-attachment-connections/{id}", handleNetworkingPrivateLinkAttachmentConnection},
 	{"/networking/v1/transit-gateway-attachments", handleNetworkingTransitGatewayAttachments},
 	{"/networking/v1/transit-gateway-attachments/{id}", handleNetworkingTransitGatewayAttachment},
+	{"/networking/v1/network-link-services/{id}", handleNetworkingNetworkLinkService},
 	{"/org/v2/environments", handleOrgEnvironments},
 	{"/org/v2/environments/{id}", handleOrgEnvironment},
 	{"/org/v2/organizations", handleOrgOrganizations},

--- a/test/test-server/networking_handlers.go
+++ b/test/test-server/networking_handlers.go
@@ -1250,7 +1250,7 @@ func handleNetworkingNetworkLinkServiceGet(t *testing.T, id string) http.Handler
 }
 
 func getNetworkLinkService(id, name, phase string) networkingv1.NetworkingV1NetworkLinkService {
-	service := networkingv1.NetworkingV1NetworkLinkService{
+	return networkingv1.NetworkingV1NetworkLinkService{
 		Id: networkingv1.PtrString(id),
 		Spec: &networkingv1.NetworkingV1NetworkLinkServiceSpec{
 			DisplayName: networkingv1.PtrString(name),
@@ -1264,7 +1264,6 @@ func getNetworkLinkService(id, name, phase string) networkingv1.NetworkingV1Netw
 		},
 		Status: &networkingv1.NetworkingV1NetworkLinkServiceStatus{Phase: phase},
 	}
-	return service
 }
 
 func handleNetworkingIpAddressList(t *testing.T) http.HandlerFunc {


### PR DESCRIPTION
What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->
Note that this is merging into the feature branch https://github.com/confluentinc/cli/tree/traffic-8850-network-cli-az. We will merge commits into main from this feature branch after all of the commands for network are implemented.

- Add `confluent network network-link service describe`
- Add `confluent network nl` alias

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->
[CLI Commands Design](https://confluentinc.atlassian.net/wiki/spaces/PM/pages/2987394300/1-pager+--+Network+CLI)
[Implementation 1-Pager](https://confluentinc.atlassian.net/wiki/spaces/~712020463029eabbac401bbe1b033ce0d3a00e/pages/3136749631/Network+CLI)

Test & Review
-------------
<!--
Has it been tested? How?
Copy and paste any instructions or steps that can save the reviewer time.
-->
Added integration tests.

Performed manual tests.