### PR TITLE
chore: remove service account warning

### DIFF
--- a/internal/flink/command.go
+++ b/internal/flink/command.go
@@ -9,10 +9,6 @@ import (
 	"github.com/confluentinc/cli/v3/pkg/config"
 )
 
-const serviceAccountWarning = "[WARN] No service account provided. To ensure that your statements run continuously, " +
-	"use a service account instead of your user identity with `confluent iam service-account use` or `--service-account`. " +
-	"Otherwise, statements will stop running after 4 hours."
-
 type command struct {
 	*pcmd.AuthenticatedCLICommand
 }

--- a/internal/flink/command_shell.go
+++ b/internal/flink/command_shell.go
@@ -15,7 +15,6 @@ import (
 	"github.com/confluentinc/cli/v3/pkg/flink/test/mock"
 	"github.com/confluentinc/cli/v3/pkg/flink/types"
 	"github.com/confluentinc/cli/v3/pkg/log"
-	"github.com/confluentinc/cli/v3/pkg/output"
 	ppanic "github.com/confluentinc/cli/v3/pkg/panic-recovery"
 )
 
@@ -118,9 +117,6 @@ func (c *command) startFlinkSqlClient(prerunner pcmd.PreRunner, cmd *cobra.Comma
 	}
 	if serviceAccount == "" {
 		serviceAccount = c.Context.GetCurrentServiceAccount()
-	}
-	if serviceAccount == "" {
-		output.ErrPrintln(c.Config.EnableColor, serviceAccountWarning)
 	}
 
 	database, err := cmd.Flags().GetString("database")

--- a/internal/flink/command_statement_create.go
+++ b/internal/flink/command_statement_create.go
@@ -109,7 +109,6 @@ func (c *command) statementCreate(cmd *cobra.Command, args []string) error {
 
 	principal := serviceAccount
 	if serviceAccount == "" {
-		output.ErrPrintln(c.Config.EnableColor, serviceAccountWarning)
 		principal = c.Context.GetUser().GetResourceId()
 	}
 

--- a/pkg/flink/internal/controller/.snapshots/TestStatementControllerTestSuite-TestExecuteStatementPrintsNoWarningWhenUserIdentityIsUsed
+++ b/pkg/flink/internal/controller/.snapshots/TestStatementControllerTestSuite-TestExecuteStatementPrintsNoWarningWhenUserIdentityIsUsed
@@ -1,0 +1,6 @@
+Statement name: test-statement
+Statement successfully submitted.
+Waiting for statement to be ready. Statement phase is PENDING.
+Statement phase is COMPLETED.
+status detail message.
+

--- a/pkg/flink/internal/controller/.snapshots/TestStatementControllerTestSuite-TestExecuteStatementPrintsWarningWhenNoServiceAccountIsUsed
+++ b/pkg/flink/internal/controller/.snapshots/TestStatementControllerTestSuite-TestExecuteStatementPrintsWarningWhenNoServiceAccountIsUsed
@@ -1,7 +1,0 @@
-Statement name: test-statement
-Statement successfully submitted.
-Waiting for statement to be ready. Statement phase is PENDING.
-[WARN] To ensure that your statements run continuously, switch to using a service account instead of your user identity by running `SET 'client.service-account'='sa-123';`. Otherwise, statements will stop running after 4 hours.
-Statement phase is COMPLETED.
-status detail message.
-

--- a/pkg/flink/internal/controller/statement_controller.go
+++ b/pkg/flink/internal/controller/statement_controller.go
@@ -3,7 +3,6 @@ package controller
 import (
 	"context"
 	"net/http"
-	"strings"
 	"time"
 
 	fColor "github.com/fatih/color"
@@ -62,15 +61,6 @@ func (c *StatementController) handleStatementError(err types.StatementError) {
 	if err.StatusCode == http.StatusUnauthorized {
 		c.applicationController.ExitApplication()
 	}
-}
-
-func (c *StatementController) isInsertOrStatementSetStatement(processedStatement *types.ProcessedStatement) bool {
-	// transform statement to uppercase and remove duplicated white spaces
-	statement := strings.ToUpper(strings.Join(strings.Fields(processedStatement.Statement), " "))
-	if strings.HasPrefix(statement, "INSERT") || strings.HasPrefix(statement, "EXECUTE STATEMENT SET") {
-		return true
-	}
-	return false
 }
 
 func (c *StatementController) waitForStatementToBeReadyOrError(processedStatement types.ProcessedStatement) (*types.ProcessedStatement, *types.StatementError) {

--- a/pkg/flink/internal/controller/statement_controller_test.go
+++ b/pkg/flink/internal/controller/statement_controller_test.go
@@ -157,7 +157,7 @@ func (s *StatementControllerTestSuite) TestExecuteStatementPrintsUserInfo() {
 	cupaloy.SnapshotT(s.T(), stdout)
 }
 
-func (s *StatementControllerTestSuite) TestExecuteStatementPrintsWarningWhenNoServiceAccountIsUsed() {
+func (s *StatementControllerTestSuite) TestExecuteStatementPrintsNoWarningWhenUserIdentityIsUsed() {
 	statementToExecute := "insert into table values (1,2);"
 	processedStatement := types.ProcessedStatement{
 		Statement:     statementToExecute,

--- a/test/fixtures/output/flink/statement/create-service-account-warning.golden
+++ b/test/fixtures/output/flink/statement/create-service-account-warning.golden
@@ -1,4 +1,3 @@
-[WARN] No service account provided. To ensure that your statements run continuously, use a service account instead of your user identity with `confluent iam service-account use` or `--service-account`. Otherwise, statements will stop running after 4 hours.
 +---------------+-------------------------------+
 | Creation Date | 2023-01-01 00:00:00 +0000 UTC |
 | Name          | my-statement                  |


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Checklist
---------
- [x] Leave this box unchecked if features are not yet available in production

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->
The 4h time limit for background statements that run with a user identity was removed, so we should also remove the warning in the CLI.

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
<!--
Has it been tested? How?
Copy and paste any instructions or steps that can save the reviewer time.
-->