### PR TITLE
[CLI-2992] Return an error instead of a panic if integer & double keys are switched in `topic produce` and `topic consume`

### DIFF
--- a/pkg/serdes/double_deserialization_provider.go
+++ b/pkg/serdes/double_deserialization_provider.go
@@ -13,6 +13,10 @@ func (DoubleDeserializationProvider) LoadSchema(_ string, _ map[string]string) e
 }
 
 func (DoubleDeserializationProvider) Deserialize(data []byte) (string, error) {
+	if len(data) == 0 {
+		return "", nil
+	}
+
 	if len(data) != 8 {
 		return "", fmt.Errorf("the double key is invalid")
 	}

--- a/pkg/serdes/double_deserialization_provider.go
+++ b/pkg/serdes/double_deserialization_provider.go
@@ -13,8 +13,8 @@ func (DoubleDeserializationProvider) LoadSchema(_ string, _ map[string]string) e
 }
 
 func (DoubleDeserializationProvider) Deserialize(data []byte) (string, error) {
-	if len(data) == 0 {
-		return "", nil
+	if len(data) != 8 {
+		return "", fmt.Errorf("the double key is invalid")
 	}
 
 	return fmt.Sprintf("%f", math.Float64frombits(binary.LittleEndian.Uint64(data))), nil

--- a/pkg/serdes/integer_deserialization_provider.go
+++ b/pkg/serdes/integer_deserialization_provider.go
@@ -12,8 +12,8 @@ func (IntegerDeserializationProvider) LoadSchema(_ string, _ map[string]string) 
 }
 
 func (IntegerDeserializationProvider) Deserialize(data []byte) (string, error) {
-	if len(data) == 0 {
-		return "", nil
+	if len(data) != 4 {
+		return "", fmt.Errorf("the integer key is invalid")
 	}
 
 	return fmt.Sprintf("%d", binary.LittleEndian.Uint32(data)), nil

--- a/pkg/serdes/integer_deserialization_provider.go
+++ b/pkg/serdes/integer_deserialization_provider.go
@@ -12,6 +12,10 @@ func (IntegerDeserializationProvider) LoadSchema(_ string, _ map[string]string) 
 }
 
 func (IntegerDeserializationProvider) Deserialize(data []byte) (string, error) {
+	if len(data) == 0 {
+		return "", nil
+	}
+
 	if len(data) != 4 {
 		return "", fmt.Errorf("the integer key is invalid")
 	}


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- PLACEHOLDER

New Features
- PLACEHOLDER

Bug Fixes
- Fix panic in `confluent kafka topic consume --key-format double` when consuming a message with an integer key

Checklist
---------
- [x] Leave this box unchecked if features are not yet available in production

What
----
Producing a message with an integer key and then deserializing it with the double deserializer produces a panic because `binary.LittleEndian.Uint64` checks that the 8th index of the key byte slice is set, but integer keys have a byte slice of length 4.

Also, producing a message with a double key and then using the integer deserializer produces garbage.

So in both cases, they now return an error if the length is incorrect.

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
Manual testing