### PR TITLE
Add confluent/api to CLI's CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
-*                             @confluentinc/cli
+*                             @confluentinc/cli @confluentinc/api
 pkg/flink/                    @confluentinc/cloud-surfaces
 pkg/ccloudv2/flink_gateway.go @confluentinc/cloud-surfaces


### PR DESCRIPTION
### What
This PR adds API team to CLI repo's CODEOWNERS.