### PR TITLE
Fix consume before produce bug

### DIFF
--- a/internal/kafka/command_topic_produce.go
+++ b/internal/kafka/command_topic_produce.go
@@ -488,9 +488,6 @@ func (c *command) initSchemaAndGetInfo(cmd *cobra.Command, topic, mode string) (
 	if err != nil {
 		return nil, nil, err
 	}
-	defer func() {
-		_ = os.RemoveAll(schemaDir)
-	}()
 
 	subject := topicNameStrategy(topic, mode)
 


### PR DESCRIPTION
Release Notes
-------------
Bug Fixes
- Fix "no such file or directory" error when running a serialized consumer before producer

Checklist
---------
- [x] Leave this box unchecked if features are not yet available in production

What
----
Closes #2519. The schema directory should only be deleted once by the producer, when it is closed or errors.

Test & Review
-------------
Manually tested with example from https://developer.confluent.io/tutorials/kafka-console-consumer-producer-avro/confluent.html