### PR TITLE
[RCCA-17800] Fix `confluent kafka cluster configuration update` config length bug

### DIFF
--- a/internal/kafka/command_cluster_configuration_update.go
+++ b/internal/kafka/command_cluster_configuration_update.go
@@ -54,7 +54,7 @@ func (c *clusterCommand) configurationUpdate(cmd *cobra.Command, _ []string) err
 		return err
 	}
 
-	data := make([]kafkarestv3.AlterConfigBatchRequestDataData, len(config))
+	data := make([]kafkarestv3.AlterConfigBatchRequestDataData, len(configMap))
 	i := 0
 	for key, value := range configMap {
 		data[i] = kafkarestv3.AlterConfigBatchRequestDataData{

--- a/test/fixtures/output/kafka/cluster/configuration/update-with-commas.golden
+++ b/test/fixtures/output/kafka/cluster/configuration/update-with-commas.golden
@@ -1,0 +1,1 @@
+Successfully requested to update configuration "ssl.cipher.suites".

--- a/test/kafka_test.go
+++ b/test/kafka_test.go
@@ -172,7 +172,7 @@ func (s *CLITestSuite) TestKafkaClusterConfiguration() {
 		{args: "kafka cluster use lkc-12345"},
 		{args: "kafka cluster configuration describe compression.type", fixture: "kafka/cluster/configuration/describe.golden"},
 		{args: "kafka cluster configuration update --config auto.create.topics.enable=true", fixture: "kafka/cluster/configuration/update.golden"},
-		{args: "kafka cluster configuration update --config ssl.cipher.suites=\"val1,val2,val3\"", fixture: "kafka/cluster/configuration/update-with-commas.golden"},
+		{args: `kafka cluster configuration update --config ssl.cipher.suites="val1,val2,val3"`, fixture: "kafka/cluster/configuration/update-with-commas.golden"},
 		{args: "kafka cluster configuration update --config test/fixtures/input/kafka/cluster/configuration/update.properties", fixture: "kafka/cluster/configuration/update.golden"},
 		{args: "kafka cluster configuration list", fixture: "kafka/cluster/configuration/list.golden"},
 	}

--- a/test/kafka_test.go
+++ b/test/kafka_test.go
@@ -172,6 +172,7 @@ func (s *CLITestSuite) TestKafkaClusterConfiguration() {
 		{args: "kafka cluster use lkc-12345"},
 		{args: "kafka cluster configuration describe compression.type", fixture: "kafka/cluster/configuration/describe.golden"},
 		{args: "kafka cluster configuration update --config auto.create.topics.enable=true", fixture: "kafka/cluster/configuration/update.golden"},
+		{args: "kafka cluster configuration update --config ssl.cipher.suites=\"val1,val2,val3\"", fixture: "kafka/cluster/configuration/update-with-commas.golden"},
 		{args: "kafka cluster configuration update --config test/fixtures/input/kafka/cluster/configuration/update.properties", fixture: "kafka/cluster/configuration/update.golden"},
 		{args: "kafka cluster configuration list", fixture: "kafka/cluster/configuration/list.golden"},
 	}

--- a/test/test-server/kafka_rest_router.go
+++ b/test/test-server/kafka_rest_router.go
@@ -1805,9 +1805,7 @@ func handleKafkaBrokerConfigsAlter(_ *testing.T) http.HandlerFunc {
 			if len(dataMap) < len(req.Data) {
 				w.WriteHeader(http.StatusBadRequest)
 			}
-			return
 		}
-		w.WriteHeader(http.StatusCreated)
 	}
 }
 

--- a/test/test-server/kafka_rest_router.go
+++ b/test/test-server/kafka_rest_router.go
@@ -1791,7 +1791,7 @@ func handleKafkaBrokerIdConfigs(t *testing.T) http.HandlerFunc {
 }
 
 // Handler for: "/kafka/v3/clusters/{cluster_id}/broker-configs:alter"
-func handleKafkaBrokerConfigsAlter(t *testing.T) http.HandlerFunc {
+func handleKafkaBrokerConfigsAlter(_ *testing.T) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodPost {
 			var req cckafkarestv3.AlterConfigBatchRequestData

--- a/test/test-server/kafka_rest_router.go
+++ b/test/test-server/kafka_rest_router.go
@@ -1791,8 +1791,22 @@ func handleKafkaBrokerIdConfigs(t *testing.T) http.HandlerFunc {
 }
 
 // Handler for: "/kafka/v3/clusters/{cluster_id}/broker-configs:alter"
-func handleKafkaBrokerConfigsAlter(_ *testing.T) http.HandlerFunc {
+func handleKafkaBrokerConfigsAlter(t *testing.T) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost {
+			var req cckafkarestv3.AlterConfigBatchRequestData
+			_ = json.NewDecoder(r.Body).Decode(&req)
+
+			dataMap := make(map[cckafkarestv3.AlterConfigBatchRequestDataData]bool)
+			for _, data := range req.Data {
+				dataMap[data] = true
+			}
+
+			if len(dataMap) < len(req.Data) {
+				w.WriteHeader(http.StatusBadRequest)
+			}
+			return
+		}
 		w.WriteHeader(http.StatusCreated)
 	}
 }


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- PLACEHOLDER

New Features
- PLACEHOLDER

Bug Fixes
- Fix an issue in `confluent kafka cluster configuration update` causing some valid inputs to return a duplicate key error

Checklist
---------
- [x] Leave this box unchecked if features are not yet available in production

What
----
When updating a configuration that accepts a list as a value, cobra will split that input along commas. When we parse this into a map we get what we intend.

But we make `[]AlterConfigBatchRequestDataData` using the length of the input slice instead of the length of the map. This causes empty key/value pairs to be sent to the backend. If there are at least 2 of these, the backend returns an error over duplicate keys.

The fix is simply to use the length of the map and not the slice when creating the request data.

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
Manual testing:
```
confluent kafka cluster configuration update --config ssl.cipher.suites="TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256"
Successfully requested to update configuration "ssl.cipher.suites".
```
```
confluent kafka cluster configuration update --config ssl.cipher.suites="TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256",auto.create.topics.enable=true
Successfully requested to update configurations "auto.create.topics.enable" and "ssl.cipher.suites".
```

Also added a check in the testing backend to return a Bad Request if it receives duplicate keys, and added a corresponding new integration test. I checked that the test succeeds with this change but fails without it.