### PR TITLE
DGS-9181: Remove "geo" parameter from SR Cluster Enable command

### DIFF
--- a/test/fixtures/output/schema-registry/cluster/enable-help.golden
+++ b/test/fixtures/output/schema-registry/cluster/enable-help.golden
@@ -6,11 +6,11 @@ Usage:
 Examples:
 Enable Schema Registry, using Google Cloud Platform in the US with the "advanced" package.
 
-  $ confluent schema-registry cluster enable --cloud gcp --geo us --package advanced
+  $ confluent schema-registry cluster enable --cloud gcp --region us-central1 --package advanced
 
 Flags:
       --cloud string         REQUIRED: Specify the cloud provider as "aws", "azure", or "gcp".
-      --geo string           REQUIRED: Specify the geo as "us", "eu", or "apac".
+      --region string        REQUIRED: Cloud region for Kafka (use "confluent kafka region list" to see all).
       --package string       Specify the type of Stream Governance package as "essentials" or "advanced". (default "essentials")
       --context string       CLI context name.
       --environment string   Environment ID.

--- a/test/fixtures/output/schema-registry/cluster/enable-invalid-geo.golden
+++ b/test/fixtures/output/schema-registry/cluster/enable-invalid-geo.golden
@@ -1,4 +1,0 @@
-Error: invalid input for flag `--geo`
-
-Suggestions:
-    Geo must be either "us", "eu", or "apac".

--- a/test/fixtures/output/schema-registry/cluster/enable-missing-flag.golden
+++ b/test/fixtures/output/schema-registry/cluster/enable-missing-flag.golden
@@ -5,11 +5,11 @@ Usage:
 Examples:
 Enable Schema Registry, using Google Cloud Platform in the US with the "advanced" package.
 
-  $ confluent schema-registry cluster enable --cloud gcp --geo us --package advanced
+  $ confluent schema-registry cluster enable --cloud gcp --region us-central1 --package advanced
 
 Flags:
       --cloud string         REQUIRED: Specify the cloud provider as "aws", "azure", or "gcp".
-      --geo string           REQUIRED: Specify the geo as "us", "eu", or "apac".
+      --region string        REQUIRED: Cloud region for Kafka (use "confluent kafka region list" to see all).
       --package string       Specify the type of Stream Governance package as "essentials" or "advanced". (default "essentials")
       --context string       CLI context name.
       --environment string   Environment ID.

--- a/test/schema_registry_test.go
+++ b/test/schema_registry_test.go
@@ -14,12 +14,11 @@ var (
 
 func (s *CLITestSuite) TestSchemaRegistryCluster() {
 	tests := []CLITest{
-		{args: "schema-registry cluster enable --cloud gcp --geo us --package advanced -o json", fixture: "schema-registry/cluster/enable-json.golden"},
-		{args: "schema-registry cluster enable --cloud gcp --geo us --package essentials -o yaml", fixture: "schema-registry/cluster/enable-yaml.golden"},
-		{args: "schema-registry cluster enable --cloud gcp --geo us --package advanced", fixture: "schema-registry/cluster/enable.golden"},
-		{args: "schema-registry cluster enable --cloud gcp --geo somethingwrong --package advanced", fixture: "schema-registry/cluster/enable-invalid-geo.golden", exitCode: 1},
-		{args: "schema-registry cluster enable --cloud aws --geo us --package invalid-package", fixture: "schema-registry/cluster/enable-invalid-package.golden", exitCode: 1},
-		{args: "schema-registry cluster enable --geo us --package essentials", fixture: "schema-registry/cluster/enable-missing-flag.golden", exitCode: 1},
+		{args: "schema-registry cluster enable --cloud gcp --region us-central1 --package advanced -o json", fixture: "schema-registry/cluster/enable-json.golden"},
+		{args: "schema-registry cluster enable --cloud gcp --region us-central1 --package essentials -o yaml", fixture: "schema-registry/cluster/enable-yaml.golden"},
+		{args: "schema-registry cluster enable --cloud gcp --region us-central1 --package advanced", fixture: "schema-registry/cluster/enable.golden"},
+		{args: "schema-registry cluster enable --cloud aws --region us-west-2 --package invalid-package", fixture: "schema-registry/cluster/enable-invalid-package.golden", exitCode: 1},
+		{args: "schema-registry cluster enable --region us-central1 --package essentials", fixture: "schema-registry/cluster/enable-missing-flag.golden", exitCode: 1},
 		{args: fmt.Sprintf("schema-registry cluster delete --environment %s", testserver.SRApiEnvId), input: "y\n", fixture: "schema-registry/cluster/delete.golden"},
 		{args: fmt.Sprintf("schema-registry cluster delete --environment %s", testserver.SRApiEnvId), input: "n\n", fixture: "schema-registry/cluster/delete-terminated.golden"},
 		{args: fmt.Sprintf("schema-registry cluster delete --environment %s", testserver.SRApiEnvId), input: "invalid_confirmation\n", fixture: "schema-registry/cluster/delete-invalid-confirmation.golden", exitCode: 1},


### PR DESCRIPTION
Release Notes
-------------

Breaking Changes
- Removed `--geo` flag which fed into the deprecated `Location` field of cluster config. Users must instead specify a specific cloud region using the `--region` flag which feeds into the `ServiceProviderRegion` field of cluster config. Failure to provide this field will result in an error.

Checklist
---------
- [x] Leave this box unchecked if features are not yet available in production

References
----------
[DGS-9181](https://confluentinc.atlassian.net/browse/DGS-9181)

Test & Review
-------------
```
make build
# ... log in and set current environment ...
dist/confluent_darwin_arm64/confluent schema-registry cluster enable --cloud aws --package essentials --region us-west-2
```

[DGS-9181]: https://confluentinc.atlassian.net/browse/DGS-9181?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ