### PR TITLE
Log the encrypted string in encryption.go

### DIFF
--- a/pkg/secret/encryption_other.go
+++ b/pkg/secret/encryption_other.go
@@ -90,7 +90,7 @@ func Decrypt(username, encrypted string, salt, nonce []byte) (string, error) {
 		return "", err
 	}
 
-	log.CliLogger.Debugf("Decrypting secret: %s", encrypted)
+	log.CliLogger.Tracef("Decrypting secret: %s", encrypted)
 	encrypted = strings.TrimPrefix(encrypted, AesGcm+":")
 
 	cipherText, err := base64.RawStdEncoding.DecodeString(encrypted)

--- a/pkg/secret/encryption_other.go
+++ b/pkg/secret/encryption_other.go
@@ -90,6 +90,7 @@ func Decrypt(username, encrypted string, salt, nonce []byte) (string, error) {
 		return "", err
 	}
 
+	log.CliLogger.Debugf("Decrypting secret: %s", encrypted)
 	encrypted = strings.TrimPrefix(encrypted, AesGcm+":")
 
 	cipherText, err := base64.RawStdEncoding.DecodeString(encrypted)
@@ -100,7 +101,7 @@ func Decrypt(username, encrypted string, salt, nonce []byte) (string, error) {
 	if len(nonce) != NonceLength {
 		return "", fmt.Errorf(errors.IncorrectNonceLengthErrorMsg)
 	}
-	log.CliLogger.Debugf("Decrypting secret: %s", cipherText)
+
 	decryptedPassword, err := aesgcm.Open(nil, nonce, cipherText, []byte(username))
 	if err != nil {
 		return "", fmt.Errorf("CLI does not have write permission for `/etc/machine-id`, or `~/.confluent/config.json` is corrupted: %w", err)

--- a/pkg/secret/encryption_windows.go
+++ b/pkg/secret/encryption_windows.go
@@ -28,7 +28,7 @@ func Encrypt(_, password string, _, _ []byte) (string, error) {
 }
 
 func Decrypt(_, encrypted string, _, _ []byte) (string, error) {
-	log.CliLogger.Debugf("Decrypting secret: %s", encrypted)
+	log.CliLogger.Tracef("Decrypting secret: %s", encrypted)
 	decryptedPassword, err := dpapi.Decrypt(encrypted)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- PLACEHOLDER

New Features
- PLACEHOLDER

Bug Fixes
- PLACEHOLDER

Checklist
---------
- [x] Leave this box unchecked if features are not yet available in production

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->
cipherText is a binary-formatted []byte. Log the `encrypted` string instead to check if has the correct prefix / if it's truncated...

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
<!--
Has it been tested? How?
Copy and paste any instructions or steps that can save the reviewer time.
-->