### PR TITLE
KGLOBAL-4375: Support getting link task info on prem

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,7 @@ require (
 	github.com/confluentinc/go-netrc v0.0.0-20220321173724-4d50f36ff450
 	github.com/confluentinc/go-prompt v0.2.24
 	github.com/confluentinc/go-ps1 v1.0.2
-	github.com/confluentinc/kafka-rest-sdk-go/kafkarestv3 v0.3.17
+	github.com/confluentinc/kafka-rest-sdk-go/kafkarestv3 v0.3.18
 	github.com/confluentinc/mds-sdk-go-public/mdsv1 v0.0.0-20230117192233-7e6d894d74a9
 	github.com/confluentinc/mds-sdk-go-public/mdsv2alpha1 v0.0.0-20230117192233-7e6d894d74a9
 	github.com/confluentinc/properties v0.0.0-20190814194548-42c10394a787

--- a/go.sum
+++ b/go.sum
@@ -171,8 +171,8 @@ github.com/confluentinc/go-prompt v0.2.24 h1:vSYjaE+UjjdjV7jq87g8+dCWxu8GJxpdJvF
 github.com/confluentinc/go-prompt v0.2.24/go.mod h1:4/tf63YzhSsiXnsKosCmv1H0ivpXVezZHaMpSVB+DXw=
 github.com/confluentinc/go-ps1 v1.0.2 h1:+4cKOzWs3AWmxL2s96oHu0QutZESDRXECnhFzm2ic4o=
 github.com/confluentinc/go-ps1 v1.0.2/go.mod h1:qmgG9xQgFd4u7/CS6eA9nNP8eQqOtXuRHmZ4+w7Vprs=
-github.com/confluentinc/kafka-rest-sdk-go/kafkarestv3 v0.3.17 h1:OXDvG8h8h77w3jH8N26BZaHILWeKw67/177fZxXDQdw=
-github.com/confluentinc/kafka-rest-sdk-go/kafkarestv3 v0.3.17/go.mod h1:qJAUraWU9BERQWyalrPsxt+ECELWPV+qsyOaP00VidY=
+github.com/confluentinc/kafka-rest-sdk-go/kafkarestv3 v0.3.18 h1:M9/yzpG+eOTp/peiHNHRQWax0If6+GAJIC/NcvbzAOI=
+github.com/confluentinc/kafka-rest-sdk-go/kafkarestv3 v0.3.18/go.mod h1:qJAUraWU9BERQWyalrPsxt+ECELWPV+qsyOaP00VidY=
 github.com/confluentinc/mds-sdk-go-public/mdsv1 v0.0.0-20230117192233-7e6d894d74a9 h1:z8+7/YVstZwsyPFt+s+fCWk8wa+JIgj6pEhEUMVmUcI=
 github.com/confluentinc/mds-sdk-go-public/mdsv1 v0.0.0-20230117192233-7e6d894d74a9/go.mod h1:2Ug8TKPkJXnazoTwlf72RawtttFZYNB3WB/8w3Hgfro=
 github.com/confluentinc/mds-sdk-go-public/mdsv2alpha1 v0.0.0-20230117192233-7e6d894d74a9 h1:O3xty/V/9T3uMH3RAWsBSeh+Qo1lUKh4v1BgfHRjLvo=

--- a/internal/kafka/command_link.go
+++ b/internal/kafka/command_link.go
@@ -45,6 +45,7 @@ func newLinkCommand(cfg *config.Config, prerunner pcmd.PreRunner) *cobra.Command
 		cmd.AddCommand(c.newDeleteCommandOnPrem())
 		cmd.AddCommand(c.newDescribeCommandOnPrem())
 		cmd.AddCommand(c.newListCommandOnPrem())
+		cmd.AddCommand(c.newTaskCommandOnPrem())
 	}
 
 	return cmd

--- a/internal/kafka/command_link_describe_onprem.go
+++ b/internal/kafka/command_link_describe_onprem.go
@@ -1,7 +1,10 @@
 package kafka
 
 import (
+	"github.com/antihax/optional"
 	"github.com/spf13/cobra"
+
+	"github.com/confluentinc/kafka-rest-sdk-go/kafkarestv3"
 
 	pcmd "github.com/confluentinc/cli/v3/pkg/cmd"
 	"github.com/confluentinc/cli/v3/pkg/output"
@@ -31,7 +34,10 @@ func (c *linkCommand) describeOnPrem(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	data, httpResp, err := client.ClusterLinkingV3Api.GetKafkaLink(ctx, clusterId, linkName)
+	linkOpts := kafkarestv3.GetKafkaLinkOpts{
+		IncludeTasks: optional.NewBool(false),
+	}
+	data, httpResp, err := client.ClusterLinkingV3Api.GetKafkaLink(ctx, clusterId, linkName, &linkOpts)
 	if err != nil {
 		return handleOpenApiError(httpResp, err, client)
 	}

--- a/internal/kafka/command_link_describe_onprem.go
+++ b/internal/kafka/command_link_describe_onprem.go
@@ -34,9 +34,7 @@ func (c *linkCommand) describeOnPrem(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	linkOpts := kafkarestv3.GetKafkaLinkOpts{
-		IncludeTasks: optional.NewBool(false),
-	}
+	linkOpts := kafkarestv3.GetKafkaLinkOpts{IncludeTasks: optional.NewBool(false)}
 	data, httpResp, err := client.ClusterLinkingV3Api.GetKafkaLink(ctx, clusterId, linkName, &linkOpts)
 	if err != nil {
 		return handleOpenApiError(httpResp, err, client)

--- a/internal/kafka/command_link_task_list.go
+++ b/internal/kafka/command_link_task_list.go
@@ -88,9 +88,9 @@ func (c *linkCommand) taskList(cmd *cobra.Command, args []string) error {
 	}
 	tasks := make([]task, len(link.GetTasks()))
 	for i, t := range link.GetTasks() {
-		errs := make([]taskErr, len(t.Errors))
+		errors := make([]taskErr, len(t.Errors))
 		for j, e := range t.Errors {
-			errs[j] = taskErr{
+			errors[j] = taskErr{
 				ErrorCode:    e.ErrorCode,
 				ErrorMessage: e.ErrorMessage,
 			}
@@ -98,12 +98,11 @@ func (c *linkCommand) taskList(cmd *cobra.Command, args []string) error {
 		tasks[i] = task{
 			TaskName: t.TaskName,
 			State:    t.State,
-			Errors:   errs,
+			Errors:   errors,
 		}
 	}
 
-	isSerialized := output.GetFormat(cmd).IsSerialized()
-	if isSerialized {
+	if output.GetFormat(cmd).IsSerialized() {
 		return writeSerialized(cmd, tasks)
 	} else {
 		return writeHuman(cmd, tasks)

--- a/internal/kafka/command_link_task_list.go
+++ b/internal/kafka/command_link_task_list.go
@@ -14,6 +14,17 @@ import (
 	"github.com/confluentinc/cli/v3/pkg/output"
 )
 
+type task struct {
+	TaskName string
+	State    string
+	Errors   []taskErr
+}
+
+type taskErr struct {
+	ErrorCode    string
+	ErrorMessage string
+}
+
 type serializedTaskOut struct {
 	TaskName string                   `serialized:"task_name"`
 	State    string                   `serialized:"state"`
@@ -75,24 +86,36 @@ func (c *linkCommand) taskList(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	tasks := make([]task, len(link.GetTasks()))
+	for i, t := range link.GetTasks() {
+		errs := make([]taskErr, len(t.Errors))
+		for j, e := range t.Errors {
+			errs[j] = taskErr{
+				ErrorCode:    e.ErrorCode,
+				ErrorMessage: e.ErrorMessage,
+			}
+		}
+		tasks[i] = task{
+			TaskName: t.TaskName,
+			State:    t.State,
+			Errors:   errs,
+		}
+	}
 
 	isSerialized := output.GetFormat(cmd).IsSerialized()
 	if isSerialized {
-		return writeSerialized(cmd, link)
+		return writeSerialized(cmd, tasks)
 	} else {
-		return writeHuman(cmd, link)
+		return writeHuman(cmd, tasks)
 	}
 }
 
-func writeSerialized(cmd *cobra.Command, link kafkarestv3.ListLinksResponseData) error {
+func writeSerialized(cmd *cobra.Command, tasks []task) error {
 	list := output.NewList(cmd)
-	for _, task := range link.GetTasks() {
+	for _, task := range tasks {
 		errs := make([]serializedTaskErrorOut, len(task.Errors))
 		for i, err := range task.Errors {
-			errs[i] = serializedTaskErrorOut{
-				ErrorCode:    err.ErrorCode,
-				ErrorMessage: err.ErrorMessage,
-			}
+			errs[i] = serializedTaskErrorOut(err)
 		}
 		list.Add(&serializedTaskOut{
 			TaskName: task.TaskName,
@@ -103,9 +126,9 @@ func writeSerialized(cmd *cobra.Command, link kafkarestv3.ListLinksResponseData)
 	return list.Print()
 }
 
-func writeHuman(cmd *cobra.Command, link kafkarestv3.ListLinksResponseData) error {
+func writeHuman(cmd *cobra.Command, tasks []task) error {
 	list := output.NewList(cmd)
-	for _, task := range link.GetTasks() {
+	for _, task := range tasks {
 		errs := make([]string, len(task.Errors))
 		for i, err := range task.Errors {
 			errs[i] = fmt.Sprintf(`%s: "%s"`, err.ErrorCode, err.ErrorMessage)

--- a/internal/kafka/command_link_task_list_onprem.go
+++ b/internal/kafka/command_link_task_list_onprem.go
@@ -1,0 +1,77 @@
+package kafka
+
+import (
+	"github.com/antihax/optional"
+	"github.com/spf13/cobra"
+
+	"github.com/confluentinc/kafka-rest-sdk-go/kafkarestv3"
+
+	pcmd "github.com/confluentinc/cli/v3/pkg/cmd"
+	"github.com/confluentinc/cli/v3/pkg/output"
+)
+
+func (c *linkCommand) newTaskCommandOnPrem() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "task",
+		Short: "Manager a cluster link's tasks.",
+	}
+
+	cmd.AddCommand(c.newLinkTaskListCommandOnPrem())
+
+	return cmd
+}
+
+func (c *linkCommand) newLinkTaskListCommandOnPrem() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:               "list <link>",
+		Short:             "List a cluster link's tasks.",
+		Args:              cobra.ExactArgs(1),
+		ValidArgsFunction: pcmd.NewValidArgsFunction(c.validArgs),
+		RunE:              c.taskListOnPrem,
+	}
+
+	cmd.Flags().AddFlagSet(pcmd.OnPremKafkaRestSet())
+	pcmd.AddContextFlag(cmd, c.CLICommand)
+	pcmd.AddOutputFlag(cmd)
+
+	return cmd
+}
+
+func (c *linkCommand) taskListOnPrem(cmd *cobra.Command, args []string) error {
+	linkName := args[0]
+
+	client, ctx, clusterId, err := initKafkaRest(c.AuthenticatedCLICommand, cmd)
+	if err != nil {
+		return err
+	}
+
+	linkOpts := kafkarestv3.GetKafkaLinkOpts{
+		IncludeTasks: optional.NewBool(true),
+	}
+	link, httpResp, err := client.ClusterLinkingV3Api.GetKafkaLink(ctx, clusterId, linkName, &linkOpts)
+	if err != nil {
+		return handleOpenApiError(httpResp, err, client)
+	}
+
+	tasks := make([]task, len(*link.Tasks))
+	for i, t := range *link.Tasks {
+		errs := make([]taskErr, len(t.Errors))
+		for j, e := range t.Errors {
+			errs[j] = taskErr{
+				ErrorCode:    e.ErrorCode,
+				ErrorMessage: e.ErrorMessage,
+			}
+		}
+		tasks[i] = task{
+			TaskName: t.TaskName,
+			State:    t.State,
+			Errors:   errs,
+		}
+	}
+	isSerialized := output.GetFormat(cmd).IsSerialized()
+	if isSerialized {
+		return writeSerialized(cmd, tasks)
+	} else {
+		return writeHuman(cmd, tasks)
+	}
+}

--- a/internal/kafka/command_link_task_list_onprem.go
+++ b/internal/kafka/command_link_task_list_onprem.go
@@ -45,9 +45,7 @@ func (c *linkCommand) taskListOnPrem(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	linkOpts := kafkarestv3.GetKafkaLinkOpts{
-		IncludeTasks: optional.NewBool(true),
-	}
+	linkOpts := kafkarestv3.GetKafkaLinkOpts{IncludeTasks: optional.NewBool(true)}
 	link, httpResp, err := client.ClusterLinkingV3Api.GetKafkaLink(ctx, clusterId, linkName, &linkOpts)
 	if err != nil {
 		return handleOpenApiError(httpResp, err, client)
@@ -55,9 +53,9 @@ func (c *linkCommand) taskListOnPrem(cmd *cobra.Command, args []string) error {
 
 	tasks := make([]task, len(*link.Tasks))
 	for i, t := range *link.Tasks {
-		errs := make([]taskErr, len(t.Errors))
+		errors := make([]taskErr, len(t.Errors))
 		for j, e := range t.Errors {
-			errs[j] = taskErr{
+			errors[j] = taskErr{
 				ErrorCode:    e.ErrorCode,
 				ErrorMessage: e.ErrorMessage,
 			}
@@ -65,11 +63,10 @@ func (c *linkCommand) taskListOnPrem(cmd *cobra.Command, args []string) error {
 		tasks[i] = task{
 			TaskName: t.TaskName,
 			State:    t.State,
-			Errors:   errs,
+			Errors:   errors,
 		}
 	}
-	isSerialized := output.GetFormat(cmd).IsSerialized()
-	if isSerialized {
+	if output.GetFormat(cmd).IsSerialized() {
 		return writeSerialized(cmd, tasks)
 	} else {
 		return writeHuman(cmd, tasks)

--- a/test/fixtures/output/kafka/link/help-onprem.golden
+++ b/test/fixtures/output/kafka/link/help-onprem.golden
@@ -9,6 +9,7 @@ Available Commands:
   delete        Delete one or more cluster links.
   describe      Describe a cluster link.
   list          List cluster links.
+  task          Manager a cluster link's tasks.
 
 Global Flags:
   -h, --help            Show help for this command.

--- a/test/fixtures/output/kafka/link/list-tasks-onprem-json.golden
+++ b/test/fixtures/output/kafka/link/list-tasks-onprem-json.golden
@@ -1,0 +1,40 @@
+[
+  {
+    "task_name": "AclSync",
+    "state": "IN_ERROR",
+    "errors": [
+      {
+        "error_code": "AUTHENTICATION_ERROR",
+        "error_message": "Auth issue."
+      },
+      {
+        "error_code": "MISCONFIGURATION_ERROR",
+        "error_message": "Wrong config."
+      }
+    ]
+  },
+  {
+    "task_name": "AutoCreateMirror",
+    "state": "NOT_CONFIGURED",
+    "errors": []
+  },
+  {
+    "task_name": "ConsumerOffsetSync",
+    "state": "ACTIVE",
+    "errors": []
+  },
+  {
+    "task_name": "TopicConfigsSync",
+    "state": "IN_ERROR",
+    "errors": [
+      {
+        "error_code": "INTERNAL_ERROR",
+        "error_message": "Internal error."
+      },
+      {
+        "error_code": "REMOTE_LINK_NOT_FOUND_ERROR",
+        "error_message": "Remote link not found."
+      }
+    ]
+  }
+]

--- a/test/fixtures/output/kafka/link/list-tasks-onprem-yaml.golden
+++ b/test/fixtures/output/kafka/link/list-tasks-onprem-yaml.golden
@@ -1,0 +1,20 @@
+- task_name: AclSync
+  state: IN_ERROR
+  errors:
+    - error_code: AUTHENTICATION_ERROR
+      error_message: Auth issue.
+    - error_code: MISCONFIGURATION_ERROR
+      error_message: Wrong config.
+- task_name: AutoCreateMirror
+  state: NOT_CONFIGURED
+  errors: []
+- task_name: ConsumerOffsetSync
+  state: ACTIVE
+  errors: []
+- task_name: TopicConfigsSync
+  state: IN_ERROR
+  errors:
+    - error_code: INTERNAL_ERROR
+      error_message: Internal error.
+    - error_code: REMOTE_LINK_NOT_FOUND_ERROR
+      error_message: Remote link not found.

--- a/test/fixtures/output/kafka/link/list-tasks-onprem.golden
+++ b/test/fixtures/output/kafka/link/list-tasks-onprem.golden
@@ -1,0 +1,12 @@
+      Task Name      |     State      |             Errors              
+---------------------+----------------+---------------------------------
+  AclSync            | IN_ERROR       | AUTHENTICATION_ERROR:           
+                     |                | "Auth issue.",                  
+                     |                | MISCONFIGURATION_ERROR: "Wrong  
+                     |                | config."                        
+  AutoCreateMirror   | NOT_CONFIGURED |                                 
+  ConsumerOffsetSync | ACTIVE         |                                 
+  TopicConfigsSync   | IN_ERROR       | INTERNAL_ERROR:                 
+                     |                | "Internal error.",              
+                     |                | REMOTE_LINK_NOT_FOUND_ERROR:    
+                     |                | "Remote link not found."        

--- a/test/fixtures/output/kafka/link/task/help-onprem.golden
+++ b/test/fixtures/output/kafka/link/task/help-onprem.golden
@@ -1,0 +1,14 @@
+Manager a cluster link's tasks.
+
+Usage:
+  confluent kafka link task [command]
+
+Available Commands:
+  list        List a cluster link's tasks.
+
+Global Flags:
+  -h, --help            Show help for this command.
+      --unsafe-trace    Equivalent to -vvvv, but also log HTTP requests and responses which might contain plaintext secrets.
+  -v, --verbose count   Increase verbosity (-v for warn, -vv for info, -vvv for debug, -vvvv for trace).
+
+Use "confluent kafka link task [command] --help" for more information about a command.

--- a/test/fixtures/output/kafka/link/task/list-help-onprem.golden
+++ b/test/fixtures/output/kafka/link/task/list-help-onprem.golden
@@ -1,0 +1,19 @@
+List a cluster link's tasks.
+
+Usage:
+  confluent kafka link task list <link> [flags]
+
+Flags:
+      --url string                Base URL of REST Proxy Endpoint of Kafka Cluster (include "/kafka" for embedded Rest Proxy). Must set flag or CONFLUENT_REST_URL.
+      --ca-cert-path string       Path to a PEM-encoded CA to verify the Confluent REST Proxy.
+      --client-cert-path string   Path to client cert to be verified by Confluent REST Proxy. Include for mTLS authentication.
+      --client-key-path string    Path to client private key, include for mTLS authentication.
+      --no-authentication         Include if requests should be made without authentication headers and user will not be prompted for credentials.
+      --prompt                    Bypass use of available login credentials and prompt for Kafka Rest credentials.
+      --context string            CLI context name.
+  -o, --output string             Specify the output format as "human", "json", or "yaml". (default "human")
+
+Global Flags:
+  -h, --help            Show help for this command.
+      --unsafe-trace    Equivalent to -vvvv, but also log HTTP requests and responses which might contain plaintext secrets.
+  -v, --verbose count   Increase verbosity (-v for warn, -vv for info, -vvv for debug, -vvvv for trace).

--- a/test/kafka_test.go
+++ b/test/kafka_test.go
@@ -146,6 +146,7 @@ func (s *CLITestSuite) TestKafka() {
 
 	tests = []CLITest{
 		{args: fmt.Sprintf("kafka link describe link-1 --url %s", s.TestBackend.GetKafkaRestUrl()), fixture: "kafka/link/describe-onprem.golden"},
+		{args: fmt.Sprintf("kafka link task list link-5 --url %s", s.TestBackend.GetKafkaRestUrl()), fixture: "kafka/link/list-tasks-onprem.golden"},
 	}
 
 	for _, test := range tests {

--- a/test/kafka_test.go
+++ b/test/kafka_test.go
@@ -147,6 +147,8 @@ func (s *CLITestSuite) TestKafka() {
 	tests = []CLITest{
 		{args: fmt.Sprintf("kafka link describe link-1 --url %s", s.TestBackend.GetKafkaRestUrl()), fixture: "kafka/link/describe-onprem.golden"},
 		{args: fmt.Sprintf("kafka link task list link-5 --url %s", s.TestBackend.GetKafkaRestUrl()), fixture: "kafka/link/list-tasks-onprem.golden"},
+		{args: fmt.Sprintf("kafka link task list link-5 --url %s -o yaml", s.TestBackend.GetKafkaRestUrl()), fixture: "kafka/link/list-tasks-onprem-yaml.golden"},
+		{args: fmt.Sprintf("kafka link task list link-5 --url %s -o json", s.TestBackend.GetKafkaRestUrl()), fixture: "kafka/link/list-tasks-onprem-json.golden"},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

New Features
- Add `confluent kafka link task list` for listing cluster link task information on-premises
- Add `confluent kafka mirror state-transition-error list` for listing cluster linking mirror state transition errors on-premises

Checklist
---------
- [ ] Leave this box unchecked if features are not yet available in production

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->
This is a follow-up to https://github.com/confluentinc/cli/pull/2516 to support on prem. Note we apparently don't support the mirror operations on prem - so in this patch I'm just supporting the link resource.

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
<!--
Has it been tested? How?
Copy and paste any instructions or steps that can save the reviewer time.
-->