### PR TITLE
Change to macOS ARM64 Semaphore agents

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -46,7 +46,7 @@ blocks:
     task:
       agent:
         machine:
-          type: s1-prod-macos-13-5-amd64 
+          type: s1-prod-macos-13-5-arm64 
       jobs:
         - name: darwin/amd64
           commands:


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- PLACEHOLDER

New Features
- PLACEHOLDER

Bug Fixes
- PLACEHOLDER

Checklist
---------
- [ ] Leave this box unchecked if features are not yet available in production

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->
This changes the Semaphore pipeline to macOS ARM64 agents instead of AMD64 agents. The ARM64 agents perform better.

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
<!--
Has it been tested? How?
Copy and paste any instructions or steps that can save the reviewer time.
-->