### PR TITLE
Add missing flags to `connect custom-plugin create`

### DIFF
--- a/internal/connect/command_custom_plugin_create.go
+++ b/internal/connect/command_custom_plugin_create.go
@@ -9,6 +9,7 @@ import (
 
 	connectcustompluginv1 "github.com/confluentinc/ccloud-sdk-go-v2/connect-custom-plugin/v1"
 
+	pcmd "github.com/confluentinc/cli/v3/pkg/cmd"
 	"github.com/confluentinc/cli/v3/pkg/examples"
 	"github.com/confluentinc/cli/v3/pkg/output"
 )
@@ -39,6 +40,8 @@ func (c *customPluginCommand) newCreateCommand() *cobra.Command {
 	cmd.Flags().String("description", "", "Description of custom plugin.")
 	cmd.Flags().String("documentation-link", "", "Document link of custom plugin.")
 	cmd.Flags().StringSlice("sensitive-properties", nil, "A comma-separated list of sensitive property names.")
+	pcmd.AddContextFlag(cmd, c.CLICommand)
+	pcmd.AddOutputFlag(cmd)
 
 	cobra.CheckErr(cmd.MarkFlagRequired("plugin-file"))
 	cobra.CheckErr(cmd.MarkFlagRequired("connector-class"))

--- a/test/fixtures/output/connect/custom-plugin/create-help.golden
+++ b/test/fixtures/output/connect/custom-plugin/create-help.golden
@@ -15,6 +15,8 @@ Flags:
       --description string             Description of custom plugin.
       --documentation-link string      Document link of custom plugin.
       --sensitive-properties strings   A comma-separated list of sensitive property names.
+      --context string                 CLI context name.
+  -o, --output string                  Specify the output format as "human", "json", or "yaml". (default "human")
 
 Global Flags:
   -h, --help            Show help for this command.


### PR DESCRIPTION
Release Notes
-------------
New Features
- Add `--context` and `--output` to `confluent connect custom-plugin create`

Checklist
---------
- [x] Leave this box unchecked if features are not yet available in production

What
----
This command was missing two standard flags.

Test & Review
-------------
Updated integration tests