### PR TITLE
CLI-3041: Fix nil panic when reading configuration files on Windows

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -26,7 +26,7 @@ func FileExists(filename string) bool {
 	if os.IsNotExist(err) {
 		return false
 	}
-	return !info.IsDir()
+	return info != nil && !info.IsDir()
 }
 
 func LoadPropertiesFile(path string) (*properties.Properties, error) {


### PR DESCRIPTION
Release Notes
-------------
Bug Fixes
- Avoid crash when reading configuration files on Windows

Checklist
---------
- [x] Leave this box unchecked if features are not yet available in production

What
----
Fix `nil` panic when reading configuration files. Likely only happens on Windows when `os.Stat()` returns `nil`.

References
----------
https://confluentinc.atlassian.net/browse/CLI-3041

Test & Review
-------------
Tests still pass