### PR TITLE
[TRAFFIC-9341] Add `confluent network network-link service create`

### DIFF
--- a/internal/network/command.go
+++ b/internal/network/command.go
@@ -241,3 +241,30 @@ func (c *command) addPrivateLinkAttachmentFlag(cmd *cobra.Command) {
 	cmd.Flags().String("attachment", "", "Private link attachment ID.")
 	pcmd.RegisterFlagCompletionFunc(cmd, "attachment", c.validPrivateLinkAttachmentArgsMultiple)
 }
+
+func addAcceptNetworksFlag(cmd *cobra.Command, c *pcmd.AuthenticatedCLICommand) {
+	cmd.Flags().StringSlice("accept-networks", nil, "A comma-separated list of accept policy networks.")
+	pcmd.RegisterFlagCompletionFunc(cmd, "accept-networks", func(cmd *cobra.Command, args []string) []string {
+		if err := c.PersistentPreRunE(cmd, args); err != nil {
+			return nil
+		}
+
+		environmentId, err := c.Context.EnvironmentId()
+		if err != nil {
+			return nil
+		}
+
+		return autocompleteNetworks(c.V2Client, environmentId)
+	})
+}
+
+func addAcceptEnvironmentsFlag(cmd *cobra.Command, command *pcmd.AuthenticatedCLICommand) {
+	cmd.Flags().StringSlice("accept-environments", nil, "A comma-separated list of accept policy environments.")
+	pcmd.RegisterFlagCompletionFunc(cmd, "accept-environments", func(cmd *cobra.Command, args []string) []string {
+		if err := command.PersistentPreRunE(cmd, args); err != nil {
+			return nil
+		}
+
+		return pcmd.AutocompleteEnvironments(command.Client, command.V2Client)
+	})
+}

--- a/internal/network/command_network_link_service.go
+++ b/internal/network/command_network_link_service.go
@@ -15,7 +15,7 @@ import (
 type networkLinkServiceHumanOut struct {
 	Id                   string `human:"ID"`
 	Name                 string `human:"Name"`
-	Network              string `human:"Network"`
+	NetworkId            string `human:"Network ID"`
 	Environment          string `human:"Environment"`
 	Description          string `human:"Description,omitempty"`
 	AcceptedEnvironments string `human:"Accepted Environments,omitempty"`
@@ -26,7 +26,7 @@ type networkLinkServiceHumanOut struct {
 type networkLinkServiceSerializedOut struct {
 	Id                   string   `serialized:"id"`
 	Name                 string   `serialized:"name"`
-	Network              string   `serialized:"network"`
+	NetworkId            string   `serialized:"network_id"`
 	Environment          string   `serialized:"environment"`
 	Description          string   `serialized:"description,omitempty"`
 	AcceptedEnvironments []string `serialized:"accepted_environments,omitempty"`
@@ -41,6 +41,7 @@ func (c *command) newNetworkLinkServiceCommand() *cobra.Command {
 		Args:  cobra.NoArgs,
 	}
 
+	cmd.AddCommand(c.newNetworkLinkServiceCreateCommand())
 	cmd.AddCommand(c.newNetworkLinkServiceDeleteCommand())
 	cmd.AddCommand(c.newNetworkLinkServiceDescribeCommand())
 	cmd.AddCommand(c.newNetworkLinkServiceListCommand())
@@ -99,7 +100,7 @@ func printNetworkLinkServiceTable(cmd *cobra.Command, service networkingv1.Netwo
 		table.Add(&networkLinkServiceHumanOut{
 			Id:                   service.GetId(),
 			Name:                 service.Spec.GetDisplayName(),
-			Network:              service.Spec.Network.GetId(),
+			NetworkId:            service.Spec.Network.GetId(),
 			Environment:          service.Spec.Environment.GetId(),
 			Description:          service.Spec.GetDescription(),
 			AcceptedEnvironments: strings.Join(service.Spec.Accept.GetEnvironments(), ", "),
@@ -110,7 +111,7 @@ func printNetworkLinkServiceTable(cmd *cobra.Command, service networkingv1.Netwo
 		table.Add(&networkLinkServiceSerializedOut{
 			Id:                   service.GetId(),
 			Name:                 service.Spec.GetDisplayName(),
-			Network:              service.Spec.Network.GetId(),
+			NetworkId:            service.Spec.Network.GetId(),
 			Environment:          service.Spec.Environment.GetId(),
 			Description:          service.Spec.GetDescription(),
 			AcceptedEnvironments: service.Spec.Accept.GetEnvironments(),

--- a/internal/network/command_network_link_service_create.go
+++ b/internal/network/command_network_link_service_create.go
@@ -1,0 +1,91 @@
+package network
+
+import (
+	"github.com/spf13/cobra"
+
+	networkingv1 "github.com/confluentinc/ccloud-sdk-go-v2/networking/v1"
+
+	pcmd "github.com/confluentinc/cli/v3/pkg/cmd"
+	"github.com/confluentinc/cli/v3/pkg/examples"
+)
+
+func (c *command) newNetworkLinkServiceCreateCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "create <name>",
+		Short: "Create a network link service.",
+		Args:  cobra.ExactArgs(1),
+		RunE:  c.networkLinkServiceCreate,
+		Example: examples.BuildExampleString(
+			examples.Example{
+				Text: "Create a network link service.",
+				Code: "confluent network network-link service create test_nls --network n-123456 --description 'test description' --accept-environments env-00000",
+			},
+		),
+	}
+
+	addNetworkFlag(cmd, c.AuthenticatedCLICommand)
+	addAcceptNetworksFlag(cmd, c.AuthenticatedCLICommand)
+	addAcceptEnvironmentsFlag(cmd, c.AuthenticatedCLICommand)
+	cmd.Flags().String("description", "", "Network link service description.")
+	pcmd.AddContextFlag(cmd, c.CLICommand)
+	pcmd.AddEnvironmentFlag(cmd, c.AuthenticatedCLICommand)
+	pcmd.AddOutputFlag(cmd)
+
+	cobra.CheckErr(cmd.MarkFlagRequired("network"))
+
+	return cmd
+}
+
+func (c *command) networkLinkServiceCreate(cmd *cobra.Command, args []string) error {
+	name := args[0]
+
+	networkId, err := cmd.Flags().GetString("network")
+	if err != nil {
+		return err
+	}
+
+	environmentId, err := c.Context.EnvironmentId()
+	if err != nil {
+		return err
+	}
+
+	description, err := cmd.Flags().GetString("description")
+	if err != nil {
+		return err
+	}
+
+	acceptedNetworks, err := cmd.Flags().GetStringSlice("accept-networks")
+	if err != nil {
+		return err
+	}
+
+	acceptedEnvironments, err := cmd.Flags().GetStringSlice("accept-environments")
+	if err != nil {
+		return err
+	}
+
+	createNetworkLinkService := networkingv1.NetworkingV1NetworkLinkService{
+		Spec: &networkingv1.NetworkingV1NetworkLinkServiceSpec{
+			DisplayName: networkingv1.PtrString(name),
+			Description: networkingv1.PtrString(description),
+			Environment: &networkingv1.GlobalObjectReference{Id: environmentId},
+			Network:     &networkingv1.EnvScopedObjectReference{Id: networkId},
+			Accept:      &networkingv1.NetworkingV1NetworkLinkServiceAcceptPolicy{},
+		},
+	}
+
+	if len(acceptedNetworks) > 0 {
+		createNetworkLinkService.Spec.Accept.SetNetworks(acceptedNetworks)
+	}
+
+	if len(acceptedEnvironments) > 0 {
+		createNetworkLinkService.Spec.Accept.SetEnvironments(acceptedEnvironments)
+	}
+
+	service, err := c.V2Client.CreateNetworkLinkService(createNetworkLinkService)
+	if err != nil {
+		return err
+	}
+
+	return printNetworkLinkServiceTable(cmd, service)
+}

--- a/internal/network/command_network_link_service_list.go
+++ b/internal/network/command_network_link_service_list.go
@@ -14,7 +14,7 @@ import (
 type listNetworkLinkServiceHumanOut struct {
 	Id                   string `human:"ID"`
 	Name                 string `human:"Name"`
-	Network              string `human:"Network"`
+	NetworkId            string `human:"Network ID"`
 	Description          string `human:"Description,omitempty"`
 	AcceptedEnvironments string `human:"Accepted Environments,omitempty"`
 	AcceptedNetworks     string `human:"Accepted Networks,omitempty"`
@@ -24,7 +24,7 @@ type listNetworkLinkServiceHumanOut struct {
 type listNetworkLinkServiceSerializedOut struct {
 	Id                   string   `serialized:"id"`
 	Name                 string   `serialized:"name"`
-	Network              string   `serialized:"network"`
+	NetworkId            string   `serialized:"network_id"`
 	Description          string   `serialized:"description,omitempty"`
 	AcceptedEnvironments []string `serialized:"accepted_environments,omitempty"`
 	AcceptedNetworks     []string `serialized:"accepted_networks,omitempty"`
@@ -65,7 +65,7 @@ func (c *command) networkLinkServiceList(cmd *cobra.Command, _ []string) error {
 			list.Add(&listNetworkLinkServiceHumanOut{
 				Id:                   service.GetId(),
 				Name:                 service.Spec.GetDisplayName(),
-				Network:              service.Spec.Network.GetId(),
+				NetworkId:            service.Spec.Network.GetId(),
 				Description:          service.Spec.GetDescription(),
 				AcceptedEnvironments: strings.Join(service.Spec.Accept.GetEnvironments(), ", "),
 				AcceptedNetworks:     strings.Join(service.Spec.Accept.GetNetworks(), ", "),
@@ -75,7 +75,7 @@ func (c *command) networkLinkServiceList(cmd *cobra.Command, _ []string) error {
 			list.Add(&listNetworkLinkServiceSerializedOut{
 				Id:                   service.GetId(),
 				Name:                 service.Spec.GetDisplayName(),
-				Network:              service.Spec.Network.GetId(),
+				NetworkId:            service.Spec.Network.GetId(),
 				Description:          service.Spec.GetDescription(),
 				AcceptedEnvironments: service.Spec.Accept.GetEnvironments(),
 				AcceptedNetworks:     service.Spec.Accept.GetNetworks(),

--- a/pkg/ccloudv2/networking.go
+++ b/pkg/ccloudv2/networking.go
@@ -261,3 +261,8 @@ func (c *Client) DeleteNetworkLinkService(environment, id string) error {
 	httpResp, err := c.NetworkingClient.NetworkLinkServicesNetworkingV1Api.DeleteNetworkingV1NetworkLinkService(c.networkingApiContext(), id).Environment(environment).Execute()
 	return errors.CatchCCloudV2Error(err, httpResp)
 }
+
+func (c *Client) CreateNetworkLinkService(service networkingv1.NetworkingV1NetworkLinkService) (networkingv1.NetworkingV1NetworkLinkService, error) {
+	resp, httpResp, err := c.NetworkingClient.NetworkLinkServicesNetworkingV1Api.CreateNetworkingV1NetworkLinkService(c.networkingApiContext()).NetworkingV1NetworkLinkService(service).Execute()
+	return resp, errors.CatchCCloudV2Error(err, httpResp)
+}

--- a/test/fixtures/output/network/network-link/service/create-accept-environments.golden
+++ b/test/fixtures/output/network/network-link/service/create-accept-environments.golden
@@ -1,10 +1,9 @@
 +-----------------------+----------------------+
-| ID                    | nls-123456           |
+| ID                    | nls-abcde1           |
 | Name                  | nls-test             |
-| Network ID            | n-abcde1             |
+| Network ID            | n-123456             |
 | Environment           | env-00000            |
-| Description           | test nls             |
+| Description           | test description     |
 | Accepted Environments | env-11111, env-22222 |
-| Accepted Networks     | n-abcde2, n-abcde3   |
 | Phase                 | READY                |
 +-----------------------+----------------------+

--- a/test/fixtures/output/network/network-link/service/create-accept-networks.golden
+++ b/test/fixtures/output/network/network-link/service/create-accept-networks.golden
@@ -1,0 +1,9 @@
++-------------------+--------------------+
+| ID                | nls-abcde1         |
+| Name              | nls-test           |
+| Network ID        | n-123456           |
+| Environment       | env-00000          |
+| Description       | test description   |
+| Accepted Networks | n-111111, n-222222 |
+| Phase             | READY              |
++-------------------+--------------------+

--- a/test/fixtures/output/network/network-link/service/create-autocomplete.golden
+++ b/test/fixtures/output/network/network-link/service/create-autocomplete.golden
@@ -1,0 +1,5 @@
+n-abcde1	prod-aws-us-east1
+n-abcde2	prod-gcp-us-central1
+n-abcde3	prod-azure-eastus2
+:4
+Completion ended with directive: ShellCompDirectiveNoFileComp

--- a/test/fixtures/output/network/network-link/service/create-duplicate.golden
+++ b/test/fixtures/output/network/network-link/service/create-duplicate.golden
@@ -1,0 +1,1 @@
+Error: Exceeds the maximum number of network link service (1) supported per network.: 409 Conflict

--- a/test/fixtures/output/network/network-link/service/create-help.golden
+++ b/test/fixtures/output/network/network-link/service/create-help.golden
@@ -1,0 +1,23 @@
+Create a network link service.
+
+Usage:
+  confluent network network-link service create <name> [flags]
+
+Examples:
+Create a network link service.
+
+  $ confluent network network-link service create test_nls --network n-123456 --description 'test description' --accept-environments env-00000
+
+Flags:
+      --network string                REQUIRED: Network ID.
+      --accept-networks strings       A comma-separated list of accept policy networks.
+      --accept-environments strings   A comma-separated list of accept policy environments.
+      --description string            Network link service description.
+      --context string                CLI context name.
+      --environment string            Environment ID.
+  -o, --output string                 Specify the output format as "human", "json", or "yaml". (default "human")
+
+Global Flags:
+  -h, --help            Show help for this command.
+      --unsafe-trace    Equivalent to -vvvv, but also log HTTP requests and responses which might contain plaintext secrets.
+  -v, --verbose count   Increase verbosity (-v for warn, -vv for info, -vvv for debug, -vvvv for trace).

--- a/test/fixtures/output/network/network-link/service/create-missing-args.golden
+++ b/test/fixtures/output/network/network-link/service/create-missing-args.golden
@@ -1,0 +1,23 @@
+Error: accepts 1 arg(s), received 0
+Usage:
+  confluent network network-link service create <name> [flags]
+
+Examples:
+Create a network link service.
+
+  $ confluent network network-link service create test_nls --network n-123456 --description 'test description' --accept-environments env-00000
+
+Flags:
+      --network string                Network ID.
+      --accept-networks strings       A comma-separated list of accept policy networks.
+      --accept-environments strings   A comma-separated list of accept policy environments.
+      --description string            Network link service description.
+      --context string                CLI context name.
+      --environment string            Environment ID.
+  -o, --output string                 Specify the output format as "human", "json", or "yaml". (default "human")
+
+Global Flags:
+  -h, --help            Show help for this command.
+      --unsafe-trace    Equivalent to -vvvv, but also log HTTP requests and responses which might contain plaintext secrets.
+  -v, --verbose count   Increase verbosity (-v for warn, -vv for info, -vvv for debug, -vvvv for trace).
+

--- a/test/fixtures/output/network/network-link/service/create.golden
+++ b/test/fixtures/output/network/network-link/service/create.golden
@@ -1,10 +1,10 @@
 +-----------------------+----------------------+
-| ID                    | nls-123456           |
+| ID                    | nls-abcde1           |
 | Name                  | nls-test             |
-| Network ID            | n-abcde1             |
+| Network ID            | n-123456             |
 | Environment           | env-00000            |
-| Description           | test nls             |
+| Description           | test description     |
 | Accepted Environments | env-11111, env-22222 |
-| Accepted Networks     | n-abcde2, n-abcde3   |
+| Accepted Networks     | n-111111, n-222222   |
 | Phase                 | READY                |
 +-----------------------+----------------------+

--- a/test/fixtures/output/network/network-link/service/delete-autocomplete.golden
+++ b/test/fixtures/output/network/network-link/service/delete-autocomplete.golden
@@ -1,5 +1,5 @@
-nls-11111	test-nls1
-nls-22222	test-nls2
-nls-33333	test-nls3
+nls-11111	nls-test1
+nls-22222	nls-test2
+nls-33333	nls-test3
 :4
 Completion ended with directive: ShellCompDirectiveNoFileComp

--- a/test/fixtures/output/network/network-link/service/describe-autocomplete.golden
+++ b/test/fixtures/output/network/network-link/service/describe-autocomplete.golden
@@ -1,5 +1,5 @@
-nls-11111	test-nls1
-nls-22222	test-nls2
-nls-33333	test-nls3
+nls-11111	nls-test1
+nls-22222	nls-test2
+nls-33333	nls-test3
 :4
 Completion ended with directive: ShellCompDirectiveNoFileComp

--- a/test/fixtures/output/network/network-link/service/describe-json.golden
+++ b/test/fixtures/output/network/network-link/service/describe-json.golden
@@ -1,7 +1,7 @@
 {
   "id": "nls-123456",
-  "name": "test-nls",
-  "network": "n-abcde1",
+  "name": "nls-test",
+  "network_id": "n-abcde1",
   "environment": "env-00000",
   "description": "test nls",
   "accepted_environments": ["env-11111", "env-22222"],

--- a/test/fixtures/output/network/network-link/service/help.golden
+++ b/test/fixtures/output/network/network-link/service/help.golden
@@ -4,6 +4,7 @@ Usage:
   confluent network network-link service [command]
 
 Available Commands:
+  create      Create a network link service.
   delete      Delete a network link service.
   describe    Describe a network link service.
   list        List network link services.

--- a/test/fixtures/output/network/network-link/service/list-json.golden
+++ b/test/fixtures/output/network/network-link/service/list-json.golden
@@ -1,8 +1,8 @@
 [
   {
     "id": "nls-11111",
-    "name": "test-nls1",
-    "network": "n-abcde1",
+    "name": "nls-test1",
+    "network_id": "n-abcde1",
     "description": "test nls",
     "accepted_environments": ["env-11111"],
     "accepted_networks": ["n-abcde2"],
@@ -10,8 +10,8 @@
   },
   {
     "id": "nls-22222",
-    "name": "test-nls2",
-    "network": "n-abcde1",
+    "name": "nls-test2",
+    "network_id": "n-abcde1",
     "description": "test nls",
     "accepted_environments": ["env-11111", "env-22222"],
     "accepted_networks": ["n-abcde2", "n-abcde3"],
@@ -19,8 +19,8 @@
   },
   {
     "id": "nls-33333",
-    "name": "test-nls3",
-    "network": "n-abcde1",
+    "name": "nls-test3",
+    "network_id": "n-abcde1",
     "description": "test nls",
     "accepted_environments": ["env-11111", "env-22222", "env-33333"],
     "accepted_networks": ["n-abcde2", "n-abcde3", "n-abcde4"],

--- a/test/fixtures/output/network/network-link/service/list.golden
+++ b/test/fixtures/output/network/network-link/service/list.golden
@@ -1,6 +1,6 @@
-     ID     |   Name    | Network  | Description |     Accepted Environments      |      Accepted Networks       | Phase  
-------------+-----------+----------+-------------+--------------------------------+------------------------------+--------
-  nls-11111 | test-nls1 | n-abcde1 | test nls    | env-11111                      | n-abcde2                     | READY  
-  nls-22222 | test-nls2 | n-abcde1 | test nls    | env-11111, env-22222           | n-abcde2, n-abcde3           | READY  
-  nls-33333 | test-nls3 | n-abcde1 | test nls    | env-11111, env-22222,          | n-abcde2, n-abcde3, n-abcde4 | READY  
-            |           |          |             | env-33333                      |                              |        
+     ID     |   Name    | Network ID | Description |     Accepted Environments      |      Accepted Networks       | Phase  
+------------+-----------+------------+-------------+--------------------------------+------------------------------+--------
+  nls-11111 | nls-test1 | n-abcde1   | test nls    | env-11111                      | n-abcde2                     | READY  
+  nls-22222 | nls-test2 | n-abcde1   | test nls    | env-11111, env-22222           | n-abcde2, n-abcde3           | READY  
+  nls-33333 | nls-test3 | n-abcde1   | test nls    | env-11111, env-22222,          | n-abcde2, n-abcde3, n-abcde4 | READY  
+            |           |            |             | env-33333                      |                              |        

--- a/test/network_test.go
+++ b/test/network_test.go
@@ -589,10 +589,26 @@ func (s *CLITestSuite) TestNetworkNetworkLinkServiceLDelete() {
 	}
 }
 
+func (s *CLITestSuite) TestNetworkLinkServiceCreate() {
+	tests := []CLITest{
+		{args: "network network-link service create", fixture: "network/network-link/service/create-missing-args.golden", exitCode: 1},
+		{args: "network network-link service create nls-test --network n-123456 --description 'test description' --accept-environments env-11111,env-22222", fixture: "network/network-link/service/create-accept-environments.golden"},
+		{args: "network network-link service create nls-test --network n-123456 --description 'test description' --accept-networks n-111111,n-222222", fixture: "network/network-link/service/create-accept-networks.golden"},
+		{args: "network network-link service create nls-test --network n-123456 --description 'test description' --accept-networks n-111111,n-222222 --accept-environments env-11111,env-22222", fixture: "network/network-link/service/create.golden"},
+		{args: "network network-link service create nls-duplicate --network n-123455", fixture: "network/network-link/service/create-duplicate.golden", exitCode: 1},
+	}
+
+	for _, test := range tests {
+		test.login = "cloud"
+		s.runIntegrationTest(test)
+	}
+}
+
 func (s *CLITestSuite) TestNetworkNetworkLinkService_Autocomplete() {
 	tests := []CLITest{
 		{args: `__complete network network-link service describe ""`, login: "cloud", fixture: "network/network-link/service/describe-autocomplete.golden"},
 		{args: `__complete network network-link service delete ""`, login: "cloud", fixture: "network/network-link/service/delete-autocomplete.golden"},
+		{args: `__complete network network-link service create nls-test --network ""`, login: "cloud", fixture: "network/network-link/service/create-autocomplete.golden"},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->
Note that this is merging into the feature branch https://github.com/confluentinc/cli/tree/traffic-8850-network-cli-az. We will merge commits into main from this feature branch after all of the commands for network are implemented.

- Add `confluent network network-link service create`

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->
[CLI Commands Design](https://confluentinc.atlassian.net/wiki/spaces/PM/pages/2987394300/1-pager+--+Network+CLI)
[Implementation 1-Pager](https://confluentinc.atlassian.net/wiki/spaces/~712020463029eabbac401bbe1b033ce0d3a00e/pages/3136749631/Network+CLI)

Test & Review
-------------
<!--
Has it been tested? How?
Copy and paste any instructions or steps that can save the reviewer time.
-->
Added integration tests.

Performed manual tests.