### PR TITLE
[CLI-3010] chore: upgrade go-prompt to v0.2.26

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,7 @@ require (
 	github.com/confluentinc/confluent-kafka-go v1.9.3-RC3
 	github.com/confluentinc/go-editor v0.11.0
 	github.com/confluentinc/go-netrc v0.0.0-20220321173724-4d50f36ff450
-	github.com/confluentinc/go-prompt v0.2.24
+	github.com/confluentinc/go-prompt v0.2.26
 	github.com/confluentinc/go-ps1 v1.0.2
 	github.com/confluentinc/kafka-rest-sdk-go/kafkarestv3 v0.3.18
 	github.com/confluentinc/mds-sdk-go-public/mdsv1 v0.0.0-20230117192233-7e6d894d74a9

--- a/go.sum
+++ b/go.sum
@@ -166,8 +166,8 @@ github.com/confluentinc/go-editor v0.11.0 h1:fcEALYHj7xV/fRSp54/IHi2DS4GlZMJWVgr
 github.com/confluentinc/go-editor v0.11.0/go.mod h1:nEjwqdqx8S7ZGjXsDvRgawsA04Fu2P/KAtA8fa5afMI=
 github.com/confluentinc/go-netrc v0.0.0-20220321173724-4d50f36ff450 h1:YJq9ZRhj049uo3hX7V8imJid+FJEBFyRmVcdruhU3y4=
 github.com/confluentinc/go-netrc v0.0.0-20220321173724-4d50f36ff450/go.mod h1:GGVB1yDj9YYQTxoo5vTRGWuQKccGN00bvyit4O5jznI=
-github.com/confluentinc/go-prompt v0.2.24 h1:vSYjaE+UjjdjV7jq87g8+dCWxu8GJxpdJvFJjUxSS2g=
-github.com/confluentinc/go-prompt v0.2.24/go.mod h1:4/tf63YzhSsiXnsKosCmv1H0ivpXVezZHaMpSVB+DXw=
+github.com/confluentinc/go-prompt v0.2.26 h1:DuzCAzU2dQoka8dJ0TiNDHXEbgIN5iVMZCLbSdtZgD4=
+github.com/confluentinc/go-prompt v0.2.26/go.mod h1:zevvJDLYjJBw/CFOd+9O1xBChio6z3WP7skZbw0YDC4=
 github.com/confluentinc/go-ps1 v1.0.2 h1:+4cKOzWs3AWmxL2s96oHu0QutZESDRXECnhFzm2ic4o=
 github.com/confluentinc/go-ps1 v1.0.2/go.mod h1:qmgG9xQgFd4u7/CS6eA9nNP8eQqOtXuRHmZ4+w7Vprs=
 github.com/confluentinc/kafka-rest-sdk-go/kafkarestv3 v0.3.18 h1:M9/yzpG+eOTp/peiHNHRQWax0If6+GAJIC/NcvbzAOI=

--- a/pkg/flink/test/mock/prompt_mock.go
+++ b/pkg/flink/test/mock/prompt_mock.go
@@ -5,6 +5,7 @@
 //
 //	mockgen -destination prompt_mock.go -package=mock github.com/confluentinc/go-prompt IPrompt
 //
+
 // Package mock is a generated GoMock package.
 package mock
 
@@ -12,6 +13,7 @@ import (
 	reflect "reflect"
 
 	prompt "github.com/confluentinc/go-prompt"
+	lsp "github.com/sourcegraph/go-lsp"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -200,6 +202,18 @@ func (m *MockIPrompt) SetConsoleParser(arg0 prompt.ConsoleParser) {
 func (mr *MockIPromptMockRecorder) SetConsoleParser(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetConsoleParser", reflect.TypeOf((*MockIPrompt)(nil).SetConsoleParser), arg0)
+}
+
+// SetDiagnostics mocks base method.
+func (m *MockIPrompt) SetDiagnostics(arg0 []lsp.Diagnostic) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetDiagnostics", arg0)
+}
+
+// SetDiagnostics indicates an expected call of SetDiagnostics.
+func (mr *MockIPromptMockRecorder) SetDiagnostics(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetDiagnostics", reflect.TypeOf((*MockIPrompt)(nil).SetDiagnostics), arg0)
 }
 
 // SetExitChecker mocks base method.


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Checklist
---------
- [X] Leave this box unchecked if features are not yet available in production

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->
Upgrade go-prompt's version, which includes a fix to avoid panics caused by multibyte(special characters) when using `confluent flink shell`.

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
<!--
Has it been tested? How?
Copy and paste any instructions or steps that can save the reviewer time.
-->