### PR TITLE
fix error where confluent local couldn't work with newer docker desktop versions

### DIFF
--- a/internal/local/command_kafka.go
+++ b/internal/local/command_kafka.go
@@ -12,7 +12,7 @@ import (
 const (
 	dockerImageName             = "confluentinc/confluent-local:latest"
 	localhostPrefix             = "http://localhost:%s"
-	localhost                   = "localhost"
+	localhost                   = "0.0.0.0"
 	kafkaRestNotReadySuggestion = "Kafka REST connection is not ready. Re-running the command may solve the issue."
 )
 

--- a/internal/local/command_kafka_start.go
+++ b/internal/local/command_kafka_start.go
@@ -29,7 +29,7 @@ import (
 )
 
 const (
-	dockerWorkingVersionMsg   = "The local commands have been verified to work with Docker Desktop version as late as 4.25.0. Verify that you are not using an unverified version of Docker (versions greater than v4.25.0)."
+	dockerWorkingVersionMsg   = "The local commands have been verified to work with Docker Desktop version as late as 4.25.0. Verify that you are not using an unverified version of Docker."
 	confluentBrokerPrefix     = "confluent-local-broker-%d"
 	controllerVoterPrefix     = "%d@confluent-local-broker-%d:%s"
 	bootstrapServerPrefix     = "confluent-local-broker-%d:%s"

--- a/internal/local/command_kafka_start.go
+++ b/internal/local/command_kafka_start.go
@@ -29,6 +29,7 @@ import (
 )
 
 const (
+	dockerWorkingVersionMsg   = "The local commands have been verified to work with Docker Desktop version as late as 4.25.0."
 	confluentBrokerPrefix     = "confluent-local-broker-%d"
 	controllerVoterPrefix     = "%d@confluent-local-broker-%d:%s"
 	bootstrapServerPrefix     = "confluent-local-broker-%d:%s"
@@ -78,7 +79,7 @@ func (c *command) kafkaStart(cmd *cobra.Command, _ []string) error {
 
 	containers, err := dockerClient.ContainerList(context.Background(), types.ContainerListOptions{All: true})
 	if err != nil {
-		output.ErrPrintln(false, "The local commands have been verified to work with Docker Desktop version as late as 4.25.0.")
+		output.ErrPrintln(false, dockerWorkingVersionMsg)
 		return err
 	}
 
@@ -106,7 +107,7 @@ func (c *command) kafkaStart(cmd *cobra.Command, _ []string) error {
 
 	out, err := dockerClient.ImagePull(context.Background(), dockerImageName, types.ImagePullOptions{})
 	if err != nil {
-		output.ErrPrintln(false, "The local commands have been verified to work with Docker Desktop version as late as 4.25.0.")
+		output.ErrPrintln(false, dockerWorkingVersionMsg)
 		return err
 	}
 	defer out.Close()
@@ -163,7 +164,7 @@ func (c *command) kafkaStart(cmd *cobra.Command, _ []string) error {
 		Driver:         "bridge",
 	}
 	if _, err := dockerClient.NetworkCreate(context.Background(), confluentLocalNetworkName, options); err != nil && !strings.Contains(err.Error(), "already exists") {
-		output.ErrPrintln(false, "The local commands have been verified to work with Docker Desktop version as late as 4.25.0.")
+		output.ErrPrintln(false, dockerWorkingVersionMsg)
 		return err
 	}
 
@@ -197,12 +198,12 @@ func (c *command) kafkaStart(cmd *cobra.Command, _ []string) error {
 
 		createResp, err := dockerClient.ContainerCreate(context.Background(), config, hostConfig, nil, platform, fmt.Sprintf(confluentBrokerPrefix, brokerId))
 		if err != nil {
-			output.ErrPrintln(false, "The local commands have been verified to work with Docker Desktop version as late as 4.25.0.")
+			output.ErrPrintln(false, dockerWorkingVersionMsg)
 			return err
 		}
 		log.CliLogger.Trace(fmt.Sprintf("Successfully created a Confluent Local container for broker %d", brokerId))
 		if err := dockerClient.ContainerStart(context.Background(), createResp.ID, types.ContainerStartOptions{}); err != nil {
-			output.ErrPrintln(false, "The local commands have been verified to work with Docker Desktop version as late as 4.25.0.")
+			output.ErrPrintln(false, dockerWorkingVersionMsg)
 			return err
 		}
 		containerIds = append(containerIds, getShortenedContainerId(createResp.ID))

--- a/internal/local/command_kafka_start.go
+++ b/internal/local/command_kafka_start.go
@@ -78,6 +78,7 @@ func (c *command) kafkaStart(cmd *cobra.Command, _ []string) error {
 
 	containers, err := dockerClient.ContainerList(context.Background(), types.ContainerListOptions{All: true})
 	if err != nil {
+		output.ErrPrintln(false, "The local commands have been verified to work with Docker Desktop version as late as 4.25.0.")
 		return err
 	}
 
@@ -105,6 +106,7 @@ func (c *command) kafkaStart(cmd *cobra.Command, _ []string) error {
 
 	out, err := dockerClient.ImagePull(context.Background(), dockerImageName, types.ImagePullOptions{})
 	if err != nil {
+		output.ErrPrintln(false, "The local commands have been verified to work with Docker Desktop version as late as 4.25.0.")
 		return err
 	}
 	defer out.Close()
@@ -161,6 +163,7 @@ func (c *command) kafkaStart(cmd *cobra.Command, _ []string) error {
 		Driver:         "bridge",
 	}
 	if _, err := dockerClient.NetworkCreate(context.Background(), confluentLocalNetworkName, options); err != nil && !strings.Contains(err.Error(), "already exists") {
+		output.ErrPrintln(false, "The local commands have been verified to work with Docker Desktop version as late as 4.25.0.")
 		return err
 	}
 
@@ -194,10 +197,12 @@ func (c *command) kafkaStart(cmd *cobra.Command, _ []string) error {
 
 		createResp, err := dockerClient.ContainerCreate(context.Background(), config, hostConfig, nil, platform, fmt.Sprintf(confluentBrokerPrefix, brokerId))
 		if err != nil {
+			output.ErrPrintln(false, "The local commands have been verified to work with Docker Desktop version as late as 4.25.0.")
 			return err
 		}
 		log.CliLogger.Trace(fmt.Sprintf("Successfully created a Confluent Local container for broker %d", brokerId))
 		if err := dockerClient.ContainerStart(context.Background(), createResp.ID, types.ContainerStartOptions{}); err != nil {
+			output.ErrPrintln(false, "The local commands have been verified to work with Docker Desktop version as late as 4.25.0.")
 			return err
 		}
 		containerIds = append(containerIds, getShortenedContainerId(createResp.ID))

--- a/internal/local/command_kafka_start.go
+++ b/internal/local/command_kafka_start.go
@@ -29,7 +29,7 @@ import (
 )
 
 const (
-	dockerWorkingVersionMsg   = "The local commands have been verified to work with Docker Desktop version as late as 4.25.0."
+	dockerWorkingVersionMsg   = "The local commands have been verified to work with Docker Desktop version as late as 4.25.0. Verify that you are not using an unverified version of Docker (versions greater than v4.25.0)."
 	confluentBrokerPrefix     = "confluent-local-broker-%d"
 	controllerVoterPrefix     = "%d@confluent-local-broker-%d:%s"
 	bootstrapServerPrefix     = "confluent-local-broker-%d:%s"

--- a/pkg/cmd/prerunner.go
+++ b/pkg/cmd/prerunner.go
@@ -793,12 +793,14 @@ func (r *PreRun) shouldCheckForUpdates(cmd *cobra.Command) bool {
 func warnIfConfluentLocal(cmd *cobra.Command) {
 	if strings.HasPrefix(cmd.CommandPath(), "confluent local kafka start") {
 		output.ErrPrintln(false, "The local commands are intended for a single-node development environment only, NOT for production usage. See more: https://docs.confluent.io/current/cli/index.html")
+		output.ErrPrintln(false, "The local commands have been verified to work with Docker Desktop version as late as 4.25.0.")
 		output.ErrPrintln(false, "")
 		return
 	}
 	if strings.HasPrefix(cmd.CommandPath(), "confluent local") && !strings.HasPrefix(cmd.CommandPath(), "confluent local kafka") {
 		output.ErrPrintln(false, "The local commands are intended for a single-node development environment only, NOT for production usage. See more: https://docs.confluent.io/current/cli/index.html")
 		output.ErrPrintln(false, "As of Confluent Platform 8.0, Java 8 will no longer be supported.")
+		output.ErrPrintln(false, "The local commands have been verified to work with Docker Desktop version as late as 4.25.0.")
 		output.ErrPrintln(false, "")
 	}
 }

--- a/pkg/cmd/prerunner.go
+++ b/pkg/cmd/prerunner.go
@@ -793,14 +793,12 @@ func (r *PreRun) shouldCheckForUpdates(cmd *cobra.Command) bool {
 func warnIfConfluentLocal(cmd *cobra.Command) {
 	if strings.HasPrefix(cmd.CommandPath(), "confluent local kafka start") {
 		output.ErrPrintln(false, "The local commands are intended for a single-node development environment only, NOT for production usage. See more: https://docs.confluent.io/current/cli/index.html")
-		output.ErrPrintln(false, "The local commands have been verified to work with Docker Desktop version as late as 4.25.0.")
 		output.ErrPrintln(false, "")
 		return
 	}
 	if strings.HasPrefix(cmd.CommandPath(), "confluent local") && !strings.HasPrefix(cmd.CommandPath(), "confluent local kafka") {
 		output.ErrPrintln(false, "The local commands are intended for a single-node development environment only, NOT for production usage. See more: https://docs.confluent.io/current/cli/index.html")
 		output.ErrPrintln(false, "As of Confluent Platform 8.0, Java 8 will no longer be supported.")
-		output.ErrPrintln(false, "The local commands have been verified to work with Docker Desktop version as late as 4.25.0.")
 		output.ErrPrintln(false, "")
 	}
 }


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- PLACEHOLDER

New Features
- PLACEHOLDER

Bug Fixes
- Resolved the `no such host` error when running `confluent local kafka start`. Confluent Local is now working with the latest Docker Desktop version 4.25.0

Checklist
---------
- [x] Leave this box unchecked if features are not yet available in production

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->
Something changed in the way the docker client looks up host. `localhost` the string doesn't work as it failed to map it to `0.0.0.0`. instead, explicitly declare it as `0.0.0.0` will resolve the issue.

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
<!--
Has it been tested? How?
Copy and paste any instructions or steps that can save the reviewer time.
-->