### PR TITLE
DGS-10129: Fix SR cluster login bug

### DIFF
--- a/internal/schema-registry/command_cluster.go
+++ b/internal/schema-registry/command_cluster.go
@@ -10,7 +10,7 @@ import (
 func (c *command) newClusterCommand(cfg *config.Config) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:         "cluster",
-		Annotations: map[string]string{pcmd.RunRequirement: pcmd.RequireCloudLoginOrOnPremLogin},
+		Annotations: map[string]string{pcmd.RunRequirement: pcmd.RequireNonAPIKeyCloudLoginOrOnPremLogin},
 	}
 
 	if cfg.IsCloudLogin() {

--- a/internal/schema-registry/command_cluster_delete.go
+++ b/internal/schema-registry/command_cluster_delete.go
@@ -19,7 +19,7 @@ func (c *command) newClusterDeleteCommand() *cobra.Command {
 		Short:       "Delete the Schema Registry cluster for this environment.",
 		Args:        cobra.NoArgs,
 		RunE:        c.clusterDelete,
-		Annotations: map[string]string{pcmd.RunRequirement: pcmd.RequireCloudLogin},
+		Annotations: map[string]string{pcmd.RunRequirement: pcmd.RequireNonAPIKeyCloudLogin},
 		Example: examples.BuildExampleString(
 			examples.Example{
 				Text: `Delete the Schema Registry cluster for environment "env-123456".`,

--- a/internal/schema-registry/command_cluster_describe.go
+++ b/internal/schema-registry/command_cluster_describe.go
@@ -44,7 +44,7 @@ func (c *command) newClusterDescribeCommand() *cobra.Command {
 		Short:       "Describe the Schema Registry cluster for this environment.",
 		Args:        cobra.NoArgs,
 		RunE:        c.clusterDescribe,
-		Annotations: map[string]string{pcmd.RunRequirement: pcmd.RequireCloudLogin},
+		Annotations: map[string]string{pcmd.RunRequirement: pcmd.RequireNonAPIKeyCloudLogin},
 	}
 
 	pcmd.AddContextFlag(cmd, c.CLICommand)

--- a/internal/schema-registry/command_cluster_enable.go
+++ b/internal/schema-registry/command_cluster_enable.go
@@ -28,7 +28,7 @@ func (c *command) newClusterEnableCommand() *cobra.Command {
 		Short:       "Enable Schema Registry for this environment.",
 		Args:        cobra.NoArgs,
 		RunE:        c.clusterEnable,
-		Annotations: map[string]string{pcmd.RunRequirement: pcmd.RequireCloudLogin},
+		Annotations: map[string]string{pcmd.RunRequirement: pcmd.RequireNonAPIKeyCloudLogin},
 		Example: examples.BuildExampleString(
 			examples.Example{
 				Text: `Enable Schema Registry, using Google Cloud Platform in the US with the "advanced" package.`,

--- a/internal/schema-registry/command_cluster_update.go
+++ b/internal/schema-registry/command_cluster_update.go
@@ -20,7 +20,7 @@ func (c *command) newClusterUpdateCommand() *cobra.Command {
 		Short:       "Update global mode or compatibility of Schema Registry.",
 		Args:        cobra.NoArgs,
 		RunE:        c.clusterUpdate,
-		Annotations: map[string]string{pcmd.RunRequirement: pcmd.RequireCloudLogin},
+		Annotations: map[string]string{pcmd.RunRequirement: pcmd.RequireNonAPIKeyCloudLogin},
 		Example: examples.BuildExampleString(
 			examples.Example{
 				Text: "Update top-level compatibility of Schema Registry.",

--- a/internal/schema-registry/command_cluster_upgrade.go
+++ b/internal/schema-registry/command_cluster_upgrade.go
@@ -19,7 +19,7 @@ func (c *command) newClusterUpgradeCommand() *cobra.Command {
 		Short:       "Upgrade the Schema Registry package for this environment.",
 		Args:        cobra.NoArgs,
 		RunE:        c.clusterUpgrade,
-		Annotations: map[string]string{pcmd.RunRequirement: pcmd.RequireCloudLogin},
+		Annotations: map[string]string{pcmd.RunRequirement: pcmd.RequireNonAPIKeyCloudLogin},
 		Example: examples.BuildExampleString(
 			examples.Example{
 				Text: `Upgrade Schema Registry to the "advanced" package for environment "env-123456".`,


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- PLACEHOLDER

New Features
- PLACEHOLDER

Bug Fixes
- no need to run login a second time to run SR cluster commands

Checklist
---------
- [N/A] Leave this box unchecked if features are not yet available in production

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->
As identified in an Always-On Governance [Bug bash](https://confluentinc.atlassian.net/wiki/spaces/DG/pages/3324280858/Always-On+Bug+Bash#Bugs), after running the following commands with v4 CLI:
```
confluent login
confluent environment create aog_cli_bug --governance-package essentials
confluent environment use <new-id>
confluent kafka cluster create cluster_0 --cloud gcp --region us-central1
confluent sr cluster describe
```
... the sr cluster describe command returns the following error:
```
Error: failed to validate Schema Registry client: 401 Unauthorized
```
Updating the annotation on the SR cluster describe command (to the same as parent) fixed this behavior. The parent command (`sr cluster`) annotation matches the annotation on the `environment` and `kafka cluster` commands.

References
----------
[DGS-10129](https://confluentinc.atlassian.net/browse/DGS-10129)
Duplicate PR: https://github.com/confluentinc/cli/pull/2641

Test & Review
-------------
<!--
Has it been tested? How?
Copy and paste any instructions or steps that can save the reviewer time.
-->

[DGS-10129]: https://confluentinc.atlassian.net/browse/DGS-10129?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ