### PR TITLE
[KFS-1676] remove check for /dev/tty existence

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,7 @@ require (
 	github.com/confluentinc/confluent-kafka-go v1.9.3-RC3
 	github.com/confluentinc/go-editor v0.11.0
 	github.com/confluentinc/go-netrc v0.0.0-20220321173724-4d50f36ff450
-	github.com/confluentinc/go-prompt v0.2.26
+	github.com/confluentinc/go-prompt v0.2.28
 	github.com/confluentinc/go-ps1 v1.0.2
 	github.com/confluentinc/kafka-rest-sdk-go/kafkarestv3 v0.3.18
 	github.com/confluentinc/mds-sdk-go-public/mdsv1 v0.0.0-20230117192233-7e6d894d74a9

--- a/go.sum
+++ b/go.sum
@@ -166,8 +166,12 @@ github.com/confluentinc/go-editor v0.11.0 h1:fcEALYHj7xV/fRSp54/IHi2DS4GlZMJWVgr
 github.com/confluentinc/go-editor v0.11.0/go.mod h1:nEjwqdqx8S7ZGjXsDvRgawsA04Fu2P/KAtA8fa5afMI=
 github.com/confluentinc/go-netrc v0.0.0-20220321173724-4d50f36ff450 h1:YJq9ZRhj049uo3hX7V8imJid+FJEBFyRmVcdruhU3y4=
 github.com/confluentinc/go-netrc v0.0.0-20220321173724-4d50f36ff450/go.mod h1:GGVB1yDj9YYQTxoo5vTRGWuQKccGN00bvyit4O5jznI=
-github.com/confluentinc/go-prompt v0.2.26 h1:DuzCAzU2dQoka8dJ0TiNDHXEbgIN5iVMZCLbSdtZgD4=
-github.com/confluentinc/go-prompt v0.2.26/go.mod h1:zevvJDLYjJBw/CFOd+9O1xBChio6z3WP7skZbw0YDC4=
+github.com/confluentinc/go-prompt v0.2.27-0.20240213181507-604017e2bb08 h1:Q9sQIhMeRxlNZaIaBBt21dyjzpNfIwaUxoYmVZVF828=
+github.com/confluentinc/go-prompt v0.2.27-0.20240213181507-604017e2bb08/go.mod h1:zevvJDLYjJBw/CFOd+9O1xBChio6z3WP7skZbw0YDC4=
+github.com/confluentinc/go-prompt v0.2.27 h1:OfodwY4NIYaF6aJ0W7S2vblijwZ7RJ+CkqEy5hDcoSY=
+github.com/confluentinc/go-prompt v0.2.27/go.mod h1:zevvJDLYjJBw/CFOd+9O1xBChio6z3WP7skZbw0YDC4=
+github.com/confluentinc/go-prompt v0.2.28 h1:ZyONKnCcLAwi2wonacTE/Rfx/ddSlyEf4vA386ZpuEg=
+github.com/confluentinc/go-prompt v0.2.28/go.mod h1:zevvJDLYjJBw/CFOd+9O1xBChio6z3WP7skZbw0YDC4=
 github.com/confluentinc/go-ps1 v1.0.2 h1:+4cKOzWs3AWmxL2s96oHu0QutZESDRXECnhFzm2ic4o=
 github.com/confluentinc/go-ps1 v1.0.2/go.mod h1:qmgG9xQgFd4u7/CS6eA9nNP8eQqOtXuRHmZ4+w7Vprs=
 github.com/confluentinc/kafka-rest-sdk-go/kafkarestv3 v0.3.18 h1:M9/yzpG+eOTp/peiHNHRQWax0If6+GAJIC/NcvbzAOI=

--- a/go.sum
+++ b/go.sum
@@ -166,10 +166,6 @@ github.com/confluentinc/go-editor v0.11.0 h1:fcEALYHj7xV/fRSp54/IHi2DS4GlZMJWVgr
 github.com/confluentinc/go-editor v0.11.0/go.mod h1:nEjwqdqx8S7ZGjXsDvRgawsA04Fu2P/KAtA8fa5afMI=
 github.com/confluentinc/go-netrc v0.0.0-20220321173724-4d50f36ff450 h1:YJq9ZRhj049uo3hX7V8imJid+FJEBFyRmVcdruhU3y4=
 github.com/confluentinc/go-netrc v0.0.0-20220321173724-4d50f36ff450/go.mod h1:GGVB1yDj9YYQTxoo5vTRGWuQKccGN00bvyit4O5jznI=
-github.com/confluentinc/go-prompt v0.2.27-0.20240213181507-604017e2bb08 h1:Q9sQIhMeRxlNZaIaBBt21dyjzpNfIwaUxoYmVZVF828=
-github.com/confluentinc/go-prompt v0.2.27-0.20240213181507-604017e2bb08/go.mod h1:zevvJDLYjJBw/CFOd+9O1xBChio6z3WP7skZbw0YDC4=
-github.com/confluentinc/go-prompt v0.2.27 h1:OfodwY4NIYaF6aJ0W7S2vblijwZ7RJ+CkqEy5hDcoSY=
-github.com/confluentinc/go-prompt v0.2.27/go.mod h1:zevvJDLYjJBw/CFOd+9O1xBChio6z3WP7skZbw0YDC4=
 github.com/confluentinc/go-prompt v0.2.28 h1:ZyONKnCcLAwi2wonacTE/Rfx/ddSlyEf4vA386ZpuEg=
 github.com/confluentinc/go-prompt v0.2.28/go.mod h1:zevvJDLYjJBw/CFOd+9O1xBChio6z3WP7skZbw0YDC4=
 github.com/confluentinc/go-ps1 v1.0.2 h1:+4cKOzWs3AWmxL2s96oHu0QutZESDRXECnhFzm2ic4o=

--- a/pkg/flink/app/application.go
+++ b/pkg/flink/app/application.go
@@ -66,8 +66,8 @@ func StartApp(gatewayClient ccloudv2.GatewayClientInterface, tokenRefreshFunc fu
 	lspClient := lsp.NewLSPClientWS(getAuthToken, appOptions.GetLSPBaseUrl(), appOptions.GetOrganizationId(), appOptions.GetEnvironmentId())
 
 	stdinBefore := utils.GetStdin()
-	consoleParser := utils.GetConsoleParser()
-	if consoleParser == nil {
+	consoleParser, err := utils.GetConsoleParser()
+	if err != nil {
 		utils.OutputErr("Error: failed to initialize console parser")
 		return errors.NewErrorWithSuggestions("failed to initialize console parser", "Restart your shell session or try another terminal.")
 	}

--- a/pkg/flink/internal/controller/input_controller.go
+++ b/pkg/flink/internal/controller/input_controller.go
@@ -38,7 +38,9 @@ func NewInputController(history *history.History, lspCompleter prompt.Completer)
 		reverseISearch:  reverseisearch.NewReverseISearch(),
 		lspCompleter:    lspCompleter,
 	}
-	inputController.prompt = inputController.Prompt()
+	if prompt, err := inputController.Prompt(); err == nil {
+		inputController.prompt = prompt
+	}
 	return inputController
 }
 
@@ -113,7 +115,7 @@ func (c *InputController) getMaxCol() (int, error) {
 	return int(maxCol), nil
 }
 
-func (c *InputController) Prompt() prompt.IPrompt {
+func (c *InputController) Prompt() (prompt.IPrompt, error) {
 	return prompt.New(
 		nil,
 		c.promptCompleter(),

--- a/pkg/flink/internal/controller/statement_controller.go
+++ b/pkg/flink/internal/controller/statement_controller.go
@@ -136,7 +136,7 @@ func (c *StatementController) userInputIsOneOf(keyEvents ...func(key prompt.Key)
 }
 
 func isCancelEvent(key prompt.Key) bool {
-	return lo.Contains([]prompt.Key{prompt.ControlC, prompt.ControlD, prompt.ControlQ, prompt.Escape}, key)
+	return lo.Contains([]prompt.Key{prompt.ControlC, prompt.ControlD, prompt.ControlQ, prompt.ControlSpace}, key)
 }
 
 func isDetachEvent(key prompt.Key) bool {

--- a/pkg/flink/internal/controller/statement_controller_test.go
+++ b/pkg/flink/internal/controller/statement_controller_test.go
@@ -411,7 +411,7 @@ func TestIsCancelEvent(t *testing.T) {
 		},
 		{
 			name: "Escape",
-			key:  prompt.Escape,
+			key:  prompt.ControlSpace,
 			want: true,
 		},
 		{

--- a/pkg/flink/internal/reverseisearch/reverse_i_search.go
+++ b/pkg/flink/internal/reverseisearch/reverse_i_search.go
@@ -53,7 +53,7 @@ func (r reverseISearch) ReverseISearch(history []string, initialBufferText strin
 		reverseISearchEnabled = false
 		livePrefixState.LivePrefix = ""
 	}
-	in := prompt.New(
+	in, err := prompt.New(
 		func(s string) {},
 		searchCompleter(history, writer, searchState, livePrefixState),
 		prompt.OptionSetExitCheckerOnInput(func(input string, lineBreak bool) bool {
@@ -88,7 +88,9 @@ func (r reverseISearch) ReverseISearch(history []string, initialBufferText strin
 			return false
 		}),
 	)
-	in.Run()
+	if err == nil {
+		in.Run()
+	}
 	return searchState.CurrentMatch
 }
 

--- a/pkg/flink/internal/utils/input.go
+++ b/pkg/flink/internal/utils/input.go
@@ -19,20 +19,17 @@ func GetStdin() *term.State {
 	return state
 }
 
-func GetConsoleParser() prompt.ConsoleParser {
-	if fileInfo, err := os.Stat("/dev/tty"); err != nil {
-		log.CliLogger.Warnf(`Couldn't open "/dev/tty" file: %v`, err)
-		return nil
-	} else if fileInfo.Mode().Perm()&0444 == 0 {
-		log.CliLogger.Warn(`Couldn't read "/dev/tty" file because read permissions are not set.`)
-		return nil
-	}
-	consoleParser := prompt.NewStandardInputParser()
-	err := consoleParser.Setup()
+func GetConsoleParser() (prompt.ConsoleParser, error) {
+	consoleParser, err := prompt.NewStandardInputParser()
 	if err != nil {
-		log.CliLogger.Warnf("Couldn't setup console parser: %v", err)
+		log.CliLogger.Warnf("Couldn't create console parser: %v", err)
+		return nil, err
 	}
-	return consoleParser
+	if err := consoleParser.Setup(); err != nil {
+		log.CliLogger.Warnf("Couldn't set up console parser: %v", err)
+		return nil, err
+	}
+	return consoleParser, nil
 }
 
 func TearDownConsoleParser(consoleParser prompt.ConsoleParser) {


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Bug Fixes
- Fixes an issue where `confluent flink shell` didn't work on Windows
- Fixes an issue where pending statements couldn't be cancelled in `confluent flink shell`

Checklist
---------
- [x] Leave this box unchecked if features are not yet available in production

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->
On Windows you will never be able to open /dev/tty, so this check doesn't really make sense here.

To still address the original intent of this check, I've updated go-prompt to return an error instead of panicking when it fails to access /dev/tty

**Note: we still need to officially change go-prompt and release a new tag, so I'm depending on a branch here. Will update once go-prompt was released**

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
<!--
Has it been tested? How?
Copy and paste any instructions or steps that can save the reviewer time.
-->