### PR TITLE
Update goreleaser version and change build names in goreleaser files

### DIFF
--- a/.goreleaser-linux-amd64.yml
+++ b/.goreleaser-linux-amd64.yml
@@ -18,7 +18,7 @@ builds:
       - linux
     goarch:
       - amd64
-  - id: confluent-linux-amd64-homebrew
+  - id: confluent-linux-amd64-disableupdates
     binary: confluent
     main: cmd/confluent/main.go
     flags:

--- a/.goreleaser-linux-arm64.yml
+++ b/.goreleaser-linux-arm64.yml
@@ -18,7 +18,7 @@ builds:
       - linux
     goarch:
       - arm64
-  - id: confluent-linux-arm64-homebrew
+  - id: confluent-linux-arm64-disableupdates
     binary: confluent
     main: cmd/confluent/main.go
     flags:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -205,13 +205,13 @@ archives:
     files:
       - LICENSE
       - legal/**/*
-  - id: archive-homebrew
+  - id: archive-disableupdates
     format: tar.gz
     builds:
       - confluent-darwin-amd64-disableupdates
       - confluent-darwin-arm64-disableupdates
       - confluent-linux-disableupdates
-    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}_homebrew"
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}_disableupdates"
     wrap_in_directory: "{{ .ProjectName }}"
     files:
       - LICENSE
@@ -283,7 +283,7 @@ blobs:
   - ids:
     - archive
     - archive-alpine
-    - archive-homebrew
+    - archive-disableupdates
     provider: s3
     bucket: confluent.cloud
     region: us-west-2
@@ -293,7 +293,7 @@ blobs:
 brews:
   - name: cli
     ids:
-      - archive-homebrew
+      - archive-disableupdates
     repository:
       owner: confluentinc
       name: homebrew-tap

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -62,7 +62,7 @@ builds:
         - cmd: zip "{{ .Path }}_signed.zip" {{ .Path }}
         - cmd: xcrun notarytool submit "{{ .Path }}_signed.zip" --apple-id {{ .Env.AC_USERNAME }} --password {{ .Env.AC_PASSWORD }} --team-id RTSX8FNWR2 --wait
           output: true
-  - id: confluent-darwin-amd64-homebrew
+  - id: confluent-darwin-amd64-disableupdates
     binary: confluent
     main: cmd/confluent/main.go
     flags:
@@ -106,7 +106,7 @@ builds:
         - cmd: zip "{{ .Path }}_signed.zip" {{ .Path }}
         - cmd: xcrun notarytool submit "{{ .Path }}_signed.zip" --apple-id {{ .Env.AC_USERNAME }} --password {{ .Env.AC_PASSWORD }} --team-id RTSX8FNWR2 --wait
           output: true
-  - id: confluent-darwin-arm64-homebrew
+  - id: confluent-darwin-arm64-disableupdates
     binary: confluent
     main: cmd/confluent/main.go
     flags:
@@ -141,7 +141,7 @@ builds:
       - v1
     prebuilt:
       path: "prebuilt/confluent-{{ .Os }}-{{ .Arch }}_{{ .Os }}_{{ .Arch }}{{ with .Amd64 }}_{{ . }}{{ end }}/confluent"
-  - id: confluent-linux-homebrew
+  - id: confluent-linux-disableupdates
     builder: prebuilt
     goos:
       - linux
@@ -151,7 +151,7 @@ builds:
     goamd64:
       - v1
     prebuilt:
-      path: "prebuilt/confluent-{{ .Os }}-{{ .Arch }}-homebrew_{{ .Os }}_{{ .Arch }}{{ with .Amd64 }}_{{ . }}{{ end }}/confluent"
+      path: "prebuilt/confluent-{{ .Os }}-{{ .Arch }}-disableupdates_{{ .Os }}_{{ .Arch }}{{ with .Amd64 }}_{{ . }}{{ end }}/confluent"
   - id: confluent-windows-amd64
     binary: confluent
     main: cmd/confluent/main.go
@@ -208,9 +208,9 @@ archives:
   - id: archive-homebrew
     format: tar.gz
     builds:
-      - confluent-darwin-amd64-homebrew
-      - confluent-darwin-arm64-homebrew
-      - confluent-linux-homebrew
+      - confluent-darwin-amd64-disableupdates
+      - confluent-darwin-arm64-disableupdates
+      - confluent-linux-disableupdates
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}_homebrew"
     wrap_in_directory: "{{ .ProjectName }}"
     files:

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 SHELL := /bin/bash
-GORELEASER_VERSION := v1.17.2
+GORELEASER_VERSION := v1.21.2
 
 # Compile natively based on the current system
 .PHONY: build 

--- a/debian/patches/standard_build_layout.patch
+++ b/debian/patches/standard_build_layout.patch
@@ -1,8 +1,8 @@
---- cli/Makefile	2023-09-29 13:08:09.000000000 -0700
-+++ debian/Makefile	2023-09-22 14:40:16.000000000 -0700
+--- cli/Makefile	2023-11-29 13:34:54.000000000 -0800
++++ debian/Makefile	2023-11-27 16:05:28.000000000 -0800
 @@ -1,120 +1,130 @@
 -SHELL := /bin/bash
--GORELEASER_VERSION := v1.17.2
+-GORELEASER_VERSION := v1.21.2
 +SHELL=/bin/bash
  
 -# Compile natively based on the current system


### PR DESCRIPTION
…for builds (but not archive)

Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- PLACEHOLDER

New Features
- PLACEHOLDER

Bug Fixes
- PLACEHOLDER

Checklist
---------
- [ ] Leave this box unchecked if features are not yet available in production

What
----
Some preparation for adding rpm/deb support. Two things:
- Update the goreleaser version. The current version has an rpm naming bug that's fixed in the newer versions.
- Change the build id suffix from `-homebrew` to `-disableupdates` for the Darwin and Linux builds. The Linux binaries will be used to create the deb/rpm packages, so not just homebrew. Changing the suffix for the Darwin builds is simply for consistency.

I did not change the `archive-homebrew` archive id since that is still only used for Homebrew.

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
Since this change also changes the prebuilt path for the linux binaries, I ran `scripts/build_linux.sh` and checked that the prebuilt path matches the updated pattern in this PR.