### PR TITLE
[TRAFFIC-9345] Add confluent network network-link endpoint update

### DIFF
--- a/internal/network/command_network_link_endpoint.go
+++ b/internal/network/command_network_link_endpoint.go
@@ -32,6 +32,7 @@ func (c *command) newNetworkLinkEndpointCommand() *cobra.Command {
 	cmd.AddCommand(c.newNetworkLinkEndpointDeleteCommand())
 	cmd.AddCommand(c.newNetworkLinkEndpointDescribeCommand())
 	cmd.AddCommand(c.newNetworkLinkEndpointListCommand())
+	cmd.AddCommand(c.newNetworkLinkEndpointUpdateCommand())
 
 	return cmd
 }

--- a/internal/network/command_network_link_endpoint_update.go
+++ b/internal/network/command_network_link_endpoint_update.go
@@ -1,0 +1,72 @@
+package network
+
+import (
+	"github.com/spf13/cobra"
+
+	networkingv1 "github.com/confluentinc/ccloud-sdk-go-v2/networking/v1"
+
+	pcmd "github.com/confluentinc/cli/v3/pkg/cmd"
+	"github.com/confluentinc/cli/v3/pkg/examples"
+)
+
+func (c *command) newNetworkLinkEndpointUpdateCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:               "update <id>",
+		Short:             "Update an existing network link endpoint.",
+		Args:              cobra.ExactArgs(1),
+		ValidArgsFunction: pcmd.NewValidArgsFunction(c.validNetworkLinkEndpointArgs),
+		RunE:              c.networkLinkEndpointUpdate,
+		Example: examples.BuildExampleString(
+			examples.Example{
+				Text: `Update the name and description of network link endpoint "nle-123456".`,
+				Code: `confluent network network-link endpoint update nle-123456 --name my-network-link-endpoint --description "example network link endpoint"`,
+			},
+		),
+	}
+
+	cmd.Flags().String("name", "", "Name of the network link endpoint.")
+	cmd.Flags().String("description", "", "Description of the network link endpoint.")
+	pcmd.AddContextFlag(cmd, c.CLICommand)
+	pcmd.AddEnvironmentFlag(cmd, c.AuthenticatedCLICommand)
+	pcmd.AddOutputFlag(cmd)
+
+	cmd.MarkFlagsOneRequired("name", "description")
+
+	return cmd
+}
+
+func (c *command) networkLinkEndpointUpdate(cmd *cobra.Command, args []string) error {
+	environmentId, err := c.Context.EnvironmentId()
+	if err != nil {
+		return err
+	}
+
+	updateNetworkLinkEndpoint := networkingv1.NetworkingV1NetworkLinkEndpointUpdate{
+		Spec: &networkingv1.NetworkingV1NetworkLinkEndpointSpecUpdate{
+			Environment: &networkingv1.GlobalObjectReference{Id: environmentId},
+		},
+	}
+
+	if cmd.Flags().Changed("name") {
+		name, err := cmd.Flags().GetString("name")
+		if err != nil {
+			return err
+		}
+		updateNetworkLinkEndpoint.Spec.SetDisplayName(name)
+	}
+
+	if cmd.Flags().Changed("description") {
+		description, err := cmd.Flags().GetString("description")
+		if err != nil {
+			return err
+		}
+		updateNetworkLinkEndpoint.Spec.SetDescription(description)
+	}
+
+	endpoint, err := c.V2Client.UpdateNetworkLinkEndpoint(args[0], updateNetworkLinkEndpoint)
+	if err != nil {
+		return err
+	}
+
+	return printNetworkLinkEndpointTable(cmd, endpoint)
+}

--- a/pkg/ccloudv2/networking.go
+++ b/pkg/ccloudv2/networking.go
@@ -317,3 +317,8 @@ func (c *Client) CreateNetworkLinkEndpoint(endpoint networkingv1.NetworkingV1Net
 	resp, httpResp, err := c.NetworkingClient.NetworkLinkEndpointsNetworkingV1Api.CreateNetworkingV1NetworkLinkEndpoint(c.networkingApiContext()).NetworkingV1NetworkLinkEndpoint(endpoint).Execute()
 	return resp, errors.CatchCCloudV2Error(err, httpResp)
 }
+
+func (c *Client) UpdateNetworkLinkEndpoint(id string, networkLinkEndpointUpdate networkingv1.NetworkingV1NetworkLinkEndpointUpdate) (networkingv1.NetworkingV1NetworkLinkEndpoint, error) {
+	resp, httpResp, err := c.NetworkingClient.NetworkLinkEndpointsNetworkingV1Api.UpdateNetworkingV1NetworkLinkEndpoint(c.networkingApiContext(), id).NetworkingV1NetworkLinkEndpointUpdate(networkLinkEndpointUpdate).Execute()
+	return resp, errors.CatchCCloudV2Error(err, httpResp)
+}

--- a/test/fixtures/output/network/network-link/endpoint/help.golden
+++ b/test/fixtures/output/network/network-link/endpoint/help.golden
@@ -8,6 +8,7 @@ Available Commands:
   delete      Delete one or more network link endpoints.
   describe    Describe a network link endpoint.
   list        List network link endpoints.
+  update      Update an existing network link endpoint.
 
 Global Flags:
   -h, --help            Show help for this command.

--- a/test/fixtures/output/network/network-link/endpoint/update-autocomplete.golden
+++ b/test/fixtures/output/network/network-link/endpoint/update-autocomplete.golden
@@ -1,0 +1,7 @@
+--name	Name of the network link endpoint.
+--description	Description of the network link endpoint.
+nle-111111	my-network-link-endpoint-1
+nle-222222	my-network-link-endpoint-2
+nle-333333	my-network-link-endpoint-3
+:4
+Completion ended with directive: ShellCompDirectiveNoFileComp

--- a/test/fixtures/output/network/network-link/endpoint/update-help.golden
+++ b/test/fixtures/output/network/network-link/endpoint/update-help.golden
@@ -1,0 +1,21 @@
+Update an existing network link endpoint.
+
+Usage:
+  confluent network network-link endpoint update <id> [flags]
+
+Examples:
+Update the name and description of network link endpoint "nle-123456".
+
+  $ confluent network network-link endpoint update nle-123456 --name my-network-link-endpoint --description "example network link endpoint"
+
+Flags:
+      --name string          Name of the network link endpoint.
+      --description string   Description of the network link endpoint.
+      --context string       CLI context name.
+      --environment string   Environment ID.
+  -o, --output string        Specify the output format as "human", "json", or "yaml". (default "human")
+
+Global Flags:
+  -h, --help            Show help for this command.
+      --unsafe-trace    Equivalent to -vvvv, but also log HTTP requests and responses which might contain plaintext secrets.
+  -v, --verbose count   Increase verbosity (-v for warn, -vv for info, -vvv for debug, -vvvv for trace).

--- a/test/fixtures/output/network/network-link/endpoint/update-missing-args.golden
+++ b/test/fixtures/output/network/network-link/endpoint/update-missing-args.golden
@@ -1,0 +1,21 @@
+Error: accepts 1 arg(s), received 0
+Usage:
+  confluent network network-link endpoint update <id> [flags]
+
+Examples:
+Update the name and description of network link endpoint "nle-123456".
+
+  $ confluent network network-link endpoint update nle-123456 --name my-network-link-endpoint --description "example network link endpoint"
+
+Flags:
+      --name string          Name of the network link endpoint.
+      --description string   Description of the network link endpoint.
+      --context string       CLI context name.
+      --environment string   Environment ID.
+  -o, --output string        Specify the output format as "human", "json", or "yaml". (default "human")
+
+Global Flags:
+  -h, --help            Show help for this command.
+      --unsafe-trace    Equivalent to -vvvv, but also log HTTP requests and responses which might contain plaintext secrets.
+  -v, --verbose count   Increase verbosity (-v for warn, -vv for info, -vvv for debug, -vvvv for trace).
+

--- a/test/fixtures/output/network/network-link/endpoint/update-missing-flags.golden
+++ b/test/fixtures/output/network/network-link/endpoint/update-missing-flags.golden
@@ -1,0 +1,21 @@
+Error: at least one of the flags in the group [name description] is required
+Usage:
+  confluent network network-link endpoint update <id> [flags]
+
+Examples:
+Update the name and description of network link endpoint "nle-123456".
+
+  $ confluent network network-link endpoint update nle-123456 --name my-network-link-endpoint --description "example network link endpoint"
+
+Flags:
+      --name string          Name of the network link endpoint.
+      --description string   Description of the network link endpoint.
+      --context string       CLI context name.
+      --environment string   Environment ID.
+  -o, --output string        Specify the output format as "human", "json", or "yaml". (default "human")
+
+Global Flags:
+  -h, --help            Show help for this command.
+      --unsafe-trace    Equivalent to -vvvv, but also log HTTP requests and responses which might contain plaintext secrets.
+  -v, --verbose count   Increase verbosity (-v for warn, -vv for info, -vvv for debug, -vvvv for trace).
+

--- a/test/fixtures/output/network/network-link/endpoint/update-name-description.golden
+++ b/test/fixtures/output/network/network-link/endpoint/update-name-description.golden
@@ -1,0 +1,9 @@
++----------------------+-----------------------------------+
+| ID                   | nle-111111                        |
+| Name                 | my-new-network-link-endpoint      |
+| Network              | n-abcde1                          |
+| Environment          | env-00000                         |
+| Description          | example new network link endpoint |
+| Network Link Service | nls-123456                        |
+| Phase                | READY                             |
++----------------------+-----------------------------------+

--- a/test/fixtures/output/network/network-link/endpoint/update-nle-not-exist.golden
+++ b/test/fixtures/output/network/network-link/endpoint/update-nle-not-exist.golden
@@ -1,0 +1,1 @@
+Error: The network link endpoint nle-invalid was not found.: 404 Not Found

--- a/test/fixtures/output/network/network-link/endpoint/update.golden
+++ b/test/fixtures/output/network/network-link/endpoint/update.golden
@@ -1,0 +1,9 @@
++----------------------+-------------------------------+
+| ID                   | nle-111111                    |
+| Name                 | my-new-network-link-endpoint  |
+| Network              | n-abcde1                      |
+| Environment          | env-00000                     |
+| Description          | example network link endpoint |
+| Network Link Service | nls-123456                    |
+| Phase                | READY                         |
++----------------------+-------------------------------+

--- a/test/network_test.go
+++ b/test/network_test.go
@@ -605,7 +605,7 @@ func (s *CLITestSuite) TestNetworkNetworkLinkServiceDelete() {
 	}
 }
 
-func (s *CLITestSuite) TestNetworkLinkServiceCreate() {
+func (s *CLITestSuite) TestNetworkNetworkLinkServiceCreate() {
 	tests := []CLITest{
 		{args: "network network-link service create", fixture: "network/network-link/service/create-missing-args.golden", exitCode: 1},
 		{args: "network network-link service create my-network-link-service --network n-123456 --description 'example network link service' --accepted-environments env-11111,env-22222", fixture: "network/network-link/service/create-accepted-environments.golden"},
@@ -709,11 +709,27 @@ func (s *CLITestSuite) TestNetworkNetworkLinkEndpointCreate() {
 	}
 }
 
+func (s *CLITestSuite) TestNetworkNetworkLinkEndpointUpdate() {
+	tests := []CLITest{
+		{args: "network network-link endpoint update", fixture: "network/network-link/endpoint/update-missing-args.golden", exitCode: 1},
+		{args: "network network-link endpoint update nle-111111", fixture: "network/network-link/endpoint/update-missing-flags.golden", exitCode: 1},
+		{args: "network nl endpoint update nle-111111 --name my-new-network-link-endpoint", fixture: "network/network-link/endpoint/update.golden"},
+		{args: "network network-link endpoint update nle-111111 --name my-new-network-link-endpoint --description 'example new network link endpoint'", fixture: "network/network-link/endpoint/update-name-description.golden"},
+		{args: "network network-link endpoint update nle-invalid --name 'my-network-link-endpoint'", fixture: "network/network-link/endpoint/update-nle-not-exist.golden", exitCode: 1},
+	}
+
+	for _, test := range tests {
+		test.login = "cloud"
+		s.runIntegrationTest(test)
+	}
+}
+
 func (s *CLITestSuite) TestNetworkNetworkLinkEndpoint_Autocomplete() {
 	tests := []CLITest{
 		{args: `__complete network network-link endpoint describe ""`, login: "cloud", fixture: "network/network-link/endpoint/describe-autocomplete.golden"},
 		{args: `__complete network network-link endpoint delete ""`, login: "cloud", fixture: "network/network-link/endpoint/delete-autocomplete.golden"},
 		{args: `__complete network network-link endpoint create my-network-link-endpoint --network ""`, login: "cloud", fixture: "network/network-link/endpoint/create-autocomplete.golden"},
+		{args: `__complete network network-link endpoint update ""`, login: "cloud", fixture: "network/network-link/endpoint/update-autocomplete.golden"},
 	}
 
 	for _, test := range tests {

--- a/test/test-server/networking_handlers.go
+++ b/test/test-server/networking_handlers.go
@@ -224,6 +224,8 @@ func handleNetworkingNetworkLinkEndpoint(t *testing.T) http.HandlerFunc {
 			handleNetworkingNetworkLinkEndpointGet(t, id)(w, r)
 		case http.MethodDelete:
 			handleNetworkingNetworkLinkEndpointDelete(t, id)(w, r)
+		case http.MethodPatch:
+			handleNetworkingNetworkLinkEndpointUpdate(t, id)(w, r)
 		}
 	}
 }
@@ -1645,6 +1647,31 @@ func handleNetworkingNetworkLinkEndpointCreate(t *testing.T) http.HandlerFunc {
 					NetworkLinkService: &networkingv1.EnvScopedObjectReference{Id: body.Spec.NetworkLinkService.GetId()},
 				},
 				Status: &networkingv1.NetworkingV1NetworkLinkEndpointStatus{Phase: "PENDING_ACCEPT"},
+			}
+			err = json.NewEncoder(w).Encode(endpoint)
+			require.NoError(t, err)
+		}
+	}
+}
+
+func handleNetworkingNetworkLinkEndpointUpdate(t *testing.T, id string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		switch id {
+		case "nle-invalid":
+			w.WriteHeader(http.StatusNotFound)
+			err := writeErrorJson(w, "The network link endpoint nle-invalid was not found.")
+			require.NoError(t, err)
+		default:
+			body := &networkingv1.NetworkingV1NetworkLinkEndpoint{}
+			err := json.NewDecoder(r.Body).Decode(body)
+			require.NoError(t, err)
+
+			endpoint := getNetworkLinkEndpoint("nle-111111", "my-network-link-endpoint")
+			if body.Spec.DisplayName != nil {
+				endpoint.Spec.SetDisplayName(body.Spec.GetDisplayName())
+			}
+			if body.Spec.Description != nil {
+				endpoint.Spec.SetDescription(body.Spec.GetDescription())
 			}
 			err = json.NewEncoder(w).Encode(endpoint)
 			require.NoError(t, err)


### PR DESCRIPTION
What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->
Note that this is merging into the feature branch https://github.com/confluentinc/cli/tree/traffic-8850-network-cli-az. We will merge commits into main from this feature branch after all of the commands for network are implemented.

- Add confluent network network-link endpoint update

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->
[CLI Commands Design](https://confluentinc.atlassian.net/wiki/spaces/PM/pages/2987394300/1-pager+--+Network+CLI)
[Implementation 1-Pager](https://confluentinc.atlassian.net/wiki/spaces/~712020463029eabbac401bbe1b033ce0d3a00e/pages/3136749631/Network+CLI)

Test & Review
-------------
<!--
Has it been tested? How?
Copy and paste any instructions or steps that can save the reviewer time.
-->
Added integration tests.

Performed manual tests.