### PR TITLE
Update filter for `kafka region list`

### DIFF
--- a/internal/kafka/command_cluster_test.go
+++ b/internal/kafka/command_cluster_test.go
@@ -87,8 +87,7 @@ func (suite *KafkaClusterTestSuite) SetupTest() {
 			cloudMeta := &ccloudv1.CloudMetadata{
 				Id: cloudId,
 				Regions: []*ccloudv1.Region{{
-					Id:            regionId,
-					IsSchedulable: true,
+					Id: regionId,
 				}},
 			}
 			return []*ccloudv1.CloudMetadata{cloudMeta}, nil

--- a/pkg/kafka/region.go
+++ b/pkg/kafka/region.go
@@ -25,10 +25,6 @@ func ListRegions(client *ccloudv1.Client, cloud string) ([]*region, error) {
 		}
 
 		for _, r := range metadata.GetRegions() {
-			if !r.GetIsSchedulable() {
-				continue
-			}
-
 			regions = append(regions, &region{
 				CloudId:    metadata.GetId(),
 				CloudName:  metadata.GetName(),

--- a/test/fixtures/output/kafka/10.golden
+++ b/test/fixtures/output/kafka/10.golden
@@ -1,3 +1,4 @@
-  Cloud ID |     Cloud Name      | Region ID |       Region Name        
------------+---------------------+-----------+--------------------------
-  aws      | Amazon Web Services | us-east-1 | us-east-1 (N. Virginia)  
+  Cloud ID |     Cloud Name      |   Region ID    |       Region Name        
+-----------+---------------------+----------------+--------------------------
+  aws      | Amazon Web Services | ap-northeast-1 | ap-northeast-1 (Tokyo)   
+  aws      | Amazon Web Services | us-east-1      | us-east-1 (N. Virginia)  

--- a/test/fixtures/output/kafka/11.golden
+++ b/test/fixtures/output/kafka/11.golden
@@ -1,1 +1,3 @@
-None found.
+  Cloud ID | Cloud Name |   Region ID   |        Region Name         
+-----------+------------+---------------+----------------------------
+  azure    | Azure      | southeastasia | southeastasia (Singapore)  

--- a/test/fixtures/output/kafka/14.golden
+++ b/test/fixtures/output/kafka/14.golden
@@ -1,5 +1,7 @@
   Cloud ID |      Cloud Name       |    Region ID    |         Region Name          
 -----------+-----------------------+-----------------+------------------------------
+  aws      | Amazon Web Services   | ap-northeast-1  | ap-northeast-1 (Tokyo)       
   aws      | Amazon Web Services   | us-east-1       | us-east-1 (N. Virginia)      
+  azure    | Azure                 | southeastasia   | southeastasia (Singapore)    
   gcp      | Google Cloud Platform | asia-east2      | asia-east2 (Hong Kong)       
   gcp      | Google Cloud Platform | asia-southeast1 | asia-southeast1 (Singapore)  

--- a/test/fixtures/output/kafka/15.golden
+++ b/test/fixtures/output/kafka/15.golden
@@ -2,8 +2,20 @@
   {
     "cloud_id": "aws",
     "cloud_name": "Amazon Web Services",
+    "region_id": "ap-northeast-1",
+    "region_name": "ap-northeast-1 (Tokyo)"
+  },
+  {
+    "cloud_id": "aws",
+    "cloud_name": "Amazon Web Services",
     "region_id": "us-east-1",
     "region_name": "us-east-1 (N. Virginia)"
+  },
+  {
+    "cloud_id": "azure",
+    "cloud_name": "Azure",
+    "region_id": "southeastasia",
+    "region_name": "southeastasia (Singapore)"
   },
   {
     "cloud_id": "gcp",

--- a/test/fixtures/output/kafka/16.golden
+++ b/test/fixtures/output/kafka/16.golden
@@ -2,8 +2,20 @@
   {
     "cloud_id": "aws",
     "cloud_name": "Amazon Web Services",
+    "region_id": "ap-northeast-1",
+    "region_name": "ap-northeast-1 (Tokyo)"
+  },
+  {
+    "cloud_id": "aws",
+    "cloud_name": "Amazon Web Services",
     "region_id": "us-east-1",
     "region_name": "us-east-1 (N. Virginia)"
+  },
+  {
+    "cloud_id": "azure",
+    "cloud_name": "Azure",
+    "region_id": "southeastasia",
+    "region_name": "southeastasia (Singapore)"
   },
   {
     "cloud_id": "gcp",

--- a/test/test-server/ccloud_handlers.go
+++ b/test/test-server/ccloud_handlers.go
@@ -251,14 +251,12 @@ func handleEnvMetadata(t *testing.T) http.HandlerFunc {
 				Name: "Google Cloud Platform",
 				Regions: []*ccloudv1.Region{
 					{
-						Id:            "asia-southeast1",
-						Name:          "asia-southeast1 (Singapore)",
-						IsSchedulable: true,
+						Id:   "asia-southeast1",
+						Name: "asia-southeast1 (Singapore)",
 					},
 					{
-						Id:            "asia-east2",
-						Name:          "asia-east2 (Hong Kong)",
-						IsSchedulable: true,
+						Id:   "asia-east2",
+						Name: "asia-east2 (Hong Kong)",
 					},
 				},
 			},
@@ -267,14 +265,12 @@ func handleEnvMetadata(t *testing.T) http.HandlerFunc {
 				Name: "Amazon Web Services",
 				Regions: []*ccloudv1.Region{
 					{
-						Id:            "ap-northeast-1",
-						Name:          "ap-northeast-1 (Tokyo)",
-						IsSchedulable: false,
+						Id:   "ap-northeast-1",
+						Name: "ap-northeast-1 (Tokyo)",
 					},
 					{
-						Id:            "us-east-1",
-						Name:          "us-east-1 (N. Virginia)",
-						IsSchedulable: true,
+						Id:   "us-east-1",
+						Name: "us-east-1 (N. Virginia)",
 					},
 				},
 			},
@@ -283,9 +279,8 @@ func handleEnvMetadata(t *testing.T) http.HandlerFunc {
 				Name: "Azure",
 				Regions: []*ccloudv1.Region{
 					{
-						Id:            "southeastasia",
-						Name:          "southeastasia (Singapore)",
-						IsSchedulable: false,
+						Id:   "southeastasia",
+						Name: "southeastasia (Singapore)",
 					},
 				},
 			},


### PR DESCRIPTION
Checklist
---------
- [x] Leave this box unchecked if features are not yet available in production

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->
`is_schedulable` is a legacy flag that is unused, removed `is_schedulable` filter in `confluent kafka region list`. 

Test & Review
-------------
<!--
Has it been tested? How?
Copy and paste any instructions or steps that can save the reviewer time.
-->
Updated integration tests