### PR TITLE
Pin `confluent local` docker version

### DIFF
--- a/internal/local/command_kafka.go
+++ b/internal/local/command_kafka.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	dockerImageName             = "confluentinc/confluent-local:latest"
+	dockerImageName             = "confluentinc/confluent-local:7.6.0"
 	localhostPrefix             = "http://localhost:%s"
 	localhost                   = "0.0.0.0"
 	kafkaRestNotReadySuggestion = "Kafka REST connection is not ready. Re-running the command may solve the issue."


### PR DESCRIPTION
Checklist
---------
- [x] Leave this box unchecked if features are not yet available in production

What
----
Tests broke because version was not pinned. See: https://github.com/confluentinc/cli/pull/2603

Test & Review
-------------
Confluent Local tests will either pass or fail CI