### PR TITLE
Add debug logs in decryption and ckgo producer/consumer creation

### DIFF
--- a/internal/kafka/confluent_kafka.go
+++ b/internal/kafka/confluent_kafka.go
@@ -127,6 +127,7 @@ func retrieveUnsecuredToken(e ckafka.OAuthBearerTokenRefresh, tokenValue string)
 func newProducer(kafka *config.KafkaClusterConfig, clientID, configPath string, configStrings []string) (*ckafka.Producer, error) {
 	configMap, err := getProducerConfigMap(kafka, clientID)
 	if err != nil {
+		log.CliLogger.Warn("Failed to get Confluent Kafka producer configuration map.")
 		return nil, err
 	}
 
@@ -136,6 +137,7 @@ func newProducer(kafka *config.KafkaClusterConfig, clientID, configPath string, 
 func newConsumer(group string, kafka *config.KafkaClusterConfig, clientID, configPath string, configStrings []string) (*ckafka.Consumer, error) {
 	configMap, err := getConsumerConfigMap(group, kafka, clientID)
 	if err != nil {
+		log.CliLogger.Warn("Failed to get Confluent Kafka consumer configuration map.")
 		return nil, err
 	}
 
@@ -145,6 +147,7 @@ func newConsumer(group string, kafka *config.KafkaClusterConfig, clientID, confi
 func newOnPremProducer(cmd *cobra.Command, clientID, configPath string, configStrings []string) (*ckafka.Producer, error) {
 	configMap, err := getOnPremProducerConfigMap(cmd, clientID)
 	if err != nil {
+		log.CliLogger.Warn("Failed to get Confluent Kafka producer configuration map.")
 		return nil, err
 	}
 
@@ -154,6 +157,7 @@ func newOnPremProducer(cmd *cobra.Command, clientID, configPath string, configSt
 func newOnPremConsumer(cmd *cobra.Command, clientID, configPath string, configStrings []string) (*ckafka.Consumer, error) {
 	configMap, err := getOnPremConsumerConfigMap(cmd, clientID)
 	if err != nil {
+		log.CliLogger.Warn("Failed to get Confluent Kafka consumer configuration map.")
 		return nil, err
 	}
 

--- a/internal/kafka/confluent_kafka.go
+++ b/internal/kafka/confluent_kafka.go
@@ -127,8 +127,7 @@ func retrieveUnsecuredToken(e ckafka.OAuthBearerTokenRefresh, tokenValue string)
 func newProducer(kafka *config.KafkaClusterConfig, clientID, configPath string, configStrings []string) (*ckafka.Producer, error) {
 	configMap, err := getProducerConfigMap(kafka, clientID)
 	if err != nil {
-		log.CliLogger.Warn("Failed to get Confluent Kafka producer configuration map.")
-		return nil, err
+		return nil, fmt.Errorf(errors.FailedToGetConfigurationErrorMsg, err)
 	}
 
 	return newProducerWithOverwrittenConfigs(configMap, configPath, configStrings)
@@ -137,8 +136,7 @@ func newProducer(kafka *config.KafkaClusterConfig, clientID, configPath string, 
 func newConsumer(group string, kafka *config.KafkaClusterConfig, clientID, configPath string, configStrings []string) (*ckafka.Consumer, error) {
 	configMap, err := getConsumerConfigMap(group, kafka, clientID)
 	if err != nil {
-		log.CliLogger.Warn("Failed to get Confluent Kafka consumer configuration map.")
-		return nil, err
+		return nil, fmt.Errorf(errors.FailedToGetConfigurationErrorMsg, err)
 	}
 
 	return newConsumerWithOverwrittenConfigs(configMap, configPath, configStrings)
@@ -147,8 +145,7 @@ func newConsumer(group string, kafka *config.KafkaClusterConfig, clientID, confi
 func newOnPremProducer(cmd *cobra.Command, clientID, configPath string, configStrings []string) (*ckafka.Producer, error) {
 	configMap, err := getOnPremProducerConfigMap(cmd, clientID)
 	if err != nil {
-		log.CliLogger.Warn("Failed to get Confluent Kafka producer configuration map.")
-		return nil, err
+		return nil, fmt.Errorf(errors.FailedToGetConfigurationErrorMsg, err)
 	}
 
 	return newProducerWithOverwrittenConfigs(configMap, configPath, configStrings)
@@ -157,8 +154,7 @@ func newOnPremProducer(cmd *cobra.Command, clientID, configPath string, configSt
 func newOnPremConsumer(cmd *cobra.Command, clientID, configPath string, configStrings []string) (*ckafka.Consumer, error) {
 	configMap, err := getOnPremConsumerConfigMap(cmd, clientID)
 	if err != nil {
-		log.CliLogger.Warn("Failed to get Confluent Kafka consumer configuration map.")
-		return nil, err
+		return nil, fmt.Errorf(errors.FailedToGetConfigurationErrorMsg, err)
 	}
 
 	return newConsumerWithOverwrittenConfigs(configMap, configPath, configStrings)

--- a/internal/kafka/confluent_kafka_configs.go
+++ b/internal/kafka/confluent_kafka_configs.go
@@ -357,7 +357,7 @@ func newProducerWithOverwrittenConfigs(configMap *ckafka.ConfigMap, configPath s
 	if err := OverwriteKafkaClientConfigs(configMap, configPath, configStrings); err != nil {
 		return nil, err
 	}
-
+	log.CliLogger.Debug("Creating Confluent Kafka producer with the configuration map.")
 	return ckafka.NewProducer(configMap)
 }
 
@@ -365,7 +365,7 @@ func newConsumerWithOverwrittenConfigs(configMap *ckafka.ConfigMap, configPath s
 	if err := OverwriteKafkaClientConfigs(configMap, configPath, configStrings); err != nil {
 		return nil, err
 	}
-
+	log.CliLogger.Debug("Creating Confluent Kafka consumer with the configuration map.")
 	return ckafka.NewConsumer(configMap)
 }
 

--- a/pkg/errors/error_message.go
+++ b/pkg/errors/error_message.go
@@ -38,6 +38,7 @@ const (
 	// kafka topic commands
 	FailedToCreateProducerErrorMsg    = "failed to create producer: %v"
 	FailedToCreateConsumerErrorMsg    = "failed to create consumer: %v"
+	FailedToGetConfigurationErrorMsg  = "failed to get configuration map: %v"
 	FailedToCreateAdminClientErrorMsg = "failed to create confluent-kafka-go admin client: %w"
 	FailedToProduceErrorMsg           = "failed to produce offset %d: %s\n"
 	UnknownValueFormatErrorMsg        = "unknown value schema format"

--- a/pkg/errors/error_message.go
+++ b/pkg/errors/error_message.go
@@ -38,7 +38,7 @@ const (
 	// kafka topic commands
 	FailedToCreateProducerErrorMsg    = "failed to create producer: %v"
 	FailedToCreateConsumerErrorMsg    = "failed to create consumer: %v"
-	FailedToGetConfigurationErrorMsg  = "failed to get configuration map: %v"
+	FailedToGetConfigurationErrorMsg  = "failed to get configuration map: %w"
 	FailedToCreateAdminClientErrorMsg = "failed to create confluent-kafka-go admin client: %w"
 	FailedToProduceErrorMsg           = "failed to produce offset %d: %s\n"
 	UnknownValueFormatErrorMsg        = "unknown value schema format"

--- a/pkg/secret/encryption_other.go
+++ b/pkg/secret/encryption_other.go
@@ -16,6 +16,7 @@ import (
 	"golang.org/x/crypto/pbkdf2"
 
 	"github.com/confluentinc/cli/v3/pkg/errors"
+	"github.com/confluentinc/cli/v3/pkg/log"
 )
 
 const (
@@ -99,6 +100,7 @@ func Decrypt(username, encrypted string, salt, nonce []byte) (string, error) {
 	if len(nonce) != NonceLength {
 		return "", fmt.Errorf(errors.IncorrectNonceLengthErrorMsg)
 	}
+	log.CliLogger.Debugf("Decrypting secret: %s", cipherText)
 	decryptedPassword, err := aesgcm.Open(nil, nonce, cipherText, []byte(username))
 	if err != nil {
 		return "", fmt.Errorf("CLI does not have write permission for `/etc/machine-id`, or `~/.confluent/config.json` is corrupted: %w", err)

--- a/pkg/secret/encryption_windows.go
+++ b/pkg/secret/encryption_windows.go
@@ -4,6 +4,7 @@ package secret
 
 import (
 	"github.com/billgraziano/dpapi"
+	"github.com/confluentinc/cli/v3/pkg/log"
 )
 
 func generateRandomBytes(_ int) ([]byte, error) {
@@ -27,6 +28,7 @@ func Encrypt(_, password string, _, _ []byte) (string, error) {
 }
 
 func Decrypt(_, encrypted string, _, _ []byte) (string, error) {
+	log.CliLogger.Debugf("Decrypting secret: %s", encrypted)
 	decryptedPassword, err := dpapi.Decrypt(encrypted)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- PLACEHOLDER

New Features
- PLACEHOLDER

Bug Fixes
- PLACEHOLDER

Checklist
---------
- [x] Leave this box unchecked if features are not yet available in production

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->
Add debug logs in decryption and ckgo producer/consumer creation. Windows users have been reporting see: Error: failed to create consumer: decryptbytes: procdecryptdata: The parameter is incorrect.
Adding logs in ckgo as well, as this doesn't really look like a dpapi error. Possibilities: sasl authentication?

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->
https://github.com/confluentinc/cli/issues/2412

Test & Review
-------------
<!--
Has it been tested? How?
Copy and paste any instructions or steps that can save the reviewer time.
-->