### PR TITLE
[TRAFFIC-9346][TRAFFIC-9347] Add confluent network network-link endpoint create/delete

### DIFF
--- a/internal/network/command.go
+++ b/internal/network/command.go
@@ -268,3 +268,8 @@ func addAcceptedEnvironmentsFlag(cmd *cobra.Command, command *pcmd.Authenticated
 		return pcmd.AutocompleteEnvironments(command.Client, command.V2Client)
 	})
 }
+
+func (c *command) addNetworkLinkServiceFlag(cmd *cobra.Command) {
+	cmd.Flags().String("network-link-service", "", "Network link service ID.")
+	pcmd.RegisterFlagCompletionFunc(cmd, "network-link-service", c.validNetworkLinkServicesArgsMultiple)
+}

--- a/internal/network/command_network_link_endpoint.go
+++ b/internal/network/command_network_link_endpoint.go
@@ -28,6 +28,8 @@ func (c *command) newNetworkLinkEndpointCommand() *cobra.Command {
 		Args:  cobra.NoArgs,
 	}
 
+	cmd.AddCommand(c.newNetworkLinkEndpointCreateCommand())
+	cmd.AddCommand(c.newNetworkLinkEndpointDeleteCommand())
 	cmd.AddCommand(c.newNetworkLinkEndpointDescribeCommand())
 	cmd.AddCommand(c.newNetworkLinkEndpointListCommand())
 

--- a/internal/network/command_network_link_endpoint_create.go
+++ b/internal/network/command_network_link_endpoint_create.go
@@ -1,0 +1,78 @@
+package network
+
+import (
+	"github.com/spf13/cobra"
+
+	networkingv1 "github.com/confluentinc/ccloud-sdk-go-v2/networking/v1"
+
+	pcmd "github.com/confluentinc/cli/v3/pkg/cmd"
+	"github.com/confluentinc/cli/v3/pkg/examples"
+)
+
+func (c *command) newNetworkLinkEndpointCreateCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "create <name>",
+		Short: "Create a network link endpoint.",
+		Args:  cobra.ExactArgs(1),
+		RunE:  c.networkLinkEndpointCreate,
+		Example: examples.BuildExampleString(
+			examples.Example{
+				Text: `Create a network link endpoint for network "n-123456" and network link service "nls-abcde1".`,
+				Code: `confluent network network-link endpoint create my-network-link-endpoint --network n-123456 --description "example network link endpoint" --network-link-service nls-abcde1`,
+			},
+		),
+	}
+
+	addNetworkFlag(cmd, c.AuthenticatedCLICommand)
+	c.addNetworkLinkServiceFlag(cmd)
+	cmd.Flags().String("description", "", "Network link endpoint description.")
+	pcmd.AddContextFlag(cmd, c.CLICommand)
+	pcmd.AddEnvironmentFlag(cmd, c.AuthenticatedCLICommand)
+	pcmd.AddOutputFlag(cmd)
+
+	cobra.CheckErr(cmd.MarkFlagRequired("network"))
+	cobra.CheckErr(cmd.MarkFlagRequired("network-link-service"))
+
+	return cmd
+}
+
+func (c *command) networkLinkEndpointCreate(cmd *cobra.Command, args []string) error {
+	name := args[0]
+
+	networkId, err := cmd.Flags().GetString("network")
+	if err != nil {
+		return err
+	}
+
+	environmentId, err := c.Context.EnvironmentId()
+	if err != nil {
+		return err
+	}
+
+	description, err := cmd.Flags().GetString("description")
+	if err != nil {
+		return err
+	}
+
+	service, err := cmd.Flags().GetString("network-link-service")
+	if err != nil {
+		return err
+	}
+
+	createNetworkLinkEndpoint := networkingv1.NetworkingV1NetworkLinkEndpoint{
+		Spec: &networkingv1.NetworkingV1NetworkLinkEndpointSpec{
+			DisplayName:        networkingv1.PtrString(name),
+			Description:        networkingv1.PtrString(description),
+			Environment:        &networkingv1.GlobalObjectReference{Id: environmentId},
+			Network:            &networkingv1.EnvScopedObjectReference{Id: networkId},
+			NetworkLinkService: &networkingv1.EnvScopedObjectReference{Id: service},
+		},
+	}
+
+	endpoint, err := c.V2Client.CreateNetworkLinkEndpoint(createNetworkLinkEndpoint)
+	if err != nil {
+		return err
+	}
+
+	return printNetworkLinkEndpointTable(cmd, endpoint)
+}

--- a/internal/network/command_network_link_endpoint_delete.go
+++ b/internal/network/command_network_link_endpoint_delete.go
@@ -1,0 +1,63 @@
+package network
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	pcmd "github.com/confluentinc/cli/v3/pkg/cmd"
+	"github.com/confluentinc/cli/v3/pkg/deletion"
+	"github.com/confluentinc/cli/v3/pkg/errors"
+	"github.com/confluentinc/cli/v3/pkg/output"
+	"github.com/confluentinc/cli/v3/pkg/resource"
+	"github.com/confluentinc/cli/v3/pkg/utils"
+)
+
+func (c *command) newNetworkLinkEndpointDeleteCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:               "delete <id>",
+		Short:             "Delete a network link endpoint.",
+		Args:              cobra.MinimumNArgs(1),
+		ValidArgsFunction: pcmd.NewValidArgsFunction(c.validNetworkLinkEndpointArgs),
+		RunE:              c.networkLinkEndpointDelete,
+	}
+
+	pcmd.AddForceFlag(cmd)
+	pcmd.AddContextFlag(cmd, c.CLICommand)
+	pcmd.AddEnvironmentFlag(cmd, c.AuthenticatedCLICommand)
+
+	return cmd
+}
+
+func (c *command) networkLinkEndpointDelete(cmd *cobra.Command, args []string) error {
+	environmentId, err := c.Context.EnvironmentId()
+	if err != nil {
+		return err
+	}
+
+	existenceFunc := func(id string) bool {
+		_, err := c.V2Client.GetNetworkLinkEndpoint(environmentId, id)
+		return err == nil
+	}
+
+	if err := deletion.ValidateAndConfirmDeletionYesNo(cmd, args, existenceFunc, resource.NetworkLinkEndpoint); err != nil {
+		return err
+	}
+
+	deleteFunc := func(id string) error {
+		if err := c.V2Client.DeleteNetworkLinkEndpoint(environmentId, id); err != nil {
+			return fmt.Errorf(errors.DeleteResourceErrorMsg, resource.NetworkLinkEndpoint, id, err)
+		}
+		return nil
+	}
+
+	deletedIds, err := deletion.DeleteWithoutMessage(args, deleteFunc)
+	deleteMsg := "Requested to delete %s %s.\n"
+	if len(deletedIds) == 1 {
+		output.Printf(c.Config.EnableColor, deleteMsg, resource.NetworkLinkEndpoint, fmt.Sprintf(`"%s"`, deletedIds[0]))
+	} else if len(deletedIds) > 1 {
+		output.Printf(c.Config.EnableColor, deleteMsg, resource.Plural(resource.NetworkLinkEndpoint), utils.ArrayToCommaDelimitedString(deletedIds, "and"))
+	}
+
+	return err
+}

--- a/internal/network/command_network_link_endpoint_delete.go
+++ b/internal/network/command_network_link_endpoint_delete.go
@@ -15,8 +15,8 @@ import (
 
 func (c *command) newNetworkLinkEndpointDeleteCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:               "delete <id>",
-		Short:             "Delete a network link endpoint.",
+		Use:               "delete <id-1> [id-2] ... [id-n]",
+		Short:             "Delete one or more network link endpoints.",
 		Args:              cobra.MinimumNArgs(1),
 		ValidArgsFunction: pcmd.NewValidArgsFunction(c.validNetworkLinkEndpointArgs),
 		RunE:              c.networkLinkEndpointDelete,

--- a/internal/network/command_network_link_service_delete.go
+++ b/internal/network/command_network_link_service_delete.go
@@ -15,8 +15,8 @@ import (
 
 func (c *command) newNetworkLinkServiceDeleteCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:               "delete <id>",
-		Short:             "Delete a network link service.",
+		Use:               "delete <id-1> [id-2] ... [id-n]",
+		Short:             "Delete one or more network link services.",
 		Args:              cobra.MinimumNArgs(1),
 		ValidArgsFunction: pcmd.NewValidArgsFunction(c.validNetworkLinkServiceArgs),
 		RunE:              c.networkLinkServiceDelete,

--- a/pkg/ccloudv2/networking.go
+++ b/pkg/ccloudv2/networking.go
@@ -302,3 +302,13 @@ func (c *Client) GetNetworkLinkEndpoint(environment, id string) (networkingv1.Ne
 	resp, httpResp, err := c.NetworkingClient.NetworkLinkEndpointsNetworkingV1Api.GetNetworkingV1NetworkLinkEndpoint(c.networkingApiContext(), id).Environment(environment).Execute()
 	return resp, errors.CatchCCloudV2Error(err, httpResp)
 }
+
+func (c *Client) DeleteNetworkLinkEndpoint(environment, id string) error {
+	httpResp, err := c.NetworkingClient.NetworkLinkEndpointsNetworkingV1Api.DeleteNetworkingV1NetworkLinkEndpoint(c.networkingApiContext(), id).Environment(environment).Execute()
+	return errors.CatchCCloudV2Error(err, httpResp)
+}
+
+func (c *Client) CreateNetworkLinkEndpoint(endpoint networkingv1.NetworkingV1NetworkLinkEndpoint) (networkingv1.NetworkingV1NetworkLinkEndpoint, error) {
+	resp, httpResp, err := c.NetworkingClient.NetworkLinkEndpointsNetworkingV1Api.CreateNetworkingV1NetworkLinkEndpoint(c.networkingApiContext()).NetworkingV1NetworkLinkEndpoint(endpoint).Execute()
+	return resp, errors.CatchCCloudV2Error(err, httpResp)
+}

--- a/pkg/resource/resource.go
+++ b/pkg/resource/resource.go
@@ -36,6 +36,7 @@ const (
 	KsqlCluster                     = "KSQL cluster"
 	MirrorTopic                     = "mirror topic"
 	Network                         = "network"
+	NetworkLinkEndpoint             = "network link endpoint"
 	NetworkLinkService              = "network link service"
 	Organization                    = "organization"
 	Peering                         = "peering"

--- a/test/fixtures/output/network/network-link/endpoint/create-autocomplete.golden
+++ b/test/fixtures/output/network/network-link/endpoint/create-autocomplete.golden
@@ -1,0 +1,5 @@
+n-abcde1	prod-aws-us-east1
+n-abcde2	prod-gcp-us-central1
+n-abcde3	prod-azure-eastus2
+:4
+Completion ended with directive: ShellCompDirectiveNoFileComp

--- a/test/fixtures/output/network/network-link/endpoint/create-duplicate.golden
+++ b/test/fixtures/output/network/network-link/endpoint/create-duplicate.golden
@@ -1,0 +1,1 @@
+Error: Cannot have more than 1 active/in provision/pending accept/disconnected NetworkLinkEndpoint attached to the same NetworkLinkService in the same network.: 409 Conflict

--- a/test/fixtures/output/network/network-link/endpoint/create-help.golden
+++ b/test/fixtures/output/network/network-link/endpoint/create-help.golden
@@ -1,10 +1,14 @@
 Create a network link endpoint.
 
 Usage:
-  confluent network network-link endpoint create <name> [flags]
+  confluent network network-link endpoint create [name] [flags]
 
 Examples:
 Create a network link endpoint for network "n-123456" and network link service "nls-abcde1".
+
+  $ confluent network network-link endpoint create --network n-123456 --description "example network link endpoint" --network-link-service nls-abcde1
+
+Create a named network link endpoint for network "n-123456" and network link service "nls-abcde1".
 
   $ confluent network network-link endpoint create my-network-link-endpoint --network n-123456 --description "example network link endpoint" --network-link-service nls-abcde1
 

--- a/test/fixtures/output/network/network-link/endpoint/create-help.golden
+++ b/test/fixtures/output/network/network-link/endpoint/create-help.golden
@@ -1,0 +1,22 @@
+Create a network link endpoint.
+
+Usage:
+  confluent network network-link endpoint create <name> [flags]
+
+Examples:
+Create a network link endpoint for network "n-123456" and network link service "nls-abcde1".
+
+  $ confluent network network-link endpoint create my-network-link-endpoint --network n-123456 --description "example network link endpoint" --network-link-service nls-abcde1
+
+Flags:
+      --network string                REQUIRED: Network ID.
+      --network-link-service string   REQUIRED: Network link service ID.
+      --description string            Network link endpoint description.
+      --context string                CLI context name.
+      --environment string            Environment ID.
+  -o, --output string                 Specify the output format as "human", "json", or "yaml". (default "human")
+
+Global Flags:
+  -h, --help            Show help for this command.
+      --unsafe-trace    Equivalent to -vvvv, but also log HTTP requests and responses which might contain plaintext secrets.
+  -v, --verbose count   Increase verbosity (-v for warn, -vv for info, -vvv for debug, -vvvv for trace).

--- a/test/fixtures/output/network/network-link/endpoint/create-missing-args.golden
+++ b/test/fixtures/output/network/network-link/endpoint/create-missing-args.golden
@@ -1,0 +1,22 @@
+Error: accepts 1 arg(s), received 0
+Usage:
+  confluent network network-link endpoint create <name> [flags]
+
+Examples:
+Create a network link endpoint for network "n-123456" and network link service "nls-abcde1".
+
+  $ confluent network network-link endpoint create my-network-link-endpoint --network n-123456 --description "example network link endpoint" --network-link-service nls-abcde1
+
+Flags:
+      --network string                Network ID.
+      --network-link-service string   Network link service ID.
+      --description string            Network link endpoint description.
+      --context string                CLI context name.
+      --environment string            Environment ID.
+  -o, --output string                 Specify the output format as "human", "json", or "yaml". (default "human")
+
+Global Flags:
+  -h, --help            Show help for this command.
+      --unsafe-trace    Equivalent to -vvvv, but also log HTTP requests and responses which might contain plaintext secrets.
+  -v, --verbose count   Increase verbosity (-v for warn, -vv for info, -vvv for debug, -vvvv for trace).
+

--- a/test/fixtures/output/network/network-link/endpoint/create-missing-flags.golden
+++ b/test/fixtures/output/network/network-link/endpoint/create-missing-flags.golden
@@ -1,15 +1,19 @@
-Error: accepts 1 arg(s), received 0
+Error: required flag(s) "network", "network-link-service" not set
 Usage:
-  confluent network network-link endpoint create <name> [flags]
+  confluent network network-link endpoint create [name] [flags]
 
 Examples:
 Create a network link endpoint for network "n-123456" and network link service "nls-abcde1".
 
+  $ confluent network network-link endpoint create --network n-123456 --description "example network link endpoint" --network-link-service nls-abcde1
+
+Create a named network link endpoint for network "n-123456" and network link service "nls-abcde1".
+
   $ confluent network network-link endpoint create my-network-link-endpoint --network n-123456 --description "example network link endpoint" --network-link-service nls-abcde1
 
 Flags:
-      --network string                Network ID.
-      --network-link-service string   Network link service ID.
+      --network string                REQUIRED: Network ID.
+      --network-link-service string   REQUIRED: Network link service ID.
       --description string            Network link endpoint description.
       --context string                CLI context name.
       --environment string            Environment ID.

--- a/test/fixtures/output/network/network-link/endpoint/create-no-name.golden
+++ b/test/fixtures/output/network/network-link/endpoint/create-no-name.golden
@@ -1,0 +1,8 @@
++----------------------+-------------------------------+
+| ID                   | nle-abcde1                    |
+| Network              | n-123456                      |
+| Environment          | env-00000                     |
+| Description          | example network link endpoint |
+| Network Link Service | nls-abcde1                    |
+| Phase                | PENDING_ACCEPT                |
++----------------------+-------------------------------+

--- a/test/fixtures/output/network/network-link/endpoint/create-same-id.golden
+++ b/test/fixtures/output/network/network-link/endpoint/create-same-id.golden
@@ -1,1 +1,1 @@
-Error: Network id for NetworkLinkEndpoint and NetworkLinkService cannot be the same.: 409 Conflict
+Error: Network ID for NetworkLinkEndpoint and NetworkLinkService cannot be the same.: 409 Conflict

--- a/test/fixtures/output/network/network-link/endpoint/create-same-id.golden
+++ b/test/fixtures/output/network/network-link/endpoint/create-same-id.golden
@@ -1,0 +1,1 @@
+Error: Network id for NetworkLinkEndpoint and NetworkLinkService cannot be the same.: 409 Conflict

--- a/test/fixtures/output/network/network-link/endpoint/create.golden
+++ b/test/fixtures/output/network/network-link/endpoint/create.golden
@@ -1,0 +1,9 @@
++----------------------+-------------------------------+
+| ID                   | nle-abcde1                    |
+| Name                 | my-network-link-endpoint      |
+| Network              | n-123456                      |
+| Environment          | env-00000                     |
+| Description          | example network link endpoint |
+| Network Link Service | nls-abcde1                    |
+| Phase                | PENDING_ACCEPT                |
++----------------------+-------------------------------+

--- a/test/fixtures/output/network/network-link/endpoint/delete-autocomplete.golden
+++ b/test/fixtures/output/network/network-link/endpoint/delete-autocomplete.golden
@@ -1,0 +1,5 @@
+nle-111111	my-network-link-endpoint-1
+nle-222222	my-network-link-endpoint-2
+nle-333333	my-network-link-endpoint-3
+:4
+Completion ended with directive: ShellCompDirectiveNoFileComp

--- a/test/fixtures/output/network/network-link/endpoint/delete-help.golden
+++ b/test/fixtures/output/network/network-link/endpoint/delete-help.golden
@@ -1,7 +1,7 @@
-Delete a network link endpoint.
+Delete one or more network link endpoints.
 
 Usage:
-  confluent network network-link endpoint delete <id> [flags]
+  confluent network network-link endpoint delete <id-1> [id-2] ... [id-n] [flags]
 
 Flags:
       --force                Skip the deletion confirmation prompt.

--- a/test/fixtures/output/network/network-link/endpoint/delete-help.golden
+++ b/test/fixtures/output/network/network-link/endpoint/delete-help.golden
@@ -1,0 +1,14 @@
+Delete a network link endpoint.
+
+Usage:
+  confluent network network-link endpoint delete <id> [flags]
+
+Flags:
+      --force                Skip the deletion confirmation prompt.
+      --context string       CLI context name.
+      --environment string   Environment ID.
+
+Global Flags:
+  -h, --help            Show help for this command.
+      --unsafe-trace    Equivalent to -vvvv, but also log HTTP requests and responses which might contain plaintext secrets.
+  -v, --verbose count   Increase verbosity (-v for warn, -vv for info, -vvv for debug, -vvvv for trace).

--- a/test/fixtures/output/network/network-link/endpoint/delete-multiple-fail.golden
+++ b/test/fixtures/output/network/network-link/endpoint/delete-multiple-fail.golden
@@ -1,0 +1,4 @@
+Error: network link endpoint "nle-invalid" not found
+
+Suggestions:
+    List available network link endpoints with `confluent network network-link endpoint list`.

--- a/test/fixtures/output/network/network-link/endpoint/delete-multiple-refuse.golden
+++ b/test/fixtures/output/network/network-link/endpoint/delete-multiple-refuse.golden
@@ -1,0 +1,1 @@
+Are you sure you want to delete network link endpoints "nle-111111" and "nle-222222"? (y/n): 

--- a/test/fixtures/output/network/network-link/endpoint/delete-multiple-success.golden
+++ b/test/fixtures/output/network/network-link/endpoint/delete-multiple-success.golden
@@ -1,0 +1,1 @@
+Are you sure you want to delete network link endpoints "nle-111111" and "nle-222222"? (y/n): Requested to delete network link endpoints "nle-111111" and "nle-222222".

--- a/test/fixtures/output/network/network-link/endpoint/delete-nle-not-exist.golden
+++ b/test/fixtures/output/network/network-link/endpoint/delete-nle-not-exist.golden
@@ -1,0 +1,4 @@
+Error: network link endpoint "nle-invalid" not found
+
+Suggestions:
+    List available network link endpoints with `confluent network network-link endpoint list`.

--- a/test/fixtures/output/network/network-link/endpoint/delete-prompt.golden
+++ b/test/fixtures/output/network/network-link/endpoint/delete-prompt.golden
@@ -1,0 +1,1 @@
+Are you sure you want to delete network link endpoint "nle-111111"? (y/n): Requested to delete network link endpoint "nle-111111".

--- a/test/fixtures/output/network/network-link/endpoint/delete.golden
+++ b/test/fixtures/output/network/network-link/endpoint/delete.golden
@@ -1,0 +1,1 @@
+Requested to delete network link endpoint "nle-111111".

--- a/test/fixtures/output/network/network-link/endpoint/help.golden
+++ b/test/fixtures/output/network/network-link/endpoint/help.golden
@@ -5,7 +5,7 @@ Usage:
 
 Available Commands:
   create      Create a network link endpoint.
-  delete      Delete a network link endpoint.
+  delete      Delete one or more network link endpoints.
   describe    Describe a network link endpoint.
   list        List network link endpoints.
 

--- a/test/fixtures/output/network/network-link/endpoint/help.golden
+++ b/test/fixtures/output/network/network-link/endpoint/help.golden
@@ -4,6 +4,8 @@ Usage:
   confluent network network-link endpoint [command]
 
 Available Commands:
+  create      Create a network link endpoint.
+  delete      Delete a network link endpoint.
   describe    Describe a network link endpoint.
   list        List network link endpoints.
 

--- a/test/fixtures/output/network/network-link/service/delete-help.golden
+++ b/test/fixtures/output/network/network-link/service/delete-help.golden
@@ -1,7 +1,7 @@
-Delete a network link service.
+Delete one or more network link services.
 
 Usage:
-  confluent network network-link service delete <id> [flags]
+  confluent network network-link service delete <id-1> [id-2] ... [id-n] [flags]
 
 Flags:
       --force                Skip the deletion confirmation prompt.

--- a/test/fixtures/output/network/network-link/service/help.golden
+++ b/test/fixtures/output/network/network-link/service/help.golden
@@ -5,7 +5,7 @@ Usage:
 
 Available Commands:
   create      Create a network link service.
-  delete      Delete a network link service.
+  delete      Delete one or more network link services.
   describe    Describe a network link service.
   list        List network link services.
 

--- a/test/network_test.go
+++ b/test/network_test.go
@@ -663,7 +663,8 @@ func (s *CLITestSuite) TestNetworkNetworkLinkEndpointDelete() {
 
 func (s *CLITestSuite) TestNetworkNetworkLinkEndpointCreate() {
 	tests := []CLITest{
-		{args: "network network-link endpoint create", fixture: "network/network-link/endpoint/create-missing-args.golden", exitCode: 1},
+		{args: "network network-link endpoint create", fixture: "network/network-link/endpoint/create-missing-flags.golden", exitCode: 1},
+		{args: "network network-link endpoint create --network n-123456 --description 'example network link endpoint' --network-link-service nls-abcde1", fixture: "network/network-link/endpoint/create-no-name.golden"},
 		{args: "network network-link endpoint create my-network-link-endpoint --network n-123456 --description 'example network link endpoint' --network-link-service nls-abcde1", fixture: "network/network-link/endpoint/create.golden"},
 		{args: "network network-link endpoint create nle-duplicate --network n-123455 --network-link-service nls-abcde1", fixture: "network/network-link/endpoint/create-duplicate.golden", exitCode: 1},
 		{args: "network network-link endpoint create nle-same-id --network n-123455 --network-link-service nls-abcde1", fixture: "network/network-link/endpoint/create-same-id.golden", exitCode: 1},

--- a/test/network_test.go
+++ b/test/network_test.go
@@ -645,9 +645,41 @@ func (s *CLITestSuite) TestNetworkNetworkLinkEndpointList() {
 	}
 }
 
+func (s *CLITestSuite) TestNetworkNetworkLinkEndpointDelete() {
+	tests := []CLITest{
+		{args: "network network-link endpoint delete nle-111111 --force", fixture: "network/network-link/endpoint/delete.golden"},
+		{args: "network network-link endpoint delete nle-111111", input: "y\n", fixture: "network/network-link/endpoint/delete-prompt.golden"},
+		{args: "network network-link endpoint delete nle-111111 nle-222222", input: "n\n", fixture: "network/network-link/endpoint/delete-multiple-refuse.golden"},
+		{args: "network network-link endpoint delete nle-111111 nle-222222", input: "y\n", fixture: "network/network-link/endpoint/delete-multiple-success.golden"},
+		{args: "network network-link endpoint delete nle-111111 nle-invalid", fixture: "network/network-link/endpoint/delete-multiple-fail.golden", exitCode: 1},
+		{args: "network network-link endpoint delete nle-invalid --force", fixture: "network/network-link/endpoint/delete-nle-not-exist.golden", exitCode: 1},
+	}
+
+	for _, test := range tests {
+		test.login = "cloud"
+		s.runIntegrationTest(test)
+	}
+}
+
+func (s *CLITestSuite) TestNetworkNetworkLinkEndpointCreate() {
+	tests := []CLITest{
+		{args: "network network-link endpoint create", fixture: "network/network-link/endpoint/create-missing-args.golden", exitCode: 1},
+		{args: "network network-link endpoint create my-network-link-endpoint --network n-123456 --description 'example network link endpoint' --network-link-service nls-abcde1", fixture: "network/network-link/endpoint/create.golden"},
+		{args: "network network-link endpoint create nle-duplicate --network n-123455 --network-link-service nls-abcde1", fixture: "network/network-link/endpoint/create-duplicate.golden", exitCode: 1},
+		{args: "network network-link endpoint create nle-same-id --network n-123455 --network-link-service nls-abcde1", fixture: "network/network-link/endpoint/create-same-id.golden", exitCode: 1},
+	}
+
+	for _, test := range tests {
+		test.login = "cloud"
+		s.runIntegrationTest(test)
+	}
+}
+
 func (s *CLITestSuite) TestNetworkNetworkLinkEndpoint_Autocomplete() {
 	tests := []CLITest{
 		{args: `__complete network network-link endpoint describe ""`, login: "cloud", fixture: "network/network-link/endpoint/describe-autocomplete.golden"},
+		{args: `__complete network network-link endpoint delete ""`, login: "cloud", fixture: "network/network-link/endpoint/delete-autocomplete.golden"},
+		{args: `__complete network network-link endpoint create my-network-link-endpoint --network ""`, login: "cloud", fixture: "network/network-link/endpoint/create-autocomplete.golden"},
 	}
 
 	for _, test := range tests {

--- a/test/test-server/networking_handlers.go
+++ b/test/test-server/networking_handlers.go
@@ -1463,7 +1463,6 @@ func handleNetworkingNetworkLinkEndpointDelete(_ *testing.T, id string) http.Han
 		switch id {
 		case "nle-invalid":
 			w.WriteHeader(http.StatusNotFound)
-			return
 		case "nle-111111", "nle-222222":
 			w.WriteHeader(http.StatusNoContent)
 		}
@@ -1476,15 +1475,14 @@ func handleNetworkingNetworkLinkEndpointCreate(t *testing.T) http.HandlerFunc {
 		err := json.NewDecoder(r.Body).Decode(body)
 		require.NoError(t, err)
 
-		name := body.Spec.GetDisplayName()
-		switch name {
+		switch body.Spec.GetDisplayName() {
 		case "nle-duplicate":
 			w.WriteHeader(http.StatusConflict)
 			err := writeErrorJson(w, "Cannot have more than 1 active/in provision/pending accept/disconnected NetworkLinkEndpoint attached to the same NetworkLinkService in the same network.")
 			require.NoError(t, err)
 		case "nle-same-id":
 			w.WriteHeader(http.StatusConflict)
-			err := writeErrorJson(w, "Network id for NetworkLinkEndpoint and NetworkLinkService cannot be the same.")
+			err := writeErrorJson(w, "Network ID for NetworkLinkEndpoint and NetworkLinkService cannot be the same.")
 			require.NoError(t, err)
 		default:
 			endpoint := networkingv1.NetworkingV1NetworkLinkEndpoint{


### PR DESCRIPTION
What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->
Note that this is merging into the feature branch https://github.com/confluentinc/cli/tree/traffic-8850-network-cli-az. We will merge commits into main from this feature branch after all of the commands for network are implemented.

- Add `confluent network network-link endpoint create`
- Add `confluent network network-link endpoint delete`

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->
[CLI Commands Design](https://confluentinc.atlassian.net/wiki/spaces/PM/pages/2987394300/1-pager+--+Network+CLI)
[Implementation 1-Pager](https://confluentinc.atlassian.net/wiki/spaces/~712020463029eabbac401bbe1b033ce0d3a00e/pages/3136749631/Network+CLI)

Test & Review
-------------
<!--
Has it been tested? How?
Copy and paste any instructions or steps that can save the reviewer time.
-->
Added integration tests.

Performed manual tests.