### PR TITLE
DGS-10013: Do not provide default SG package to new environments

### DIFF
--- a/internal/environment/command_create.go
+++ b/internal/environment/command_create.go
@@ -21,7 +21,7 @@ func (c *command) newCreateCommand() *cobra.Command {
 		RunE:  c.create,
 	}
 
-	c.addStreamGovernancePackageFlag(cmd, "essentials")
+	c.addStreamGovernancePackageFlag(cmd, "")
 	pcmd.AddContextFlag(cmd, c.CLICommand)
 	pcmd.AddOutputFlag(cmd)
 

--- a/test/environment_test.go
+++ b/test/environment_test.go
@@ -9,7 +9,7 @@ func (s *CLITestSuite) TestEnvironment() {
 		{args: "environment list -o json", fixture: "environment/5.golden"},
 		{args: "environment list -o yaml", fixture: "environment/6.golden"},
 		{args: "environment use env-dne", fixture: "environment/7.golden", exitCode: 1},
-		{args: "environment create saucayyy", fixture: "environment/8.golden"},
+		{args: "environment create saucayyy --governance-package essentials", fixture: "environment/8.golden"},
 		{args: "environment create saucayyy -o json --governance-package advanced", fixture: "environment/9.golden"},
 		{args: "environment create saucayyy -o yaml", fixture: "environment/10.golden"},
 	}

--- a/test/fixtures/output/environment/10.golden
+++ b/test/fixtures/output/environment/10.golden
@@ -1,4 +1,4 @@
 is_current: false
 id: env-5555
 name: saucayyy
-stream_governance_package: ESSENTIALS
+stream_governance_package: ""

--- a/test/fixtures/output/environment/create-help.golden
+++ b/test/fixtures/output/environment/create-help.golden
@@ -4,7 +4,7 @@ Usage:
   confluent environment create <name> [flags]
 
 Flags:
-      --governance-package string   Specify the Stream Governance package as "essentials" or "advanced". (default "essentials")
+      --governance-package string   Specify the Stream Governance package as "essentials" or "advanced".
       --context string              CLI context name.
   -o, --output string               Specify the output format as "human", "json", or "yaml". (default "human")
 

--- a/test/test-server/org_handlers.go
+++ b/test/test-server/org_handlers.go
@@ -74,7 +74,7 @@ func handleOrgEnvironments(t *testing.T) http.HandlerFunc {
 			require.NoError(t, err)
 		case http.MethodPost:
 			req := &orgv2.OrgV2Environment{
-				StreamGovernanceConfig: &orgv2.OrgV2StreamGovernanceConfig{Package: orgv2.PtrString("ESSENTIALS")}}
+				StreamGovernanceConfig: &orgv2.OrgV2StreamGovernanceConfig{Package: orgv2.PtrString("")}}
 			err := json.NewDecoder(r.Body).Decode(req)
 			require.NoError(t, err)
 


### PR DESCRIPTION
Release Notes
-------------

Breaking Changes
- PLACEHOLDER

New Features
- PLACEHOLDER

Bug Fixes
- PLACEHOLDER

Checklist
---------
- [ ] Leave this box unchecked if features are not yet available in production

What
----
Defaulting the stream governance package to Essentials for new environments causes a potentially breaking change for users who automate environment and SR cluster creation. This breaking change should only be included in v4 deployment and not the current minor release.


References
----------
https://confluentinc.atlassian.net/browse/DGS-10013
https://confluentinc.atlassian.net/wiki/x/twI3xQ
