### PR TITLE
[RCCA-17513] Fix group mapping errors in `confluent iam rbac role-binding` commands

### DIFF
--- a/internal/iam/command_rbac_role_binding.go
+++ b/internal/iam/command_rbac_role_binding.go
@@ -55,8 +55,6 @@ var (
 
 	literalPatternType  = "LITERAL"
 	prefixedPatternType = "PREFIXED"
-
-	nonUserPrincipalTypes = []string{presource.ServiceAccount, presource.IdentityPool, presource.SsoGroupMapping}
 )
 
 type roleBindingOptions struct {
@@ -401,6 +399,8 @@ func (c *roleBindingCommand) displayCCloudCreateAndDeleteOutput(cmd *cobra.Comma
 
 	userId := strings.TrimPrefix(roleBinding.GetPrincipal(), "User:")
 	principalType := presource.LookupType(userId)
+
+	nonUserPrincipalTypes := []string{presource.ServiceAccount, presource.IdentityPool, presource.SsoGroupMapping}
 
 	var fields []string
 	if slices.Contains(nonUserPrincipalTypes, principalType) {

--- a/internal/iam/command_rbac_role_binding.go
+++ b/internal/iam/command_rbac_role_binding.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"slices"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -54,6 +55,8 @@ var (
 
 	literalPatternType  = "LITERAL"
 	prefixedPatternType = "PREFIXED"
+
+	nonUserPrincipalTypes = []string{presource.ServiceAccount, presource.IdentityPool, presource.SsoGroupMapping}
 )
 
 type roleBindingOptions struct {
@@ -400,7 +403,7 @@ func (c *roleBindingCommand) displayCCloudCreateAndDeleteOutput(cmd *cobra.Comma
 	principalType := presource.LookupType(userId)
 
 	var fields []string
-	if principalType == presource.ServiceAccount || principalType == presource.IdentityPool || principalType == presource.SsoGroupMapping {
+	if slices.Contains(nonUserPrincipalTypes, principalType) {
 		if resource != "" {
 			fields = resourcePatternListFields
 		} else {

--- a/internal/iam/command_rbac_role_binding.go
+++ b/internal/iam/command_rbac_role_binding.go
@@ -400,7 +400,7 @@ func (c *roleBindingCommand) displayCCloudCreateAndDeleteOutput(cmd *cobra.Comma
 	principalType := presource.LookupType(userId)
 
 	var fields []string
-	if principalType == presource.ServiceAccount || principalType == presource.IdentityPool {
+	if principalType == presource.ServiceAccount || principalType == presource.IdentityPool || principalType == presource.SsoGroupMapping {
 		if resource != "" {
 			fields = resourcePatternListFields
 		} else {

--- a/internal/iam/command_rbac_role_binding_list.go
+++ b/internal/iam/command_rbac_role_binding_list.go
@@ -149,6 +149,18 @@ func (c *roleBindingCommand) getPoolToNameMap() (map[string]string, error) {
 	return poolToName, nil
 }
 
+func (c *roleBindingCommand) getGroupMappingToNameMap() (map[string]string, error) {
+	groupMappings, err := c.V2Client.ListGroupMappings()
+	if err != nil {
+		return map[string]string{}, err
+	}
+	groupMappingToNameMap := make(map[string]string)
+	for _, groupMapping := range groupMappings {
+		groupMappingToNameMap["User:"+groupMapping.GetId()] = groupMapping.GetDisplayName()
+	}
+	return groupMappingToNameMap, nil
+}
+
 func (c *roleBindingCommand) getPrincipalToUserMap() (map[string]*iamv2.IamV2User, error) {
 	users, err := c.V2Client.ListIamUsers()
 	if err != nil {
@@ -473,8 +485,15 @@ func (c *roleBindingCommand) ccloudListRolePrincipals(cmd *cobra.Command, listRo
 		return err
 	}
 
-	// TODO: Catch this error once Identity Providers goes GA
-	poolToNameMap, _ := c.getPoolToNameMap()
+	poolToNameMap, err := c.getPoolToNameMap()
+	if err != nil {
+		return err
+	}
+
+	groupMappingToNameMap, err := c.getGroupMappingToNameMap()
+	if err != nil {
+		return err
+	}
 
 	sort.Strings(principalStrings)
 	for _, principal := range principalStrings {
@@ -488,6 +507,10 @@ func (c *roleBindingCommand) ccloudListRolePrincipals(cmd *cobra.Command, listRo
 			list.Add(row)
 		}
 		if name, ok := poolToNameMap[principal]; ok {
+			row.Name = name
+			list.Add(row)
+		}
+		if name, ok := groupMappingToNameMap[principal]; ok {
 			row.Name = name
 			list.Add(row)
 		}

--- a/pkg/resource/resource.go
+++ b/pkg/resource/resource.go
@@ -66,6 +66,7 @@ const (
 	KsqlClusterPrefix           = "lksqlc"
 	SchemaRegistryClusterPrefix = "lsrc"
 	ServiceAccountPrefix        = "sa"
+	SsoGroupMappingPrefix       = "group"
 	UserPrefix                  = "u"
 )
 
@@ -79,6 +80,7 @@ var prefixToResource = map[string]string{
 	KsqlClusterPrefix:           KsqlCluster,
 	SchemaRegistryClusterPrefix: SchemaRegistryCluster,
 	ServiceAccountPrefix:        ServiceAccount,
+	SsoGroupMappingPrefix:       SsoGroupMapping,
 	UserPrefix:                  User,
 }
 
@@ -90,6 +92,7 @@ var resourceToPrefix = map[string]string{
 	KsqlCluster:           KsqlClusterPrefix,
 	SchemaRegistryCluster: SchemaRegistryClusterPrefix,
 	ServiceAccount:        ServiceAccountPrefix,
+	SsoGroupMapping:       SsoGroupMappingPrefix,
 	User:                  UserPrefix,
 }
 

--- a/pkg/resource/resource.go
+++ b/pkg/resource/resource.go
@@ -117,6 +117,12 @@ func ValidatePrefixes(resourceType string, args []string) error {
 		return nil
 	}
 
+	// old group mappings may still have "pool-" instead of "group-"
+	// so we must skip the check for this resource
+	if prefix == SsoGroupMappingPrefix {
+		return nil
+	}
+
 	var malformed []string
 	for _, id := range args {
 		if LookupType(id) != resourceType {

--- a/test/fixtures/output/iam/group-mapping/create.golden
+++ b/test/fixtures/output/iam/group-mapping/create.golden
@@ -1,9 +1,9 @@
 +-------------+--------------------------------+
-| ID          | pool-12345                     |
+| ID          | group-12345                    |
 | Name        | my-group-mapping               |
 | Description | new description                |
 | Filter      | "engineering" in claims.group  |
 |             | || "marketing" in claims.group |
-| Principal   | pool-12345                     |
+| Principal   | group-12345                    |
 | State       | ENABLED                        |
 +-------------+--------------------------------+

--- a/test/fixtures/output/iam/group-mapping/delete-dne.golden
+++ b/test/fixtures/output/iam/group-mapping/delete-dne.golden
@@ -1,4 +1,4 @@
-Error: SSO group mapping "pool-dne" not found
+Error: SSO group mapping "group-dne" not found
 
 Suggestions:
     List available SSO group mappings with `confluent iam group-mapping list`.

--- a/test/fixtures/output/iam/group-mapping/delete-multiple-refuse.golden
+++ b/test/fixtures/output/iam/group-mapping/delete-multiple-refuse.golden
@@ -1,1 +1,1 @@
-Are you sure you want to delete SSO group mappings "pool-abc" and "pool-def"? (y/n): 
+Are you sure you want to delete SSO group mappings "group-abc" and "group-def"? (y/n): 

--- a/test/fixtures/output/iam/group-mapping/delete-multiple-success.golden
+++ b/test/fixtures/output/iam/group-mapping/delete-multiple-success.golden
@@ -1,1 +1,1 @@
-Are you sure you want to delete SSO group mappings "pool-abc" and "pool-def"? (y/n): Deleted SSO group mappings "pool-abc" and "pool-def".
+Are you sure you want to delete SSO group mappings "group-abc" and "group-def"? (y/n): Deleted SSO group mappings "group-abc" and "group-def".

--- a/test/fixtures/output/iam/group-mapping/delete-prompt.golden
+++ b/test/fixtures/output/iam/group-mapping/delete-prompt.golden
@@ -1,2 +1,2 @@
-Are you sure you want to delete SSO group mapping "pool-abc"?
-To confirm, type "another-group-mapping". To cancel, press Ctrl-C: Deleted SSO group mapping "pool-abc".
+Are you sure you want to delete SSO group mapping "group-abc"?
+To confirm, type "another-group-mapping". To cancel, press Ctrl-C: Deleted SSO group mapping "group-abc".

--- a/test/fixtures/output/iam/group-mapping/delete.golden
+++ b/test/fixtures/output/iam/group-mapping/delete.golden
@@ -1,1 +1,1 @@
-Deleted SSO group mapping "pool-abc".
+Deleted SSO group mapping "group-abc".

--- a/test/fixtures/output/iam/group-mapping/describe.golden
+++ b/test/fixtures/output/iam/group-mapping/describe.golden
@@ -1,8 +1,8 @@
 +-------------+-----------------------+
-| ID          | pool-abc              |
+| ID          | group-abc             |
 | Name        | another-group-mapping |
 | Description | another description   |
 | Filter      | true                  |
-| Principal   | pool-abc              |
+| Principal   | group-abc             |
 | State       | ENABLED               |
 +-------------+-----------------------+

--- a/test/fixtures/output/iam/group-mapping/list.golden
+++ b/test/fixtures/output/iam/group-mapping/list.golden
@@ -1,5 +1,5 @@
-      ID     |         Name          |     Description     |             Filter             | Principal  |  State   
--------------+-----------------------+---------------------+--------------------------------+------------+----------
-  pool-12345 | my-group-mapping      | new description     | "engineering" in claims.group  | pool-12345 | ENABLED  
-             |                       |                     | || "marketing" in claims.group |            |          
-  pool-abc   | another-group-mapping | another description | true                           | pool-abc   | ENABLED  
+      ID      |         Name          |     Description     |             Filter             |  Principal  |  State   
+--------------+-----------------------+---------------------+--------------------------------+-------------+----------
+  group-12345 | my-group-mapping      | new description     | "engineering" in claims.group  | group-12345 | ENABLED  
+              |                       |                     | || "marketing" in claims.group |             |          
+  group-abc   | another-group-mapping | another description | true                           | group-abc   | ENABLED  

--- a/test/fixtures/output/iam/group-mapping/update.golden
+++ b/test/fixtures/output/iam/group-mapping/update.golden
@@ -1,8 +1,8 @@
 +-------------+-----------------------------------+
-| ID          | pool-abc                          |
+| ID          | group-abc                         |
 | Name        | updated-group-mapping             |
 | Description | updated description               |
 | Filter      | claims.principal.startsWith(user) |
-| Principal   | pool-abc                          |
+| Principal   | group-abc                         |
 | State       | ENABLED                           |
 +-------------+-----------------------------------+

--- a/test/fixtures/output/iam/rbac/role-binding/list-user-orgadmin-cloud.golden
+++ b/test/fixtures/output/iam/rbac/role-binding/list-user-orgadmin-cloud.golden
@@ -1,5 +1,6 @@
-     Principal    |      Name       |        Email          
-------------------+-----------------+-----------------------
-  User:pool-12345 | identity-pool   |                       
-  User:sa-12345   | service-account |                       
-  User:u-11aaa    |                 | u-11aaa@confluent.io  
+     Principal    |         Name          |        Email          
+------------------+-----------------------+-----------------------
+  User:group-abc  | another-group-mapping |                       
+  User:pool-12345 | identity-pool         |                       
+  User:sa-12345   | service-account       |                       
+  User:u-11aaa    |                       | u-11aaa@confluent.io  

--- a/test/iam_test.go
+++ b/test/iam_test.go
@@ -296,13 +296,13 @@ func (s *CLITestSuite) TestIamPool() {
 func (s *CLITestSuite) TestIamGroupMapping() {
 	tests := []CLITest{
 		{args: `iam group-mapping create group_mapping --description new-group-description --filter '"engineering" in claims.group || "marketing" in claims.group'`, fixture: "iam/group-mapping/create.golden"},
-		{args: "iam group-mapping delete pool-abc --force", fixture: "iam/group-mapping/delete.golden"},
-		{args: "iam group-mapping delete pool-abc", input: "another-group-mapping\n", fixture: "iam/group-mapping/delete-prompt.golden"},
-		{args: "iam group-mapping delete pool-abc pool-def", input: "n\n", fixture: "iam/group-mapping/delete-multiple-refuse.golden"},
-		{args: "iam group-mapping delete pool-abc pool-def", input: "y\n", fixture: "iam/group-mapping/delete-multiple-success.golden"},
-		{args: "iam group-mapping delete pool-dne --force", fixture: "iam/group-mapping/delete-dne.golden", exitCode: 1},
-		{args: "iam group-mapping describe pool-abc", fixture: "iam/group-mapping/describe.golden"},
-		{args: `iam group-mapping update pool-abc --name updated-group-mapping --description "updated description" --filter claims.principal.startsWith("user")`, fixture: "iam/group-mapping/update.golden"},
+		{args: "iam group-mapping delete group-abc --force", fixture: "iam/group-mapping/delete.golden"},
+		{args: "iam group-mapping delete group-abc", input: "another-group-mapping\n", fixture: "iam/group-mapping/delete-prompt.golden"},
+		{args: "iam group-mapping delete group-abc group-def", input: "n\n", fixture: "iam/group-mapping/delete-multiple-refuse.golden"},
+		{args: "iam group-mapping delete group-abc group-def", input: "y\n", fixture: "iam/group-mapping/delete-multiple-success.golden"},
+		{args: "iam group-mapping delete group-dne --force", fixture: "iam/group-mapping/delete-dne.golden", exitCode: 1},
+		{args: "iam group-mapping describe group-abc", fixture: "iam/group-mapping/describe.golden"},
+		{args: `iam group-mapping update group-abc --name updated-group-mapping --description "updated description" --filter claims.principal.startsWith("user")`, fixture: "iam/group-mapping/update.golden"},
 		{args: "iam group-mapping list", fixture: "iam/group-mapping/list.golden"},
 	}
 

--- a/test/test-server/ccloud_handlers.go
+++ b/test/test-server/ccloud_handlers.go
@@ -51,7 +51,7 @@ var (
 const (
 	serviceAccountId                 = int32(12345)
 	serviceAccountResourceId         = "sa-12345"
-	groupMappingId                   = "pool-abc"
+	groupMappingId                   = "group-abc"
 	identityProviderId               = "op-12345"
 	identityPoolId                   = "pool-12345"
 	ipGroupId                        = "ipg-wjnde"

--- a/test/test-server/iam_handlers.go
+++ b/test/test-server/iam_handlers.go
@@ -28,6 +28,8 @@ var (
 			"crn://confluent.cloud/organization=abc-123"),
 		buildRoleBinding("rb-12345", "sa-12345", "OrganizationAdmin",
 			"crn://confluent.cloud/organization=abc-123"),
+		buildRoleBinding("rb-123ab", "group-abc", "OrganizationAdmin",
+			"crn://confluent.cloud/organization=abc-123"),
 		buildRoleBinding("rb-111aa", "u-11aaa", "CloudClusterAdmin",
 			"crn://confluent.cloud/organization=abc-123/environment=env-596/cloud-cluster=lkc-1111aaa"),
 		buildRoleBinding("rb-22bbb", "u-22bbb", "CloudClusterAdmin",
@@ -589,7 +591,7 @@ func handleIamInvitations(t *testing.T) http.HandlerFunc {
 // Handler for "iam/v2/sso/group-mappings"
 func handleIamGroupMappings(t *testing.T) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		groupMapping := buildIamGroupMapping("pool-12345", "my-group-mapping", "new description", `"engineering" in claims.group || "marketing" in claims.group`)
+		groupMapping := buildIamGroupMapping("group-12345", "my-group-mapping", "new description", `"engineering" in claims.group || "marketing" in claims.group`)
 		switch r.Method {
 		case http.MethodGet:
 			anotherMapping := buildIamGroupMapping(groupMappingId, "another-group-mapping", "another description", "true")
@@ -609,7 +611,7 @@ func handleIamGroupMappings(t *testing.T) http.HandlerFunc {
 func handleIamGroupMapping(t *testing.T) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		id := mux.Vars(r)["id"]
-		if id != groupMappingId && id != "pool-def" {
+		if id != groupMappingId && id != "group-def" {
 			err := writeResourceNotFoundError(w)
 			require.NoError(t, err)
 			return


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- PLACEHOLDER

New Features
- PLACEHOLDER

Bug Fixes
- Fix a bug preventing role bindings with an SSO group mapping principal from displaying in `confluent iam rbac role-binding list`
- Fix a bug causing an incorrect error message to be displayed in `confluent iam rbac role-binding create` and `confluent iam rbac role-binding delete` when the principal is an SSO group mapping

Checklist
---------
- [x] Leave this box unchecked if features are not yet available in production

What
----
We weren't handling group mappings in `conflulent iam rbac role-binding` commands, so `list` omitted role bindings for group mappings, and `create|delete` treated group mapping IDs as user IDs and subsequently produced an error while trying to display the result, even though the underlying create/delete succeeded.

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
I added a group mapping role binding to the test backend and updated the tests.
I also switched `pool-` to `group-` throughout the tests.