### PR TITLE
Add dry run to the `dockers` block in goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -230,7 +230,7 @@ archives:
       - confluent-alpine-amd64
       - confluent-alpine-arm64
     name_template: "{{ .ProjectName }}_{{ .Version }}_alpine_{{ .Arch }}"
-    
+
 dockers:
   - ids:
       - confluent-alpine-amd64
@@ -241,6 +241,7 @@ dockers:
     dockerfile: "docker/Dockerfile"
     build_flag_templates:
       - --platform=linux/amd64
+    skip_push: "{{ .Env.DRY_RUN }}"
   - ids:
       - confluent-alpine-arm64
     goarch: arm64
@@ -250,6 +251,7 @@ dockers:
     dockerfile: "docker/Dockerfile"
     build_flag_templates:
       - --platform=linux/arm64
+    skip_push: "{{ .Env.DRY_RUN }}"
 
 docker_manifests:
   - name_template: "confluentinc/confluent-cli:{{ .Version }}"


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- PLACEHOLDER

New Features
- PLACEHOLDER

Bug Fixes
- PLACEHOLDER

Checklist
---------
- [x] Leave this box unchecked if features are not yet available in production

What
----
I meant to bundle this with the previous goreleaser PR but missed it.

goreleaser added `skip_push` to `dockers`, so we should now have full `DRY_RUN` support in goreleaser. I also removed some random trailing whitespace.

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
Ran `goreleaser check .goreleaser*.yml` and got no errors.