### PR TITLE
KGLOBAL-4436: Replace special characters when parsing the configurations

### DIFF
--- a/pkg/properties/properties.go
+++ b/pkg/properties/properties.go
@@ -39,7 +39,7 @@ func ConfigSliceToMap(configs []string) (map[string]string, error) {
 			return nil, fmt.Errorf(`failed to parse "key=value" pattern from configuration: %s`, config)
 		}
 
-		m[x[0]] = x[1]
+		m[x[0]] = replaceSpecialCharacters(x[1])
 	}
 
 	return m, nil
@@ -69,7 +69,7 @@ func ConfigFlagToMap(configs []string) (map[string]string, error) {
 		if strings.Contains(configs[i], "=") {
 			x := strings.SplitN(configs[i], "=", 2)
 			if _, ok := m[x[0]]; !ok {
-				m[x[0]] = x[1]
+				m[x[0]] = replaceSpecialCharacters(x[1])
 			}
 		} else {
 			if i-1 >= 0 {
@@ -95,4 +95,11 @@ func CreateKeyValuePairs(m map[string]string) string {
 		fmt.Fprintf(b, "\"%s\"=\"%s\"\n", k, m[k])
 	}
 	return b.String()
+}
+
+func replaceSpecialCharacters(val string) string {
+	// Replace \\n, \\r and \\t with newline, carriage return and tab characters as specified in
+	// https://docs.oracle.com/cd/E23095_01/Platform.93/ATGProgGuide/html/s0204propertiesfileformat01.html.
+	return strings.ReplaceAll(strings.ReplaceAll(
+		strings.ReplaceAll(val, "\\n", "\n"), "\\r", "\r"), "\\t", "\t")
 }

--- a/pkg/properties/properties_test.go
+++ b/pkg/properties/properties_test.go
@@ -82,6 +82,24 @@ func TestConfigFlagToMap_ValueWithEquals(t *testing.T) {
 	require.Equal(t, map[string]string{"key": "val1=val2"}, m)
 }
 
+func TestConfigFlagToMap_NewLine(t *testing.T) {
+	m, err := ConfigFlagToMap([]string{"key=val1\\nval2"})
+	require.NoError(t, err)
+	require.Equal(t, map[string]string{"key": "val1\nval2"}, m)
+}
+
+func TestConfigFlagToMap_CarriageReturn(t *testing.T) {
+	m, err := ConfigFlagToMap([]string{"key=val1\\rval2"})
+	require.NoError(t, err)
+	require.Equal(t, map[string]string{"key": "val1\rval2"}, m)
+}
+
+func TestConfigFlagToMap_Tab(t *testing.T) {
+	m, err := ConfigFlagToMap([]string{"key=val1\\tval2"})
+	require.NoError(t, err)
+	require.Equal(t, map[string]string{"key": "val1\tval2"}, m)
+}
+
 func TestCreateKeyValuePairsEmptyMap(t *testing.T) {
 	m := make(map[string]string)
 	require.Equal(t, "", CreateKeyValuePairs(m))


### PR DESCRIPTION
Release Notes
-------------
Bug Fixes
- Fix a bug causing `confluent kafka link create` and `confluent kafka link configuration update` to fail when the cluster link configuration "ssl.truststore.certificates" contains an explicit "\n" character

Checklist
---------
- [x] Leave this box unchecked if features are not yet available in production

What
----
Replace explicit special characters (newline, carriage return and tab) in config value as specified in https://docs.oracle.com/cd/E23095_01/Platform.93/ATGProgGuide/html/s0204propertiesfileformat01.html. More specifically, explicit \n in the value is treated as \\n by current CLI parser while the Java property parser treats it as \n.

References
----------
https://confluentinc.atlassian.net/browse/KGLOBAL-4436

Test & Review
-------------
Tested on real cluster. Added unit test.