### PR TITLE
fix: make colors more visible in interactive output

### DIFF
--- a/pkg/color/color.go
+++ b/pkg/color/color.go
@@ -12,3 +12,5 @@ const AccentColor = color.FgCyan
 
 const ErrorColor = color.FgHiRed
 const WarnColor = color.FgHiYellow
+
+const CyanHexCode = "#178e92"

--- a/pkg/flink/components/shortcuts.go
+++ b/pkg/flink/components/shortcuts.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/rivo/tview"
 
+	"github.com/confluentinc/cli/v3/pkg/color"
 	"github.com/confluentinc/cli/v3/pkg/flink/types"
 )
 
@@ -24,7 +25,7 @@ func NewShortcuts(shortcuts []types.Shortcut) *tview.TextView {
 func formatShortcuts(shortcuts []types.Shortcut) string {
 	sb := strings.Builder{}
 	for index, shortcut := range shortcuts {
-		sb.WriteString(fmt.Sprintf(`[[white]%s] ["%d"][darkcyan]%s[white][""]  `, shortcut.KeyText, index, shortcut.Text))
+		sb.WriteString(fmt.Sprintf(`[[white]%s] ["%d"][%s]%s[white][""]  `, shortcut.KeyText, index, color.CyanHexCode, shortcut.Text))
 	}
 	return sb.String()
 }

--- a/pkg/flink/components/table_info_bar.go
+++ b/pkg/flink/components/table_info_bar.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/rivo/tview"
 
+	"github.com/confluentinc/cli/v3/pkg/color"
 	"github.com/confluentinc/cli/v3/pkg/flink/types"
 )
 
@@ -55,21 +56,22 @@ func (t *TableInfoBar) constructRefreshInfo() tview.Primitive {
 	return tview.NewTextView().
 		SetDynamicColors(true).
 		SetTextAlign(tview.AlignLeft).
-		SetText(fmt.Sprintf("Refresh: [darkcyan]%s[white]", t.refreshState.ToString()))
+		SetText(fmt.Sprintf("Refresh: [%s]%s[white]", color.CyanHexCode, t.refreshState.ToString()))
 }
 
 func (t *TableInfoBar) constructRowInfo() tview.Primitive {
 	rowInfo := tview.NewTextView().SetDynamicColors(true).SetTextAlign(tview.AlignCenter).SetText("")
 	if t.selectedRowIdx > 0 && t.totalNumRows > 0 {
-		rowInfo.SetText(fmt.Sprintf("Row: [darkcyan]%v[white] of [darkcyan]%v[white]", t.selectedRowIdx, t.totalNumRows))
+		rowInfo.SetText(fmt.Sprintf("Row: [%s]%v[white] of [%s]%v[white]", color.CyanHexCode, t.selectedRowIdx, color.CyanHexCode, t.totalNumRows))
 	}
 	return rowInfo
 }
 
 func (t *TableInfoBar) constructLastRefreshInfo() tview.Primitive {
-	lastRefreshInfo := tview.NewTextView().SetDynamicColors(true).SetTextAlign(tview.AlignRight).SetText("Last refresh: [darkcyan]-[white]")
+	lastRefreshInfo := tview.NewTextView().SetDynamicColors(true).SetTextAlign(tview.AlignRight).
+		SetText(fmt.Sprintf("Last refresh: [%s]-[white]", color.CyanHexCode))
 	if t.lastRefreshTimestamp != nil {
-		lastRefreshInfo.SetText(fmt.Sprintf("Last refresh: [darkcyan]%s[white]", t.lastRefreshTimestamp.Format("15:04:05.000")))
+		lastRefreshInfo.SetText(fmt.Sprintf("Last refresh: [%s]%s[white]", color.CyanHexCode, t.lastRefreshTimestamp.Format("15:04:05.000")))
 	}
 	return lastRefreshInfo
 }


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Bug Fixes
- Improve text visibility in interactive output of `confluent flink shell`

Checklist
---------
- [x] Leave this box unchecked if features are not yet available in production

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->
Switch from dark cyan color name to hex code, since the color is different on Windows and Mac

Windows before:
<img width="1173" alt="image" src="https://github.com/confluentinc/cli/assets/37211050/ab66c10f-cb62-4271-bdd1-e158f35ff54d">


Windows after:
<img width="1171" alt="image" src="https://github.com/confluentinc/cli/assets/37211050/cdaaf07f-9007-4ea9-9efd-ea1eff0fe1f2">

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
<!--
Has it been tested? How?
Copy and paste any instructions or steps that can save the reviewer time.
-->