### PR TITLE
Fix cross compile issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ endif
 
 .PHONY: cli-builder
 cli-builder:
-	GOOS="" GOARCH="" go install github.com/goreleaser/goreleaser@$(GORELEASER_VERSION) && \
+	GOOS="" GOARCH="" CC="" CXX="" CGO_LDFLAGS="" go install github.com/goreleaser/goreleaser@$(GORELEASER_VERSION) && \
 	TAGS=$(TAGS) CC=$(CC) CXX=$(CXX) CGO_LDFLAGS=$(CGO_LDFLAGS) goreleaser build --config .goreleaser-build.yml --clean --single-target --snapshot
 
 include ./mk-files/semver.mk

--- a/debian/patches/standard_build_layout.patch
+++ b/debian/patches/standard_build_layout.patch
@@ -1,5 +1,5 @@
---- cli/Makefile	2024-01-18 12:30:40.334194366 -0800
-+++ debian/Makefile	2024-01-12 08:35:04.157968782 -0800
+--- cli/Makefile	2024-02-14 12:44:40.000000000 -0800
++++ debian/Makefile	2024-02-14 10:24:04.000000000 -0800
 @@ -1,132 +1,144 @@
 -SHELL := /bin/bash
 -GORELEASER_VERSION := v1.21.2
@@ -41,7 +41,7 @@
 -
 -.PHONY: cli-builder
 -cli-builder:
--	GOOS="" GOARCH="" go install github.com/goreleaser/goreleaser@$(GORELEASER_VERSION) && \
+-	GOOS="" GOARCH="" CC="" CXX="" CGO_LDFLAGS="" go install github.com/goreleaser/goreleaser@$(GORELEASER_VERSION) && \
 -	TAGS=$(TAGS) CC=$(CC) CXX=$(CXX) CGO_LDFLAGS=$(CGO_LDFLAGS) goreleaser build --config .goreleaser-build.yml --clean --single-target --snapshot
 -
 -include ./mk-files/semver.mk


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- PLACEHOLDER

New Features
- PLACEHOLDER

Bug Fixes
- PLACEHOLDER

Checklist
---------
- [x] Leave this box unchecked if features are not yet available in production

What
----
`CC`, `CXX`, and `CGO_LDFLAGS` also need to be set to the empty string in the `go install` line if `GOOS` and `GOARCH` are set to the empty string.

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
Manual testing:
- `make`
- `GOOS=linux make cross-build`
- `GOOS=windows make cross-build`
- uninstalled all instances of goreleaser and ran `make`
- uninstalled all instances of goreleaser and ran `GOOS=linux make cross-build`
- uninstalled all instances of goreleaser and ran `GOOS=windows make cross-build`