### PR TITLE
Omit Stream governance package in environment list/describe commands when not specified

### DIFF
--- a/internal/environment/command_describe.go
+++ b/internal/environment/command_describe.go
@@ -12,7 +12,7 @@ type out struct {
 	IsCurrent               bool   `human:"Current" serialized:"is_current"`
 	Id                      string `human:"ID" serialized:"id"`
 	Name                    string `human:"Name" serialized:"name"`
-	StreamGovernancePackage string `human:"Stream Governance Package" serialized:"stream_governance_package"`
+	StreamGovernancePackage string `human:"Stream Governance Package,omitempty" serialized:"stream_governance_package"`
 }
 
 func (c *command) newDescribeCommand() *cobra.Command {

--- a/internal/environment/command_describe.go
+++ b/internal/environment/command_describe.go
@@ -12,7 +12,7 @@ type out struct {
 	IsCurrent               bool   `human:"Current" serialized:"is_current"`
 	Id                      string `human:"ID" serialized:"id"`
 	Name                    string `human:"Name" serialized:"name"`
-	StreamGovernancePackage string `human:"Stream Governance Package,omitempty" serialized:"stream_governance_package"`
+	StreamGovernancePackage string `human:"Stream Governance Package,omitempty" serialized:"stream_governance_package,omitempty"`
 }
 
 func (c *command) newDescribeCommand() *cobra.Command {


### PR DESCRIPTION
Release Notes
-------------

Breaking Changes
- PLACEHOLDER

New Features
- PLACEHOLDER

Bug Fixes
- PLACEHOLDER

Checklist
---------
- [x] Leave this box unchecked if features are not yet available in production

What
----
As part of changes made in DGS-10013, environments created before the release of always-on governance are not guaranteed to have a stream governance package. Omit this field from the output when it is empty.

References
----------
https://github.com/confluentinc/cli/pull/2600

Test & Review
-------------
```
$ dist/confluent_$(go env GOOS)_$(go env GOARCH)/confluent env list           
  Current |       ID       |           Name            | Stream Governance Package  
----------+----------------+---------------------------+----------------------------
          | env-stgc28j622 | greenfield-v4             | ESSENTIALS                 
  *       | env-stgcn5xpmv | tf_brownfield_environment |                            
          | env-stgco5xvgx | tf_greenfield_environment | ESSENTIALS                 
```
```
$ dist/confluent_$(go env GOOS)_$(go env GOARCH)/confluent env describe       
+---------+---------------------------+
| Current | true                      |
| ID      | env-stgcn5xpmv            |
| Name    | tf_brownfield_environment |
+---------+---------------------------+

```