### PR TITLE
[CLI-1992] Add `--output` flag to `secret` commands

### DIFF
--- a/internal/secret/command_file_rotate.go
+++ b/internal/secret/command_file_rotate.go
@@ -3,6 +3,7 @@ package secret
 import (
 	"github.com/spf13/cobra"
 
+	pcmd "github.com/confluentinc/cli/v3/pkg/cmd"
 	"github.com/confluentinc/cli/v3/pkg/errors"
 	"github.com/confluentinc/cli/v3/pkg/output"
 )
@@ -25,6 +26,7 @@ func (c *command) newRotateCommand() *cobra.Command {
 	cmd.Flags().Bool("data-key", false, "Rotate data key. Generates a new data key and re-encrypts the file with the new key.")
 	cmd.Flags().String("passphrase", "", `Master key passphrase. You can use dash ("-") to pipe from stdin or @file.txt to read from file.`)
 	cmd.Flags().String("passphrase-new", "", `New master key passphrase. You can use dash ("-") to pipe from stdin or @file.txt to read from file.`)
+	pcmd.AddOutputFlag(cmd)
 
 	cobra.CheckErr(cmd.MarkFlagRequired("local-secrets-file"))
 

--- a/internal/secret/command_master_key_generate.go
+++ b/internal/secret/command_master_key_generate.go
@@ -32,6 +32,7 @@ func (c *command) newGenerateFunction() *cobra.Command {
 
 	cmd.Flags().String("local-secrets-file", "", "Path to the local encrypted configuration properties file.")
 	cmd.Flags().String("passphrase", "", "The key passphrase.")
+	pcmd.AddOutputFlag(cmd)
 
 	cobra.CheckErr(cmd.MarkFlagRequired("local-secrets-file"))
 

--- a/test/fixtures/output/secret/file/rotate-help-onprem.golden
+++ b/test/fixtures/output/secret/file/rotate-help-onprem.golden
@@ -9,6 +9,7 @@ Flags:
       --data-key                    Rotate data key. Generates a new data key and re-encrypts the file with the new key.
       --passphrase string           Master key passphrase. You can use dash ("-") to pipe from stdin or @file.txt to read from file.
       --passphrase-new string       New master key passphrase. You can use dash ("-") to pipe from stdin or @file.txt to read from file.
+  -o, --output string               Specify the output format as "human", "json", or "yaml". (default "human")
 
 Global Flags:
   -h, --help            Show help for this command.

--- a/test/fixtures/output/secret/master-key/generate-help-onprem.golden
+++ b/test/fixtures/output/secret/master-key/generate-help-onprem.golden
@@ -15,6 +15,7 @@ Read the passphrase from the file "/User/bob/secret.properties":
 Flags:
       --local-secrets-file string   REQUIRED: Path to the local encrypted configuration properties file.
       --passphrase string           The key passphrase.
+  -o, --output string               Specify the output format as "human", "json", or "yaml". (default "human")
 
 Global Flags:
   -h, --help            Show help for this command.


### PR DESCRIPTION
Release Notes
-------------
New Features
- Add `--output` flag to `confluent secret file rotate` and `confluent secret master-key generate`

Checklist
---------
- [x] Leave this box unchecked if features are not yet available in production

What
----
These commands print tables, but do not offer the `--output` flag.

Test & Review
-------------
Updated integration tests