### PR TITLE
Rename "ci" to "pint" in docs release make targets

### DIFF
--- a/mk-files/docs.mk
+++ b/mk-files/docs.mk
@@ -40,7 +40,7 @@ publish-docs:
 	rm -rf command-reference && \
 	cp -R $(CLI)/docs command-reference && \
 	git add . && \
-	git commit --allow-empty -m "[ci skip] chore: update CLI docs for v$(CLEAN_VERSION)" && \
+	git commit --allow-empty -m "[pint skip] chore: update CLI docs for v$(CLEAN_VERSION)" && \
 	$(call dry-run,git push origin publish-docs-v$(CLEAN_VERSION)) && \
 	base="master" && \
 	if [[ $(CLEAN_VERSION) != *.0 ]]; then \
@@ -53,7 +53,7 @@ publish-docs:
 # NB: When releasing a new version, the -post branch is updated to the current state of the .x branch,
 # whether the -post branch exists or not. The `git checkout -B ...` handles this behavior.
 # If this is a patch release, we don't have to update master.
-# The .x branch has been updated to ignore [ci skip] for minor branches since it is a pure upstream branch of minor branches.
+# The .x branch has been updated to ignore [pint skip] for minor branches since it is a pure upstream branch of minor branches.
 # To ensure pint merge will work correctly, we will manually merge the -post branch into the .x branch using `-s ours`. Then, these
 # branches will be pushed at the same time. This ensure there are no errors with pint merge.
 .PHONY: release-docs
@@ -78,7 +78,7 @@ release-docs:
 		$(SED) -i 's/export PUBLIC_VERSION=.*/export PUBLIC_VERSION=$(SHORT_NEXT_MINOR_VERSION)/g' settings.sh && \
 		$(SED) -i "s/^version = '.*'/version = \'$(SHORT_NEXT_MINOR_VERSION)\'/g" conf.py && \
 		$(SED) -i "s/^release = '.*'/release = \'$(NEXT_MINOR_VERSION)-SNAPSHOT\'/g" conf.py && \
-		git commit -am "[ci skip] chore: update settings.sh and conf.py due to $(CLEAN_VERSION) release" && \
+		git commit -am "[pint skip] chore: update settings.sh and conf.py due to $(CLEAN_VERSION) release" && \
 		$(call dry-run,git push origin release-docs-$(CLEAN_VERSION)) && \
 		$(call dry-run,gh pr create --base master --title "Release docs for v$(CLEAN_VERSION)" --body ""); \
 	fi
@@ -98,17 +98,17 @@ release-docs-staging:
 	$(SED) -i 's/export PUBLIC_VERSION=.*/export PUBLIC_VERSION=$(CURRENT_SHORT_MINOR_VERSION)/g' settings.sh && \
 	$(SED) -i "s/^version = '.*'/version = \'$(CURRENT_SHORT_MINOR_VERSION)\'/g" conf.py && \
 	$(SED) -i "s/^release = '.*'/release = \'$(CLEAN_VERSION)\'/g" conf.py && \
-	git commit -am "[ci skip] chore: update settings.sh and conf.py due to $(CLEAN_VERSION) release" && \
+	git commit -am "[pint skip] chore: update settings.sh and conf.py due to $(CLEAN_VERSION) release" && \
 	$(call dry-run,git push origin release-docs-staging-$(CURRENT_SHORT_MINOR_VERSION_DASH)) && \
-	$(call dry-run,gh pr create --base $(CURRENT_SHORT_MINOR_VERSION)-post --title "[ci skip] Release docs to staging for v$(CLEAN_VERSION) release" --body "") && \
+	$(call dry-run,gh pr create --base $(CURRENT_SHORT_MINOR_VERSION)-post --title "[pint skip] Release docs to staging for v$(CLEAN_VERSION) release" --body "") && \
 	git checkout -b release-docs-staging-$(STAGING_BRANCH_DASH) origin/$(STAGING_BRANCH) && \
 	$(SED) -i 's/export RELEASE_VERSION=.*/export RELEASE_VERSION=$(NEXT_PATCH_VERSION)-SNAPSHOT/g' settings.sh && \
 	$(SED) -i 's/export PUBLIC_VERSION=.*/export PUBLIC_VERSION=$(CURRENT_SHORT_MINOR_VERSION)/g' settings.sh && \
 	$(SED) -i "s/^version = '.*'/version = \'$(CURRENT_SHORT_MINOR_VERSION)\'/g" conf.py && \
 	$(SED) -i "s/^release = '.*'/release = \'$(NEXT_PATCH_VERSION)-SNAPSHOT\'/g" conf.py && \
-	git commit -am "[ci skip] chore: update settings.sh and conf.py due to $(CLEAN_VERSION) release" && \
+	git commit -am "[pint skip] chore: update settings.sh and conf.py due to $(CLEAN_VERSION) release" && \
 	git merge -s ours -m "Merge branch 'release-docs-staging-$(CURRENT_SHORT_MINOR_VERSION_DASH)' into release-docs-staging-$(STAGING_BRANCH_DASH)" release-docs-staging-$(CURRENT_SHORT_MINOR_VERSION_DASH) && \
 	$(call dry-run,git push origin release-docs-staging-$(STAGING_BRANCH_DASH)) && \
-	$(call dry-run,gh pr create --base $(STAGING_BRANCH) --title "[ci skip] Release docs to staging for v$(CLEAN_VERSION) release" --body "")
+	$(call dry-run,gh pr create --base $(STAGING_BRANCH) --title "[pint skip] Release docs to staging for v$(CLEAN_VERSION) release" --body "")
 
 	rm -rf $(DIR)


### PR DESCRIPTION
What
----
Rename `[ci skip]` to `[pint skip]` as per docs team recommendation