### PR TITLE
[TRAFFIC-10544] Add `confluent network dns forwarder update/create`

### DIFF
--- a/cmd/lint/main.go
+++ b/cmd/lint/main.go
@@ -207,6 +207,7 @@ var vocabWords = []string{
 	"hostname",
 	"iam",
 	"ip",
+	"ips",
 	"json",
 	"jit",
 	"jsonschema",

--- a/internal/network/command_dns_forwarder.go
+++ b/internal/network/command_dns_forwarder.go
@@ -38,9 +38,11 @@ func (c *command) newDnsForwarderCommand() *cobra.Command {
 		Short: "Manage DNS forwarders.",
 	}
 
+	cmd.AddCommand(c.newDnsForwarderCreateCommand())
 	cmd.AddCommand(c.newDnsForwarderDeleteCommand())
 	cmd.AddCommand(c.newDnsForwarderDescribeCommand())
 	cmd.AddCommand(c.newDnsForwarderListCommand())
+	cmd.AddCommand(c.newDnsForwarderUpdateCommand())
 
 	return cmd
 }

--- a/internal/network/command_dns_forwarder_create.go
+++ b/internal/network/command_dns_forwarder_create.go
@@ -22,7 +22,7 @@ func (c *command) newDnsForwarderCreateCommand() *cobra.Command {
 			},
 			examples.Example{
 				Text: "Create a named DNS forwarder.",
-				Code: "confluent network dns forwarder my-dns-forwarder create --domains abc.com,def.com --dns-server-ips 10.200.0.0,10.201.0.0 --gateway gw-123456",
+				Code: "confluent network dns forwarder create my-dns-forwarder --domains abc.com,def.com --dns-server-ips 10.200.0.0,10.201.0.0 --gateway gw-123456",
 			},
 		),
 	}

--- a/internal/network/command_dns_forwarder_create.go
+++ b/internal/network/command_dns_forwarder_create.go
@@ -1,0 +1,93 @@
+package network
+
+import (
+	"github.com/spf13/cobra"
+
+	networkingdnsforwarderv1 "github.com/confluentinc/ccloud-sdk-go-v2-internal/networking-dnsforwarder/v1"
+
+	pcmd "github.com/confluentinc/cli/v3/pkg/cmd"
+	"github.com/confluentinc/cli/v3/pkg/examples"
+)
+
+func (c *command) newDnsForwarderCreateCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "create [name]",
+		Short: "Create a DNS forwarder.",
+		Args:  cobra.MaximumNArgs(1),
+		RunE:  c.dnsForwarderCreate,
+		Example: examples.BuildExampleString(
+			examples.Example{
+				Text: "Create a DNS forwarder.",
+				Code: "confluent network dns forwarder create --domains abc.com,def.com --dns-server-ips 10.200.0.0,10.201.0.0 --gateway gw-123456",
+			},
+			examples.Example{
+				Text: "Create a named DNS forwarder.",
+				Code: "confluent network dns forwarder my-dns-forwarder create --domains abc.com,def.com --dns-server-ips 10.200.0.0,10.201.0.0 --gateway gw-123456",
+			},
+		),
+	}
+
+	cmd.Flags().StringSlice("dns-server-ips", nil, "A comma-separated list of IP addresses for the DNS server.")
+	cmd.Flags().String("gateway", "", "Gateway ID.")
+	cmd.Flags().StringSlice("domains", nil, "A comma-separated list of domains for the DNS forwarder to use.")
+	pcmd.AddContextFlag(cmd, c.CLICommand)
+	pcmd.AddEnvironmentFlag(cmd, c.AuthenticatedCLICommand)
+	pcmd.AddOutputFlag(cmd)
+
+	cobra.CheckErr(cmd.MarkFlagRequired("dns-server-ips"))
+	cobra.CheckErr(cmd.MarkFlagRequired("gateway"))
+
+	return cmd
+}
+
+func (c *command) dnsForwarderCreate(cmd *cobra.Command, args []string) error {
+	name := ""
+	if len(args) == 1 {
+		name = args[0]
+	}
+
+	domains, err := cmd.Flags().GetStringSlice("domains")
+	if err != nil {
+		return err
+	}
+
+	gatewayId, err := cmd.Flags().GetString("gateway")
+	if err != nil {
+		return err
+	}
+
+	dnsServerIps, err := cmd.Flags().GetStringSlice("dns-server-ips")
+	if err != nil {
+		return err
+	}
+
+	environmentId, err := c.Context.EnvironmentId()
+	if err != nil {
+		return err
+	}
+
+	createDnsForwarder := networkingdnsforwarderv1.NetworkingV1DnsForwarder{
+		Spec: &networkingdnsforwarderv1.NetworkingV1DnsForwarderSpec{
+			Domains: &domains,
+			Config: &networkingdnsforwarderv1.NetworkingV1DnsForwarderSpecConfigOneOf{
+				NetworkingV1ForwardViaIp: &networkingdnsforwarderv1.NetworkingV1ForwardViaIp{
+					Kind:         "ForwardViaIp",
+					DnsServerIps: dnsServerIps,
+				},
+			},
+			Environment: &networkingdnsforwarderv1.ObjectReference{Id: environmentId},
+			Gateway:     &networkingdnsforwarderv1.ObjectReference{Id: gatewayId},
+		},
+	}
+
+	if name != "" {
+		createDnsForwarder.Spec.SetDisplayName(name)
+	}
+
+	forwarder, err := c.V2Client.CreateDnsForwarder(createDnsForwarder)
+	if err != nil {
+		return err
+	}
+
+	return printDnsForwarderTable(cmd, forwarder)
+}

--- a/internal/network/command_dns_forwarder_update.go
+++ b/internal/network/command_dns_forwarder_update.go
@@ -28,13 +28,13 @@ func (c *command) newDnsForwarderUpdateCommand() *cobra.Command {
 	}
 
 	cmd.Flags().StringSlice("dns-server-ips", nil, "A comma-separated list of IP addresses for the DNS server.")
-	cmd.Flags().String("name", "", "Name of the DNS forwarder.")
 	cmd.Flags().StringSlice("domains", nil, "A comma-separated list of domains for the DNS forwarder to use.")
+	cmd.Flags().String("name", "", "Name of the DNS forwarder.")
 	pcmd.AddContextFlag(cmd, c.CLICommand)
 	pcmd.AddEnvironmentFlag(cmd, c.AuthenticatedCLICommand)
 	pcmd.AddOutputFlag(cmd)
 
-	cmd.MarkFlagsOneRequired("name", "domains", "dns-server-ips")
+	cmd.MarkFlagsOneRequired("dns-server-ips", "domains", "name")
 
 	return cmd
 }

--- a/internal/network/command_dns_forwarder_update.go
+++ b/internal/network/command_dns_forwarder_update.go
@@ -18,23 +18,23 @@ func (c *command) newDnsForwarderUpdateCommand() *cobra.Command {
 		Example: examples.BuildExampleString(
 			examples.Example{
 				Text: `Update the name of DNS forwarder "dnsf-123456".`,
-				Code: `confluent network dns forwarder update dnsf-123456 --name "my-new-dns-forwarder"`,
+				Code: "confluent network dns forwarder update dnsf-123456 --name my-new-dns-forwarder",
 			},
 			examples.Example{
-				Text: `Update the gateway and domains of DNS forwarder "dnsf-123456".`,
-				Code: `confluent network dns forwarder update dnsf-123456 --gateway gw-123456 --domains abc.com,def.com`,
+				Text: `Update the DNS server IPs and domains of DNS forwarder "dnsf-123456".`,
+				Code: "confluent network dns forwarder update dnsf-123456 --dns-server-ips 10.200.0.0,10.201.0.0 --domains abc.com,def.com",
 			},
 		),
 	}
 
+	cmd.Flags().StringSlice("dns-server-ips", nil, "A comma-separated list of IP addresses for the DNS server.")
 	cmd.Flags().String("name", "", "Name of the DNS forwarder.")
 	cmd.Flags().StringSlice("domains", nil, "A comma-separated list of domains for the DNS forwarder to use.")
-	cmd.Flags().String("gateway", "", "Gateway ID.")
 	pcmd.AddContextFlag(cmd, c.CLICommand)
 	pcmd.AddEnvironmentFlag(cmd, c.AuthenticatedCLICommand)
 	pcmd.AddOutputFlag(cmd)
 
-	cmd.MarkFlagsOneRequired("name", "domains", "gateway")
+	cmd.MarkFlagsOneRequired("name", "domains", "dns-server-ips")
 
 	return cmd
 }
@@ -53,7 +53,7 @@ func (c *command) dnsForwarderUpdate(cmd *cobra.Command, args []string) error {
 	updateDnsForwarder := networkingdnsforwarderv1.NetworkingV1DnsForwarder{
 		Spec: &networkingdnsforwarderv1.NetworkingV1DnsForwarderSpec{
 			Environment: &networkingdnsforwarderv1.ObjectReference{Id: environmentId},
-			Gateway:     dnsForwarder.Spec.Gateway,
+			Config:      dnsForwarder.Spec.Config,
 		},
 	}
 
@@ -73,12 +73,12 @@ func (c *command) dnsForwarderUpdate(cmd *cobra.Command, args []string) error {
 		updateDnsForwarder.Spec.SetDomains(domains)
 	}
 
-	if cmd.Flags().Changed("gateway") {
-		gateway, err := cmd.Flags().GetString("gateway")
+	if cmd.Flags().Changed("dns-server-ips") {
+		dnsServerIps, err := cmd.Flags().GetStringSlice("dns-server-ips")
 		if err != nil {
 			return err
 		}
-		updateDnsForwarder.Spec.Gateway.SetId(gateway)
+		updateDnsForwarder.Spec.Config.NetworkingV1ForwardViaIp.SetDnsServerIps(dnsServerIps)
 	}
 
 	forwarder, err := c.V2Client.UpdateDnsForwarder(environmentId, args[0], updateDnsForwarder)

--- a/internal/network/command_dns_forwarder_update.go
+++ b/internal/network/command_dns_forwarder_update.go
@@ -27,14 +27,14 @@ func (c *command) newDnsForwarderUpdateCommand() *cobra.Command {
 		),
 	}
 
-	cmd.Flags().StringSlice("dns-server-ips", nil, "A comma-separated list of IP addresses for the DNS server.")
-	cmd.Flags().StringSlice("domains", nil, "A comma-separated list of domains for the DNS forwarder to use.")
 	cmd.Flags().String("name", "", "Name of the DNS forwarder.")
+	cmd.Flags().StringSlice("domains", nil, "A comma-separated list of domains for the DNS forwarder to use.")
+	cmd.Flags().StringSlice("dns-server-ips", nil, "A comma-separated list of IP addresses for the DNS server.")
 	pcmd.AddContextFlag(cmd, c.CLICommand)
 	pcmd.AddEnvironmentFlag(cmd, c.AuthenticatedCLICommand)
 	pcmd.AddOutputFlag(cmd)
 
-	cmd.MarkFlagsOneRequired("dns-server-ips", "domains", "name")
+	cmd.MarkFlagsOneRequired("name", "domains", "dns-server-ips")
 
 	return cmd
 }

--- a/internal/network/command_dns_forwarder_update.go
+++ b/internal/network/command_dns_forwarder_update.go
@@ -1,0 +1,90 @@
+package network
+
+import (
+	"github.com/spf13/cobra"
+
+	networkingdnsforwarderv1 "github.com/confluentinc/ccloud-sdk-go-v2-internal/networking-dnsforwarder/v1"
+
+	pcmd "github.com/confluentinc/cli/v3/pkg/cmd"
+	"github.com/confluentinc/cli/v3/pkg/examples"
+)
+
+func (c *command) newDnsForwarderUpdateCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "update <id>",
+		Short: "Update an existing DNS forwarder.",
+		Args:  cobra.ExactArgs(1),
+		RunE:  c.dnsForwarderUpdate,
+		Example: examples.BuildExampleString(
+			examples.Example{
+				Text: `Update the name of DNS forwarder "dnsf-123456".`,
+				Code: `confluent network dns forwarder update dnsf-123456 --name "my-new-dns-forwarder"`,
+			},
+			examples.Example{
+				Text: `Update the gateway and domains of DNS forwarder "dnsf-123456".`,
+				Code: `confluent network dns forwarder update dnsf-123456 --gateway gw-123456 --domains abc.com,def.com`,
+			},
+		),
+	}
+
+	cmd.Flags().String("name", "", "Name of the DNS forwarder.")
+	cmd.Flags().StringSlice("domains", nil, "A comma-separated list of domains for the DNS forwarder to use.")
+	cmd.Flags().String("gateway", "", "Gateway ID.")
+	pcmd.AddContextFlag(cmd, c.CLICommand)
+	pcmd.AddEnvironmentFlag(cmd, c.AuthenticatedCLICommand)
+	pcmd.AddOutputFlag(cmd)
+
+	cmd.MarkFlagsOneRequired("name", "domains", "gateway")
+
+	return cmd
+}
+
+func (c *command) dnsForwarderUpdate(cmd *cobra.Command, args []string) error {
+	environmentId, err := c.Context.EnvironmentId()
+	if err != nil {
+		return err
+	}
+
+	dnsForwarder, err := c.V2Client.GetDnsForwarder(environmentId, args[0])
+	if err != nil {
+		return err
+	}
+
+	updateDnsForwarder := networkingdnsforwarderv1.NetworkingV1DnsForwarder{
+		Spec: &networkingdnsforwarderv1.NetworkingV1DnsForwarderSpec{
+			Environment: &networkingdnsforwarderv1.ObjectReference{Id: environmentId},
+			Gateway:     dnsForwarder.Spec.Gateway,
+		},
+	}
+
+	if cmd.Flags().Changed("name") {
+		name, err := cmd.Flags().GetString("name")
+		if err != nil {
+			return err
+		}
+		updateDnsForwarder.Spec.SetDisplayName(name)
+	}
+
+	if cmd.Flags().Changed("domains") {
+		domains, err := cmd.Flags().GetStringSlice("domains")
+		if err != nil {
+			return err
+		}
+		updateDnsForwarder.Spec.SetDomains(domains)
+	}
+
+	if cmd.Flags().Changed("gateway") {
+		gateway, err := cmd.Flags().GetString("gateway")
+		if err != nil {
+			return err
+		}
+		updateDnsForwarder.Spec.Gateway.SetId(gateway)
+	}
+
+	forwarder, err := c.V2Client.UpdateDnsForwarder(environmentId, args[0], updateDnsForwarder)
+	if err != nil {
+		return err
+	}
+
+	return printDnsForwarderTable(cmd, forwarder)
+}

--- a/pkg/ccloudv2/networking_dnsforwarder.go
+++ b/pkg/ccloudv2/networking_dnsforwarder.go
@@ -62,3 +62,13 @@ func (c *Client) DeleteDnsForwarder(environment, id string) error {
 	httpResp, err := c.NetworkingDnsForwarderClient.DnsForwardersNetworkingV1Api.DeleteNetworkingV1DnsForwarder(c.networkingDnsForwarderApiContext(), id).Environment(environment).Execute()
 	return errors.CatchCCloudV2Error(err, httpResp)
 }
+
+func (c *Client) CreateDnsForwarder(forwarder networkingdnsforwarderv1.NetworkingV1DnsForwarder) (networkingdnsforwarderv1.NetworkingV1DnsForwarder, error) {
+	resp, httpResp, err := c.NetworkingDnsForwarderClient.DnsForwardersNetworkingV1Api.CreateNetworkingV1DnsForwarder(c.networkingApiContext()).NetworkingV1DnsForwarder(forwarder).Execute()
+	return resp, errors.CatchCCloudV2Error(err, httpResp)
+}
+
+func (c *Client) UpdateDnsForwarder(environment, id string, dnsForwarderUpdate networkingdnsforwarderv1.NetworkingV1DnsForwarder) (networkingdnsforwarderv1.NetworkingV1DnsForwarder, error) {
+	resp, httpResp, err := c.NetworkingDnsForwarderClient.DnsForwardersNetworkingV1Api.UpdateNetworkingV1DnsForwarder(c.networkingDnsForwarderApiContext(), id).NetworkingV1DnsForwarder(dnsForwarderUpdate).Execute()
+	return resp, errors.CatchCCloudV2Error(err, httpResp)
+}

--- a/test/fixtures/output/network/dns/forwarder/create-duplicate.golden
+++ b/test/fixtures/output/network/dns/forwarder/create-duplicate.golden
@@ -1,0 +1,1 @@
+Error: DNS Forwarder already exists for gateway.: 409 Conflict

--- a/test/fixtures/output/network/dns/forwarder/create-exceed-quota.golden
+++ b/test/fixtures/output/network/dns/forwarder/create-exceed-quota.golden
@@ -1,0 +1,1 @@
+Error: Provided number of dns server ips '1' exceeds quota '3': 409 Conflict

--- a/test/fixtures/output/network/dns/forwarder/create-help.golden
+++ b/test/fixtures/output/network/dns/forwarder/create-help.golden
@@ -1,0 +1,26 @@
+Create a DNS forwarder.
+
+Usage:
+  confluent network dns forwarder create [name] [flags]
+
+Examples:
+Create a DNS forwarder.
+
+  $ confluent network dns forwarder create --domains abc.com,def.com --dns-server-ips 10.200.0.0,10.201.0.0 --gateway gw-123456
+
+Create a named DNS forwarder.
+
+  $ confluent network dns forwarder my-dns-forwarder create --domains abc.com,def.com --dns-server-ips 10.200.0.0,10.201.0.0 --gateway gw-123456
+
+Flags:
+      --dns-server-ips strings   REQUIRED: A comma-separated list of IP addresses for the DNS server.
+      --gateway string           REQUIRED: Gateway ID.
+      --domains strings          A comma-separated list of domains for the DNS forwarder to use.
+      --context string           CLI context name.
+      --environment string       Environment ID.
+  -o, --output string            Specify the output format as "human", "json", or "yaml". (default "human")
+
+Global Flags:
+  -h, --help            Show help for this command.
+      --unsafe-trace    Equivalent to -vvvv, but also log HTTP requests and responses which might contain plaintext secrets.
+  -v, --verbose count   Increase verbosity (-v for warn, -vv for info, -vvv for debug, -vvvv for trace).

--- a/test/fixtures/output/network/dns/forwarder/create-help.golden
+++ b/test/fixtures/output/network/dns/forwarder/create-help.golden
@@ -10,7 +10,7 @@ Create a DNS forwarder.
 
 Create a named DNS forwarder.
 
-  $ confluent network dns forwarder my-dns-forwarder create --domains abc.com,def.com --dns-server-ips 10.200.0.0,10.201.0.0 --gateway gw-123456
+  $ confluent network dns forwarder create my-dns-forwarder --domains abc.com,def.com --dns-server-ips 10.200.0.0,10.201.0.0 --gateway gw-123456
 
 Flags:
       --dns-server-ips strings   REQUIRED: A comma-separated list of IP addresses for the DNS server.

--- a/test/fixtures/output/network/dns/forwarder/create-invalid-gateway.golden
+++ b/test/fixtures/output/network/dns/forwarder/create-invalid-gateway.golden
@@ -1,0 +1,1 @@
+Error: The provided gateway doesn't exist.: 404 Not Found

--- a/test/fixtures/output/network/dns/forwarder/create-missing-flags.golden
+++ b/test/fixtures/output/network/dns/forwarder/create-missing-flags.golden
@@ -1,0 +1,26 @@
+Error: required flag(s) "dns-server-ips", "gateway" not set
+Usage:
+  confluent network dns forwarder create [name] [flags]
+
+Examples:
+Create a DNS forwarder.
+
+  $ confluent network dns forwarder create --domains abc.com,def.com --dns-server-ips 10.200.0.0,10.201.0.0 --gateway gw-123456
+
+Create a named DNS forwarder.
+
+  $ confluent network dns forwarder my-dns-forwarder create --domains abc.com,def.com --dns-server-ips 10.200.0.0,10.201.0.0 --gateway gw-123456
+
+Flags:
+      --dns-server-ips strings   REQUIRED: A comma-separated list of IP addresses for the DNS server.
+      --gateway string           REQUIRED: Gateway ID.
+      --domains strings          A comma-separated list of domains for the DNS forwarder to use.
+      --context string           CLI context name.
+      --environment string       Environment ID.
+  -o, --output string            Specify the output format as "human", "json", or "yaml". (default "human")
+
+Global Flags:
+  -h, --help            Show help for this command.
+      --unsafe-trace    Equivalent to -vvvv, but also log HTTP requests and responses which might contain plaintext secrets.
+  -v, --verbose count   Increase verbosity (-v for warn, -vv for info, -vvv for debug, -vvvv for trace).
+

--- a/test/fixtures/output/network/dns/forwarder/create-missing-flags.golden
+++ b/test/fixtures/output/network/dns/forwarder/create-missing-flags.golden
@@ -9,7 +9,7 @@ Create a DNS forwarder.
 
 Create a named DNS forwarder.
 
-  $ confluent network dns forwarder my-dns-forwarder create --domains abc.com,def.com --dns-server-ips 10.200.0.0,10.201.0.0 --gateway gw-123456
+  $ confluent network dns forwarder create my-dns-forwarder --domains abc.com,def.com --dns-server-ips 10.200.0.0,10.201.0.0 --gateway gw-123456
 
 Flags:
       --dns-server-ips strings   REQUIRED: A comma-separated list of IP addresses for the DNS server.

--- a/test/fixtures/output/network/dns/forwarder/create-no-name.golden
+++ b/test/fixtures/output/network/dns/forwarder/create-no-name.golden
@@ -1,0 +1,8 @@
++----------------+---------------------------+
+| ID             | dnsf-abcde1               |
+| Domains        | abc.com, def.com, xyz.com |
+| DNS Server IPs | 10.200.0.0                |
+| Environment    | env-00000                 |
+| Gateway        | gw-123456                 |
+| Phase          | READY                     |
++----------------+---------------------------+

--- a/test/fixtures/output/network/dns/forwarder/create.golden
+++ b/test/fixtures/output/network/dns/forwarder/create.golden
@@ -1,0 +1,9 @@
++----------------+---------------------------+
+| ID             | dnsf-abcde1               |
+| Name           | my-dns-forwarder          |
+| Domains        | abc.com, def.com, xyz.com |
+| DNS Server IPs | 10.200.0.0                |
+| Environment    | env-00000                 |
+| Gateway        | gw-123456                 |
+| Phase          | READY                     |
++----------------+---------------------------+

--- a/test/fixtures/output/network/dns/forwarder/help.golden
+++ b/test/fixtures/output/network/dns/forwarder/help.golden
@@ -4,9 +4,11 @@ Usage:
   confluent network dns forwarder [command]
 
 Available Commands:
+  create      Create a DNS forwarder.
   delete      Delete one or more DNS forwarders.
   describe    Describe a DNS forwarder.
   list        List DNS forwarders.
+  update      Update an existing DNS forwarder.
 
 Global Flags:
   -h, --help            Show help for this command.

--- a/test/fixtures/output/network/dns/forwarder/update-dnsf-not-exist.golden
+++ b/test/fixtures/output/network/dns/forwarder/update-dnsf-not-exist.golden
@@ -1,0 +1,1 @@
+Error: The dns forwarder dnsf-invalid was not found.: 404 Not Found

--- a/test/fixtures/output/network/dns/forwarder/update-gateway.golden
+++ b/test/fixtures/output/network/dns/forwarder/update-gateway.golden
@@ -1,0 +1,11 @@
++----------------+---------------------------------+
+| ID             | dns-111111                      |
+| Name           | my-dns-forwarder                |
+| Domains        | abc.com, def.com,               |
+|                | example.domain, xyz.com,        |
+|                | my.dns.forwarder.example.domain |
+| DNS Server IPs | 10.200.0.0                      |
+| Environment    | env-00000                       |
+| Gateway        | gw-222222                       |
+| Phase          | READY                           |
++----------------+---------------------------------+

--- a/test/fixtures/output/network/dns/forwarder/update-help.golden
+++ b/test/fixtures/output/network/dns/forwarder/update-help.golden
@@ -13,9 +13,9 @@ Update the DNS server IPs and domains of DNS forwarder "dnsf-123456".
   $ confluent network dns forwarder update dnsf-123456 --dns-server-ips 10.200.0.0,10.201.0.0 --domains abc.com,def.com
 
 Flags:
-      --dns-server-ips strings   A comma-separated list of IP addresses for the DNS server.
-      --domains strings          A comma-separated list of domains for the DNS forwarder to use.
       --name string              Name of the DNS forwarder.
+      --domains strings          A comma-separated list of domains for the DNS forwarder to use.
+      --dns-server-ips strings   A comma-separated list of IP addresses for the DNS server.
       --context string           CLI context name.
       --environment string       Environment ID.
   -o, --output string            Specify the output format as "human", "json", or "yaml". (default "human")

--- a/test/fixtures/output/network/dns/forwarder/update-help.golden
+++ b/test/fixtures/output/network/dns/forwarder/update-help.golden
@@ -14,8 +14,8 @@ Update the DNS server IPs and domains of DNS forwarder "dnsf-123456".
 
 Flags:
       --dns-server-ips strings   A comma-separated list of IP addresses for the DNS server.
-      --name string              Name of the DNS forwarder.
       --domains strings          A comma-separated list of domains for the DNS forwarder to use.
+      --name string              Name of the DNS forwarder.
       --context string           CLI context name.
       --environment string       Environment ID.
   -o, --output string            Specify the output format as "human", "json", or "yaml". (default "human")

--- a/test/fixtures/output/network/dns/forwarder/update-help.golden
+++ b/test/fixtures/output/network/dns/forwarder/update-help.golden
@@ -1,0 +1,26 @@
+Update an existing DNS forwarder.
+
+Usage:
+  confluent network dns forwarder update <id> [flags]
+
+Examples:
+Update the name of DNS forwarder "dnsf-123456".
+
+  $ confluent network dns forwarder update dnsf-123456 --name "my-new-dns-forwarder"
+
+Update the gateway and domains of DNS forwarder "dnsf-123456".
+
+  $ confluent network dns forwarder update dnsf-123456 --gateway gw-123456 --domains abc.com,def.com
+
+Flags:
+      --name string          Name of the DNS forwarder.
+      --domains strings      A comma-separated list of domains for the DNS forwarder to use.
+      --gateway string       Gateway ID.
+      --context string       CLI context name.
+      --environment string   Environment ID.
+  -o, --output string        Specify the output format as "human", "json", or "yaml". (default "human")
+
+Global Flags:
+  -h, --help            Show help for this command.
+      --unsafe-trace    Equivalent to -vvvv, but also log HTTP requests and responses which might contain plaintext secrets.
+  -v, --verbose count   Increase verbosity (-v for warn, -vv for info, -vvv for debug, -vvvv for trace).

--- a/test/fixtures/output/network/dns/forwarder/update-help.golden
+++ b/test/fixtures/output/network/dns/forwarder/update-help.golden
@@ -6,19 +6,19 @@ Usage:
 Examples:
 Update the name of DNS forwarder "dnsf-123456".
 
-  $ confluent network dns forwarder update dnsf-123456 --name "my-new-dns-forwarder"
+  $ confluent network dns forwarder update dnsf-123456 --name my-new-dns-forwarder
 
-Update the gateway and domains of DNS forwarder "dnsf-123456".
+Update the DNS server IPs and domains of DNS forwarder "dnsf-123456".
 
-  $ confluent network dns forwarder update dnsf-123456 --gateway gw-123456 --domains abc.com,def.com
+  $ confluent network dns forwarder update dnsf-123456 --dns-server-ips 10.200.0.0,10.201.0.0 --domains abc.com,def.com
 
 Flags:
-      --name string          Name of the DNS forwarder.
-      --domains strings      A comma-separated list of domains for the DNS forwarder to use.
-      --gateway string       Gateway ID.
-      --context string       CLI context name.
-      --environment string   Environment ID.
-  -o, --output string        Specify the output format as "human", "json", or "yaml". (default "human")
+      --dns-server-ips strings   A comma-separated list of IP addresses for the DNS server.
+      --name string              Name of the DNS forwarder.
+      --domains strings          A comma-separated list of domains for the DNS forwarder to use.
+      --context string           CLI context name.
+      --environment string       Environment ID.
+  -o, --output string            Specify the output format as "human", "json", or "yaml". (default "human")
 
 Global Flags:
   -h, --help            Show help for this command.

--- a/test/fixtures/output/network/dns/forwarder/update-ips.golden
+++ b/test/fixtures/output/network/dns/forwarder/update-ips.golden
@@ -1,11 +1,12 @@
-+----------------+---------------------------------+
-| ID             | dns-111111                      |
-| Name           | my-dns-forwarder                |
-| Domains        | abc.com, def.com,               |
-|                | example.domain, xyz.com,        |
-|                | my.dns.forwarder.example.domain |
-| DNS Server IPs | 10.208.0.0, 10.209.0.0          |
-| Environment    | env-00000                       |
-| Gateway        | gw-111111                       |
-| Phase          | READY                           |
-+----------------+---------------------------------+
++----------------+----------------------------------+
+| ID             | dns-111111                       |
+| Name           | my-dns-forwarder                 |
+| Domains        | abc.com, def.com,                |
+|                | example.domain,                  |
+|                | my.dns.forwarder.example.domain, |
+|                | xyz.com                          |
+| DNS Server IPs | 10.208.0.0, 10.209.0.0           |
+| Environment    | env-00000                        |
+| Gateway        | gw-111111                        |
+| Phase          | READY                            |
++----------------+----------------------------------+

--- a/test/fixtures/output/network/dns/forwarder/update-ips.golden
+++ b/test/fixtures/output/network/dns/forwarder/update-ips.golden
@@ -4,8 +4,8 @@
 | Domains        | abc.com, def.com,               |
 |                | example.domain, xyz.com,        |
 |                | my.dns.forwarder.example.domain |
-| DNS Server IPs | 10.200.0.0                      |
+| DNS Server IPs | 10.208.0.0, 10.209.0.0          |
 | Environment    | env-00000                       |
-| Gateway        | gw-222222                       |
+| Gateway        | gw-111111                       |
 | Phase          | READY                           |
 +----------------+---------------------------------+

--- a/test/fixtures/output/network/dns/forwarder/update-missing-args.golden
+++ b/test/fixtures/output/network/dns/forwarder/update-missing-args.golden
@@ -1,0 +1,26 @@
+Error: accepts 1 arg(s), received 0
+Usage:
+  confluent network dns forwarder update <id> [flags]
+
+Examples:
+Update the name of DNS forwarder "dnsf-123456".
+
+  $ confluent network dns forwarder update dnsf-123456 --name "my-new-dns-forwarder"
+
+Update the gateway and domains of DNS forwarder "dnsf-123456".
+
+  $ confluent network dns forwarder update dnsf-123456 --gateway gw-123456 --domains abc.com,def.com
+
+Flags:
+      --name string          Name of the DNS forwarder.
+      --domains strings      A comma-separated list of domains for the DNS forwarder to use.
+      --gateway string       Gateway ID.
+      --context string       CLI context name.
+      --environment string   Environment ID.
+  -o, --output string        Specify the output format as "human", "json", or "yaml". (default "human")
+
+Global Flags:
+  -h, --help            Show help for this command.
+      --unsafe-trace    Equivalent to -vvvv, but also log HTTP requests and responses which might contain plaintext secrets.
+  -v, --verbose count   Increase verbosity (-v for warn, -vv for info, -vvv for debug, -vvvv for trace).
+

--- a/test/fixtures/output/network/dns/forwarder/update-missing-args.golden
+++ b/test/fixtures/output/network/dns/forwarder/update-missing-args.golden
@@ -13,8 +13,8 @@ Update the DNS server IPs and domains of DNS forwarder "dnsf-123456".
 
 Flags:
       --dns-server-ips strings   A comma-separated list of IP addresses for the DNS server.
-      --name string              Name of the DNS forwarder.
       --domains strings          A comma-separated list of domains for the DNS forwarder to use.
+      --name string              Name of the DNS forwarder.
       --context string           CLI context name.
       --environment string       Environment ID.
   -o, --output string            Specify the output format as "human", "json", or "yaml". (default "human")

--- a/test/fixtures/output/network/dns/forwarder/update-missing-args.golden
+++ b/test/fixtures/output/network/dns/forwarder/update-missing-args.golden
@@ -5,19 +5,19 @@ Usage:
 Examples:
 Update the name of DNS forwarder "dnsf-123456".
 
-  $ confluent network dns forwarder update dnsf-123456 --name "my-new-dns-forwarder"
+  $ confluent network dns forwarder update dnsf-123456 --name my-new-dns-forwarder
 
-Update the gateway and domains of DNS forwarder "dnsf-123456".
+Update the DNS server IPs and domains of DNS forwarder "dnsf-123456".
 
-  $ confluent network dns forwarder update dnsf-123456 --gateway gw-123456 --domains abc.com,def.com
+  $ confluent network dns forwarder update dnsf-123456 --dns-server-ips 10.200.0.0,10.201.0.0 --domains abc.com,def.com
 
 Flags:
-      --name string          Name of the DNS forwarder.
-      --domains strings      A comma-separated list of domains for the DNS forwarder to use.
-      --gateway string       Gateway ID.
-      --context string       CLI context name.
-      --environment string   Environment ID.
-  -o, --output string        Specify the output format as "human", "json", or "yaml". (default "human")
+      --dns-server-ips strings   A comma-separated list of IP addresses for the DNS server.
+      --name string              Name of the DNS forwarder.
+      --domains strings          A comma-separated list of domains for the DNS forwarder to use.
+      --context string           CLI context name.
+      --environment string       Environment ID.
+  -o, --output string            Specify the output format as "human", "json", or "yaml". (default "human")
 
 Global Flags:
   -h, --help            Show help for this command.

--- a/test/fixtures/output/network/dns/forwarder/update-missing-args.golden
+++ b/test/fixtures/output/network/dns/forwarder/update-missing-args.golden
@@ -12,9 +12,9 @@ Update the DNS server IPs and domains of DNS forwarder "dnsf-123456".
   $ confluent network dns forwarder update dnsf-123456 --dns-server-ips 10.200.0.0,10.201.0.0 --domains abc.com,def.com
 
 Flags:
-      --dns-server-ips strings   A comma-separated list of IP addresses for the DNS server.
-      --domains strings          A comma-separated list of domains for the DNS forwarder to use.
       --name string              Name of the DNS forwarder.
+      --domains strings          A comma-separated list of domains for the DNS forwarder to use.
+      --dns-server-ips strings   A comma-separated list of IP addresses for the DNS server.
       --context string           CLI context name.
       --environment string       Environment ID.
   -o, --output string            Specify the output format as "human", "json", or "yaml". (default "human")

--- a/test/fixtures/output/network/dns/forwarder/update-missing-flags.golden
+++ b/test/fixtures/output/network/dns/forwarder/update-missing-flags.golden
@@ -1,0 +1,26 @@
+Error: at least one of the flags in the group [name domains gateway] is required
+Usage:
+  confluent network dns forwarder update <id> [flags]
+
+Examples:
+Update the name of DNS forwarder "dnsf-123456".
+
+  $ confluent network dns forwarder update dnsf-123456 --name "my-new-dns-forwarder"
+
+Update the gateway and domains of DNS forwarder "dnsf-123456".
+
+  $ confluent network dns forwarder update dnsf-123456 --gateway gw-123456 --domains abc.com,def.com
+
+Flags:
+      --name string          Name of the DNS forwarder.
+      --domains strings      A comma-separated list of domains for the DNS forwarder to use.
+      --gateway string       Gateway ID.
+      --context string       CLI context name.
+      --environment string   Environment ID.
+  -o, --output string        Specify the output format as "human", "json", or "yaml". (default "human")
+
+Global Flags:
+  -h, --help            Show help for this command.
+      --unsafe-trace    Equivalent to -vvvv, but also log HTTP requests and responses which might contain plaintext secrets.
+  -v, --verbose count   Increase verbosity (-v for warn, -vv for info, -vvv for debug, -vvvv for trace).
+

--- a/test/fixtures/output/network/dns/forwarder/update-missing-flags.golden
+++ b/test/fixtures/output/network/dns/forwarder/update-missing-flags.golden
@@ -1,4 +1,4 @@
-Error: at least one of the flags in the group [name domains dns-server-ips] is required
+Error: at least one of the flags in the group [dns-server-ips domains name] is required
 Usage:
   confluent network dns forwarder update <id> [flags]
 
@@ -13,8 +13,8 @@ Update the DNS server IPs and domains of DNS forwarder "dnsf-123456".
 
 Flags:
       --dns-server-ips strings   A comma-separated list of IP addresses for the DNS server.
-      --name string              Name of the DNS forwarder.
       --domains strings          A comma-separated list of domains for the DNS forwarder to use.
+      --name string              Name of the DNS forwarder.
       --context string           CLI context name.
       --environment string       Environment ID.
   -o, --output string            Specify the output format as "human", "json", or "yaml". (default "human")

--- a/test/fixtures/output/network/dns/forwarder/update-missing-flags.golden
+++ b/test/fixtures/output/network/dns/forwarder/update-missing-flags.golden
@@ -1,23 +1,23 @@
-Error: at least one of the flags in the group [name domains gateway] is required
+Error: at least one of the flags in the group [name domains dns-server-ips] is required
 Usage:
   confluent network dns forwarder update <id> [flags]
 
 Examples:
 Update the name of DNS forwarder "dnsf-123456".
 
-  $ confluent network dns forwarder update dnsf-123456 --name "my-new-dns-forwarder"
+  $ confluent network dns forwarder update dnsf-123456 --name my-new-dns-forwarder
 
-Update the gateway and domains of DNS forwarder "dnsf-123456".
+Update the DNS server IPs and domains of DNS forwarder "dnsf-123456".
 
-  $ confluent network dns forwarder update dnsf-123456 --gateway gw-123456 --domains abc.com,def.com
+  $ confluent network dns forwarder update dnsf-123456 --dns-server-ips 10.200.0.0,10.201.0.0 --domains abc.com,def.com
 
 Flags:
-      --name string          Name of the DNS forwarder.
-      --domains strings      A comma-separated list of domains for the DNS forwarder to use.
-      --gateway string       Gateway ID.
-      --context string       CLI context name.
-      --environment string   Environment ID.
-  -o, --output string        Specify the output format as "human", "json", or "yaml". (default "human")
+      --dns-server-ips strings   A comma-separated list of IP addresses for the DNS server.
+      --name string              Name of the DNS forwarder.
+      --domains strings          A comma-separated list of domains for the DNS forwarder to use.
+      --context string           CLI context name.
+      --environment string       Environment ID.
+  -o, --output string            Specify the output format as "human", "json", or "yaml". (default "human")
 
 Global Flags:
   -h, --help            Show help for this command.

--- a/test/fixtures/output/network/dns/forwarder/update-missing-flags.golden
+++ b/test/fixtures/output/network/dns/forwarder/update-missing-flags.golden
@@ -1,4 +1,4 @@
-Error: at least one of the flags in the group [dns-server-ips domains name] is required
+Error: at least one of the flags in the group [name domains dns-server-ips] is required
 Usage:
   confluent network dns forwarder update <id> [flags]
 
@@ -12,9 +12,9 @@ Update the DNS server IPs and domains of DNS forwarder "dnsf-123456".
   $ confluent network dns forwarder update dnsf-123456 --dns-server-ips 10.200.0.0,10.201.0.0 --domains abc.com,def.com
 
 Flags:
-      --dns-server-ips strings   A comma-separated list of IP addresses for the DNS server.
-      --domains strings          A comma-separated list of domains for the DNS forwarder to use.
       --name string              Name of the DNS forwarder.
+      --domains strings          A comma-separated list of domains for the DNS forwarder to use.
+      --dns-server-ips strings   A comma-separated list of IP addresses for the DNS server.
       --context string           CLI context name.
       --environment string       Environment ID.
   -o, --output string            Specify the output format as "human", "json", or "yaml". (default "human")

--- a/test/fixtures/output/network/dns/forwarder/update.golden
+++ b/test/fixtures/output/network/dns/forwarder/update.golden
@@ -1,0 +1,9 @@
++----------------+---------------------------+
+| ID             | dns-111111                |
+| Name           | my-new-dns-forwarder      |
+| Domains        | ghi.com, jkl.com, xyz.com |
+| DNS Server IPs | 10.200.0.0                |
+| Environment    | env-00000                 |
+| Gateway        | gw-111111                 |
+| Phase          | READY                     |
++----------------+---------------------------+

--- a/test/fixtures/output/network/dns/forwarder/update.golden
+++ b/test/fixtures/output/network/dns/forwarder/update.golden
@@ -2,7 +2,7 @@
 | ID             | dns-111111                |
 | Name           | my-new-dns-forwarder      |
 | Domains        | ghi.com, jkl.com, xyz.com |
-| DNS Server IPs | 10.200.0.0                |
+| DNS Server IPs | 10.200.0.0, 10.206.0.0    |
 | Environment    | env-00000                 |
 | Gateway        | gw-111111                 |
 | Phase          | READY                     |

--- a/test/network_test.go
+++ b/test/network_test.go
@@ -614,6 +614,37 @@ func (s *CLITestSuite) TestNetworkDnsForwarderDelete() {
 	}
 }
 
+func (s *CLITestSuite) TestNetworkDnsForwarderUpdate() {
+	tests := []CLITest{
+		{args: "network dns forwarder update", fixture: "network/dns/forwarder/update-missing-args.golden", exitCode: 1},
+		{args: "network dns forwarder update dnsf-111111", fixture: "network/dns/forwarder/update-missing-flags.golden", exitCode: 1},
+		{args: "network dns forwarder update dnsf-111111 --name my-new-dns-forwarder --domains ghi.com,jkl.com,xyz.com", fixture: "network/dns/forwarder/update.golden"},
+		{args: "network dns forwarder update dnsf-111111 --gateway gw-222222", fixture: "network/dns/forwarder/update-gateway.golden"},
+		{args: "network dns forwarder update dnsf-invalid --name my-new-dns-forwarder", fixture: "network/dns/forwarder/update-dnsf-not-exist.golden", exitCode: 1},
+	}
+
+	for _, test := range tests {
+		test.login = "cloud"
+		s.runIntegrationTest(test)
+	}
+}
+
+func (s *CLITestSuite) TestNetworkDnsForwarderCreate() {
+	tests := []CLITest{
+		{args: "network dns forwarder create my-dns-forwarder", fixture: "network/dns/forwarder/create-missing-flags.golden", exitCode: 1},
+		{args: "network dns forwarder create dnsf-invalid-gateway --dns-server-ips 10.200.0.0 --gateway gw-123456", fixture: "network/dns/forwarder/create-invalid-gateway.golden", exitCode: 1},
+		{args: "network dns forwarder create dnsf-duplicate --dns-server-ips 10.200.0.0 --gateway gw-123456", fixture: "network/dns/forwarder/create-duplicate.golden", exitCode: 1},
+		{args: "network dns forwarder create dnsf-exceed-quota --dns-server-ips 10.200.0.0 --gateway gw-123456", fixture: "network/dns/forwarder/create-exceed-quota.golden", exitCode: 1},
+		{args: "network dns forwarder create my-dns-forwarder --dns-server-ips 10.200.0.0 --gateway gw-123456 --domains abc.com,def.com,xyz.com", fixture: "network/dns/forwarder/create.golden"},
+		{args: "network dns forwarder create --dns-server-ips 10.200.0.0 --gateway gw-123456 --domains abc.com,def.com,xyz.com", fixture: "network/dns/forwarder/create-no-name.golden"},
+	}
+
+	for _, test := range tests {
+		test.login = "cloud"
+		s.runIntegrationTest(test)
+	}
+}
+
 func (s *CLITestSuite) TestNetworkDnsForwarder_Autocomplete() {
 	tests := []CLITest{
 		{args: `__complete network dns forwarder describe ""`, login: "cloud", fixture: "network/dns/forwarder/describe-autocomplete.golden"},

--- a/test/network_test.go
+++ b/test/network_test.go
@@ -619,7 +619,7 @@ func (s *CLITestSuite) TestNetworkDnsForwarderUpdate() {
 		{args: "network dns forwarder update", fixture: "network/dns/forwarder/update-missing-args.golden", exitCode: 1},
 		{args: "network dns forwarder update dnsf-111111", fixture: "network/dns/forwarder/update-missing-flags.golden", exitCode: 1},
 		{args: "network dns forwarder update dnsf-111111 --name my-new-dns-forwarder --domains ghi.com,jkl.com,xyz.com", fixture: "network/dns/forwarder/update.golden"},
-		{args: "network dns forwarder update dnsf-111111 --gateway gw-222222", fixture: "network/dns/forwarder/update-gateway.golden"},
+		{args: "network dns forwarder update dnsf-111111 --dns-server-ips 10.208.0.0,10.209.0.0", fixture: "network/dns/forwarder/update-ips.golden"},
 		{args: "network dns forwarder update dnsf-invalid --name my-new-dns-forwarder", fixture: "network/dns/forwarder/update-dnsf-not-exist.golden", exitCode: 1},
 	}
 

--- a/test/test-server/networking_handlers.go
+++ b/test/test-server/networking_handlers.go
@@ -1538,8 +1538,8 @@ func handleNetworkingDnsForwarderUpdate(t *testing.T, id string) http.HandlerFun
 			if body.Spec.Domains != nil {
 				forwarder.Spec.SetDomains(body.Spec.GetDomains())
 			}
-			if body.Spec.Gateway != nil {
-				forwarder.Spec.Gateway.SetId(body.Spec.Gateway.GetId())
+			if body.Spec.Config != nil {
+				forwarder.Spec.Config.NetworkingV1ForwardViaIp.SetDnsServerIps(body.Spec.Config.NetworkingV1ForwardViaIp.GetDnsServerIps())
 			}
 			err = json.NewEncoder(w).Encode(forwarder)
 			require.NoError(t, err)


### PR DESCRIPTION
What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->
Note that this is merging into the feature branch https://github.com/confluentinc/cli/tree/traffic-10544-dnsforwarder. We will merge commits into main from this feature branch after all of the commands for dns forwarder are implemented.

- Add `confluent network dns forwarder create`
- Add `confluent network dns forwarder update`


References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->
[DNS Peering for Managed Connectors](https://confluentinc.atlassian.net/wiki/spaces/CIRE/pages/2947056320/1-Pager+--+DNS+peering+for+managed+connectors)

Test & Review
-------------
<!--
Has it been tested? How?
Copy and paste any instructions or steps that can save the reviewer time.
-->
Added integration tests