### PR TITLE
Fix `update-packaging` and `update-muckrake` targets

### DIFF
--- a/mk-files/release.mk
+++ b/mk-files/release.mk
@@ -166,15 +166,13 @@ update-muckrake:
 	$(eval MUCKRAKE=$(DIR)/muckrake)
 
 	git clone git@github.com:confluentinc/cli-release.git $(CLI_RELEASE) && \
-	cd $(CLI_RELEASE) && \
-	version=$$(ls release-notes | $(SED) "s/.json$$//" | sort --version-sort | tail -1) && \
+	version=$$(ls $(CLI_RELEASE)/release-notes | $(SED) "s/.json$$//" | sort --version-sort | tail -1) && \
 	git clone git@github.com:confluentinc/muckrake.git $(MUCKRAKE) && \
 	cd $(MUCKRAKE) && \
-	git fetch --all && \
-	branch=bump-cli && \
 	base=$$(git branch --remote --format "%(refname:short)" | sed -n "s|^origin/\([1-9][0-9]*\.[0-9][0-9]*\.x\)$$|\1|p" | tail -1) && \
 	git checkout $$base && \
-	git checkout $$branch || git checkout -b $$branch && \
+	branch=bump-cli && \
+	git checkout -b $$branch && \
 	$(SED) -i "s|confluent-cli-.*=\$${confluent_s3}/confluent\.cloud/confluent-cli/archives/.*/confluent_.*_linux_amd64\.tar\.gz|confluent-cli-$${version}=\$${confluent_s3}/confluent.cloud/confluent-cli/archives/$${version}/confluent_$${version}_linux_amd64.tar.gz|" ducker/ducker && \
 	$(SED) -i "s|VERSION = \".*\"|VERSION = \"$${version}\"|" muckrake/services/cli.py && \
 	$(SED) -i "s|get_cli .*|get_cli $${version}|" vagrant/base-redhat.sh && \
@@ -182,8 +180,8 @@ update-muckrake:
 	$(SED) -i "s|get_cli .*|get_cli $${version}|" vagrant/base-redhat9.sh && \
 	$(SED) -i "s|get_cli .*|get_cli $${version}|" vagrant/base-ubuntu.sh && \
 	git commit -am "bump cli to v$${version}" && \
-	$(call dry-run,git push -u origin $$branch) && \
-	if gh pr view $$branch --json state --jq .state | grep "no pull requests found|MERGED"; then \
+	$(call dry-run,git push --force --set-upstream origin $$branch) && \
+	if gh pr view $$branch --json state --jq .state 2>&1 | grep -E "no pull requests found|MERGED"; then \
 		$(call dry-run,gh pr create --base $${base} --title "Bump CLI to v$${version}" --body "") && \
 		$(call dry-run,gh pr merge --squash --auto); \
 	fi
@@ -197,20 +195,18 @@ update-packaging:
 	$(eval PACKAGING=$(DIR)/packaging)
 
 	git clone git@github.com:confluentinc/cli-release.git $(CLI_RELEASE) && \
-	cd $(CLI_RELEASE) && \
-	version=$$(ls release-notes | $(SED) "s/.json$$//" | sort --version-sort | tail -1) && \
+	version=$$(ls $(CLI_RELEASE)/release-notes | $(SED) "s/.json$$//" | sort --version-sort | tail -1) && \
 	git clone git@github.com:confluentinc/packaging.git $(PACKAGING) && \
 	cd $(PACKAGING) && \
-	git fetch --all && \
-	branch="bump-cli" && \
 	base=$$(git branch --remote --format "%(refname:short)" | sed -n "s|^origin/\([1-9][0-9]*\.[0-9][0-9]*\.x\)$$|\1|p" | tail -1) && \
 	git checkout $$base && \
-	git checkout $$branch || git checkout -b $$branch && \
-	$(SED) -i "s|cli_BRANCH=\".*\"|cli_BRANCH=\"$${version}\"|" settings.sh && \
+	branch="bump-cli" && \
+	git checkout -b $$branch && \
+	$(SED) -i "s|cli_BRANCH=\".*\"|cli_BRANCH=\"v$${version}\"|" settings.sh && \
 	$(SED) -i "s|CLI_VERSION=.*|CLI_VERSION=$${version}|" release_testing/bin/smoke_test.sh && \
 	git commit -am "bump cli to v$${version}" && \
-	$(call dry-run,git push -u origin $$branch) && \
-	if gh pr view $$branch --json state --jq .state | grep "no pull requests found|MERGED"; then \
+	$(call dry-run,git push --force --set-upstream origin $$branch) && \
+	if gh pr view $$branch --json state --jq .state 2>&1 | grep -E "no pull requests found|MERGED"; then \
 		$(call dry-run,gh pr create --base $${base} --title "Bump CLI to v$${version}" --body "") && \
 		$(call dry-run,gh pr merge --squash --auto); \
 	fi


### PR DESCRIPTION
What
----
Force push to avoid merge conflicts, and fix `grep` when `gh` prints to stderr

Test & Review
-------------
Used for the last release:
* https://github.com/confluentinc/packaging/pull/1154
* https://github.com/confluentinc/muckrake/pull/2239