### PR TITLE
feat: add cloud provider to output for compute pool commands

### DIFF
--- a/internal/flink/command_compute_pool.go
+++ b/internal/flink/command_compute_pool.go
@@ -10,6 +10,7 @@ type computePoolOut struct {
 	Name       string `human:"Name" serialized:"name"`
 	CurrentCfu int32  `human:"Current CFU" serialized:"currrent_cfu"`
 	MaxCfu     int32  `human:"Max CFU" serialized:"max_cfu"`
+	Cloud      string `human:"Cloud" serialized:"cloud"`
 	Region     string `human:"Region" serialized:"region"`
 	Status     string `human:"Status" serialized:"status"`
 }

--- a/internal/flink/command_compute_pool_create.go
+++ b/internal/flink/command_compute_pool_create.go
@@ -86,6 +86,7 @@ func (c *command) computePoolCreate(cmd *cobra.Command, args []string) error {
 		Name:       computePool.Spec.GetDisplayName(),
 		CurrentCfu: computePool.Status.GetCurrentCfu(),
 		MaxCfu:     computePool.Spec.GetMaxCfu(),
+		Cloud:      computePool.Spec.GetCloud(),
 		Region:     computePool.Spec.GetRegion(),
 		Status:     computePool.Status.GetPhase(),
 	})

--- a/internal/flink/command_compute_pool_describe.go
+++ b/internal/flink/command_compute_pool_describe.go
@@ -52,6 +52,7 @@ func (c *command) computePoolDescribe(cmd *cobra.Command, args []string) error {
 		Name:       computePool.Spec.GetDisplayName(),
 		CurrentCfu: computePool.Status.GetCurrentCfu(),
 		MaxCfu:     computePool.Spec.GetMaxCfu(),
+		Cloud:      computePool.Spec.GetCloud(),
 		Region:     computePool.Spec.GetRegion(),
 		Status:     computePool.Status.GetPhase(),
 	})

--- a/internal/flink/command_compute_pool_list.go
+++ b/internal/flink/command_compute_pool_list.go
@@ -46,6 +46,7 @@ func (c *command) computePoolList(cmd *cobra.Command, _ []string) error {
 			Name:       computePool.Spec.GetDisplayName(),
 			CurrentCfu: computePool.Status.GetCurrentCfu(),
 			MaxCfu:     computePool.Spec.GetMaxCfu(),
+			Cloud:      computePool.Spec.GetCloud(),
 			Region:     computePool.Spec.GetRegion(),
 			Status:     computePool.Status.GetPhase(),
 		})

--- a/internal/flink/command_compute_pool_update.go
+++ b/internal/flink/command_compute_pool_update.go
@@ -103,6 +103,7 @@ func (c *command) computePoolUpdate(cmd *cobra.Command, args []string) error {
 		Name:       updatedComputePool.Spec.GetDisplayName(),
 		CurrentCfu: computePool.Status.GetCurrentCfu(),
 		MaxCfu:     updatedComputePool.Spec.GetMaxCfu(),
+		Cloud:      computePool.Spec.GetCloud(),
 		Region:     computePool.Spec.GetRegion(),
 		Status:     computePool.Status.GetPhase(),
 	})

--- a/test/fixtures/output/flink/compute-pool/create.golden
+++ b/test/fixtures/output/flink/compute-pool/create.golden
@@ -4,7 +4,7 @@
 | Name        | my-compute-pool |
 | Current CFU | 0               |
 | Max CFU     | 5               |
-| Cloud       | aws             |
+| Cloud       | AWS             |
 | Region      | us-west-2       |
 | Status      | PROVISIONING    |
 +-------------+-----------------+

--- a/test/fixtures/output/flink/compute-pool/create.golden
+++ b/test/fixtures/output/flink/compute-pool/create.golden
@@ -4,6 +4,7 @@
 | Name        | my-compute-pool |
 | Current CFU | 0               |
 | Max CFU     | 5               |
+| Cloud       | aws             |
 | Region      | us-west-2       |
 | Status      | PROVISIONING    |
 +-------------+-----------------+

--- a/test/fixtures/output/flink/compute-pool/describe-after-use.golden
+++ b/test/fixtures/output/flink/compute-pool/describe-after-use.golden
@@ -4,6 +4,7 @@
 | Name        | my-compute-pool-1 |
 | Current CFU | 0                 |
 | Max CFU     | 1                 |
+| Cloud       | AWS               |
 | Region      | us-west-2         |
 | Status      | PROVISIONED       |
 +-------------+-------------------+

--- a/test/fixtures/output/flink/compute-pool/describe.golden
+++ b/test/fixtures/output/flink/compute-pool/describe.golden
@@ -4,6 +4,7 @@
 | Name        | my-compute-pool-1 |
 | Current CFU | 0                 |
 | Max CFU     | 1                 |
+| Cloud       | AWS               |
 | Region      | us-west-2         |
 | Status      | PROVISIONED       |
 +-------------+-------------------+

--- a/test/fixtures/output/flink/compute-pool/list-after-use.golden
+++ b/test/fixtures/output/flink/compute-pool/list-after-use.golden
@@ -1,4 +1,4 @@
-  Current |     ID      |       Name        | Current CFU | Max CFU |  Region   |   Status     
-----------+-------------+-------------------+-------------+---------+-----------+--------------
-  *       | lfcp-123456 | my-compute-pool-1 |           0 |       1 | us-west-1 | PROVISIONED  
-          | lfcp-222222 | my-compute-pool-2 |           0 |       2 | us-west-2 | PROVISIONED  
+  Current |     ID      |       Name        | Current CFU | Max CFU | Cloud |  Region   |   Status     
+----------+-------------+-------------------+-------------+---------+-------+-----------+--------------
+  *       | lfcp-123456 | my-compute-pool-1 |           0 |       1 | AWS   | us-west-1 | PROVISIONED  
+          | lfcp-222222 | my-compute-pool-2 |           0 |       2 | AWS   | us-west-2 | PROVISIONED  

--- a/test/fixtures/output/flink/compute-pool/list-region.golden
+++ b/test/fixtures/output/flink/compute-pool/list-region.golden
@@ -1,3 +1,3 @@
-  Current |     ID      |       Name        | Current CFU | Max CFU |  Region   |   Status     
-----------+-------------+-------------------+-------------+---------+-----------+--------------
-          | lfcp-222222 | my-compute-pool-2 |           0 |       2 | us-west-2 | PROVISIONED  
+  Current |     ID      |       Name        | Current CFU | Max CFU | Cloud |  Region   |   Status     
+----------+-------------+-------------------+-------------+---------+-------+-----------+--------------
+          | lfcp-222222 | my-compute-pool-2 |           0 |       2 | AWS   | us-west-2 | PROVISIONED  

--- a/test/fixtures/output/flink/compute-pool/list.golden
+++ b/test/fixtures/output/flink/compute-pool/list.golden
@@ -1,4 +1,4 @@
-  Current |     ID      |       Name        | Current CFU | Max CFU |  Region   |   Status     
-----------+-------------+-------------------+-------------+---------+-----------+--------------
-          | lfcp-123456 | my-compute-pool-1 |           0 |       1 | us-west-1 | PROVISIONED  
-          | lfcp-222222 | my-compute-pool-2 |           0 |       2 | us-west-2 | PROVISIONED  
+  Current |     ID      |       Name        | Current CFU | Max CFU | Cloud |  Region   |   Status     
+----------+-------------+-------------------+-------------+---------+-------+-----------+--------------
+          | lfcp-123456 | my-compute-pool-1 |           0 |       1 | AWS   | us-west-1 | PROVISIONED  
+          | lfcp-222222 | my-compute-pool-2 |           0 |       2 | AWS   | us-west-2 | PROVISIONED  

--- a/test/fixtures/output/flink/compute-pool/update-after-use.golden
+++ b/test/fixtures/output/flink/compute-pool/update-after-use.golden
@@ -4,6 +4,7 @@
 | Name        | my-compute-pool-1 |
 | Current CFU | 0                 |
 | Max CFU     | 5                 |
+| Cloud       | AWS               |
 | Region      | us-west-2         |
 | Status      | PROVISIONED       |
 +-------------+-------------------+

--- a/test/fixtures/output/flink/compute-pool/update.golden
+++ b/test/fixtures/output/flink/compute-pool/update.golden
@@ -4,6 +4,7 @@
 | Name        | my-compute-pool-1 |
 | Current CFU | 0                 |
 | Max CFU     | 5                 |
+| Cloud       | AWS               |
 | Region      | us-west-2         |
 | Status      | PROVISIONED       |
 +-------------+-------------------+

--- a/test/test-server/fcpm_handlers.go
+++ b/test/test-server/fcpm_handlers.go
@@ -23,6 +23,7 @@ func handleFcpmComputePools(t *testing.T) http.HandlerFunc {
 					DisplayName: flinkv2.PtrString("my-compute-pool-1"),
 					MaxCfu:      flinkv2.PtrInt32(1),
 					Region:      flinkv2.PtrString("us-west-1"),
+					Cloud:       flinkv2.PtrString("AWS"),
 				},
 				Status: &flinkv2.FcpmV2ComputePoolStatus{Phase: "PROVISIONED"},
 			}
@@ -32,6 +33,7 @@ func handleFcpmComputePools(t *testing.T) http.HandlerFunc {
 					DisplayName: flinkv2.PtrString("my-compute-pool-2"),
 					MaxCfu:      flinkv2.PtrInt32(2),
 					Region:      flinkv2.PtrString("us-west-2"),
+					Cloud:       flinkv2.PtrString("AWS"),
 				},
 				Status: &flinkv2.FcpmV2ComputePoolStatus{Phase: "PROVISIONED"},
 			}
@@ -75,6 +77,7 @@ func handleFcpmComputePoolsId(t *testing.T) http.HandlerFunc {
 					DisplayName:  flinkv2.PtrString("my-compute-pool-1"),
 					HttpEndpoint: flinkv2.PtrString(TestFlinkGatewayUrl.String()),
 					MaxCfu:       flinkv2.PtrInt32(1),
+					Cloud:        flinkv2.PtrString("AWS"),
 					Region:       flinkv2.PtrString("us-west-2"),
 				},
 				Status: &flinkv2.FcpmV2ComputePoolStatus{Phase: "PROVISIONED"},
@@ -92,6 +95,7 @@ func handleFcpmComputePoolsId(t *testing.T) http.HandlerFunc {
 				Spec: &flinkv2.FcpmV2ComputePoolSpec{
 					DisplayName: flinkv2.PtrString("my-compute-pool-1"),
 					MaxCfu:      flinkv2.PtrInt32(update.Spec.GetMaxCfu()),
+					Cloud:       flinkv2.PtrString("AWS"),
 					Region:      flinkv2.PtrString("us-west-2"),
 				},
 				Status: &flinkv2.FcpmV2ComputePoolStatus{Phase: "PROVISIONED"},

--- a/test/test-server/fcpm_handlers.go
+++ b/test/test-server/fcpm_handlers.go
@@ -3,6 +3,7 @@ package testserver
 import (
 	"encoding/json"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/gorilla/mux"
@@ -47,6 +48,7 @@ func handleFcpmComputePools(t *testing.T) http.HandlerFunc {
 			create := new(flinkv2.FcpmV2ComputePool)
 			err := json.NewDecoder(r.Body).Decode(create)
 			require.NoError(t, err)
+			create.Spec.Cloud = flinkv2.PtrString(strings.ToUpper(create.Spec.GetCloud()))
 
 			v = flinkv2.FcpmV2ComputePool{
 				Id:     flinkv2.PtrString("lfcp-123456"),


### PR DESCRIPTION
Release Notes
---------
New Features
- [Early Access] Add "Cloud" to the output of the `confluent flink compute-pool` commands

Checklist
---------
- [x] Leave this box unchecked if features are not yet available in production

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->
We will be launching Azure pretty soon followed by GCP. The compute pool CLI commands currently do not mention the cloud provider, so we should add it

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
<!--
Has it been tested? How?
Copy and paste any instructions or steps that can save the reviewer time.
-->