### PR TITLE
Let `confluent local service` commands work with Java versions above 12

### DIFF
--- a/internal/local/command_service.go
+++ b/internal/local/command_service.go
@@ -730,11 +730,6 @@ func isValidJavaVersion(service, javaVersion string) (bool, error) {
 		return true, nil
 	}
 
-	v12, _ := version.NewSemver("12")
-	if v.Compare(v12) >= 0 {
-		return false, nil
-	}
-
 	return true, nil
 }
 

--- a/internal/local/command_service_test.go
+++ b/internal/local/command_service_test.go
@@ -73,8 +73,4 @@ func TestIsValidJavaVersion(t *testing.T) {
 	isValid, err = isValidJavaVersion("zookeeper", "13")
 	req.NoError(err)
 	req.True(isValid)
-
-	isValid, err = isValidJavaVersion("", "13")
-	req.NoError(err)
-	req.False(isValid)
 }

--- a/service.yml
+++ b/service.yml
@@ -2,7 +2,7 @@ name: cli
 lang: go
 git:
   enable: true
-  hook:
+  hooks:
     enable: true
 github:
   enable: true


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- PLACEHOLDER

New Features
- Allow `confluent local service` commands work with Java versions above 12

Bug Fixes
- PLACEHOLDER

Checklist
---------
- [x] Leave this box unchecked if features are not yet available in production

What
----
Closes https://github.com/confluentinc/cli/issues/2612

Test & Review
-------------
Untested as this command is no longer maintained.