### PR TITLE
[CLI-3057] Fix panic in `confluent api-key use`

### DIFF
--- a/internal/api-key/command_use.go
+++ b/internal/api-key/command_use.go
@@ -76,7 +76,7 @@ func (c *command) useAPIKey(apiKey, clusterId string) error {
 			return errors.CatchCCloudV2Error(err, httpResp)
 		}
 		// check if the key is for the right cluster
-		if key.Spec.Resource.Id != clusterId {
+		if key.Spec.GetResource().Id != clusterId {
 			return errors.NewErrorWithSuggestions(
 				fmt.Sprintf(errors.InvalidApiKeyErrorMsg, apiKey, clusterId),
 				fmt.Sprintf(errors.InvalidApiKeySuggestions, clusterId),


### PR DESCRIPTION
…for an api key

Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- PLACEHOLDER

New Features
- PLACEHOLDER

Bug Fixes
- Fix a panic in `confluent api-key use`

Checklist
---------
- [x] Leave this box unchecked if features are not yet available in production

What
----
We get a panic from
```
if key.Spec.Resource.Id != clusterId {
```
Since `Key` is not a pointer, the panic here will happen if either `Spec` or `Resource` are nil. Using `GetResource()` instead of `Resource` will return a default `ObjectReference` struct if either `Spec` or `Resource` is nil, which should resolve this panic.

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
<!--
Has it been tested? How?
Copy and paste any instructions or steps that can save the reviewer time.
-->