### PR TITLE
Autocomplete `--credential-identity` flag

### DIFF
--- a/test/fixtures/output/ksql/cluster/create-credential-identity-autocomplete.golden
+++ b/test/fixtures/output/ksql/cluster/create-credential-identity-autocomplete.golden
@@ -1,0 +1,9 @@
+u11	Brian Strauch
+u-17	Miles Todzo
+u-11aaa	11 Aaa
+u-22bbb	22 Bbb
+u-33ccc	33 Ccc
+u-44ddd	Muwei He
+sa-12345	service-account: at your service.
+:4
+Completion ended with directive: ShellCompDirectiveNoFileComp

--- a/test/ksql_test.go
+++ b/test/ksql_test.go
@@ -39,6 +39,13 @@ func (s *CLITestSuite) TestKsqlClusterConfigureAcls() {
 }
 
 func (s *CLITestSuite) TestKsql_Autocomplete() {
-	test := CLITest{args: `__complete ksql cluster describe ""`, login: "cloud", fixture: "ksql/cluster/describe-autocomplete.golden"}
-	s.runIntegrationTest(test)
+	tests := []CLITest{
+		{args: `__complete ksql cluster describe ""`, fixture: "ksql/cluster/describe-autocomplete.golden"},
+		{args: `__complete ksql cluster create my-cluster --credential-identity ""`, fixture: "ksql/cluster/create-credential-identity-autocomplete.golden"},
+	}
+
+	for _, test := range tests {
+		test.login = "cloud"
+		s.runIntegrationTest(test)
+	}
 }


### PR DESCRIPTION
Release Notes
-------------
New Features
- Autocomplete `confluent ksql cluster create --credential-identity`

Checklist
---------
- [x] Leave this box unchecked if features are not yet available in production

What
----
Autocomplete with all users and service accounts

Test & Review
-------------
Added integration test