### PR TITLE
feat: add AltEnter shortcut as command termination trigger

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,7 @@ require (
 	github.com/confluentinc/confluent-kafka-go v1.9.3-RC3
 	github.com/confluentinc/go-editor v0.11.0
 	github.com/confluentinc/go-netrc v0.0.0-20220321173724-4d50f36ff450
-	github.com/confluentinc/go-prompt v0.2.19
+	github.com/confluentinc/go-prompt v0.2.23
 	github.com/confluentinc/go-ps1 v1.0.2
 	github.com/confluentinc/kafka-rest-sdk-go/kafkarestv3 v0.3.17
 	github.com/confluentinc/mds-sdk-go-public/mdsv1 v0.0.0-20230117192233-7e6d894d74a9

--- a/go.sum
+++ b/go.sum
@@ -167,8 +167,8 @@ github.com/confluentinc/go-editor v0.11.0 h1:fcEALYHj7xV/fRSp54/IHi2DS4GlZMJWVgr
 github.com/confluentinc/go-editor v0.11.0/go.mod h1:nEjwqdqx8S7ZGjXsDvRgawsA04Fu2P/KAtA8fa5afMI=
 github.com/confluentinc/go-netrc v0.0.0-20220321173724-4d50f36ff450 h1:YJq9ZRhj049uo3hX7V8imJid+FJEBFyRmVcdruhU3y4=
 github.com/confluentinc/go-netrc v0.0.0-20220321173724-4d50f36ff450/go.mod h1:GGVB1yDj9YYQTxoo5vTRGWuQKccGN00bvyit4O5jznI=
-github.com/confluentinc/go-prompt v0.2.19 h1:R579FzoZVUfvtyO6x1UhFngTNuqYqIl/rhByTIpNr2U=
-github.com/confluentinc/go-prompt v0.2.19/go.mod h1:4/tf63YzhSsiXnsKosCmv1H0ivpXVezZHaMpSVB+DXw=
+github.com/confluentinc/go-prompt v0.2.23 h1:AO7W9ZPZ1c3aL8UkPSMVgbMgSNQvgMaw0S176DyTbn8=
+github.com/confluentinc/go-prompt v0.2.23/go.mod h1:4/tf63YzhSsiXnsKosCmv1H0ivpXVezZHaMpSVB+DXw=
 github.com/confluentinc/go-ps1 v1.0.2 h1:+4cKOzWs3AWmxL2s96oHu0QutZESDRXECnhFzm2ic4o=
 github.com/confluentinc/go-ps1 v1.0.2/go.mod h1:qmgG9xQgFd4u7/CS6eA9nNP8eQqOtXuRHmZ4+w7Vprs=
 github.com/confluentinc/kafka-rest-sdk-go/kafkarestv3 v0.3.17 h1:OXDvG8h8h77w3jH8N26BZaHILWeKw67/177fZxXDQdw=

--- a/pkg/flink/internal/controller/input_controller.go
+++ b/pkg/flink/internal/controller/input_controller.go
@@ -161,6 +161,10 @@ func (c *InputController) Prompt() prompt.IPrompt {
 			ASCIICode: []byte{0x1b, 0x66},
 			Fn:        prompt.GoRightWord,
 		}),
+		prompt.OptionAddASCIICodeBind(prompt.ASCIICodeBind{
+			ASCIICode: []byte{0x1b, 0x7F},
+			Fn:        prompt.DeleteWord,
+		}),
 		prompt.OptionPrefixTextColor(prompt.Yellow),
 		prompt.OptionPreviewSuggestionTextColor(prompt.Blue),
 		prompt.OptionSelectedSuggestionBGColor(prompt.LightGray),
@@ -169,14 +173,10 @@ func (c *InputController) Prompt() prompt.IPrompt {
 		prompt.OptionSetStatementTerminator(func(lastKeyStroke prompt.Key, buffer *prompt.Buffer) bool {
 			text := buffer.Text()
 			text = strings.TrimSpace(text)
-			// We add exit here because we also want to exit without the need of adding semicolon, which is the default flow for all statements
-			if text == "exit" {
-				return true
-			}
-			if text == "" || !strings.HasSuffix(text, ";") {
+			if text == "" {
 				return false
 			}
-			return true
+			return text == "exit" || strings.HasSuffix(text, ";") || lastKeyStroke == prompt.AltEnter
 		}),
 	)
 }


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

New Features
- [Early Access] Alt + Enter can now be used to trigger statement submission, without having to add a semicolon at the end of the statement
- [Early Access] Alt + Backspace can now be used to delete the previous word


Checklist
---------
- [x] Leave this box unchecked if features are not yet available in production

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->
- Alt + Enter can now be used to trigger statement submission, without having to add a semicolon at the end of the statement 
- Alt + Backspace can now be used to delete the previous word

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
<!--
Has it been tested? How?
Copy and paste any instructions or steps that can save the reviewer time.
-->