### PR TITLE
Clone CLI in publish-docs target

### DIFF
--- a/mk-files/docs.mk
+++ b/mk-files/docs.mk
@@ -36,7 +36,7 @@ publish-docs:
 	git clone git@github.com:confluentinc/docs-confluent-cli.git $(DOCS_CONFLUENT_CLI) && \
 	cd $(DOCS_CONFLUENT_CLI) && \
 	git checkout -b publish-docs-v$(CLEAN_VERSION) && \
-	$(SED) -i "10r $(DIR)/release-notes.rst" $(DOCS_CONFLUENT_CLI)/release-notes.rst && \
+	$(SED) -i "10r $(DIR)/release-notes.rst" release-notes.rst && \
 	rm -rf command-reference && \
 	cp -R $(CLI)/docs command-reference && \
 	git add . && \

--- a/mk-files/docs.mk
+++ b/mk-files/docs.mk
@@ -30,9 +30,9 @@ publish-docs:
 	git clone git@github.com:confluentinc/cli-release.git $(CLI_RELEASE) && \
 	go run $(CLI_RELEASE)/cmd/releasenotes/formatter/main.go $(CLI_RELEASE)/release-notes/$(CLEAN_VERSION).json docs > $(DIR)/release-notes.rst && \
 	git clone git@github.com:confluentinc/cli.git $(CLI) && \
-    cd $(CLI) && \
+	cd $(CLI) && \
 	go run cmd/docs/main.go && \
-    cd - && \
+	cd - && \
 	git clone git@github.com:confluentinc/docs-confluent-cli.git $(DOCS_CONFLUENT_CLI) && \
 	cd $(DOCS_CONFLUENT_CLI) && \
 	git checkout -b publish-docs-v$(CLEAN_VERSION) && \


### PR DESCRIPTION
What
----
Improve the CLI release by cloning the CLI repo in `make publish-docs`. This removes the requirement that the CLI must be located at ~/git/go/src/...

Test & Review
-------------
Ran with `DRY_RUN=true`