### PR TITLE
Refresh session on HTTP retry: Metrics and Schema Registry clients

### DIFF
--- a/pkg/cmd/authenticated_cli_command.go
+++ b/pkg/cmd/authenticated_cli_command.go
@@ -234,7 +234,7 @@ func (c *AuthenticatedCLICommand) GetSchemaRegistryClient(cmd *cobra.Command) (*
 		schemaRegistryApiSecret, _ := cmd.Flags().GetString("schema-registry-api-secret")
 
 		if schemaRegistryApiKey != "" && schemaRegistryApiSecret != "" {
-			apiKey := &srsdk.BasicAuth{
+			apiKey := srsdk.BasicAuth{
 				UserName: schemaRegistryApiKey,
 				Password: schemaRegistryApiSecret,
 			}

--- a/pkg/cmd/authenticated_cli_command.go
+++ b/pkg/cmd/authenticated_cli_command.go
@@ -2,13 +2,13 @@ package cmd
 
 import (
 	"fmt"
-	"net/http"
 	"net/url"
 	"strings"
 
 	"github.com/spf13/cobra"
 
 	ccloudv1 "github.com/confluentinc/ccloud-sdk-go-v1-public"
+	metricsv2 "github.com/confluentinc/ccloud-sdk-go-v2/metrics/v2"
 	"github.com/confluentinc/mds-sdk-go-public/mdsv1"
 	"github.com/confluentinc/mds-sdk-go-public/mdsv2alpha1"
 	srsdk "github.com/confluentinc/schema-registry-sdk-go"
@@ -150,6 +150,11 @@ func (c *AuthenticatedCLICommand) GetKafkaREST() (*KafkaREST, error) {
 
 func (c *AuthenticatedCLICommand) GetMetricsClient() (*ccloudv2.MetricsClient, error) {
 	if c.metricsClient == nil {
+		unsafeTrace, err := c.Flags().GetBool("unsafe-trace")
+		if err != nil {
+			return nil, err
+		}
+
 		url := "https://api.telemetry.confluent.cloud"
 		if c.Config.IsTest {
 			url = testserver.TestV2CloudUrl.String()
@@ -159,55 +164,16 @@ func (c *AuthenticatedCLICommand) GetMetricsClient() (*ccloudv2.MetricsClient, e
 			url = "https://stag-sandbox-api.telemetry.aws.confluent.cloud"
 		}
 
-		unsafeTrace, err := c.Flags().GetBool("unsafe-trace")
-		if err != nil {
-			return nil, err
-		}
+		configuration := metricsv2.NewConfiguration()
+		configuration.Debug = unsafeTrace
+		configuration.HTTPClient = ccloudv2.NewRetryableHttpClient(c.Config.Config, unsafeTrace)
+		configuration.Servers = metricsv2.ServerConfigurations{{URL: url}}
+		configuration.UserAgent = c.Config.Version.UserAgent
 
-		dataplaneToken, err := auth.GetDataplaneToken(c.Context.Context)
-		if err != nil {
-			return nil, err
-		}
-
-		c.metricsClient = ccloudv2.NewMetricsClient(url, c.Version.UserAgent, unsafeTrace, dataplaneToken)
+		c.metricsClient = ccloudv2.NewMetricsClient(configuration, c.Config.Config)
 	}
 
 	return c.metricsClient, nil
-}
-
-func (c *AuthenticatedCLICommand) getSchemaRegistryClientByFlags(cmd *cobra.Command, unsafeTrace bool) error {
-	configuration := srsdk.NewConfiguration()
-	configuration.UserAgent = c.Config.Version.UserAgent
-	configuration.Debug = unsafeTrace
-	configuration.HTTPClient = ccloudv2.NewRetryableHttpClient(nil, unsafeTrace)
-	schemaRegistryEndpoint, err := cmd.Flags().GetString("schema-registry-endpoint")
-	if err != nil {
-		return err
-	}
-	if schemaRegistryEndpoint == "" {
-		return fmt.Errorf(errors.SREndpointNotSpecifiedErrorMsg)
-	}
-	if !strings.HasPrefix(schemaRegistryEndpoint, "http://") && !strings.HasPrefix(schemaRegistryEndpoint, "https://") {
-		schemaRegistryEndpoint = fmt.Sprintf("https://%s", schemaRegistryEndpoint)
-	}
-	configuration.BasePath = schemaRegistryEndpoint
-
-	schemaRegistryApiKey, err := cmd.Flags().GetString("schema-registry-api-key")
-	if err != nil {
-		return err
-	}
-	schemaRegistryApiSecret, err := cmd.Flags().GetString("schema-registry-api-secret")
-	if err != nil {
-		return err
-	}
-
-	c.schemaRegistryClient = schemaregistry.NewClientWithApiKey(configuration, schemaRegistryApiKey, schemaRegistryApiSecret)
-
-	if err := c.schemaRegistryClient.Get(); err != nil {
-		return fmt.Errorf(errors.SRClientNotValidatedErrorMsg, err)
-	}
-
-	return nil
 }
 
 func (c *AuthenticatedCLICommand) GetSchemaRegistryClient(cmd *cobra.Command) (*schemaregistry.Client, error) {
@@ -217,49 +183,20 @@ func (c *AuthenticatedCLICommand) GetSchemaRegistryClient(cmd *cobra.Command) (*
 			return nil, err
 		}
 
-		if err := c.Config.CheckIsCloudLoginOrOnPremLogin(); err != nil {
-			if c.getSchemaRegistryClientByFlags(cmd, unsafeTrace) != nil {
-				return nil, err
-			}
-		} else if c.Config.IsCloudLogin() {
-			configuration := srsdk.NewConfiguration()
-			configuration.UserAgent = c.Config.Version.UserAgent
-			configuration.Debug = unsafeTrace
-			configuration.HTTPClient = ccloudv2.NewRetryableHttpClient(nil, unsafeTrace)
+		configuration := srsdk.NewConfiguration()
+		configuration.UserAgent = c.Config.Version.UserAgent
+		configuration.Debug = unsafeTrace
+		configuration.HTTPClient = ccloudv2.NewRetryableHttpClient(c.Config.Config, unsafeTrace)
 
-			// Both parts of this conditional are needed since `c.Context` is a dynamic context
-			if c.Context != nil && c.Context.GetState() != nil {
-				clusters, err := c.V2Client.GetSchemaRegistryClustersByEnvironment(c.Context.GetCurrentEnvironment())
-				if err != nil {
-					return nil, err
-				}
-				if len(clusters) == 0 {
-					return nil, errors.NewSRNotEnabledError()
-				}
-				configuration.DefaultHeader = map[string]string{"target-sr-cluster": clusters[0].GetId()}
-				configuration.BasePath = clusters[0].Spec.GetHttpEndpoint()
-
-				dataplaneToken, err := auth.GetDataplaneToken(c.Context.Context)
-				if err != nil {
-					return nil, err
-				}
-
-				c.schemaRegistryClient = schemaregistry.NewClientWithToken(configuration, dataplaneToken)
-			} else if c.getSchemaRegistryClientByFlags(cmd, unsafeTrace) != nil {
-				// Used by `asyncapi export`, `asyncapi import`, `kafka client-config create`, `kafka topic consume`, and `kafka topic produce`
-				return nil, err
-			}
-		} else {
-			schemaRegistryEndpoint, err := cmd.Flags().GetString("schema-registry-endpoint")
+		if schemaRegistryEndpoint, _ := cmd.Flags().GetString("schema-registry-endpoint"); schemaRegistryEndpoint != "" {
+			u, err := url.Parse(schemaRegistryEndpoint)
 			if err != nil {
 				return nil, err
 			}
-			if schemaRegistryEndpoint == "" {
-				return nil, fmt.Errorf(errors.SREndpointNotSpecifiedErrorMsg)
+			if u.Scheme != "http" && u.Scheme != "https" {
+				u.Scheme = "https"
 			}
-			if !strings.HasPrefix(schemaRegistryEndpoint, "http://") && !strings.HasPrefix(schemaRegistryEndpoint, "https://") {
-				schemaRegistryEndpoint = fmt.Sprintf("https://%s", schemaRegistryEndpoint)
-			}
+			configuration.BasePath = u.String()
 
 			caLocation, err := cmd.Flags().GetString("ca-location")
 			if err != nil {
@@ -268,33 +205,54 @@ func (c *AuthenticatedCLICommand) GetSchemaRegistryClient(cmd *cobra.Command) (*
 			if caLocation == "" {
 				caLocation = auth.GetEnvWithFallback(auth.ConfluentPlatformCACertPath, auth.DeprecatedConfluentPlatformCACertPath)
 			}
-
-			var client *http.Client
 			if caLocation != "" {
-				client, err = utils.GetCAClient(caLocation)
+				caClient, err := utils.GetCAClient(caLocation)
 				if err != nil {
 					return nil, err
 				}
-			} else {
-				client = ccloudv2.NewRetryableHttpClient(nil, unsafeTrace)
+				configuration.HTTPClient = caClient
 			}
 
-			configuration := srsdk.NewConfiguration()
-			configuration.BasePath = schemaRegistryEndpoint
-			configuration.UserAgent = c.Config.Version.UserAgent
-			configuration.Debug = unsafeTrace
-			configuration.HTTPClient = client
+			schemaRegistryApiKey, err := cmd.Flags().GetString("schema-registry-api-key")
+			if err != nil {
+				return nil, err
+			}
 
-			// Both parts of this conditional are needed since `c.Context` is a dynamic context
-			if c.Context != nil && c.Context.GetState() != nil {
-				c.schemaRegistryClient = schemaregistry.NewClientWithToken(configuration, c.Context.GetAuthToken())
+			schemaRegistryApiSecret, err := cmd.Flags().GetString("schema-registry-api-secret")
+			if err != nil {
+				return nil, err
+			}
+
+			if schemaRegistryApiKey != "" && schemaRegistryApiSecret != "" {
+				apiKey := &srsdk.BasicAuth{
+					UserName: schemaRegistryApiKey,
+					Password: schemaRegistryApiSecret,
+				}
+				c.schemaRegistryClient = schemaregistry.NewClientWithApiKey(configuration, apiKey)
 			} else {
-				c.schemaRegistryClient = schemaregistry.NewClient(configuration)
+				c.schemaRegistryClient = schemaregistry.NewClient(configuration, c.Config.Config)
 			}
 
 			if err := c.schemaRegistryClient.Get(); err != nil {
-				return nil, fmt.Errorf(errors.SRClientNotValidatedErrorMsg, err)
+				return nil, fmt.Errorf("failed to validate Schema Registry client: %w", err)
 			}
+		} else if c.Config.IsCloudLogin() {
+			clusters, err := c.V2Client.GetSchemaRegistryClustersByEnvironment(c.Context.GetCurrentEnvironment())
+			if err != nil {
+				return nil, err
+			}
+			if len(clusters) == 0 {
+				return nil, errors.NewSRNotEnabledError()
+			}
+			configuration.BasePath = clusters[0].Spec.GetHttpEndpoint()
+			configuration.DefaultHeader = map[string]string{"target-sr-cluster": clusters[0].GetId()}
+
+			c.schemaRegistryClient = schemaregistry.NewClient(configuration, c.Config.Config)
+		} else {
+			return nil, errors.NewErrorWithSuggestions(
+				"Schema Registry endpoint not found",
+				"Log in to Confluent Cloud with `confluent login`.\nSupply a Schema Registry endpoint with `--schema-registry-endpoint`.",
+			)
 		}
 	}
 

--- a/pkg/errors/error_message.go
+++ b/pkg/errors/error_message.go
@@ -141,12 +141,10 @@ const (
 	NotLoggedInErrorMsg     = "not logged in"
 	AuthTokenSuggestions    = "You must be logged in to retrieve an oauthbearer token.\n" +
 		"An oauthbearer token is required to authenticate OAUTHBEARER mechanism and Schema Registry."
-	OnPremConfigGuideSuggestions   = "See configuration and produce/consume command guide: https://docs.confluent.io/confluent-cli/current/cp-produce-consume.html ."
-	SRNotAuthenticatedErrorMsg     = "not logged in, or no Schema Registry endpoint specified"
-	SREndpointNotSpecifiedErrorMsg = "no Schema Registry endpoint specified"
-	SRClientNotValidatedErrorMsg   = "failed to validate Schema Registry client: %w"
-	CorruptedTokenErrorMsg         = "corrupted auth token"
-	CorruptedTokenSuggestions      = "Please log in again.\n" +
+	OnPremConfigGuideSuggestions = "See configuration and produce/consume command guide: https://docs.confluent.io/confluent-cli/current/cp-produce-consume.html ."
+	SRNotAuthenticatedErrorMsg   = "not logged in, or no Schema Registry endpoint specified"
+	CorruptedTokenErrorMsg       = "corrupted auth token"
+	CorruptedTokenSuggestions    = "Please log in again.\n" +
 		AvoidTimeoutSuggestions
 	ExpiredTokenErrorMsg    = "expired token"
 	ExpiredTokenSuggestions = "Your session has timed out, you need to log in again.\n" +

--- a/pkg/schema-registry/client.go
+++ b/pkg/schema-registry/client.go
@@ -4,205 +4,217 @@ import (
 	"context"
 
 	srsdk "github.com/confluentinc/schema-registry-sdk-go"
+
+	"github.com/confluentinc/cli/v3/pkg/auth"
+	"github.com/confluentinc/cli/v3/pkg/config"
 )
 
 type Client struct {
 	*srsdk.APIClient
-	context context.Context
+	apiKey *srsdk.BasicAuth
+	cfg    *config.Config
 }
 
-func NewClient(configuration *srsdk.Configuration) *Client {
+func NewClient(configuration *srsdk.Configuration, cfg *config.Config) *Client {
 	return &Client{
 		APIClient: srsdk.NewAPIClient(configuration),
-		context:   context.Background(),
-	}
-}
-
-func NewClientWithToken(configuration *srsdk.Configuration, authToken string) *Client {
-	return &Client{
-		APIClient: srsdk.NewAPIClient(configuration),
-		context:   context.WithValue(context.Background(), srsdk.ContextAccessToken, authToken),
+		cfg:       cfg,
 	}
 }
 
-func NewClientWithApiKey(configuration *srsdk.Configuration, key, secret string) *Client {
-	basicAuth := srsdk.BasicAuth{
-		UserName: key,
-		Password: secret,
-	}
-
+func NewClientWithApiKey(configuration *srsdk.Configuration, apiKey *srsdk.BasicAuth) *Client {
 	return &Client{
 		APIClient: srsdk.NewAPIClient(configuration),
-		context:   context.WithValue(context.Background(), srsdk.ContextBasicAuth, basicAuth),
+		apiKey:    apiKey,
 	}
+}
+
+func (c *Client) context() context.Context {
+	ctx := context.Background()
+
+	if c.apiKey != nil {
+		return context.WithValue(ctx, srsdk.ContextBasicAuth, c.apiKey)
+	}
+
+	// Both parts of this conditional are needed since `c.cfg.Context()` is a dynamic context
+	if c.cfg.Context() != nil && c.cfg.Context().GetState() != nil {
+		dataplaneToken, err := auth.GetDataplaneToken(c.cfg.Context())
+		if err != nil {
+			return ctx
+		}
+
+		return context.WithValue(ctx, srsdk.ContextAccessToken, dataplaneToken)
+	}
+
+	return ctx
 }
 
 func (c *Client) Get() error {
-	_, _, err := c.DefaultApi.Get(c.context)
+	_, _, err := c.DefaultApi.Get(c.context())
 	return err
 }
 
 func (c *Client) GetTopLevelConfig() (srsdk.Config, error) {
-	res, _, err := c.DefaultApi.GetTopLevelConfig(c.context)
+	res, _, err := c.DefaultApi.GetTopLevelConfig(c.context())
 	return res, err
 }
 
 func (c *Client) DeleteTopLevelConfig() (string, error) {
-	res, _, err := c.DefaultApi.DeleteTopLevelConfig(c.context)
+	res, _, err := c.DefaultApi.DeleteTopLevelConfig(c.context())
 	return res, err
 }
 
 func (c *Client) UpdateTopLevelConfig(res srsdk.ConfigUpdateRequest) (srsdk.ConfigUpdateRequest, error) {
-	res, _, err := c.DefaultApi.UpdateTopLevelConfig(c.context, res)
+	res, _, err := c.DefaultApi.UpdateTopLevelConfig(c.context(), res)
 	return res, err
 }
 
 func (c *Client) GetTopLevelMode() (srsdk.Mode, error) {
-	res, _, err := c.DefaultApi.GetTopLevelMode(c.context)
+	res, _, err := c.DefaultApi.GetTopLevelMode(c.context())
 	return res, err
 }
 
 func (c *Client) UpdateTopLevelMode(res srsdk.ModeUpdateRequest) (srsdk.ModeUpdateRequest, error) {
-	res, _, err := c.DefaultApi.UpdateTopLevelMode(c.context, res)
+	res, _, err := c.DefaultApi.UpdateTopLevelMode(c.context(), res)
 	return res, err
 }
 
 func (c *Client) UpdateMode(subject string, req srsdk.ModeUpdateRequest) (srsdk.ModeUpdateRequest, error) {
-	res, _, err := c.DefaultApi.UpdateMode(c.context, subject, req)
+	res, _, err := c.DefaultApi.UpdateMode(c.context(), subject, req)
 	return res, err
 }
 
 func (c *Client) GetSubjectLevelConfig(subject string) (srsdk.Config, error) {
-	res, _, err := c.DefaultApi.GetSubjectLevelConfig(c.context, subject, nil)
+	res, _, err := c.DefaultApi.GetSubjectLevelConfig(c.context(), subject, nil)
 	return res, err
 }
 
 func (c *Client) UpdateSubjectLevelConfig(subject string, res srsdk.ConfigUpdateRequest) (srsdk.ConfigUpdateRequest, error) {
-	res, _, err := c.DefaultApi.UpdateSubjectLevelConfig(c.context, subject, res)
+	res, _, err := c.DefaultApi.UpdateSubjectLevelConfig(c.context(), subject, res)
 	return res, err
 }
 
 func (c *Client) DeleteSubjectLevelConfig(subject string) (string, error) {
-	res, _, err := c.DefaultApi.DeleteSubjectConfig(c.context, subject)
+	res, _, err := c.DefaultApi.DeleteSubjectConfig(c.context(), subject)
 	return res, err
 }
 
 func (c *Client) TestCompatibilityBySubjectName(subject, version string, body srsdk.RegisterSchemaRequest) (srsdk.CompatibilityCheckResponse, error) {
-	res, _, err := c.DefaultApi.TestCompatibilityBySubjectName(c.context, subject, version, body, nil)
+	res, _, err := c.DefaultApi.TestCompatibilityBySubjectName(c.context(), subject, version, body, nil)
 	return res, err
 }
 
 func (c *Client) CreateExporter(req srsdk.CreateExporterRequest) (srsdk.CreateExporterResponse, error) {
-	res, _, err := c.DefaultApi.CreateExporter(c.context, req)
+	res, _, err := c.DefaultApi.CreateExporter(c.context(), req)
 	return res, err
 }
 
 func (c *Client) DeleteExporter(name string) error {
-	_, err := c.DefaultApi.DeleteExporter(c.context, name)
+	_, err := c.DefaultApi.DeleteExporter(c.context(), name)
 	return err
 }
 
 func (c *Client) GetExporterInfo(name string) (srsdk.ExporterInfo, error) {
-	res, _, err := c.DefaultApi.GetExporterInfo(c.context, name)
+	res, _, err := c.DefaultApi.GetExporterInfo(c.context(), name)
 	return res, err
 }
 
 func (c *Client) GetExporterConfig(name string) (map[string]string, error) {
-	res, _, err := c.DefaultApi.GetExporterConfig(c.context, name)
+	res, _, err := c.DefaultApi.GetExporterConfig(c.context(), name)
 	return res, err
 }
 
 func (c *Client) ResumeExporter(name string) (srsdk.UpdateExporterResponse, error) {
-	res, _, err := c.DefaultApi.ResumeExporter(c.context, name)
+	res, _, err := c.DefaultApi.ResumeExporter(c.context(), name)
 	return res, err
 }
 
 func (c *Client) ResetExporter(name string) (srsdk.UpdateExporterResponse, error) {
-	res, _, err := c.DefaultApi.ResetExporter(c.context, name)
+	res, _, err := c.DefaultApi.ResetExporter(c.context(), name)
 	return res, err
 }
 
 func (c *Client) PauseExporter(name string) (srsdk.UpdateExporterResponse, error) {
-	res, _, err := c.DefaultApi.PauseExporter(c.context, name)
+	res, _, err := c.DefaultApi.PauseExporter(c.context(), name)
 	return res, err
 }
 
 func (c *Client) GetExporters() ([]string, error) {
-	res, _, err := c.DefaultApi.GetExporters(c.context)
+	res, _, err := c.DefaultApi.GetExporters(c.context())
 	return res, err
 }
 
 func (c *Client) GetExporterStatus(name string) (srsdk.ExporterStatus, error) {
-	res, _, err := c.DefaultApi.GetExporterStatus(c.context, name)
+	res, _, err := c.DefaultApi.GetExporterStatus(c.context(), name)
 	return res, err
 }
 
 func (c *Client) PutExporter(name string, req srsdk.UpdateExporterRequest) (srsdk.UpdateExporterResponse, error) {
-	res, _, err := c.DefaultApi.PutExporter(c.context, name, req)
+	res, _, err := c.DefaultApi.PutExporter(c.context(), name, req)
 	return res, err
 }
 
 func (c *Client) Register(subject string, req srsdk.RegisterSchemaRequest, opts *srsdk.RegisterOpts) (srsdk.RegisterSchemaResponse, error) {
-	res, _, err := c.DefaultApi.Register(c.context, subject, req, opts)
+	res, _, err := c.DefaultApi.Register(c.context(), subject, req, opts)
 	return res, err
 }
 
 func (c *Client) GetSchema(id int32, opts *srsdk.GetSchemaOpts) (srsdk.SchemaString, error) {
-	res, _, err := c.DefaultApi.GetSchema(c.context, id, opts)
+	res, _, err := c.DefaultApi.GetSchema(c.context(), id, opts)
 	return res, err
 }
 
 func (c *Client) GetSchemaByVersion(subject, version string, opts *srsdk.GetSchemaByVersionOpts) (srsdk.Schema, error) {
-	res, _, err := c.DefaultApi.GetSchemaByVersion(c.context, subject, version, opts)
+	res, _, err := c.DefaultApi.GetSchemaByVersion(c.context(), subject, version, opts)
 	return res, err
 }
 
 func (c *Client) ListVersions(subject string, opts *srsdk.ListVersionsOpts) ([]int32, error) {
-	res, _, err := c.DefaultApi.ListVersions(c.context, subject, opts)
+	res, _, err := c.DefaultApi.ListVersions(c.context(), subject, opts)
 	return res, err
 }
 
 func (c *Client) DeleteSchemaVersion(subject, version string, opts *srsdk.DeleteSchemaVersionOpts) (int32, error) {
-	res, _, err := c.DefaultApi.DeleteSchemaVersion(c.context, subject, version, opts)
+	res, _, err := c.DefaultApi.DeleteSchemaVersion(c.context(), subject, version, opts)
 	return res, err
 }
 
 func (c *Client) GetSchemas(opts *srsdk.GetSchemasOpts) ([]srsdk.Schema, error) {
-	res, _, err := c.DefaultApi.GetSchemas(c.context, opts)
+	res, _, err := c.DefaultApi.GetSchemas(c.context(), opts)
 	return res, err
 }
 
 func (c *Client) DeleteSubject(subject string, opts *srsdk.DeleteSubjectOpts) ([]int32, error) {
-	res, _, err := c.DefaultApi.DeleteSubject(c.context, subject, opts)
+	res, _, err := c.DefaultApi.DeleteSubject(c.context(), subject, opts)
 	return res, err
 }
 
 func (c *Client) PartialUpdateByUniqueAttributes(opts *srsdk.PartialUpdateByUniqueAttributesOpts) error {
-	_, err := c.DefaultApi.PartialUpdateByUniqueAttributes(c.context, opts)
+	_, err := c.DefaultApi.PartialUpdateByUniqueAttributes(c.context(), opts)
 	return err
 }
 
 func (c *Client) CreateTags(opts *srsdk.CreateTagsOpts) ([]srsdk.TagResponse, error) {
-	res, _, err := c.DefaultApi.CreateTags(c.context, opts)
+	res, _, err := c.DefaultApi.CreateTags(c.context(), opts)
 	return res, err
 }
 
 func (c *Client) CreateTagDefs(opts *srsdk.CreateTagDefsOpts) ([]srsdk.TagDefResponse, error) {
-	res, _, err := c.DefaultApi.CreateTagDefs(c.context, opts)
+	res, _, err := c.DefaultApi.CreateTagDefs(c.context(), opts)
 	return res, err
 }
 
 func (c *Client) GetTags(typeName, qualifiedName string) ([]srsdk.TagResponse, error) {
-	res, _, err := c.DefaultApi.GetTags(c.context, typeName, qualifiedName)
+	res, _, err := c.DefaultApi.GetTags(c.context(), typeName, qualifiedName)
 	return res, err
 }
 
 func (c *Client) List(opts *srsdk.ListOpts) ([]string, error) {
-	res, _, err := c.DefaultApi.List(c.context, opts)
+	res, _, err := c.DefaultApi.List(c.context(), opts)
 	return res, err
 }
 
 func (c *Client) GetByUniqueAttributes(typeName, qualifiedName string) (srsdk.AtlasEntityWithExtInfo, error) {
-	res, _, err := c.DefaultApi.GetByUniqueAttributes(c.context, typeName, qualifiedName, nil)
+	res, _, err := c.DefaultApi.GetByUniqueAttributes(c.context(), typeName, qualifiedName, nil)
 	return res, err
 }

--- a/pkg/schema-registry/client.go
+++ b/pkg/schema-registry/client.go
@@ -11,7 +11,7 @@ import (
 
 type Client struct {
 	*srsdk.APIClient
-	apiKey *srsdk.BasicAuth
+	apiKey srsdk.BasicAuth
 	cfg    *config.Config
 }
 
@@ -22,7 +22,7 @@ func NewClient(configuration *srsdk.Configuration, cfg *config.Config) *Client {
 	}
 }
 
-func NewClientWithApiKey(configuration *srsdk.Configuration, apiKey *srsdk.BasicAuth) *Client {
+func NewClientWithApiKey(configuration *srsdk.Configuration, apiKey srsdk.BasicAuth) *Client {
 	return &Client{
 		APIClient: srsdk.NewAPIClient(configuration),
 		apiKey:    apiKey,
@@ -32,7 +32,7 @@ func NewClientWithApiKey(configuration *srsdk.Configuration, apiKey *srsdk.Basic
 func (c *Client) context() context.Context {
 	ctx := context.Background()
 
-	if c.apiKey != nil {
+	if c.apiKey.UserName != "" && c.apiKey.Password != "" {
 		return context.WithValue(ctx, srsdk.ContextBasicAuth, c.apiKey)
 	}
 


### PR DESCRIPTION
Checklist
---------
- [x] Leave this box unchecked if features are not yet available in production

What
----
Pass the config (which contains both the auth token and the auth refresh token) instead of just the auth token to the Metrics and Schema Registry clients. If the session ends during a HTTP retry we can refresh it.

Test & Review
-------------
Tests still pass

```
confluent kafka client-config create java --schema-registry-api-key <REDACTED> --schema-registry-api-secret <REDACTED>
```