### PR TITLE
[TRAFFIC-9340] Add `confluent network network-link service delete` command

### DIFF
--- a/internal/network/command_network_link_service.go
+++ b/internal/network/command_network_link_service.go
@@ -41,6 +41,7 @@ func (c *command) newNetworkLinkServiceCommand() *cobra.Command {
 		Args:  cobra.NoArgs,
 	}
 
+	cmd.AddCommand(c.newNetworkLinkServiceDeleteCommand())
 	cmd.AddCommand(c.newNetworkLinkServiceDescribeCommand())
 	cmd.AddCommand(c.newNetworkLinkServiceListCommand())
 

--- a/internal/network/command_network_link_service_delete.go
+++ b/internal/network/command_network_link_service_delete.go
@@ -1,0 +1,63 @@
+package network
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	pcmd "github.com/confluentinc/cli/v3/pkg/cmd"
+	"github.com/confluentinc/cli/v3/pkg/deletion"
+	"github.com/confluentinc/cli/v3/pkg/errors"
+	"github.com/confluentinc/cli/v3/pkg/output"
+	"github.com/confluentinc/cli/v3/pkg/resource"
+	"github.com/confluentinc/cli/v3/pkg/utils"
+)
+
+func (c *command) newNetworkLinkServiceDeleteCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:               "delete <id>",
+		Short:             "Delete a network link service.",
+		Args:              cobra.MinimumNArgs(1),
+		ValidArgsFunction: pcmd.NewValidArgsFunction(c.validNetworkLinkServiceArgs),
+		RunE:              c.networkLinkServiceDelete,
+	}
+
+	pcmd.AddForceFlag(cmd)
+	pcmd.AddContextFlag(cmd, c.CLICommand)
+	pcmd.AddEnvironmentFlag(cmd, c.AuthenticatedCLICommand)
+
+	return cmd
+}
+
+func (c *command) networkLinkServiceDelete(cmd *cobra.Command, args []string) error {
+	environmentId, err := c.Context.EnvironmentId()
+	if err != nil {
+		return err
+	}
+
+	existenceFunc := func(id string) bool {
+		_, err := c.V2Client.GetNetworkLinkService(environmentId, id)
+		return err == nil
+	}
+
+	if err := deletion.ValidateAndConfirmDeletionYesNo(cmd, args, existenceFunc, resource.NetworkLinkService); err != nil {
+		return err
+	}
+
+	deleteFunc := func(id string) error {
+		if err := c.V2Client.DeleteNetworkLinkService(environmentId, id); err != nil {
+			return fmt.Errorf(errors.DeleteResourceErrorMsg, resource.NetworkLinkService, id, err)
+		}
+		return nil
+	}
+
+	deletedIds, err := deletion.DeleteWithoutMessage(args, deleteFunc)
+	deleteMsg := "Requested to delete %s %s.\n"
+	if len(deletedIds) == 1 {
+		output.Printf(c.Config.EnableColor, deleteMsg, resource.NetworkLinkService, fmt.Sprintf(`"%s"`, deletedIds[0]))
+	} else if len(deletedIds) > 1 {
+		output.Printf(c.Config.EnableColor, deleteMsg, resource.Plural(resource.NetworkLinkService), utils.ArrayToCommaDelimitedString(deletedIds, "and"))
+	}
+
+	return err
+}

--- a/pkg/ccloudv2/networking.go
+++ b/pkg/ccloudv2/networking.go
@@ -256,3 +256,8 @@ func (c *Client) GetNetworkLinkService(environment, id string) (networkingv1.Net
 	resp, httpResp, err := c.NetworkingClient.NetworkLinkServicesNetworkingV1Api.GetNetworkingV1NetworkLinkService(c.networkingApiContext(), id).Environment(environment).Execute()
 	return resp, errors.CatchCCloudV2Error(err, httpResp)
 }
+
+func (c *Client) DeleteNetworkLinkService(environment, id string) error {
+	httpResp, err := c.NetworkingClient.NetworkLinkServicesNetworkingV1Api.DeleteNetworkingV1NetworkLinkService(c.networkingApiContext(), id).Environment(environment).Execute()
+	return errors.CatchCCloudV2Error(err, httpResp)
+}

--- a/pkg/resource/resource.go
+++ b/pkg/resource/resource.go
@@ -34,6 +34,7 @@ const (
 	KsqlCluster                     = "KSQL cluster"
 	MirrorTopic                     = "mirror topic"
 	Network                         = "network"
+	NetworkLinkService              = "network link service"
 	Organization                    = "organization"
 	Peering                         = "peering"
 	PrivateLinkAccess               = "private link access"

--- a/test/fixtures/output/network/network-link/service/delete-autocomplete.golden
+++ b/test/fixtures/output/network/network-link/service/delete-autocomplete.golden
@@ -1,0 +1,5 @@
+nls-11111	test-nls1
+nls-22222	test-nls2
+nls-33333	test-nls3
+:4
+Completion ended with directive: ShellCompDirectiveNoFileComp

--- a/test/fixtures/output/network/network-link/service/delete-help.golden
+++ b/test/fixtures/output/network/network-link/service/delete-help.golden
@@ -1,0 +1,14 @@
+Delete a network link service.
+
+Usage:
+  confluent network network-link service delete <id> [flags]
+
+Flags:
+      --force                Skip the deletion confirmation prompt.
+      --context string       CLI context name.
+      --environment string   Environment ID.
+
+Global Flags:
+  -h, --help            Show help for this command.
+      --unsafe-trace    Equivalent to -vvvv, but also log HTTP requests and responses which might contain plaintext secrets.
+  -v, --verbose count   Increase verbosity (-v for warn, -vv for info, -vvv for debug, -vvvv for trace).

--- a/test/fixtures/output/network/network-link/service/delete-multiple-fail.golden
+++ b/test/fixtures/output/network/network-link/service/delete-multiple-fail.golden
@@ -1,0 +1,4 @@
+Error: network link service "nls-invalid" not found
+
+Suggestions:
+    List available network link services with `confluent network network-link service list`.

--- a/test/fixtures/output/network/network-link/service/delete-multiple-refuse.golden
+++ b/test/fixtures/output/network/network-link/service/delete-multiple-refuse.golden
@@ -1,0 +1,1 @@
+Are you sure you want to delete network link services "nls-111111" and "nls-222222"? (y/n): 

--- a/test/fixtures/output/network/network-link/service/delete-multiple-success.golden
+++ b/test/fixtures/output/network/network-link/service/delete-multiple-success.golden
@@ -1,0 +1,1 @@
+Are you sure you want to delete network link services "nls-111111" and "nls-222222"? (y/n): Requested to delete network link services "nls-111111" and "nls-222222".

--- a/test/fixtures/output/network/network-link/service/delete-nls-not-exist.golden
+++ b/test/fixtures/output/network/network-link/service/delete-nls-not-exist.golden
@@ -1,0 +1,4 @@
+Error: network link service "nls-invalid" not found
+
+Suggestions:
+    List available network link services with `confluent network network-link service list`.

--- a/test/fixtures/output/network/network-link/service/delete-prompt.golden
+++ b/test/fixtures/output/network/network-link/service/delete-prompt.golden
@@ -1,0 +1,1 @@
+Are you sure you want to delete network link service "nls-111111"? (y/n): Requested to delete network link service "nls-111111".

--- a/test/fixtures/output/network/network-link/service/delete.golden
+++ b/test/fixtures/output/network/network-link/service/delete.golden
@@ -1,0 +1,1 @@
+Requested to delete network link service "nls-111111".

--- a/test/fixtures/output/network/network-link/service/describe-autocomplete.golden
+++ b/test/fixtures/output/network/network-link/service/describe-autocomplete.golden
@@ -1,0 +1,5 @@
+nls-11111	test-nls1
+nls-22222	test-nls2
+nls-33333	test-nls3
+:4
+Completion ended with directive: ShellCompDirectiveNoFileComp

--- a/test/fixtures/output/network/network-link/service/help.golden
+++ b/test/fixtures/output/network/network-link/service/help.golden
@@ -4,6 +4,7 @@ Usage:
   confluent network network-link service [command]
 
 Available Commands:
+  delete      Delete a network link service.
   describe    Describe a network link service.
   list        List network link services.
 

--- a/test/network_test.go
+++ b/test/network_test.go
@@ -573,6 +573,34 @@ func (s *CLITestSuite) TestNetworkNetworkLinkServiceList() {
 	}
 }
 
+func (s *CLITestSuite) TestNetworkNetworkLinkServiceLDelete() {
+	tests := []CLITest{
+		{args: "network network-link service delete nls-111111 --force", fixture: "network/network-link/service/delete.golden"},
+		{args: "network network-link service delete nls-111111", input: "y\n", fixture: "network/network-link/service/delete-prompt.golden"},
+		{args: "network network-link service delete nls-111111 nls-222222", input: "n\n", fixture: "network/network-link/service/delete-multiple-refuse.golden"},
+		{args: "network network-link service delete nls-111111 nls-222222", input: "y\n", fixture: "network/network-link/service//delete-multiple-success.golden"},
+		{args: "network network-link service delete nls-111111 nls-invalid", fixture: "network/network-link/service/delete-multiple-fail.golden", exitCode: 1},
+		{args: "network network-link service delete nls-invalid --force", fixture: "network/network-link/service/delete-nls-not-exist.golden", exitCode: 1},
+	}
+
+	for _, test := range tests {
+		test.login = "cloud"
+		s.runIntegrationTest(test)
+	}
+}
+
+func (s *CLITestSuite) TestNetworkNetworkLinkService_Autocomplete() {
+	tests := []CLITest{
+		{args: `__complete network network-link service describe ""`, login: "cloud", fixture: "network/network-link/service/describe-autocomplete.golden"},
+		{args: `__complete network network-link service delete ""`, login: "cloud", fixture: "network/network-link/service/delete-autocomplete.golden"},
+	}
+
+	for _, test := range tests {
+		test.login = "cloud"
+		s.runIntegrationTest(test)
+	}
+}
+
 func (s *CLITestSuite) TestNetworkIpAddressList() {
 	tests := []CLITest{
 		{args: "network ip-address list", fixture: "network/ip-address/list.golden"},

--- a/test/test-server/networking_handlers.go
+++ b/test/test-server/networking_handlers.go
@@ -195,6 +195,8 @@ func handleNetworkingNetworkLinkService(t *testing.T) http.HandlerFunc {
 		switch r.Method {
 		case http.MethodGet:
 			handleNetworkingNetworkLinkServiceGet(t, id)(w, r)
+		case http.MethodDelete:
+			handleNetworkingNetworkLinkServiceDelete(t, id)(w, r)
 		}
 	}
 }
@@ -1319,6 +1321,18 @@ func handleNetworkingNetworkLinkServiceList(t *testing.T) http.HandlerFunc {
 
 		err := json.NewEncoder(w).Encode(networkLinkServiceList)
 		require.NoError(t, err)
+	}
+}
+
+func handleNetworkingNetworkLinkServiceDelete(_ *testing.T, id string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		switch id {
+		case "nls-invalid":
+			w.WriteHeader(http.StatusNotFound)
+			return
+		case "nls-111111", "nls-222222":
+			w.WriteHeader(http.StatusNoContent)
+		}
 	}
 }
 


### PR DESCRIPTION
What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->
Note that this is merging into the feature branch https://github.com/confluentinc/cli/tree/traffic-8850-network-cli-az. We will merge commits into main from this feature branch after all of the commands for network are implemented.

- Add `confluent network network-link service delete`

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->
[CLI Commands Design](https://confluentinc.atlassian.net/wiki/spaces/PM/pages/2987394300/1-pager+--+Network+CLI)
[Implementation 1-Pager](https://confluentinc.atlassian.net/wiki/spaces/~712020463029eabbac401bbe1b033ce0d3a00e/pages/3136749631/Network+CLI)

Test & Review
-------------
<!--
Has it been tested? How?
Copy and paste any instructions or steps that can save the reviewer time.
-->
Added integration tests.

Performed manual tests.