### PR TITLE
[TRAFFIC-10636] Add `confluent network region list`

### DIFF
--- a/internal/network/command.go
+++ b/internal/network/command.go
@@ -13,6 +13,7 @@ import (
 	"github.com/confluentinc/cli/v3/pkg/ccloudv2"
 	pcmd "github.com/confluentinc/cli/v3/pkg/cmd"
 	"github.com/confluentinc/cli/v3/pkg/errors"
+	"github.com/confluentinc/cli/v3/pkg/network"
 	"github.com/confluentinc/cli/v3/pkg/output"
 	"github.com/confluentinc/cli/v3/pkg/utils"
 )
@@ -101,6 +102,7 @@ func New(prerunner pcmd.PreRunner) *cobra.Command {
 	cmd.AddCommand(c.newNetworkLinkCommand())
 	cmd.AddCommand(c.newPeeringCommand())
 	cmd.AddCommand(c.newPrivateLinkCommand())
+	cmd.AddCommand(c.newRegionCommand())
 	cmd.AddCommand(c.newTransitGatewayAttachmentCommand())
 	cmd.AddCommand(c.newUpdateCommand())
 
@@ -380,4 +382,25 @@ func addAcceptedEnvironmentsFlag(cmd *cobra.Command, command *pcmd.Authenticated
 func (c *command) addNetworkLinkServiceFlag(cmd *cobra.Command) {
 	cmd.Flags().String("network-link-service", "", "Network link service ID.")
 	pcmd.RegisterFlagCompletionFunc(cmd, "network-link-service", c.validNetworkLinkServicesArgsMultiple)
+}
+
+func (c *command) addRegionFlagNetwork(cmd *cobra.Command, command *pcmd.AuthenticatedCLICommand) {
+	cmd.Flags().String("region", "", `Cloud region ID for this network.`)
+	pcmd.RegisterFlagCompletionFunc(cmd, "region", func(cmd *cobra.Command, args []string) []string {
+		if err := c.PersistentPreRunE(cmd, args); err != nil {
+			return nil
+		}
+
+		cloud, _ := cmd.Flags().GetString("cloud")
+		regions, err := network.ListRegions(command.Client, cloud)
+		if err != nil {
+			return nil
+		}
+
+		suggestions := make([]string, len(regions))
+		for i, region := range regions {
+			suggestions[i] = region.RegionId
+		}
+		return suggestions
+	})
 }

--- a/internal/network/command.go
+++ b/internal/network/command.go
@@ -399,7 +399,7 @@ func (c *command) addRegionFlagNetwork(cmd *cobra.Command, command *pcmd.Authent
 
 		suggestions := make([]string, len(regions))
 		for i, region := range regions {
-			suggestions[i] = region.GetRegionId()
+			suggestions[i] = region.RegionId
 		}
 		return suggestions
 	})

--- a/internal/network/command.go
+++ b/internal/network/command.go
@@ -385,7 +385,7 @@ func (c *command) addNetworkLinkServiceFlag(cmd *cobra.Command) {
 }
 
 func (c *command) addRegionFlagNetwork(cmd *cobra.Command, command *pcmd.AuthenticatedCLICommand) {
-	cmd.Flags().String("region", "", `Cloud region ID for this network.`)
+	cmd.Flags().String("region", "", "Cloud region ID for this network.")
 	pcmd.RegisterFlagCompletionFunc(cmd, "region", func(cmd *cobra.Command, args []string) []string {
 		if err := c.PersistentPreRunE(cmd, args); err != nil {
 			return nil

--- a/internal/network/command.go
+++ b/internal/network/command.go
@@ -399,7 +399,7 @@ func (c *command) addRegionFlagNetwork(cmd *cobra.Command, command *pcmd.Authent
 
 		suggestions := make([]string, len(regions))
 		for i, region := range regions {
-			suggestions[i] = region.RegionId
+			suggestions[i] = region.GetRegionId()
 		}
 		return suggestions
 	})

--- a/internal/network/command_create.go
+++ b/internal/network/command_create.go
@@ -47,7 +47,7 @@ func (c *command) newCreateCommand() *cobra.Command {
 	}
 
 	pcmd.AddCloudFlag(cmd)
-	cmd.Flags().String("region", "", "Cloud region ID for this network.")
+	c.addRegionFlagNetwork(cmd, c.AuthenticatedCLICommand)
 	addConnectionTypesFlag(cmd)
 	cmd.Flags().String("cidr", "", `A /16 IPv4 CIDR block. Required for networks of connection type "peering" and "transitgateway".`)
 	cmd.Flags().StringSlice("zones", nil, `A comma-separated list of availability zones for this network.`)

--- a/internal/network/command_region.go
+++ b/internal/network/command_region.go
@@ -7,7 +7,7 @@ import (
 func (c *command) newRegionCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "region",
-		Short: "Manage Confluent Cloud regions.",
+		Short: "Manage Confluent Cloud network regions.",
 		Args:  cobra.NoArgs,
 	}
 

--- a/internal/network/command_region.go
+++ b/internal/network/command_region.go
@@ -1,0 +1,17 @@
+package network
+
+import (
+	"github.com/spf13/cobra"
+)
+
+func (c *command) newRegionCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "region",
+		Short: "Manage Confluent Cloud regions.",
+		Args:  cobra.NoArgs,
+	}
+
+	cmd.AddCommand(c.newRegionListCommand())
+
+	return cmd
+}

--- a/internal/network/command_region_list.go
+++ b/internal/network/command_region_list.go
@@ -11,7 +11,7 @@ import (
 func (c *command) newRegionListCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
-		Short: "List cloud provider regions.",
+		Short: "List cloud provider regions for networking.",
 		Args:  cobra.NoArgs,
 		RunE:  c.regionList,
 	}

--- a/internal/network/command_region_list.go
+++ b/internal/network/command_region_list.go
@@ -1,0 +1,41 @@
+package network
+
+import (
+	"github.com/spf13/cobra"
+
+	pcmd "github.com/confluentinc/cli/v3/pkg/cmd"
+	"github.com/confluentinc/cli/v3/pkg/network"
+	"github.com/confluentinc/cli/v3/pkg/output"
+)
+
+func (c *command) newRegionListCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List cloud provider regions.",
+		Args:  cobra.NoArgs,
+		RunE:  c.regionList,
+	}
+
+	pcmd.AddCloudFlag(cmd)
+	pcmd.AddOutputFlag(cmd)
+
+	return cmd
+}
+
+func (c *command) regionList(cmd *cobra.Command, _ []string) error {
+	cloud, err := cmd.Flags().GetString("cloud")
+	if err != nil {
+		return err
+	}
+
+	regions, err := network.ListRegions(c.Client, cloud)
+	if err != nil {
+		return err
+	}
+
+	list := output.NewList(cmd)
+	for _, region := range regions {
+		list.Add(region)
+	}
+	return list.Print()
+}

--- a/pkg/network/region.go
+++ b/pkg/network/region.go
@@ -1,0 +1,41 @@
+package network
+
+import (
+	ccloudv1 "github.com/confluentinc/ccloud-sdk-go-v1-public"
+)
+
+type region struct {
+	CloudId    string `human:"Cloud ID" serialized:"cloud_id"`
+	CloudName  string `human:"Cloud Name" serialized:"cloud_name"`
+	RegionId   string `human:"Region ID" serialized:"region_id"`
+	RegionName string `human:"Region Name" serialized:"region_name"`
+}
+
+func ListRegions(client *ccloudv1.Client, cloud string) ([]*region, error) {
+	metadataList, err := client.EnvironmentMetadata.Get()
+	if err != nil {
+		return nil, err
+	}
+
+	var regions []*region
+
+	for _, metadata := range metadataList {
+		if cloud != "" && cloud != metadata.GetId() {
+			continue
+		}
+
+		for _, r := range metadata.GetRegions() {
+			if len(r.Schedulability.DedicatedNetwork.DedicatedCluster.High) == 0 {
+				continue
+			}
+			regions = append(regions, &region{
+				CloudId:    metadata.GetId(),
+				CloudName:  metadata.GetName(),
+				RegionId:   r.GetId(),
+				RegionName: r.GetName(),
+			})
+		}
+	}
+
+	return regions, nil
+}

--- a/test/fixtures/output/network/create-autocomplete-region-with-cloud.golden
+++ b/test/fixtures/output/network/create-autocomplete-region-with-cloud.golden
@@ -1,0 +1,3 @@
+us-east-1
+:4
+Completion ended with directive: ShellCompDirectiveNoFileComp

--- a/test/fixtures/output/network/create-autocomplete-region.golden
+++ b/test/fixtures/output/network/create-autocomplete-region.golden
@@ -1,0 +1,5 @@
+asia-southeast1
+asia-east2
+us-east-1
+:4
+Completion ended with directive: ShellCompDirectiveNoFileComp

--- a/test/fixtures/output/network/help.golden
+++ b/test/fixtures/output/network/help.golden
@@ -12,6 +12,7 @@ Available Commands:
   network-link               Manage network links.
   peering                    Manage peerings.
   private-link               Manage private links.
+  region                     Manage Confluent Cloud regions.
   transit-gateway-attachment Manage transit gateway attachments.
   update                     Update an existing network.
 

--- a/test/fixtures/output/network/help.golden
+++ b/test/fixtures/output/network/help.golden
@@ -12,7 +12,7 @@ Available Commands:
   network-link               Manage network links.
   peering                    Manage peerings.
   private-link               Manage private links.
-  region                     Manage Confluent Cloud regions.
+  region                     Manage Confluent Cloud network regions.
   transit-gateway-attachment Manage transit gateway attachments.
   update                     Update an existing network.
 

--- a/test/fixtures/output/network/region/help.golden
+++ b/test/fixtures/output/network/region/help.golden
@@ -1,10 +1,10 @@
-Manage Confluent Cloud regions.
+Manage Confluent Cloud network regions.
 
 Usage:
   confluent network region [command]
 
 Available Commands:
-  list        List cloud provider regions.
+  list        List cloud provider regions for networking.
 
 Global Flags:
   -h, --help            Show help for this command.

--- a/test/fixtures/output/network/region/help.golden
+++ b/test/fixtures/output/network/region/help.golden
@@ -1,0 +1,14 @@
+Manage Confluent Cloud regions.
+
+Usage:
+  confluent network region [command]
+
+Available Commands:
+  list        List cloud provider regions.
+
+Global Flags:
+  -h, --help            Show help for this command.
+      --unsafe-trace    Equivalent to -vvvv, but also log HTTP requests and responses which might contain plaintext secrets.
+  -v, --verbose count   Increase verbosity (-v for warn, -vv for info, -vvv for debug, -vvvv for trace).
+
+Use "confluent network region [command] --help" for more information about a command.

--- a/test/fixtures/output/network/region/list-cloud.golden
+++ b/test/fixtures/output/network/region/list-cloud.golden
@@ -1,0 +1,3 @@
+  Cloud ID |     Cloud Name      | Region ID |       Region Name        
+-----------+---------------------+-----------+--------------------------
+  aws      | Amazon Web Services | us-east-1 | us-east-1 (N. Virginia)  

--- a/test/fixtures/output/network/region/list-help.golden
+++ b/test/fixtures/output/network/region/list-help.golden
@@ -1,0 +1,13 @@
+List cloud provider regions.
+
+Usage:
+  confluent network region list [flags]
+
+Flags:
+      --cloud string    Specify the cloud provider as "aws", "azure", or "gcp".
+  -o, --output string   Specify the output format as "human", "json", or "yaml". (default "human")
+
+Global Flags:
+  -h, --help            Show help for this command.
+      --unsafe-trace    Equivalent to -vvvv, but also log HTTP requests and responses which might contain plaintext secrets.
+  -v, --verbose count   Increase verbosity (-v for warn, -vv for info, -vvv for debug, -vvvv for trace).

--- a/test/fixtures/output/network/region/list-help.golden
+++ b/test/fixtures/output/network/region/list-help.golden
@@ -1,4 +1,4 @@
-List cloud provider regions.
+List cloud provider regions for networking.
 
 Usage:
   confluent network region list [flags]

--- a/test/fixtures/output/network/region/list-json.golden
+++ b/test/fixtures/output/network/region/list-json.golden
@@ -1,0 +1,20 @@
+[
+  {
+    "cloud_id": "aws",
+    "cloud_name": "Amazon Web Services",
+    "region_id": "us-east-1",
+    "region_name": "us-east-1 (N. Virginia)"
+  },
+  {
+    "cloud_id": "gcp",
+    "cloud_name": "Google Cloud Platform",
+    "region_id": "asia-east2",
+    "region_name": "asia-east2 (Hong Kong)"
+  },
+  {
+    "cloud_id": "gcp",
+    "cloud_name": "Google Cloud Platform",
+    "region_id": "asia-southeast1",
+    "region_name": "asia-southeast1 (Singapore)"
+  }
+]

--- a/test/fixtures/output/network/region/list.golden
+++ b/test/fixtures/output/network/region/list.golden
@@ -1,0 +1,5 @@
+  Cloud ID |      Cloud Name       |    Region ID    |         Region Name          
+-----------+-----------------------+-----------------+------------------------------
+  aws      | Amazon Web Services   | us-east-1       | us-east-1 (N. Virginia)      
+  gcp      | Google Cloud Platform | asia-east2      | asia-east2 (Hong Kong)       
+  gcp      | Google Cloud Platform | asia-southeast1 | asia-southeast1 (Singapore)  

--- a/test/network_test.go
+++ b/test/network_test.go
@@ -101,6 +101,8 @@ func (s *CLITestSuite) TestNetwork_Autocomplete() {
 		{args: `__complete network delete ""`, login: "cloud", fixture: "network/delete-autocomplete.golden"},
 		{args: `__complete network create new-network --connection-types ""`, login: "cloud", fixture: "network/create-autocomplete-connection-types.golden"},
 		{args: `__complete network create new-network --dns-resolution ""`, login: "cloud", fixture: "network/create-autocomplete-dns-resolution.golden"},
+		{args: `__complete network create new-network --region ""`, login: "cloud", fixture: "network/create-autocomplete-region.golden"},
+		{args: `__complete network create new-network --cloud aws --region ""`, login: "cloud", fixture: "network/create-autocomplete-region-with-cloud.golden"},
 	}
 
 	for _, test := range tests {
@@ -730,6 +732,19 @@ func (s *CLITestSuite) TestNetworkNetworkLinkEndpoint_Autocomplete() {
 		{args: `__complete network network-link endpoint delete ""`, login: "cloud", fixture: "network/network-link/endpoint/delete-autocomplete.golden"},
 		{args: `__complete network network-link endpoint create my-network-link-endpoint --network ""`, login: "cloud", fixture: "network/network-link/endpoint/create-autocomplete.golden"},
 		{args: `__complete network network-link endpoint update ""`, login: "cloud", fixture: "network/network-link/endpoint/update-autocomplete.golden"},
+	}
+
+	for _, test := range tests {
+		test.login = "cloud"
+		s.runIntegrationTest(test)
+	}
+}
+
+func (s *CLITestSuite) TestNetworkRegionList() {
+	tests := []CLITest{
+		{args: "network region list", fixture: "network/region/list.golden"},
+		{args: "network region list --output json", fixture: "network/region/list-json.golden"},
+		{args: "network region list --cloud aws", fixture: "network/region/list-cloud.golden"},
 	}
 
 	for _, test := range tests {

--- a/test/test-server/ccloud_handlers.go
+++ b/test/test-server/ccloud_handlers.go
@@ -254,11 +254,33 @@ func handleEnvMetadata(t *testing.T) http.HandlerFunc {
 						Id:            "asia-southeast1",
 						Name:          "asia-southeast1 (Singapore)",
 						IsSchedulable: true,
+						Schedulability: &ccloudv1.Schedulability{
+							DedicatedNetwork: &ccloudv1.Schedulability_Tenancy{
+								DedicatedCluster: &ccloudv1.Schedulability_Tenancy_Durability{
+									High: []ccloudv1.NetworkType{
+										ccloudv1.NetworkType_VPC_PEERING,
+										ccloudv1.NetworkType_TRANSIT_GATEWAY,
+										ccloudv1.NetworkType_PRIVATE_LINK,
+									},
+								},
+							},
+						},
 					},
 					{
 						Id:            "asia-east2",
 						Name:          "asia-east2 (Hong Kong)",
 						IsSchedulable: true,
+						Schedulability: &ccloudv1.Schedulability{
+							DedicatedNetwork: &ccloudv1.Schedulability_Tenancy{
+								DedicatedCluster: &ccloudv1.Schedulability_Tenancy_Durability{
+									High: []ccloudv1.NetworkType{
+										ccloudv1.NetworkType_VPC_PEERING,
+										ccloudv1.NetworkType_TRANSIT_GATEWAY,
+										ccloudv1.NetworkType_PRIVATE_LINK,
+									},
+								},
+							},
+						},
 					},
 				},
 			},
@@ -270,11 +292,29 @@ func handleEnvMetadata(t *testing.T) http.HandlerFunc {
 						Id:            "ap-northeast-1",
 						Name:          "ap-northeast-1 (Tokyo)",
 						IsSchedulable: false,
+						Schedulability: &ccloudv1.Schedulability{
+							DedicatedNetwork: &ccloudv1.Schedulability_Tenancy{
+								DedicatedCluster: &ccloudv1.Schedulability_Tenancy_Durability{
+									High: []ccloudv1.NetworkType{},
+								},
+							},
+						},
 					},
 					{
 						Id:            "us-east-1",
 						Name:          "us-east-1 (N. Virginia)",
 						IsSchedulable: true,
+						Schedulability: &ccloudv1.Schedulability{
+							DedicatedNetwork: &ccloudv1.Schedulability_Tenancy{
+								DedicatedCluster: &ccloudv1.Schedulability_Tenancy_Durability{
+									High: []ccloudv1.NetworkType{
+										ccloudv1.NetworkType_VPC_PEERING,
+										ccloudv1.NetworkType_TRANSIT_GATEWAY,
+										ccloudv1.NetworkType_PRIVATE_LINK,
+									},
+								},
+							},
+						},
 					},
 				},
 			},
@@ -286,6 +326,13 @@ func handleEnvMetadata(t *testing.T) http.HandlerFunc {
 						Id:            "southeastasia",
 						Name:          "southeastasia (Singapore)",
 						IsSchedulable: false,
+						Schedulability: &ccloudv1.Schedulability{
+							DedicatedNetwork: &ccloudv1.Schedulability_Tenancy{
+								DedicatedCluster: &ccloudv1.Schedulability_Tenancy_Durability{
+									High: []ccloudv1.NetworkType{},
+								},
+							},
+						},
 					},
 				},
 			},


### PR DESCRIPTION
What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->
Note that this is merging into the feature branch https://github.com/confluentinc/cli/tree/traffic-8850-network-cli-az. We will merge commits into main from this feature branch after all of the commands for network are implemented.

- Add `confluent network region list`
- Autocomplete for `confluent network create --region`


References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->
[CLI Commands Design](https://confluentinc.atlassian.net/wiki/spaces/PM/pages/2987394300/1-pager+--+Network+CLI)
[Implementation 1-Pager](https://confluentinc.atlassian.net/wiki/spaces/~712020463029eabbac401bbe1b033ce0d3a00e/pages/3136749631/Network+CLI)

Test & Review
-------------
<!--
Has it been tested? How?
Copy and paste any instructions or steps that can save the reviewer time.
-->
Added integration tests.

Performed manual tests.