### PR TITLE
Remove caching for CI

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -21,7 +21,7 @@ blocks:
           commands:
             - checkout
             - sem-version go $(cat .go-version)
-            # - export PATH=$(go env GOPATH)/bin:$PATH
+            - export PATH=$(go env GOPATH)/bin:$PATH
             - cache restore linux-$(checksum go.sum)
             - make generate-packaging-patch
             - diff -w -u <(git cat-file --filters HEAD:debian/patches/standard_build_layout.patch | awk "{if (NR>3) {print}}") <(cat debian/patches/standard_build_layout.patch | awk "{if (NR>3) {print}}")
@@ -45,7 +45,7 @@ blocks:
           commands:
             - checkout
             - sem-version go $(cat .go-version)
-            # - export PATH=$(go env GOPATH)/bin:$PATH
+            - export PATH=$(go env GOPATH)/bin:$PATH
             - cache restore darwin-$(checksum go.sum)
             - make test
             - cache store darwin-$(checksum go.sum) $(go env GOPATH)/pkg/mod

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -22,13 +22,11 @@ blocks:
             - checkout
             - sem-version go $(cat .go-version)
             - export PATH=$(go env GOPATH)/bin:$PATH
-            # - cache restore linux-$(checksum go.sum)
             - make generate-packaging-patch
             - diff -w -u <(git cat-file --filters HEAD:debian/patches/standard_build_layout.patch | awk "{if (NR>3) {print}}") <(cat debian/patches/standard_build_layout.patch | awk "{if (NR>3) {print}}")
             - make lint
             - make test
             - make test-installer
-            # - cache store linux-$(checksum go.sum) $(go env GOPATH)/pkg/mod
       epilogue:
         always:
           commands:
@@ -46,9 +44,7 @@ blocks:
             - checkout
             - sem-version go $(cat .go-version)
             - export PATH=$(go env GOPATH)/bin:$PATH
-            # - cache restore darwin-$(checksum go.sum)
             - make test
-            # - cache store darwin-$(checksum go.sum) $(go env GOPATH)/pkg/mod
       epilogue:
         always:
           commands:
@@ -66,14 +62,12 @@ blocks:
             - checkout
             # https://confluentinc.atlassian.net/browse/DP-9532
             - choco install -y golang --version $(Get-Content .go-version)
-            # - cache restore windows-$($(Get-FileHash go.sum).Hash)
             - $env:GOCOVERDIR = 'test/coverage'
             - New-Item $env:GOCOVERDIR -ItemType Directory
             - go install gotest.tools/gotestsum@v1.8.2
             - gotestsum --junitfile unit-test-report.xml -- -v $(go list ./... | Select-String test -NotMatch) -ldflags "-buildmode=exe"
             - gotestsum --junitfile integration-test-report.xml -- -v $(go list ./... | Select-String test)
             - go tool covdata textfmt -i $env:GOCOVERDIR -o test/coverage.out
-            # - $gopath=$(go env GOPATH); cache store windows-$($(Get-FileHash go.sum).Hash) $gopath\pkg\mod
       epilogue:
         always:
           commands:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -19,22 +19,15 @@ blocks:
       jobs:
         - name: linux/amd64
           commands:
-            # Set up Go
             - checkout
             - sem-version go $(cat .go-version)
-            - export PATH=$(go env GOPATH)/bin:$PATH
-
-            # Try to restore cached dependencies
+            # - export PATH=$(go env GOPATH)/bin:$PATH
             - cache restore linux-$(checksum go.sum)
-
-            # Run tests
             - make generate-packaging-patch
             - diff -w -u <(git cat-file --filters HEAD:debian/patches/standard_build_layout.patch | awk "{if (NR>3) {print}}") <(cat debian/patches/standard_build_layout.patch | awk "{if (NR>3) {print}}")
             - make lint
             - make test
             - make test-installer
-
-            # Cache Go dependencies
             - cache store linux-$(checksum go.sum) $(go env GOPATH)/pkg/mod
       epilogue:
         always:
@@ -46,21 +39,20 @@ blocks:
     task:
       agent:
         machine:
-          type: s1-prod-macos-13-5-arm64 
+          type: s1-prod-macos-13-5-arm64
       jobs:
         - name: darwin/arm64
           commands:
-            # Set up Go
             - checkout
             - sem-version go $(cat .go-version)
-            - export PATH=$(go env GOPATH)/bin:$PATH
-
-            # Run tests
+            # - export PATH=$(go env GOPATH)/bin:$PATH
+            - cache restore darwin-$(checksum go.sum)
             - make test
+            - cache store darwin-$(checksum go.sum) $(go env GOPATH)/pkg/mod
       epilogue:
         always:
           commands:
-            - test-results publish . -N "darwin/amd64"
+            - test-results publish . -N "darwin/arm64"
 
   - name: windows/amd64
     dependencies: []
@@ -71,23 +63,16 @@ blocks:
       jobs:
         - name: windows/amd64
           commands:
-            # Set up Go
             - checkout
+            # https://confluentinc.atlassian.net/browse/DP-9532
             - choco install -y golang --version $(Get-Content .go-version)
-            # TODO: https://confluentinc.atlassian.net/browse/DP-9532
-
-            # Try to restore cached dependencies
             - cache restore windows-$($(Get-FileHash go.sum).Hash)
-
-            # Run tests
             - $env:GOCOVERDIR = 'test/coverage'
             - New-Item $env:GOCOVERDIR -ItemType Directory
             - go install gotest.tools/gotestsum@v1.8.2
             - gotestsum --junitfile unit-test-report.xml -- -v $(go list ./... | Select-String test -NotMatch) -ldflags "-buildmode=exe"
             - gotestsum --junitfile integration-test-report.xml -- -v $(go list ./... | Select-String test)
             - go tool covdata textfmt -i $env:GOCOVERDIR -o test/coverage.out
-
-            # Cache Go dependencies
             - $gopath=$(go env GOPATH); cache store windows-$($(Get-FileHash go.sum).Hash) $gopath\pkg\mod
       epilogue:
         always:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -22,13 +22,13 @@ blocks:
             - checkout
             - sem-version go $(cat .go-version)
             - export PATH=$(go env GOPATH)/bin:$PATH
-            - cache restore linux-$(checksum go.sum)
+            # - cache restore linux-$(checksum go.sum)
             - make generate-packaging-patch
             - diff -w -u <(git cat-file --filters HEAD:debian/patches/standard_build_layout.patch | awk "{if (NR>3) {print}}") <(cat debian/patches/standard_build_layout.patch | awk "{if (NR>3) {print}}")
             - make lint
             - make test
             - make test-installer
-            - cache store linux-$(checksum go.sum) $(go env GOPATH)/pkg/mod
+            # - cache store linux-$(checksum go.sum) $(go env GOPATH)/pkg/mod
       epilogue:
         always:
           commands:
@@ -46,9 +46,9 @@ blocks:
             - checkout
             - sem-version go $(cat .go-version)
             - export PATH=$(go env GOPATH)/bin:$PATH
-            - cache restore darwin-$(checksum go.sum)
+            # - cache restore darwin-$(checksum go.sum)
             - make test
-            - cache store darwin-$(checksum go.sum) $(go env GOPATH)/pkg/mod
+            # - cache store darwin-$(checksum go.sum) $(go env GOPATH)/pkg/mod
       epilogue:
         always:
           commands:
@@ -66,14 +66,14 @@ blocks:
             - checkout
             # https://confluentinc.atlassian.net/browse/DP-9532
             - choco install -y golang --version $(Get-Content .go-version)
-            - cache restore windows-$($(Get-FileHash go.sum).Hash)
+            # - cache restore windows-$($(Get-FileHash go.sum).Hash)
             - $env:GOCOVERDIR = 'test/coverage'
             - New-Item $env:GOCOVERDIR -ItemType Directory
             - go install gotest.tools/gotestsum@v1.8.2
             - gotestsum --junitfile unit-test-report.xml -- -v $(go list ./... | Select-String test -NotMatch) -ldflags "-buildmode=exe"
             - gotestsum --junitfile integration-test-report.xml -- -v $(go list ./... | Select-String test)
             - go tool covdata textfmt -i $env:GOCOVERDIR -o test/coverage.out
-            - $gopath=$(go env GOPATH); cache store windows-$($(Get-FileHash go.sum).Hash) $gopath\pkg\mod
+            # - $gopath=$(go env GOPATH); cache store windows-$($(Get-FileHash go.sum).Hash) $gopath\pkg\mod
       epilogue:
         always:
           commands:


### PR DESCRIPTION
What
----
After switching to on-prem Semaphore, adding caching actually slows down CI by 4 seconds (and 20 seconds for darwin). This is because it takes too long to upload/download the cache.