### PR TITLE
feat: add environment id to output of compute pool commands

### DIFF
--- a/internal/flink/command_compute_pool.go
+++ b/internal/flink/command_compute_pool.go
@@ -5,14 +5,15 @@ import (
 )
 
 type computePoolOut struct {
-	IsCurrent  bool   `human:"Current" serialized:"is_current"`
-	Id         string `human:"ID" serialized:"id"`
-	Name       string `human:"Name" serialized:"name"`
-	CurrentCfu int32  `human:"Current CFU" serialized:"currrent_cfu"`
-	MaxCfu     int32  `human:"Max CFU" serialized:"max_cfu"`
-	Cloud      string `human:"Cloud" serialized:"cloud"`
-	Region     string `human:"Region" serialized:"region"`
-	Status     string `human:"Status" serialized:"status"`
+	IsCurrent   bool   `human:"Current" serialized:"is_current"`
+	Id          string `human:"ID" serialized:"id"`
+	Name        string `human:"Name" serialized:"name"`
+	Environment string `human:"Environment" serialized:"environment"`
+	CurrentCfu  int32  `human:"Current CFU" serialized:"currrent_cfu"`
+	MaxCfu      int32  `human:"Max CFU" serialized:"max_cfu"`
+	Cloud       string `human:"Cloud" serialized:"cloud"`
+	Region      string `human:"Region" serialized:"region"`
+	Status      string `human:"Status" serialized:"status"`
 }
 
 func (c *command) newComputePoolCommand() *cobra.Command {

--- a/internal/flink/command_compute_pool_create.go
+++ b/internal/flink/command_compute_pool_create.go
@@ -79,13 +79,12 @@ func (c *command) computePoolCreate(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	computePoolEnv := computePool.Spec.GetEnvironment()
 	table := output.NewTable(cmd)
 	table.Add(&computePoolOut{
 		IsCurrent:   computePool.GetId() == c.Context.GetCurrentFlinkComputePool(),
 		Id:          computePool.GetId(),
 		Name:        computePool.Spec.GetDisplayName(),
-		Environment: computePoolEnv.GetId(),
+		Environment: computePool.Spec.Environment.GetId(),
 		CurrentCfu:  computePool.Status.GetCurrentCfu(),
 		MaxCfu:      computePool.Spec.GetMaxCfu(),
 		Cloud:       computePool.Spec.GetCloud(),

--- a/internal/flink/command_compute_pool_create.go
+++ b/internal/flink/command_compute_pool_create.go
@@ -79,16 +79,18 @@ func (c *command) computePoolCreate(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	computePoolEnv := computePool.Spec.GetEnvironment()
 	table := output.NewTable(cmd)
 	table.Add(&computePoolOut{
-		IsCurrent:  computePool.GetId() == c.Context.GetCurrentFlinkComputePool(),
-		Id:         computePool.GetId(),
-		Name:       computePool.Spec.GetDisplayName(),
-		CurrentCfu: computePool.Status.GetCurrentCfu(),
-		MaxCfu:     computePool.Spec.GetMaxCfu(),
-		Cloud:      computePool.Spec.GetCloud(),
-		Region:     computePool.Spec.GetRegion(),
-		Status:     computePool.Status.GetPhase(),
+		IsCurrent:   computePool.GetId() == c.Context.GetCurrentFlinkComputePool(),
+		Id:          computePool.GetId(),
+		Name:        computePool.Spec.GetDisplayName(),
+		Environment: computePoolEnv.GetId(),
+		CurrentCfu:  computePool.Status.GetCurrentCfu(),
+		MaxCfu:      computePool.Spec.GetMaxCfu(),
+		Cloud:       computePool.Spec.GetCloud(),
+		Region:      computePool.Spec.GetRegion(),
+		Status:      computePool.Status.GetPhase(),
 	})
 	return table.Print()
 }

--- a/internal/flink/command_compute_pool_describe.go
+++ b/internal/flink/command_compute_pool_describe.go
@@ -45,16 +45,18 @@ func (c *command) computePoolDescribe(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	computePoolEnv := computePool.Spec.GetEnvironment()
 	table := output.NewTable(cmd)
 	table.Add(&computePoolOut{
-		IsCurrent:  computePool.GetId() == c.Context.GetCurrentFlinkComputePool(),
-		Id:         computePool.GetId(),
-		Name:       computePool.Spec.GetDisplayName(),
-		CurrentCfu: computePool.Status.GetCurrentCfu(),
-		MaxCfu:     computePool.Spec.GetMaxCfu(),
-		Cloud:      computePool.Spec.GetCloud(),
-		Region:     computePool.Spec.GetRegion(),
-		Status:     computePool.Status.GetPhase(),
+		IsCurrent:   computePool.GetId() == c.Context.GetCurrentFlinkComputePool(),
+		Id:          computePool.GetId(),
+		Name:        computePool.Spec.GetDisplayName(),
+		Environment: computePoolEnv.GetId(),
+		CurrentCfu:  computePool.Status.GetCurrentCfu(),
+		MaxCfu:      computePool.Spec.GetMaxCfu(),
+		Cloud:       computePool.Spec.GetCloud(),
+		Region:      computePool.Spec.GetRegion(),
+		Status:      computePool.Status.GetPhase(),
 	})
 	return table.Print()
 }

--- a/internal/flink/command_compute_pool_describe.go
+++ b/internal/flink/command_compute_pool_describe.go
@@ -45,13 +45,12 @@ func (c *command) computePoolDescribe(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	computePoolEnv := computePool.Spec.GetEnvironment()
 	table := output.NewTable(cmd)
 	table.Add(&computePoolOut{
 		IsCurrent:   computePool.GetId() == c.Context.GetCurrentFlinkComputePool(),
 		Id:          computePool.GetId(),
 		Name:        computePool.Spec.GetDisplayName(),
-		Environment: computePoolEnv.GetId(),
+		Environment: computePool.Spec.Environment.GetId(),
 		CurrentCfu:  computePool.Status.GetCurrentCfu(),
 		MaxCfu:      computePool.Spec.GetMaxCfu(),
 		Cloud:       computePool.Spec.GetCloud(),

--- a/internal/flink/command_compute_pool_list.go
+++ b/internal/flink/command_compute_pool_list.go
@@ -40,12 +40,11 @@ func (c *command) computePoolList(cmd *cobra.Command, _ []string) error {
 
 	list := output.NewList(cmd)
 	for _, computePool := range computePools {
-		computePoolEnv := computePool.Spec.GetEnvironment()
 		list.Add(&computePoolOut{
 			IsCurrent:   computePool.GetId() == c.Context.GetCurrentFlinkComputePool(),
 			Id:          computePool.GetId(),
 			Name:        computePool.Spec.GetDisplayName(),
-			Environment: computePoolEnv.GetId(),
+			Environment: computePool.Spec.Environment.GetId(),
 			CurrentCfu:  computePool.Status.GetCurrentCfu(),
 			MaxCfu:      computePool.Spec.GetMaxCfu(),
 			Cloud:       computePool.Spec.GetCloud(),

--- a/internal/flink/command_compute_pool_list.go
+++ b/internal/flink/command_compute_pool_list.go
@@ -40,15 +40,17 @@ func (c *command) computePoolList(cmd *cobra.Command, _ []string) error {
 
 	list := output.NewList(cmd)
 	for _, computePool := range computePools {
+		computePoolEnv := computePool.Spec.GetEnvironment()
 		list.Add(&computePoolOut{
-			IsCurrent:  computePool.GetId() == c.Context.GetCurrentFlinkComputePool(),
-			Id:         computePool.GetId(),
-			Name:       computePool.Spec.GetDisplayName(),
-			CurrentCfu: computePool.Status.GetCurrentCfu(),
-			MaxCfu:     computePool.Spec.GetMaxCfu(),
-			Cloud:      computePool.Spec.GetCloud(),
-			Region:     computePool.Spec.GetRegion(),
-			Status:     computePool.Status.GetPhase(),
+			IsCurrent:   computePool.GetId() == c.Context.GetCurrentFlinkComputePool(),
+			Id:          computePool.GetId(),
+			Name:        computePool.Spec.GetDisplayName(),
+			Environment: computePoolEnv.GetId(),
+			CurrentCfu:  computePool.Status.GetCurrentCfu(),
+			MaxCfu:      computePool.Spec.GetMaxCfu(),
+			Cloud:       computePool.Spec.GetCloud(),
+			Region:      computePool.Spec.GetRegion(),
+			Status:      computePool.Status.GetPhase(),
 		})
 	}
 	return list.Print()

--- a/internal/flink/command_compute_pool_update.go
+++ b/internal/flink/command_compute_pool_update.go
@@ -96,13 +96,12 @@ func (c *command) computePoolUpdate(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	updatedComputePoolEnv := updatedComputePool.Spec.GetEnvironment()
 	table := output.NewTable(cmd)
 	table.Add(&computePoolOut{
 		IsCurrent:   computePool.GetId() == c.Context.GetCurrentFlinkComputePool(),
 		Id:          computePool.GetId(),
 		Name:        updatedComputePool.Spec.GetDisplayName(),
-		Environment: updatedComputePoolEnv.GetId(),
+		Environment: updatedComputePool.Spec.Environment.GetId(),
 		CurrentCfu:  computePool.Status.GetCurrentCfu(),
 		MaxCfu:      updatedComputePool.Spec.GetMaxCfu(),
 		Cloud:       computePool.Spec.GetCloud(),

--- a/internal/flink/command_compute_pool_update.go
+++ b/internal/flink/command_compute_pool_update.go
@@ -96,16 +96,18 @@ func (c *command) computePoolUpdate(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	updatedComputePoolEnv := updatedComputePool.Spec.GetEnvironment()
 	table := output.NewTable(cmd)
 	table.Add(&computePoolOut{
-		IsCurrent:  computePool.GetId() == c.Context.GetCurrentFlinkComputePool(),
-		Id:         computePool.GetId(),
-		Name:       updatedComputePool.Spec.GetDisplayName(),
-		CurrentCfu: computePool.Status.GetCurrentCfu(),
-		MaxCfu:     updatedComputePool.Spec.GetMaxCfu(),
-		Cloud:      computePool.Spec.GetCloud(),
-		Region:     computePool.Spec.GetRegion(),
-		Status:     computePool.Status.GetPhase(),
+		IsCurrent:   computePool.GetId() == c.Context.GetCurrentFlinkComputePool(),
+		Id:          computePool.GetId(),
+		Name:        updatedComputePool.Spec.GetDisplayName(),
+		Environment: updatedComputePoolEnv.GetId(),
+		CurrentCfu:  computePool.Status.GetCurrentCfu(),
+		MaxCfu:      updatedComputePool.Spec.GetMaxCfu(),
+		Cloud:       computePool.Spec.GetCloud(),
+		Region:      computePool.Spec.GetRegion(),
+		Status:      computePool.Status.GetPhase(),
 	})
 	return table.Print()
 }

--- a/test/fixtures/output/flink/compute-pool/create.golden
+++ b/test/fixtures/output/flink/compute-pool/create.golden
@@ -2,6 +2,7 @@
 | Current     | false           |
 | ID          | lfcp-123456     |
 | Name        | my-compute-pool |
+| Environment | env-596         |
 | Current CFU | 0               |
 | Max CFU     | 5               |
 | Cloud       | AWS             |

--- a/test/fixtures/output/flink/compute-pool/describe-after-use.golden
+++ b/test/fixtures/output/flink/compute-pool/describe-after-use.golden
@@ -2,6 +2,7 @@
 | Current     | true              |
 | ID          | lfcp-123456       |
 | Name        | my-compute-pool-1 |
+| Environment | env-123           |
 | Current CFU | 0                 |
 | Max CFU     | 1                 |
 | Cloud       | AWS               |

--- a/test/fixtures/output/flink/compute-pool/describe.golden
+++ b/test/fixtures/output/flink/compute-pool/describe.golden
@@ -2,6 +2,7 @@
 | Current     | false             |
 | ID          | lfcp-123456       |
 | Name        | my-compute-pool-1 |
+| Environment | env-123           |
 | Current CFU | 0                 |
 | Max CFU     | 1                 |
 | Cloud       | AWS               |

--- a/test/fixtures/output/flink/compute-pool/list-after-use.golden
+++ b/test/fixtures/output/flink/compute-pool/list-after-use.golden
@@ -1,4 +1,4 @@
-  Current |     ID      |       Name        | Current CFU | Max CFU | Cloud |  Region   |   Status     
-----------+-------------+-------------------+-------------+---------+-------+-----------+--------------
-  *       | lfcp-123456 | my-compute-pool-1 |           0 |       1 | AWS   | us-west-1 | PROVISIONED  
-          | lfcp-222222 | my-compute-pool-2 |           0 |       2 | AWS   | us-west-2 | PROVISIONED  
+  Current |     ID      |       Name        | Environment | Current CFU | Max CFU | Cloud |  Region   |   Status     
+----------+-------------+-------------------+-------------+-------------+---------+-------+-----------+--------------
+  *       | lfcp-123456 | my-compute-pool-1 | env-123     |           0 |       1 | AWS   | us-west-1 | PROVISIONED  
+          | lfcp-222222 | my-compute-pool-2 | env-456     |           0 |       2 | AWS   | us-west-2 | PROVISIONED  

--- a/test/fixtures/output/flink/compute-pool/list-region.golden
+++ b/test/fixtures/output/flink/compute-pool/list-region.golden
@@ -1,3 +1,3 @@
-  Current |     ID      |       Name        | Current CFU | Max CFU | Cloud |  Region   |   Status     
-----------+-------------+-------------------+-------------+---------+-------+-----------+--------------
-          | lfcp-222222 | my-compute-pool-2 |           0 |       2 | AWS   | us-west-2 | PROVISIONED  
+  Current |     ID      |       Name        | Environment | Current CFU | Max CFU | Cloud |  Region   |   Status     
+----------+-------------+-------------------+-------------+-------------+---------+-------+-----------+--------------
+          | lfcp-222222 | my-compute-pool-2 | env-456     |           0 |       2 | AWS   | us-west-2 | PROVISIONED  

--- a/test/fixtures/output/flink/compute-pool/list.golden
+++ b/test/fixtures/output/flink/compute-pool/list.golden
@@ -1,4 +1,4 @@
-  Current |     ID      |       Name        | Current CFU | Max CFU | Cloud |  Region   |   Status     
-----------+-------------+-------------------+-------------+---------+-------+-----------+--------------
-          | lfcp-123456 | my-compute-pool-1 |           0 |       1 | AWS   | us-west-1 | PROVISIONED  
-          | lfcp-222222 | my-compute-pool-2 |           0 |       2 | AWS   | us-west-2 | PROVISIONED  
+  Current |     ID      |       Name        | Environment | Current CFU | Max CFU | Cloud |  Region   |   Status     
+----------+-------------+-------------------+-------------+-------------+---------+-------+-----------+--------------
+          | lfcp-123456 | my-compute-pool-1 | env-123     |           0 |       1 | AWS   | us-west-1 | PROVISIONED  
+          | lfcp-222222 | my-compute-pool-2 | env-456     |           0 |       2 | AWS   | us-west-2 | PROVISIONED  

--- a/test/fixtures/output/flink/compute-pool/update-after-use.golden
+++ b/test/fixtures/output/flink/compute-pool/update-after-use.golden
@@ -2,6 +2,7 @@
 | Current     | true              |
 | ID          | lfcp-123456       |
 | Name        | my-compute-pool-1 |
+| Environment | env-123           |
 | Current CFU | 0                 |
 | Max CFU     | 5                 |
 | Cloud       | AWS               |

--- a/test/fixtures/output/flink/compute-pool/update.golden
+++ b/test/fixtures/output/flink/compute-pool/update.golden
@@ -2,6 +2,7 @@
 | Current     | false             |
 | ID          | lfcp-123456       |
 | Name        | my-compute-pool-1 |
+| Environment | env-123           |
 | Current CFU | 0                 |
 | Max CFU     | 5                 |
 | Cloud       | AWS               |

--- a/test/test-server/fcpm_handlers.go
+++ b/test/test-server/fcpm_handlers.go
@@ -25,6 +25,7 @@ func handleFcpmComputePools(t *testing.T) http.HandlerFunc {
 					MaxCfu:      flinkv2.PtrInt32(1),
 					Region:      flinkv2.PtrString("us-west-1"),
 					Cloud:       flinkv2.PtrString("AWS"),
+					Environment: flinkv2.NewGlobalObjectReference("env-123", "-", "-"),
 				},
 				Status: &flinkv2.FcpmV2ComputePoolStatus{Phase: "PROVISIONED"},
 			}
@@ -35,6 +36,7 @@ func handleFcpmComputePools(t *testing.T) http.HandlerFunc {
 					MaxCfu:      flinkv2.PtrInt32(2),
 					Region:      flinkv2.PtrString("us-west-2"),
 					Cloud:       flinkv2.PtrString("AWS"),
+					Environment: flinkv2.NewGlobalObjectReference("env-456", "-", "-"),
 				},
 				Status: &flinkv2.FcpmV2ComputePoolStatus{Phase: "PROVISIONED"},
 			}
@@ -81,6 +83,7 @@ func handleFcpmComputePoolsId(t *testing.T) http.HandlerFunc {
 					MaxCfu:       flinkv2.PtrInt32(1),
 					Cloud:        flinkv2.PtrString("AWS"),
 					Region:       flinkv2.PtrString("us-west-2"),
+					Environment:  flinkv2.NewGlobalObjectReference("env-123", "-", "-"),
 				},
 				Status: &flinkv2.FcpmV2ComputePoolStatus{Phase: "PROVISIONED"},
 			}
@@ -99,6 +102,7 @@ func handleFcpmComputePoolsId(t *testing.T) http.HandlerFunc {
 					MaxCfu:      flinkv2.PtrInt32(update.Spec.GetMaxCfu()),
 					Cloud:       flinkv2.PtrString("AWS"),
 					Region:      flinkv2.PtrString("us-west-2"),
+					Environment: flinkv2.NewGlobalObjectReference("env-123", "-", "-"),
 				},
 				Status: &flinkv2.FcpmV2ComputePoolStatus{Phase: "PROVISIONED"},
 			}

--- a/test/test-server/fcpm_handlers.go
+++ b/test/test-server/fcpm_handlers.go
@@ -25,7 +25,9 @@ func handleFcpmComputePools(t *testing.T) http.HandlerFunc {
 					MaxCfu:      flinkv2.PtrInt32(1),
 					Region:      flinkv2.PtrString("us-west-1"),
 					Cloud:       flinkv2.PtrString("AWS"),
-					Environment: flinkv2.NewGlobalObjectReference("env-123", "-", "-"),
+					Environment: &flinkv2.GlobalObjectReference{
+						Id: "env-123",
+					},
 				},
 				Status: &flinkv2.FcpmV2ComputePoolStatus{Phase: "PROVISIONED"},
 			}
@@ -36,7 +38,9 @@ func handleFcpmComputePools(t *testing.T) http.HandlerFunc {
 					MaxCfu:      flinkv2.PtrInt32(2),
 					Region:      flinkv2.PtrString("us-west-2"),
 					Cloud:       flinkv2.PtrString("AWS"),
-					Environment: flinkv2.NewGlobalObjectReference("env-456", "-", "-"),
+					Environment: &flinkv2.GlobalObjectReference{
+						Id: "env-456",
+					},
 				},
 				Status: &flinkv2.FcpmV2ComputePoolStatus{Phase: "PROVISIONED"},
 			}
@@ -83,7 +87,9 @@ func handleFcpmComputePoolsId(t *testing.T) http.HandlerFunc {
 					MaxCfu:       flinkv2.PtrInt32(1),
 					Cloud:        flinkv2.PtrString("AWS"),
 					Region:       flinkv2.PtrString("us-west-2"),
-					Environment:  flinkv2.NewGlobalObjectReference("env-123", "-", "-"),
+					Environment: &flinkv2.GlobalObjectReference{
+						Id: "env-123",
+					},
 				},
 				Status: &flinkv2.FcpmV2ComputePoolStatus{Phase: "PROVISIONED"},
 			}
@@ -102,7 +108,9 @@ func handleFcpmComputePoolsId(t *testing.T) http.HandlerFunc {
 					MaxCfu:      flinkv2.PtrInt32(update.Spec.GetMaxCfu()),
 					Cloud:       flinkv2.PtrString("AWS"),
 					Region:      flinkv2.PtrString("us-west-2"),
-					Environment: flinkv2.NewGlobalObjectReference("env-123", "-", "-"),
+					Environment: &flinkv2.GlobalObjectReference{
+						Id: "env-123",
+					},
 				},
 				Status: &flinkv2.FcpmV2ComputePoolStatus{Phase: "PROVISIONED"},
 			}


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

New Features
- [Early Access] Add "Environment" field to the output of the `confluent flink compute-pool` commands

Checklist
---------
- [x] Leave this box unchecked if features are not yet available in production

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->
Added the environment id to the output of compute pool commands

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
<!--
Has it been tested? How?
Copy and paste any instructions or steps that can save the reviewer time.
-->