### PR TITLE
[CLI-3040] On-prem users can't produce/consume without logging in

### DIFF
--- a/internal/kafka/command_topic_consume.go
+++ b/internal/kafka/command_topic_consume.go
@@ -81,7 +81,7 @@ func (c *command) newConsumeCommand() *cobra.Command {
 }
 
 func (c *command) consume(cmd *cobra.Command, args []string) error {
-	if c.Context.GetConfig().IsCloudLogin() {
+	if c.Config.IsCloudLogin() {
 		return c.consumeCloud(cmd, args)
 	}
 

--- a/internal/kafka/command_topic_consume.go
+++ b/internal/kafka/command_topic_consume.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"slices"
+	"strings"
 
 	"github.com/google/uuid"
 	"github.com/spf13/cobra"
@@ -80,24 +81,30 @@ func (c *command) newConsumeCommand() *cobra.Command {
 }
 
 func (c *command) consume(cmd *cobra.Command, args []string) error {
-	if c.Context.GetState() == nil {
-		if !cmd.Flags().Changed("bootstrap") {
-			return fmt.Errorf(errors.RequiredFlagNotSetErrorMsg, "bootstrap")
-		}
+	if c.Context.GetConfig().IsCloudLogin() {
+		return c.consumeCloud(cmd, args)
+	}
 
-		if err := c.prepareAnonymousContext(cmd); err != nil {
+	if !cmd.Flags().Changed("bootstrap") { // Required if the user isn't logged into Confluent Cloud
+		return fmt.Errorf(errors.RequiredFlagNotSetErrorMsg, "bootstrap")
+	}
+
+	if c.Context == nil || c.Context.State == nil {
+		bootstrap, err := cmd.Flags().GetString("bootstrap")
+		if err != nil {
 			return err
 		}
-		return c.consumeCloud(cmd, args)
-	} else if c.Context.Config.IsCloudLogin() {
-		return c.consumeCloud(cmd, args)
-	} else {
-		if !cmd.Flags().Changed("bootstrap") {
-			return fmt.Errorf(errors.RequiredFlagNotSetErrorMsg, "bootstrap")
-		}
 
-		return c.consumeOnPrem(cmd, args)
+		if strings.Contains(bootstrap, "confluent.cloud") {
+			if err := c.prepareAnonymousContext(cmd); err != nil {
+				return err
+			}
+
+			return c.consumeCloud(cmd, args)
+		}
 	}
+
+	return c.consumeOnPrem(cmd, args)
 }
 
 func (c *command) consumeCloud(cmd *cobra.Command, args []string) error {

--- a/internal/kafka/command_topic_consume.go
+++ b/internal/kafka/command_topic_consume.go
@@ -89,7 +89,7 @@ func (c *command) consume(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf(errors.RequiredFlagNotSetErrorMsg, "bootstrap")
 	}
 
-	if c.Context == nil || c.Context.State == nil {
+	if c.Context.GetState() == nil {
 		bootstrap, err := cmd.Flags().GetString("bootstrap")
 		if err != nil {
 			return err

--- a/internal/kafka/command_topic_produce.go
+++ b/internal/kafka/command_topic_produce.go
@@ -101,7 +101,7 @@ func (c *command) produce(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf(errors.RequiredFlagNotSetErrorMsg, "bootstrap")
 	}
 
-	if c.Context == nil || c.Context.State == nil {
+	if c.Context.GetState() == nil {
 		bootstrap, err := cmd.Flags().GetString("bootstrap")
 		if err != nil {
 			return err

--- a/internal/kafka/command_topic_produce.go
+++ b/internal/kafka/command_topic_produce.go
@@ -93,7 +93,7 @@ func (c *command) newProduceCommand() *cobra.Command {
 }
 
 func (c *command) produce(cmd *cobra.Command, args []string) error {
-	if c.Context.GetConfig().IsCloudLogin() {
+	if c.Config.IsCloudLogin() {
 		return c.produceCloud(cmd, args)
 	}
 

--- a/internal/kafka/command_topic_produce.go
+++ b/internal/kafka/command_topic_produce.go
@@ -93,28 +93,30 @@ func (c *command) newProduceCommand() *cobra.Command {
 }
 
 func (c *command) produce(cmd *cobra.Command, args []string) error {
-	if c.Context == nil || c.Context.State == nil {
-		if !cmd.Flags().Changed("bootstrap") {
-			return fmt.Errorf(errors.RequiredFlagNotSetErrorMsg, "bootstrap")
-		}
+	if c.Context.GetConfig().IsCloudLogin() {
+		return c.produceCloud(cmd, args)
+	}
 
-		if err := c.prepareAnonymousContext(cmd); err != nil {
+	if !cmd.Flags().Changed("bootstrap") { // Required if the user isn't logged into Confluent Cloud
+		return fmt.Errorf(errors.RequiredFlagNotSetErrorMsg, "bootstrap")
+	}
+
+	if c.Context == nil || c.Context.State == nil {
+		bootstrap, err := cmd.Flags().GetString("bootstrap")
+		if err != nil {
 			return err
 		}
-		return c.produceCloud(cmd, args)
-	} else if c.Context.Config.IsCloudLogin() {
-		return c.produceCloud(cmd, args)
-	} else {
-		if !cmd.Flags().Changed("bootstrap") {
-			return fmt.Errorf(errors.RequiredFlagNotSetErrorMsg, "bootstrap")
-		}
 
-		if !cmd.Flags().Changed("ca-location") {
-			return fmt.Errorf(errors.RequiredFlagNotSetErrorMsg, "ca-location")
-		}
+		if strings.Contains(bootstrap, "confluent.cloud") {
+			if err := c.prepareAnonymousContext(cmd); err != nil {
+				return err
+			}
 
-		return c.produceOnPrem(cmd, args)
+			return c.produceCloud(cmd, args)
+		}
 	}
+
+	return c.produceOnPrem(cmd, args)
 }
 
 func (c *command) produceCloud(cmd *cobra.Command, args []string) error {

--- a/pkg/config/context.go
+++ b/pkg/config/context.go
@@ -147,13 +147,6 @@ func (c *Context) GetState() *ContextState {
 	return nil
 }
 
-func (c *Context) GetConfig() *Config {
-	if c != nil {
-		return c.Config
-	}
-	return nil
-}
-
 func (c *Context) GetAuth() *AuthConfig {
 	if c.GetState() != nil {
 		return c.State.Auth

--- a/pkg/config/context.go
+++ b/pkg/config/context.go
@@ -147,6 +147,13 @@ func (c *Context) GetState() *ContextState {
 	return nil
 }
 
+func (c *Context) GetConfig() *Config {
+	if c != nil {
+		return c.Config
+	}
+	return nil
+}
+
 func (c *Context) GetAuth() *AuthConfig {
 	if c.GetState() != nil {
 		return c.State.Auth


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- PLACEHOLDER

New Features
- PLACEHOLDER

Bug Fixes
- Fix bug preventing Confluent Platform users from using `confluent kafka topic produce` and `confluent kafka topic consume` without logging in
- No longer require `--ca-location` for on-premises `confluent kafka topic produce`

Checklist
---------
- [x] Leave this box unchecked if features are not yet available in production

What
----
The code currently assumes that users are producing to or consuming from a cloud cluster topic if they aren't logged in.

This PR updates the flow to the following:
1. if Cloud login --> `produceCloud/consumeCloud`
2. if not logged in and bootstrap contains `confluent.cloud` --> `produceCloud/consumeCloud`
3. else --> `produceOnPrem/consumeOnPrem`

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
Confluent Cloud, logged in (with cluster and api key set using `confluent kafka cluster use` and `confluent api-key use`):
```
confluent kafka topic produce cloud-test-topic
Starting Kafka Producer. Use Ctrl-C or Ctrl-D to exit.
hello
```
```
confluent kafka topic consume cloud-test-topic --from-beginning
Starting Kafka Consumer. Use Ctrl-C to exit.
hello
```

Confluent Cloud, logged out:
```
confluent kafka topic produce cloud-test-topic --bootstrap <endpoint> --api-key <key> --api-secret <secret>
Starting Kafka Producer. Use Ctrl-C or Ctrl-D to exit.
hello2
```
```
confluent kafka topic consume cloud-test-topic --bootstrap <endpoint> --api-key <key> --api-secret <secret> --from-beginning
Starting Kafka Consumer. Use Ctrl-C to exit.
hello2
hello
```

Confluent Platform, logged in:
```
confluent kafka topic produce test-topic --bootstrap $HOSTNAME:9093 --ca-location my-env/certs/snakeoil-ca-1.crt --cert-location my-env/certs/client.crt --key-location my-env/certs/client.key
Starting Kafka Producer. Use Ctrl-C or Ctrl-D to exit.
hello
```
```
confluent kafka topic consume test-topic --bootstrap $HOSTNAME:9093 --ca-location my-env/certs/snakeoil-ca-1.crt --cert-location my-env/certs/client.crt --key-location my-env/certs/client.key --from-beginning
Starting Kafka Consumer. Use Ctrl-C to exit.
hello
```

Confluent Platform, logged out:
```
confluent kafka topic produce test-topic --bootstrap $HOSTNAME:9093 --ca-location my-env/certs/snakeoil-ca-1.crt --cert-location my-env/certs/client.crt --key-location my-env/certs/client.key 
Starting Kafka Producer. Use Ctrl-C or Ctrl-D to exit.
hello2
```
```
confluent kafka topic consume test-topic --bootstrap $HOSTNAME:9093 --ca-location my-env/certs/snakeoil-ca-1.crt --cert-location my-env/certs/client.crt --key-location my-env/certs/client.key --from-beginning
Starting Kafka Consumer. Use Ctrl-C to exit.
hello
hello2
```