### PR TITLE
Update network-link service display_name optional

### DIFF
--- a/internal/network/command_network_link_service.go
+++ b/internal/network/command_network_link_service.go
@@ -14,7 +14,7 @@ import (
 
 type networkLinkServiceHumanOut struct {
 	Id                   string `human:"ID"`
-	Name                 string `human:"Name"`
+	Name                 string `human:"Name,omitempty"`
 	Network              string `human:"Network"`
 	Environment          string `human:"Environment"`
 	Description          string `human:"Description,omitempty"`
@@ -25,7 +25,7 @@ type networkLinkServiceHumanOut struct {
 
 type networkLinkServiceSerializedOut struct {
 	Id                   string   `serialized:"id"`
-	Name                 string   `serialized:"name"`
+	Name                 string   `serialized:"name,omitempty"`
 	Network              string   `serialized:"network"`
 	Environment          string   `serialized:"environment"`
 	Description          string   `serialized:"description,omitempty"`

--- a/internal/network/command_network_link_service_create.go
+++ b/internal/network/command_network_link_service_create.go
@@ -21,8 +21,8 @@ func (c *command) newNetworkLinkServiceCreateCommand() *cobra.Command {
 				Code: `confluent network network-link service create --network n-123456 --description "example network link service" --accepted-environments env-111111,env-222222`,
 			},
 			examples.Example{
-				Text: `Create a named network link service for network "n-123456" with accepted environments "env-111111" and "env-222222".`,
-				Code: `confluent network network-link service create my-network-link-service --network n-123456 --description "example network link service" --accepted-environments env-111111,env-222222`,
+				Text: `Create a named network link service for network "n-123456" with accepted networks "n-abced1" and "n-abcde2".`,
+				Code: `confluent network network-link service create my-network-link-service --network n-123456 --description "example network link service" --accepted-networks n-abcde1,n-abcde2`,
 			},
 		),
 	}

--- a/internal/network/command_network_link_service_create.go
+++ b/internal/network/command_network_link_service_create.go
@@ -13,11 +13,15 @@ func (c *command) newNetworkLinkServiceCreateCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create <name>",
 		Short: "Create a network link service.",
-		Args:  cobra.ExactArgs(1),
+		Args:  cobra.MaximumNArgs(1),
 		RunE:  c.networkLinkServiceCreate,
 		Example: examples.BuildExampleString(
 			examples.Example{
 				Text: `Create a network link service for network "n-123456" with accepted environments "env-111111" and "env-222222".`,
+				Code: `confluent network network-link service create --network n-123456 --description "example network link service" --accepted-environments env-111111,env-222222`,
+			},
+			examples.Example{
+				Text: `Create a named network link service for network "n-123456" with accepted environments "env-111111" and "env-222222".`,
 				Code: `confluent network network-link service create my-network-link-service --network n-123456 --description "example network link service" --accepted-environments env-111111,env-222222`,
 			},
 		),
@@ -32,12 +36,16 @@ func (c *command) newNetworkLinkServiceCreateCommand() *cobra.Command {
 	pcmd.AddOutputFlag(cmd)
 
 	cobra.CheckErr(cmd.MarkFlagRequired("network"))
+	cmd.MarkFlagsOneRequired("accepted-networks", "accepted-environments")
 
 	return cmd
 }
 
 func (c *command) networkLinkServiceCreate(cmd *cobra.Command, args []string) error {
-	name := args[0]
+	name := ""
+	if len(args) == 1 {
+		name = args[0]
+	}
 
 	networkId, err := cmd.Flags().GetString("network")
 	if err != nil {
@@ -66,12 +74,15 @@ func (c *command) networkLinkServiceCreate(cmd *cobra.Command, args []string) er
 
 	createNetworkLinkService := networkingv1.NetworkingV1NetworkLinkService{
 		Spec: &networkingv1.NetworkingV1NetworkLinkServiceSpec{
-			DisplayName: networkingv1.PtrString(name),
 			Description: networkingv1.PtrString(description),
 			Environment: &networkingv1.GlobalObjectReference{Id: environmentId},
 			Network:     &networkingv1.EnvScopedObjectReference{Id: networkId},
 			Accept:      &networkingv1.NetworkingV1NetworkLinkServiceAcceptPolicy{},
 		},
+	}
+
+	if name != "" {
+		createNetworkLinkService.Spec.SetDisplayName(name)
 	}
 
 	if len(acceptedNetworks) > 0 {

--- a/test/fixtures/output/network/network-link/service/create-help.golden
+++ b/test/fixtures/output/network/network-link/service/create-help.golden
@@ -8,9 +8,9 @@ Create a network link service for network "n-123456" with accepted environments 
 
   $ confluent network network-link service create --network n-123456 --description "example network link service" --accepted-environments env-111111,env-222222
 
-Create a named network link service for network "n-123456" with accepted environments "env-111111" and "env-222222".
+Create a named network link service for network "n-123456" with accepted networks "n-abced1" and "n-abcde2".
 
-  $ confluent network network-link service create my-network-link-service --network n-123456 --description "example network link service" --accepted-environments env-111111,env-222222
+  $ confluent network network-link service create my-network-link-service --network n-123456 --description "example network link service" --accepted-networks n-abcde1,n-abcde2
 
 Flags:
       --network string                  REQUIRED: Network ID.

--- a/test/fixtures/output/network/network-link/service/create-missing-flag.golden
+++ b/test/fixtures/output/network/network-link/service/create-missing-flag.golden
@@ -7,9 +7,9 @@ Create a network link service for network "n-123456" with accepted environments 
 
   $ confluent network network-link service create --network n-123456 --description "example network link service" --accepted-environments env-111111,env-222222
 
-Create a named network link service for network "n-123456" with accepted environments "env-111111" and "env-222222".
+Create a named network link service for network "n-123456" with accepted networks "n-abced1" and "n-abcde2".
 
-  $ confluent network network-link service create my-network-link-service --network n-123456 --description "example network link service" --accepted-environments env-111111,env-222222
+  $ confluent network network-link service create my-network-link-service --network n-123456 --description "example network link service" --accepted-networks n-abcde1,n-abcde2
 
 Flags:
       --network string                  REQUIRED: Network ID.

--- a/test/fixtures/output/network/network-link/service/create-missing-flag.golden
+++ b/test/fixtures/output/network/network-link/service/create-missing-flag.golden
@@ -1,5 +1,4 @@
-Create a network link service.
-
+Error: at least one of the flags in the group [accepted-networks accepted-environments] is required
 Usage:
   confluent network network-link service create <name> [flags]
 
@@ -25,3 +24,4 @@ Global Flags:
   -h, --help            Show help for this command.
       --unsafe-trace    Equivalent to -vvvv, but also log HTTP requests and responses which might contain plaintext secrets.
   -v, --verbose count   Increase verbosity (-v for warn, -vv for info, -vvv for debug, -vvvv for trace).
+

--- a/test/fixtures/output/network/network-link/service/create-missing-network.golden
+++ b/test/fixtures/output/network/network-link/service/create-missing-network.golden
@@ -7,9 +7,9 @@ Create a network link service for network "n-123456" with accepted environments 
 
   $ confluent network network-link service create --network n-123456 --description "example network link service" --accepted-environments env-111111,env-222222
 
-Create a named network link service for network "n-123456" with accepted environments "env-111111" and "env-222222".
+Create a named network link service for network "n-123456" with accepted networks "n-abced1" and "n-abcde2".
 
-  $ confluent network network-link service create my-network-link-service --network n-123456 --description "example network link service" --accepted-environments env-111111,env-222222
+  $ confluent network network-link service create my-network-link-service --network n-123456 --description "example network link service" --accepted-networks n-abcde1,n-abcde2
 
 Flags:
       --network string                  REQUIRED: Network ID.

--- a/test/fixtures/output/network/network-link/service/create-missing-network.golden
+++ b/test/fixtures/output/network/network-link/service/create-missing-network.golden
@@ -1,14 +1,18 @@
-Error: accepts 1 arg(s), received 0
+Error: required flag(s) "network" not set
 Usage:
   confluent network network-link service create <name> [flags]
 
 Examples:
 Create a network link service for network "n-123456" with accepted environments "env-111111" and "env-222222".
 
+  $ confluent network network-link service create --network n-123456 --description "example network link service" --accepted-environments env-111111,env-222222
+
+Create a named network link service for network "n-123456" with accepted environments "env-111111" and "env-222222".
+
   $ confluent network network-link service create my-network-link-service --network n-123456 --description "example network link service" --accepted-environments env-111111,env-222222
 
 Flags:
-      --network string                  Network ID.
+      --network string                  REQUIRED: Network ID.
       --description string              Network link service description.
       --accepted-networks strings       A comma-separated list of networks from which connections can be accepted.
       --accepted-environments strings   A comma-separated list of environments from which connections can be accepted.

--- a/test/fixtures/output/network/network-link/service/create-no-name.golden
+++ b/test/fixtures/output/network/network-link/service/create-no-name.golden
@@ -1,0 +1,8 @@
++-----------------------+------------------------------+
+| ID                    | nls-abcde1                   |
+| Network               | n-123456                     |
+| Environment           | env-00000                    |
+| Description           | example network link service |
+| Accepted Environments | env-11111, env-22222         |
+| Phase                 | READY                        |
++-----------------------+------------------------------+

--- a/test/network_test.go
+++ b/test/network_test.go
@@ -622,11 +622,13 @@ func (s *CLITestSuite) TestNetworkNetworkLinkServiceDelete() {
 
 func (s *CLITestSuite) TestNetworkNetworkLinkServiceCreate() {
 	tests := []CLITest{
-		{args: "network network-link service create", fixture: "network/network-link/service/create-missing-args.golden", exitCode: 1},
+		{args: "network network-link service create", fixture: "network/network-link/service/create-missing-network.golden", exitCode: 1},
+		{args: "network network-link service create --network n-123456", fixture: "network/network-link/service/create-missing-flag.golden", exitCode: 1},
+		{args: "network network-link service create --network n-123456 --description 'example network link service' --accepted-environments env-11111,env-22222", fixture: "network/network-link/service/create-no-name.golden"},
 		{args: "network network-link service create my-network-link-service --network n-123456 --description 'example network link service' --accepted-environments env-11111,env-22222", fixture: "network/network-link/service/create-accepted-environments.golden"},
 		{args: "network network-link service create my-network-link-service --network n-123456 --description 'example network link service' --accepted-networks n-111111,n-222222", fixture: "network/network-link/service/create-accepted-networks.golden"},
 		{args: "network network-link service create my-network-link-service --network n-123456 --description 'example network link service' --accepted-networks n-111111,n-222222 --accepted-environments env-11111,env-22222", fixture: "network/network-link/service/create.golden"},
-		{args: "network network-link service create nls-duplicate --network n-123455", fixture: "network/network-link/service/create-duplicate.golden", exitCode: 1},
+		{args: "network network-link service create nls-duplicate --network n-123455 --accepted-networks n-111111", fixture: "network/network-link/service/create-duplicate.golden", exitCode: 1},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->
Note that this is merging into the feature branch https://github.com/confluentinc/cli/tree/traffic-8850-network-cli-az. We will merge commits into main from this feature branch after all of the commands for network are implemented.

- Update display_name for network-link service to optional ([API spec](https://docs.confluent.io/cloud/current/api.html#tag/Network-Link-Services-(networkingv1)/operation/createNetworkingV1NetworkLinkService:~:text=Network%20Link%20Service-,display_name,-string))



References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->
[CLI Commands Design](https://confluentinc.atlassian.net/wiki/spaces/PM/pages/2987394300/1-pager+--+Network+CLI)
[Implementation 1-Pager](https://confluentinc.atlassian.net/wiki/spaces/~712020463029eabbac401bbe1b033ce0d3a00e/pages/3136749631/Network+CLI)

Test & Review
-------------
<!--
Has it been tested? How?
Copy and paste any instructions or steps that can save the reviewer time.
-->
Added integration tests.

Performed manual tests.