### PR TITLE
[TRAFFIC-10482] Set up ccloudv2 client for OutboundPL

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/charmbracelet/lipgloss v0.9.1
 	github.com/client9/gospell v0.0.0-20160306015952-90dfc71015df
 	github.com/confluentinc/ccloud-sdk-go-v1-public v0.0.0-20230427001341-5f8d2cce5ad9
+	github.com/confluentinc/ccloud-sdk-go-v2-internal/networking-outbound-privatelink v0.0.2
 	github.com/confluentinc/ccloud-sdk-go-v2/apikeys v0.4.0
 	github.com/confluentinc/ccloud-sdk-go-v2/billing v0.3.0
 	github.com/confluentinc/ccloud-sdk-go-v2/byok v0.0.2

--- a/go.sum
+++ b/go.sum
@@ -110,6 +110,8 @@ github.com/cncf/xds/go v0.0.0-20211001041855-01bcc9b48dfe/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/confluentinc/ccloud-sdk-go-v1-public v0.0.0-20230427001341-5f8d2cce5ad9 h1:SPb0hN0B/XCUvaeaxferqVb9X5xFGaMKBAlP3HVW+MQ=
 github.com/confluentinc/ccloud-sdk-go-v1-public v0.0.0-20230427001341-5f8d2cce5ad9/go.mod h1:Ja+ScdwUPpLwPDi/jI4FU2hI4Ncu3o4A4nxo05ehXHQ=
+github.com/confluentinc/ccloud-sdk-go-v2-internal/networking-outbound-privatelink v0.0.2 h1:m11soaX3MczGkUGHoy1ax77b35kwxxJAXZUwM8Bx58I=
+github.com/confluentinc/ccloud-sdk-go-v2-internal/networking-outbound-privatelink v0.0.2/go.mod h1:sGGjjbxxbPCL1FlNTZv1sbPaSD4fYbbd0WBFKhWCCpk=
 github.com/confluentinc/ccloud-sdk-go-v2/apikeys v0.4.0 h1:8fWyLwMuy8ec0MVF5Avd54UvbIxhDFhZzanHBVwgxdw=
 github.com/confluentinc/ccloud-sdk-go-v2/apikeys v0.4.0/go.mod h1:wNa9Qg2e2v/+PQsUyKh+qB22hhLkPR6Ahy6rP+1jmGI=
 github.com/confluentinc/ccloud-sdk-go-v2/billing v0.3.0 h1:a2EaPzwLEYkgil7rlsqRUlt994PMGubtdgRrF8Kbo10=

--- a/pkg/ccloudv2/client.go
+++ b/pkg/ccloudv2/client.go
@@ -2,7 +2,6 @@ package ccloudv2
 
 import (
 	networkingoutboundprivatelinkv1 "github.com/confluentinc/ccloud-sdk-go-v2-internal/networking-outbound-privatelink/v1"
-
 	apikeysv2 "github.com/confluentinc/ccloud-sdk-go-v2/apikeys/v2"
 	billingv1 "github.com/confluentinc/ccloud-sdk-go-v2/billing/v1"
 	byokv1 "github.com/confluentinc/ccloud-sdk-go-v2/byok/v1"

--- a/pkg/ccloudv2/client.go
+++ b/pkg/ccloudv2/client.go
@@ -1,6 +1,8 @@
 package ccloudv2
 
 import (
+	networkingoutboundprivatelinkv1 "github.com/confluentinc/ccloud-sdk-go-v2-internal/networking-outbound-privatelink/v1"
+
 	apikeysv2 "github.com/confluentinc/ccloud-sdk-go-v2/apikeys/v2"
 	billingv1 "github.com/confluentinc/ccloud-sdk-go-v2/billing/v1"
 	byokv1 "github.com/confluentinc/ccloud-sdk-go-v2/byok/v1"
@@ -32,28 +34,29 @@ import (
 type Client struct {
 	cfg *config.Config
 
-	ApiKeysClient               *apikeysv2.APIClient
-	BillingClient               *billingv1.APIClient
-	ByokClient                  *byokv1.APIClient
-	CdxClient                   *cdxv1.APIClient
-	CliClient                   *cliv1.APIClient
-	CmkClient                   *cmkv2.APIClient
-	ConnectClient               *connectv1.APIClient
-	ConnectCustomPluginClient   *connectcustompluginv1.APIClient
-	FlinkClient                 *flinkv2.APIClient
-	IamClient                   *iamv2.APIClient
-	IdentityProviderClient      *identityproviderv2.APIClient
-	KafkaQuotasClient           *kafkaquotasv1.APIClient
-	KsqlClient                  *ksqlv2.APIClient
-	MdsClient                   *mdsv2.APIClient
-	NetworkingClient            *networkingv1.APIClient
-	NetworkingIpClient          *networkingipv1.APIClient
-	NetworkingPrivateLinkClient *networkingprivatelinkv1.APIClient
-	OrgClient                   *orgv2.APIClient
-	ServiceQuotaClient          *servicequotav1.APIClient
-	SrcmClient                  *srcmv2.APIClient
-	SsoClient                   *ssov2.APIClient
-	StreamDesignerClient        *streamdesignerv1.APIClient
+	ApiKeysClient                       *apikeysv2.APIClient
+	BillingClient                       *billingv1.APIClient
+	ByokClient                          *byokv1.APIClient
+	CdxClient                           *cdxv1.APIClient
+	CliClient                           *cliv1.APIClient
+	CmkClient                           *cmkv2.APIClient
+	ConnectClient                       *connectv1.APIClient
+	ConnectCustomPluginClient           *connectcustompluginv1.APIClient
+	FlinkClient                         *flinkv2.APIClient
+	IamClient                           *iamv2.APIClient
+	IdentityProviderClient              *identityproviderv2.APIClient
+	KafkaQuotasClient                   *kafkaquotasv1.APIClient
+	KsqlClient                          *ksqlv2.APIClient
+	MdsClient                           *mdsv2.APIClient
+	NetworkingClient                    *networkingv1.APIClient
+	NetworkingIpClient                  *networkingipv1.APIClient
+	NetworkingOutboundPrivateLinkClient *networkingoutboundprivatelinkv1.APIClient
+	NetworkingPrivateLinkClient         *networkingprivatelinkv1.APIClient
+	OrgClient                           *orgv2.APIClient
+	ServiceQuotaClient                  *servicequotav1.APIClient
+	SrcmClient                          *srcmv2.APIClient
+	SsoClient                           *ssov2.APIClient
+	StreamDesignerClient                *streamdesignerv1.APIClient
 }
 
 func NewClient(cfg *config.Config, unsafeTrace bool) *Client {
@@ -69,27 +72,28 @@ func NewClient(cfg *config.Config, unsafeTrace bool) *Client {
 	return &Client{
 		cfg: cfg,
 
-		ApiKeysClient:               newApiKeysClient(httpClient, url, userAgent, unsafeTrace),
-		BillingClient:               newBillingClient(httpClient, url, userAgent, unsafeTrace),
-		ByokClient:                  newByokV1Client(httpClient, url, userAgent, unsafeTrace),
-		CdxClient:                   newCdxClient(httpClient, url, userAgent, unsafeTrace),
-		CliClient:                   newCliClient(url, userAgent, unsafeTrace),
-		CmkClient:                   newCmkClient(httpClient, url, userAgent, unsafeTrace),
-		ConnectClient:               newConnectClient(httpClient, url, userAgent, unsafeTrace),
-		ConnectCustomPluginClient:   newConnectCustomPluginClient(httpClient, url, userAgent, unsafeTrace),
-		FlinkClient:                 newFlinkClient(httpClient, url, userAgent, unsafeTrace),
-		IamClient:                   newIamClient(httpClient, url, userAgent, unsafeTrace),
-		IdentityProviderClient:      newIdentityProviderClient(httpClient, url, userAgent, unsafeTrace),
-		KafkaQuotasClient:           newKafkaQuotasClient(httpClient, url, userAgent, unsafeTrace),
-		KsqlClient:                  newKsqlClient(httpClient, url, userAgent, unsafeTrace),
-		MdsClient:                   newMdsClient(httpClient, url, userAgent, unsafeTrace),
-		NetworkingClient:            newNetworkingClient(httpClient, url, userAgent, unsafeTrace),
-		NetworkingIpClient:          newNetworkingIpClient(httpClient, url, userAgent, unsafeTrace),
-		NetworkingPrivateLinkClient: newNetworkingPrivateLinkClient(httpClient, url, userAgent, unsafeTrace),
-		OrgClient:                   newOrgClient(httpClient, url, userAgent, unsafeTrace),
-		ServiceQuotaClient:          newServiceQuotaClient(httpClient, url, userAgent, unsafeTrace),
-		SrcmClient:                  newSrcmClient(httpClient, url, userAgent, unsafeTrace),
-		SsoClient:                   newSsoClient(httpClient, url, userAgent, unsafeTrace),
-		StreamDesignerClient:        newStreamDesignerClient(httpClient, url, userAgent, unsafeTrace),
+		ApiKeysClient:                       newApiKeysClient(httpClient, url, userAgent, unsafeTrace),
+		BillingClient:                       newBillingClient(httpClient, url, userAgent, unsafeTrace),
+		ByokClient:                          newByokV1Client(httpClient, url, userAgent, unsafeTrace),
+		CdxClient:                           newCdxClient(httpClient, url, userAgent, unsafeTrace),
+		CliClient:                           newCliClient(url, userAgent, unsafeTrace),
+		CmkClient:                           newCmkClient(httpClient, url, userAgent, unsafeTrace),
+		ConnectClient:                       newConnectClient(httpClient, url, userAgent, unsafeTrace),
+		ConnectCustomPluginClient:           newConnectCustomPluginClient(httpClient, url, userAgent, unsafeTrace),
+		FlinkClient:                         newFlinkClient(httpClient, url, userAgent, unsafeTrace),
+		IamClient:                           newIamClient(httpClient, url, userAgent, unsafeTrace),
+		IdentityProviderClient:              newIdentityProviderClient(httpClient, url, userAgent, unsafeTrace),
+		KafkaQuotasClient:                   newKafkaQuotasClient(httpClient, url, userAgent, unsafeTrace),
+		KsqlClient:                          newKsqlClient(httpClient, url, userAgent, unsafeTrace),
+		MdsClient:                           newMdsClient(httpClient, url, userAgent, unsafeTrace),
+		NetworkingClient:                    newNetworkingClient(httpClient, url, userAgent, unsafeTrace),
+		NetworkingIpClient:                  newNetworkingIpClient(httpClient, url, userAgent, unsafeTrace),
+		NetworkingOutboundPrivateLinkClient: newNetworkingOutboundPrivateLinkClient(httpClient, url, userAgent, unsafeTrace),
+		NetworkingPrivateLinkClient:         newNetworkingPrivateLinkClient(httpClient, url, userAgent, unsafeTrace),
+		OrgClient:                           newOrgClient(httpClient, url, userAgent, unsafeTrace),
+		ServiceQuotaClient:                  newServiceQuotaClient(httpClient, url, userAgent, unsafeTrace),
+		SrcmClient:                          newSrcmClient(httpClient, url, userAgent, unsafeTrace),
+		SsoClient:                           newSsoClient(httpClient, url, userAgent, unsafeTrace),
+		StreamDesignerClient:                newStreamDesignerClient(httpClient, url, userAgent, unsafeTrace),
 	}
 }

--- a/pkg/ccloudv2/networking_outbound_privatelink.go
+++ b/pkg/ccloudv2/networking_outbound_privatelink.go
@@ -1,0 +1,124 @@
+package ccloudv2
+
+import (
+	"context"
+	"net/http"
+
+	networkingoutboundprivatelinkv1 "github.com/confluentinc/ccloud-sdk-go-v2-internal/networking-outbound-privatelink/v1"
+
+	"github.com/confluentinc/cli/v3/pkg/errors"
+)
+
+func newNetworkingOutboundPrivateLinkClient(httpClient *http.Client, url, userAgent string, unsafeTrace bool) *networkingoutboundprivatelinkv1.APIClient {
+	cfg := networkingoutboundprivatelinkv1.NewConfiguration()
+	cfg.Debug = unsafeTrace
+	cfg.HTTPClient = httpClient
+	cfg.Servers = networkingoutboundprivatelinkv1.ServerConfigurations{{URL: url}}
+	cfg.UserAgent = userAgent
+
+	return networkingoutboundprivatelinkv1.NewAPIClient(cfg)
+}
+
+func (c *Client) networkingOutboundPrivateLinkApiContext() context.Context {
+	return context.WithValue(context.Background(), networkingoutboundprivatelinkv1.ContextAccessToken, c.cfg.Context().GetAuthToken())
+}
+
+func (c *Client) ListAccessPoints(environment string) ([]networkingoutboundprivatelinkv1.NetworkingV1AccessPoint, error) {
+	var list []networkingoutboundprivatelinkv1.NetworkingV1AccessPoint
+
+	done := false
+	pageToken := ""
+	for !done {
+		page, err := c.executeListAccessPoints(environment, pageToken)
+		if err != nil {
+			return nil, err
+		}
+		list = append(list, page.GetData()...)
+
+		pageToken, done, err = extractNextPageToken(page.GetMetadata().Next)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return list, nil
+}
+
+func (c *Client) executeListAccessPoints(environment, pageToken string) (networkingoutboundprivatelinkv1.NetworkingV1AccessPointList, error) {
+	req := c.NetworkingOutboundPrivateLinkClient.AccessPointsNetworkingV1Api.ListNetworkingV1AccessPoints(c.networkingOutboundPrivateLinkApiContext()).Environment(environment).PageSize(ccloudV2ListPageSize)
+	if pageToken != "" {
+		req = req.PageToken(pageToken)
+	}
+
+	resp, httpResp, err := req.Execute()
+	return resp, errors.CatchCCloudV2Error(err, httpResp)
+}
+
+func (c *Client) GetAccessPoint(environment, id string) (networkingoutboundprivatelinkv1.NetworkingV1AccessPoint, error) {
+	resp, httpResp, err := c.NetworkingOutboundPrivateLinkClient.AccessPointsNetworkingV1Api.GetNetworkingV1AccessPoint(c.networkingOutboundPrivateLinkApiContext(), id).Environment(environment).Execute()
+	return resp, errors.CatchCCloudV2Error(err, httpResp)
+}
+
+func (c *Client) DeleteAccessPoint(environment, id string) error {
+	httpResp, err := c.NetworkingOutboundPrivateLinkClient.AccessPointsNetworkingV1Api.DeleteNetworkingV1AccessPoint(c.networkingOutboundPrivateLinkApiContext(), id).Environment(environment).Execute()
+	return errors.CatchCCloudV2Error(err, httpResp)
+}
+
+func (c *Client) UpdateAccessPoint(id string, accessPointUpdate networkingoutboundprivatelinkv1.NetworkingV1AccessPointUpdate) (networkingoutboundprivatelinkv1.NetworkingV1AccessPoint, error) {
+	resp, httpResp, err := c.NetworkingOutboundPrivateLinkClient.AccessPointsNetworkingV1Api.UpdateNetworkingV1AccessPoint(c.networkingOutboundPrivateLinkApiContext(), id).NetworkingV1AccessPointUpdate(accessPointUpdate).Execute()
+	return resp, errors.CatchCCloudV2Error(err, httpResp)
+}
+
+func (c *Client) CreateAccessPoint(accessPoint networkingoutboundprivatelinkv1.NetworkingV1AccessPoint) (networkingoutboundprivatelinkv1.NetworkingV1AccessPoint, error) {
+	resp, httpResp, err := c.NetworkingOutboundPrivateLinkClient.AccessPointsNetworkingV1Api.CreateNetworkingV1AccessPoint(c.networkingOutboundPrivateLinkApiContext()).NetworkingV1AccessPoint(accessPoint).Execute()
+	return resp, errors.CatchCCloudV2Error(err, httpResp)
+}
+
+func (c *Client) ListDnsRecords(environment string) ([]networkingoutboundprivatelinkv1.NetworkingV1DnsRecord, error) {
+	var list []networkingoutboundprivatelinkv1.NetworkingV1DnsRecord
+
+	done := false
+	pageToken := ""
+	for !done {
+		page, err := c.executeListDnsRecords(environment, pageToken)
+		if err != nil {
+			return nil, err
+		}
+		list = append(list, page.GetData()...)
+
+		pageToken, done, err = extractNextPageToken(page.GetMetadata().Next)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return list, nil
+}
+
+func (c *Client) executeListDnsRecords(environment, pageToken string) (networkingoutboundprivatelinkv1.NetworkingV1DnsRecordList, error) {
+	req := c.NetworkingOutboundPrivateLinkClient.DnsRecordsNetworkingV1Api.ListNetworkingV1DnsRecords(c.networkingOutboundPrivateLinkApiContext()).Environment(environment).PageSize(ccloudV2ListPageSize)
+	if pageToken != "" {
+		req = req.PageToken(pageToken)
+	}
+
+	resp, httpResp, err := req.Execute()
+	return resp, errors.CatchCCloudV2Error(err, httpResp)
+}
+
+func (c *Client) GetDnsRecord(environment, id string) (networkingoutboundprivatelinkv1.NetworkingV1DnsRecord, error) {
+	resp, httpResp, err := c.NetworkingOutboundPrivateLinkClient.DnsRecordsNetworkingV1Api.GetNetworkingV1DnsRecord(c.networkingOutboundPrivateLinkApiContext(), id).Environment(environment).Execute()
+	return resp, errors.CatchCCloudV2Error(err, httpResp)
+}
+
+func (c *Client) DeleteDnsRecord(environment, id string) error {
+	httpResp, err := c.NetworkingOutboundPrivateLinkClient.DnsRecordsNetworkingV1Api.DeleteNetworkingV1DnsRecord(c.networkingOutboundPrivateLinkApiContext(), id).Environment(environment).Execute()
+	return errors.CatchCCloudV2Error(err, httpResp)
+}
+
+func (c *Client) UpdateDnsRecord(id string, dnsRecordUpdate networkingoutboundprivatelinkv1.NetworkingV1DnsRecordUpdate) (networkingoutboundprivatelinkv1.NetworkingV1DnsRecord, error) {
+	resp, httpResp, err := c.NetworkingOutboundPrivateLinkClient.DnsRecordsNetworkingV1Api.UpdateNetworkingV1DnsRecord(c.networkingOutboundPrivateLinkApiContext(), id).NetworkingV1DnsRecordUpdate(dnsRecordUpdate).Execute()
+	return resp, errors.CatchCCloudV2Error(err, httpResp)
+}
+
+func (c *Client) CreateDnsRecord(dnsRecord networkingoutboundprivatelinkv1.NetworkingV1DnsRecord) (networkingoutboundprivatelinkv1.NetworkingV1DnsRecord, error) {
+	resp, httpResp, err := c.NetworkingOutboundPrivateLinkClient.DnsRecordsNetworkingV1Api.CreateNetworkingV1DnsRecord(c.networkingOutboundPrivateLinkApiContext()).NetworkingV1DnsRecord(dnsRecord).Execute()
+	return resp, errors.CatchCCloudV2Error(err, httpResp)
+}

--- a/pkg/resource/resource.go
+++ b/pkg/resource/resource.go
@@ -13,6 +13,7 @@ import (
 
 const (
 	Unknown                         = "unknown"
+	AccessPoint                     = "access point"
 	ACL                             = "ACL"
 	ApiKey                          = "API key"
 	Broker                          = "broker"
@@ -25,6 +26,7 @@ const (
 	ConsumerShare                   = "consumer share"
 	Context                         = "context"
 	Dek                             = "DEK"
+	DnsRecord                       = "DNS record"
 	Environment                     = "environment"
 	Flink                           = "flink"
 	FlinkComputePool                = "Flink compute pool"


### PR DESCRIPTION
What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->
Note that this is merging into the feature branch https://github.com/confluentinc/cli/tree/traffic-10482-outbound-pl. We will merge commits into main from this feature branch after all of the commands for outbound PL are implemented.

For the Outbound PL project, we are introducing two new resources `DNS Record` and `Access Point`
* In this PR, we are setting up the ccloudv2 client for `outbound-private-link`.
* We are using the internal sdk for development as the feature is not released yet.

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

[Outbound PL - Design ](https://confluentinc.atlassian.net/wiki/spaces/CIRE/pages/3171255521/Outbound+PL+-+Design)

Test & Review
-------------
<!--
Has it been tested? How?
Copy and paste any instructions or steps that can save the reviewer time.
-->

`make build`
`make test`
`make lint`