### PR TITLE
Fix description of `--deleted` in SR commands

### DIFF
--- a/internal/schema-registry/command_subject_describe.go
+++ b/internal/schema-registry/command_subject_describe.go
@@ -33,7 +33,7 @@ func (c *command) newSubjectDescribeCommand(cfg *config.Config) *cobra.Command {
 	}
 	cmd.Example = examples.BuildExampleString(example)
 
-	cmd.Flags().Bool("deleted", false, "View the deleted schemas.")
+	cmd.Flags().Bool("deleted", false, "Include deleted schemas.")
 	pcmd.AddContextFlag(cmd, c.CLICommand)
 	if cfg.IsCloudLogin() {
 		pcmd.AddEnvironmentFlag(cmd, c.AuthenticatedCLICommand)

--- a/internal/schema-registry/command_subject_list.go
+++ b/internal/schema-registry/command_subject_list.go
@@ -23,7 +23,7 @@ func (c *command) newSubjectListCommand(cfg *config.Config) *cobra.Command {
 		RunE:  c.subjectList,
 	}
 
-	cmd.Flags().Bool("deleted", false, "View the deleted subjects.")
+	cmd.Flags().Bool("deleted", false, "Include deleted subjects.")
 	cmd.Flags().String("prefix", ":*:", "Subject prefix.")
 	pcmd.AddContextFlag(cmd, c.CLICommand)
 	if cfg.IsCloudLogin() {

--- a/test/fixtures/output/schema-registry/subject/describe-help-onprem.golden
+++ b/test/fixtures/output/schema-registry/subject/describe-help-onprem.golden
@@ -9,7 +9,7 @@ Retrieve all versions registered under subject "payments" and its compatibility 
   $ confluent schema-registry subject describe payments --ca-location <ca-file-location> --schema-registry-endpoint <schema-registry-endpoint>
 
 Flags:
-      --deleted                           View the deleted schemas.
+      --deleted                           Include deleted schemas.
       --context string                    CLI context name.
       --ca-location string                File or directory path to CA certificates to authenticate the Schema Registry client.
       --schema-registry-endpoint string   The URL of the Schema Registry cluster.

--- a/test/fixtures/output/schema-registry/subject/describe-help.golden
+++ b/test/fixtures/output/schema-registry/subject/describe-help.golden
@@ -9,7 +9,7 @@ Retrieve all versions registered under subject "payments" and its compatibility 
   $ confluent schema-registry subject describe payments
 
 Flags:
-      --deleted              View the deleted schemas.
+      --deleted              Include deleted schemas.
       --context string       CLI context name.
       --environment string   Environment ID.
   -o, --output string        Specify the output format as "human", "json", or "yaml". (default "human")

--- a/test/fixtures/output/schema-registry/subject/list-help-onprem.golden
+++ b/test/fixtures/output/schema-registry/subject/list-help-onprem.golden
@@ -4,7 +4,7 @@ Usage:
   confluent schema-registry subject list [flags]
 
 Flags:
-      --deleted                           View the deleted subjects.
+      --deleted                           Include deleted subjects.
       --prefix string                     Subject prefix. (default ":*:")
       --context string                    CLI context name.
       --ca-location string                File or directory path to CA certificates to authenticate the Schema Registry client.

--- a/test/fixtures/output/schema-registry/subject/list-help.golden
+++ b/test/fixtures/output/schema-registry/subject/list-help.golden
@@ -4,7 +4,7 @@ Usage:
   confluent schema-registry subject list [flags]
 
 Flags:
-      --deleted              View the deleted subjects.
+      --deleted              Include deleted subjects.
       --prefix string        Subject prefix. (default ":*:")
       --context string       CLI context name.
       --environment string   Environment ID.


### PR DESCRIPTION
Checklist
---------
- [x] Leave this box unchecked if features are not yet available in production

What
----
The `--deleted` flag does not filter deleted resources, it includes them in the existing list.

Test & Review
-------------
Updated integration tests