### PR TITLE
[TRAFFIC-10037] add --network option to `confluent kafka cluster create` command

### DIFF
--- a/internal/kafka/command_cluster_create.go
+++ b/internal/kafka/command_cluster_create.go
@@ -173,14 +173,14 @@ func (c *clusterCommand) create(cmd *cobra.Command, args []string) error {
 	}
 
 	if cmd.Flags().Changed("network") {
-		networkId, err := cmd.Flags().GetString("network")
+		network, err := cmd.Flags().GetString("network")
 		if err != nil {
 			return err
 		}
 		if clusterType != skuDedicated {
 			return errors.NewErrorWithSuggestions("the `--network` flag can only be used when creating a dedicated Kafka cluster", "Specify a dedicated cluster with `--type`.")
 		}
-		setClusterNetwork(&createCluster, cmkv2.NewEnvScopedObjectReference(networkId, "", ""))
+		createCluster.Spec.Network = &cmkv2.EnvScopedObjectReference{Id: network}
 	}
 
 	kafkaCluster, httpResp, err := c.V2Client.CreateKafkaCluster(createCluster)
@@ -286,10 +286,6 @@ func setCmkClusterConfig(typeString string, cku int32, encryptionKeyID string) *
 
 func setClusterConfigCku(cluster *cmkv2.CmkV2Cluster, cku int32) {
 	cluster.Spec.Config.CmkV2Dedicated.Cku = cku
-}
-
-func setClusterNetwork(cluster *cmkv2.CmkV2Cluster, network *cmkv2.EnvScopedObjectReference) {
-	cluster.Spec.Network = network
 }
 
 func getKafkaProvisionEstimate(sku ccstructs.Sku) string {

--- a/pkg/cmd/flags.go
+++ b/pkg/cmd/flags.go
@@ -466,3 +466,31 @@ func AutocompleteConsumerGroups(command *AuthenticatedCLICommand) []string {
 	}
 	return suggestions
 }
+
+func AddNetworkFlag(cmd *cobra.Command, c *AuthenticatedCLICommand) {
+	cmd.Flags().String("network", "", "Network ID.")
+	RegisterFlagCompletionFunc(cmd, "network", func(cmd *cobra.Command, args []string) []string {
+		if err := c.PersistentPreRunE(cmd, args); err != nil {
+			return nil
+		}
+
+		environmentId, err := c.Context.EnvironmentId()
+		if err != nil {
+			return nil
+		}
+		return AutocompleteNetworks(environmentId, c.V2Client)
+	})
+}
+
+func AutocompleteNetworks(environmentId string, client *ccloudv2.Client) []string {
+	networks, err := client.ListNetworks(environmentId)
+	if err != nil {
+		return nil
+	}
+
+	suggestions := make([]string, len(networks))
+	for i, network := range networks {
+		suggestions[i] = fmt.Sprintf("%s\t%s", network.GetId(), network.Spec.GetDisplayName())
+	}
+	return suggestions
+}

--- a/test/fixtures/output/kafka/1.golden
+++ b/test/fixtures/output/kafka/1.golden
@@ -21,6 +21,7 @@ Flags:
       --cku int                 Number of Confluent Kafka Units (non-negative). Required for Kafka clusters of type "dedicated".
       --encryption-key string   Resource ID of the Cloud Key Management Service key (GCP only).
       --byok string             Confluent Cloud Key ID of a registered encryption key (AWS and Azure only, use "confluent byok create" to register a key).
+      --network string          Network ID.
       --context string          CLI context name.
       --environment string      Environment ID.
   -o, --output string           Specify the output format as "human", "json", or "yaml". (default "human")

--- a/test/fixtures/output/kafka/cluster/cck-network.golden
+++ b/test/fixtures/output/kafka/cluster/cck-network.golden
@@ -1,0 +1,18 @@
+It may take up to 1 hour for the Kafka cluster to be ready. The organization admin will receive an email once the dedicated cluster is provisioned.
++----------------------+---------------------------+
+| Current              | false                     |
+| ID                   | lkc-def963                |
+| Name                 | cck-network-test          |
+| Type                 | DEDICATED                 |
+| Cluster Size         | 1                         |
+| Ingress Limit (MB/s) | 50                        |
+| Egress Limit (MB/s)  | 150                       |
+| Storage              | Infinite                  |
+| Provider             | aws                       |
+| Region               | us-east-1                 |
+| Availability         | single-zone               |
+| Network              | n-abcde1                  |
+| Status               | PROVISIONING              |
+| Endpoint             | SASL_SSL://kafka-endpoint |
+| REST Endpoint        | https://pkc-endpoint      |
++----------------------+---------------------------+

--- a/test/fixtures/output/kafka/cluster/create-help.golden
+++ b/test/fixtures/output/kafka/cluster/create-help.golden
@@ -24,6 +24,7 @@ Flags:
       --cku int                 Number of Confluent Kafka Units (non-negative). Required for Kafka clusters of type "dedicated".
       --encryption-key string   Resource ID of the Cloud Key Management Service key (GCP only).
       --byok string             Confluent Cloud Key ID of a registered encryption key (AWS and Azure only, use "confluent byok create" to register a key).
+      --network string          Network ID.
       --context string          CLI context name.
       --environment string      Environment ID.
   -o, --output string           Specify the output format as "human", "json", or "yaml". (default "human")

--- a/test/kafka_test.go
+++ b/test/kafka_test.go
@@ -637,3 +637,13 @@ func (s *CLITestSuite) TestKafka_Autocomplete() {
 		s.runIntegrationTest(test)
 	}
 }
+
+func (s *CLITestSuite) TestKafkaClusterCreate_Network() {
+	test := CLITest{
+		login:   "cloud",
+		args:    "kafka cluster create cck-network-test --cloud aws --region us-east-1 --type dedicated --cku 1 --network n-abcde1",
+		fixture: "kafka/cluster/cck-network.golden",
+	}
+
+	s.runIntegrationTest(test)
+}

--- a/test/test-server/cmk_handlers.go
+++ b/test/test-server/cmk_handlers.go
@@ -45,6 +45,9 @@ func handleCmkKafkaClusterCreate(t *testing.T) http.HandlerFunc {
 			if req.Spec.GetDisplayName() == "cck-byok-test" {
 				cluster.Spec.Byok = req.Spec.Byok
 			}
+			if req.Spec.GetDisplayName() == "cck-network-test" {
+				cluster.Spec.Network = req.Spec.Network
+			}
 			cluster.Status.Cku = cmkv2.PtrInt32(1)
 		} else if req.Spec.Config.CmkV2Enterprise != nil {
 			if req.Spec.GetAvailability() == "SINGLE_ZONE" {


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- PLACEHOLDER

New Features
- PLACEHOLDER

Bug Fixes
- PLACEHOLDER

Checklist
---------
- [] Leave this box unchecked if features are not yet available in production

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->
Note that this is merging into the feature branch https://github.com/confluentinc/cli/tree/traffic-8850-network-cli-az. We will merge commits into main from this feature branch after all of the commands for network are implemented.

- Add `--network` option to `confluent kafka cluster create` to specify a network for a cluster. Note that this can only be used when creating a dedicated cluster. 

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
<!--
Has it been tested? How?
Copy and paste any instructions or steps that can save the reviewer time.
-->
Added integration tests.

Performed manual tests.