### PR TITLE
CIAM-3912: Increase CLI error clarity

### DIFF
--- a/internal/iam/command_ipfilter_create.go
+++ b/internal/iam/command_ipfilter_create.go
@@ -31,7 +31,6 @@ func (c *ipFilterCommand) newCreateCommand() *cobra.Command {
 	pcmd.AddContextFlag(cmd, c.CLICommand)
 	pcmd.AddOutputFlag(cmd)
 
-	cobra.CheckErr(cmd.MarkFlagRequired("resource-group"))
 	cobra.CheckErr(cmd.MarkFlagRequired("ip-groups"))
 
 	return cmd

--- a/internal/iam/command_ipfilter_create.go
+++ b/internal/iam/command_ipfilter_create.go
@@ -26,8 +26,8 @@ func (c *ipFilterCommand) newCreateCommand() *cobra.Command {
 		),
 	}
 
-	pcmd.AddResourceGroupFlag(cmd)
 	cmd.Flags().StringSlice("ip-groups", []string{}, "A comma-separated list of IP group IDs.")
+	pcmd.AddResourceGroupFlag(cmd)
 	pcmd.AddContextFlag(cmd, c.CLICommand)
 	pcmd.AddOutputFlag(cmd)
 

--- a/internal/iam/command_ipfilter_update.go
+++ b/internal/iam/command_ipfilter_update.go
@@ -140,6 +140,11 @@ func (c *ipFilterCommand) update(cmd *cobra.Command, args []string) error {
 		IpGroupIdObjects[i] = iamv2.GlobalObjectReference{Id: ipGroupId}
 	}
 
+	if len(IpGroupIdObjects) == 0 {
+		return errors.NewErrorWithSuggestions("Cannot remove all IP groups from IP filter",
+			"Please double check the IP filter you are updating. Use `confluent iam ip-filter describe <ip-filter>` to see the IP groups associated with an IP filter.")
+	}
+
 	updateIpFilter.IpGroups = &IpGroupIdObjects
 
 	filter, err := c.V2Client.UpdateIamIpFilter(updateIpFilter, currentIpFilterId)

--- a/internal/iam/command_ipfilter_update.go
+++ b/internal/iam/command_ipfilter_update.go
@@ -1,6 +1,7 @@
 package iam
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -142,7 +143,7 @@ func (c *ipFilterCommand) update(cmd *cobra.Command, args []string) error {
 
 	if len(IpGroupIdObjects) == 0 {
 		return errors.NewErrorWithSuggestions("Cannot remove all IP groups from IP filter",
-			"Please double check the IP filter you are updating. Use `confluent iam ip-filter describe <ip-filter>` to see the IP groups associated with an IP filter.")
+			fmt.Sprintf("Please double check the IP filter you are updating. Use `confluent iam ip-filter describe %s` to see the IP groups associated with an IP filter.", currentIpFilter.GetId()))
 	}
 
 	updateIpFilter.IpGroups = &IpGroupIdObjects

--- a/internal/iam/command_ipgroup_update.go
+++ b/internal/iam/command_ipgroup_update.go
@@ -1,6 +1,7 @@
 package iam
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -125,7 +126,7 @@ func (c *ipGroupCommand) update(cmd *cobra.Command, args []string) error {
 
 	if len(newCidrBlocks) == 0 {
 		return errors.NewErrorWithSuggestions("Cannot remove all CIDR blocks from IP group",
-			"Please double check the IP group you are updating. Use `confluent iam ip-group describe <ip-group>` to see the CIDR blocks associated with an IP group.")
+			fmt.Sprintf("Please double check the IP group you are updating. Use `confluent iam ip-group describe %s` to see the CIDR blocks associated with an IP group.", currentIpGroup.GetId()))
 	}
 
 	updateIpGroup.CidrBlocks = &newCidrBlocks

--- a/internal/iam/command_ipgroup_update.go
+++ b/internal/iam/command_ipgroup_update.go
@@ -123,6 +123,11 @@ func (c *ipGroupCommand) update(cmd *cobra.Command, args []string) error {
 		newCidrBlocks = append(newCidrBlocks, cidrBlock)
 	}
 
+	if len(newCidrBlocks) == 0 {
+		return errors.NewErrorWithSuggestions("Cannot remove all CIDR blocks from IP group",
+			"Please double check the IP group you are updating. Use `confluent iam ip-group describe <ip-group>` to see the CIDR blocks associated with an IP group.")
+	}
+
 	updateIpGroup.CidrBlocks = &newCidrBlocks
 
 	group, err := c.V2Client.UpdateIamIpGroup(updateIpGroup, currentIpGroupId)

--- a/test/fixtures/output/iam/ip-filter/create-help.golden
+++ b/test/fixtures/output/iam/ip-filter/create-help.golden
@@ -9,8 +9,8 @@ Create an IP filter named "demo-ip-filter" with resource group "management" and 
   $ confluent iam ip-filter create demo-ip-filter --resource-group management --ip-groups ipg-12345,ipg-67890
 
 Flags:
-      --resource-group string   REQUIRED: Name of resource group. Currently, only "management" is supported. (default "management")
       --ip-groups strings       REQUIRED: A comma-separated list of IP group IDs.
+      --resource-group string   Name of resource group. Currently, only "management" is supported. (default "management")
       --context string          CLI context name.
   -o, --output string           Specify the output format as "human", "json", or "yaml". (default "human")
 

--- a/test/iam_test.go
+++ b/test/iam_test.go
@@ -347,6 +347,7 @@ func (s *CLITestSuite) TestIamIpGroup() {
 func (s *CLITestSuite) TestIamIpFilter() {
 	tests := []CLITest{
 		{args: `iam ip-filter create "demo-ip-filter" --resource-group "management" --ip-groups "ipg-3g5jw,ipg-wjnde"`, fixture: "iam/ip-filter/create.golden"},
+		{args: `iam ip-filter create "demo-ip-filter" --ip-groups "ipg-3g5jw,ipg-wjnde"`, fixture: "iam/ip-filter/create.golden"},
 		{args: `iam ip-filter list`, fixture: "iam/ip-filter/list.golden"},
 		{args: `iam ip-filter describe ipf-34dq3`, fixture: "iam/ip-filter/describe.golden"},
 		{args: `iam ip-filter delete ipf-34dq3`, fixture: "iam/ip-filter/delete.golden"},

--- a/test/iam_test.go
+++ b/test/iam_test.go
@@ -328,14 +328,14 @@ func (s *CLITestSuite) TestIam_Autocomplete() {
 
 func (s *CLITestSuite) TestIamIpGroup() {
 	tests := []CLITest{
-		{args: `iam ip-group create "demo-ip-group" --cidr-blocks "168.150.200.0/24,147.150.200.0/24"`, fixture: "iam/ip-group/create.golden"},
-		{args: `iam ip-group list`, fixture: "iam/ip-group/list.golden"},
-		{args: `iam ip-group describe ipg-wjnde`, fixture: "iam/ip-group/describe.golden"},
-		{args: `iam ip-group delete ipg-wjnde`, fixture: "iam/ip-group/delete.golden"},
-		{args: `iam ip-group update ipg-wjnde --name "new-demo-group" --add-cidr-blocks "1.2.3.4/12" --remove-cidr-blocks "168.150.200.0/24"`, fixture: "iam/ip-group/update.golden"},
-		{args: `iam ip-group update ipg-wjnde --name "new-demo-group" --add-cidr-blocks "1.2.3.4/12,147.150.200.0/24" --remove-cidr-blocks "168.150.200.0/24"`, fixture: "iam/ip-group/update-resource-duplicate.golden"},
-		{args: `iam ip-group update ipg-wjnde --name "new-demo-group" --add-cidr-blocks "1.2.3.4/12" --remove-cidr-blocks "1.2.3.4/12"`, fixture: "iam/ip-group/update-resource-add-and-remove.golden"},
-		{args: `iam ip-group update ipg-wjnde --name "new-demo-group" --add-cidr-blocks "1.2.3.4/12" --remove-cidr-blocks "1.1.1.1/1"`, fixture: "iam/ip-group/update-resource-remove-not-exist.golden"},
+		{args: "iam ip-group create demo-ip-group --cidr-blocks 168.150.200.0/24,147.150.200.0/24", fixture: "iam/ip-group/create.golden"},
+		{args: "iam ip-group list", fixture: "iam/ip-group/list.golden"},
+		{args: "iam ip-group describe ipg-wjnde", fixture: "iam/ip-group/describe.golden"},
+		{args: "iam ip-group delete ipg-wjnde", fixture: "iam/ip-group/delete.golden"},
+		{args: "iam ip-group update ipg-wjnde --name new-demo-group --add-cidr-blocks 1.2.3.4/12 --remove-cidr-blocks 168.150.200.0/24", fixture: "iam/ip-group/update.golden"},
+		{args: "iam ip-group update ipg-wjnde --name new-demo-group --add-cidr-blocks 1.2.3.4/12,147.150.200.0/24 --remove-cidr-blocks 168.150.200.0/24", fixture: "iam/ip-group/update-resource-duplicate.golden"},
+		{args: "iam ip-group update ipg-wjnde --name new-demo-group --add-cidr-blocks 1.2.3.4/12 --remove-cidr-blocks 1.2.3.4/12", fixture: "iam/ip-group/update-resource-add-and-remove.golden"},
+		{args: "iam ip-group update ipg-wjnde --name new-demo-group --add-cidr-blocks 1.2.3.4/12 --remove-cidr-blocks 1.1.1.1/1", fixture: "iam/ip-group/update-resource-remove-not-exist.golden"},
 	}
 
 	for _, test := range tests {
@@ -346,15 +346,15 @@ func (s *CLITestSuite) TestIamIpGroup() {
 
 func (s *CLITestSuite) TestIamIpFilter() {
 	tests := []CLITest{
-		{args: `iam ip-filter create "demo-ip-filter" --resource-group "management" --ip-groups "ipg-3g5jw,ipg-wjnde"`, fixture: "iam/ip-filter/create.golden"},
-		{args: `iam ip-filter create "demo-ip-filter" --ip-groups "ipg-3g5jw,ipg-wjnde"`, fixture: "iam/ip-filter/create.golden"},
-		{args: `iam ip-filter list`, fixture: "iam/ip-filter/list.golden"},
-		{args: `iam ip-filter describe ipf-34dq3`, fixture: "iam/ip-filter/describe.golden"},
-		{args: `iam ip-filter delete ipf-34dq3`, fixture: "iam/ip-filter/delete.golden"},
-		{args: `iam ip-filter update ipf-34dq3 --name "new-ip-filter-demo" --add-ip-groups "ipg-1337a,ipg-ayd3n" --remove-ip-groups "ipg-12345"`, fixture: "iam/ip-filter/update.golden"},
-		{args: `iam ip-filter update ipf-34dq3 --add-ip-groups "ipg-abcde" --remove-ip-groups "ipg-12345"`, fixture: "iam/ip-filter/update-resource-duplicate.golden"},
-		{args: `iam ip-filter update ipf-34dq3 --add-ip-groups "ipg-azbye" --remove-ip-groups "ipg-azbye"`, fixture: "iam/ip-filter/update-resource-add-and-remove.golden"},
-		{args: `iam ip-filter update ipf-34dq3 --add-ip-groups "ipg-hjkil" --remove-ip-groups "ipg-fedbc"`, fixture: "iam/ip-filter/update-resource-remove-not-exist.golden"},
+		{args: "iam ip-filter create demo-ip-filter --resource-group management --ip-groups ipg-3g5jw,ipg-wjnde", fixture: "iam/ip-filter/create.golden"},
+		{args: "iam ip-filter create demo-ip-filter --ip-groups ipg-3g5jw,ipg-wjnde", fixture: "iam/ip-filter/create.golden"},
+		{args: "iam ip-filter list", fixture: "iam/ip-filter/list.golden"},
+		{args: "iam ip-filter describe ipf-34dq3", fixture: "iam/ip-filter/describe.golden"},
+		{args: "iam ip-filter delete ipf-34dq3", fixture: "iam/ip-filter/delete.golden"},
+		{args: "iam ip-filter update ipf-34dq3 --name new-ip-filter-demo --add-ip-groups ipg-1337a,ipg-ayd3n --remove-ip-groups ipg-12345", fixture: "iam/ip-filter/update.golden"},
+		{args: "iam ip-filter update ipf-34dq3 --add-ip-groups ipg-abcde --remove-ip-groups ipg-12345", fixture: "iam/ip-filter/update-resource-duplicate.golden"},
+		{args: "iam ip-filter update ipf-34dq3 --add-ip-groups ipg-azbye --remove-ip-groups ipg-azbye", fixture: "iam/ip-filter/update-resource-add-and-remove.golden"},
+		{args: "iam ip-filter update ipf-34dq3 --add-ip-groups ipg-hjkil --remove-ip-groups ipg-fedbc", fixture: "iam/ip-filter/update-resource-remove-not-exist.golden"},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Checklist
---------
- [ ] Leave this box unchecked if features are not yet available in production

What
----
When updating an IP filter or IP group in a way which would remove all associated IP groups or CIDR blocks, respectively, it gives a more clear error about what is going wrong.

Resource group flags were given a default value, but couldn't be utilized because it was listed as "required"

References
----------
[Bug bash](https://confluentinc.atlassian.net/wiki/spaces/SECENG/pages/3240723144/IP+Filtering+CLI+Bug+Bash)
[Ticket ](https://confluentinc.atlassian.net/browse/CIAM-3912)

Test & Review
-------------
`make lint`
`make test`
Local testing after `make build`