### PR TITLE
fix: panic recovery w/ limit should only break on panic

### DIFF
--- a/pkg/flink/app/application.go
+++ b/pkg/flink/app/application.go
@@ -112,9 +112,9 @@ func StartApp(gatewayClient ccloudv2.GatewayClientInterface, tokenRefreshFunc fu
 }
 
 func (a *Application) readEvalPrintLoop() error {
-	run := utils.NewPanicRecovererWithLimit(3, 3*time.Second)
+	run := utils.NewPanicRecoveryWithLimit(3, 3*time.Second)
 	for a.isAuthenticated() {
-		err := run.WithCustomPanicRecovery(a.readEvalPrint, a.panicRecovery)()
+		err := run.WithCustomPanicRecovery(a.readEvalPrint, a.panicRecovery)
 		if err != nil {
 			return err
 		}

--- a/pkg/flink/internal/utils/panic.go
+++ b/pkg/flink/internal/utils/panic.go
@@ -7,44 +7,36 @@ import (
 	"github.com/confluentinc/cli/v3/pkg/log"
 )
 
-type PanicRecovererWithLimitImpl struct {
+type PanicRecoveryWithLimit struct {
 	recovers          int
 	lastRecover       time.Time
 	maxRecovers       int
 	timeBetweenPanics time.Duration
 }
 
-type PanicRecovererWithLimit interface {
-	WithCustomPanicRecovery(fn func(), customRecovery func()) func() error
-}
-
-func NewPanicRecovererWithLimit(maxRecovers int, timeBetweenPanics time.Duration) PanicRecovererWithLimit {
-	recoverer := PanicRecovererWithLimitImpl{
+func NewPanicRecoveryWithLimit(maxRecovers int, timeBetweenPanics time.Duration) PanicRecoveryWithLimit {
+	return PanicRecoveryWithLimit{
 		recovers:          0,
 		maxRecovers:       maxRecovers,
 		lastRecover:       time.Unix(0, 0),
 		timeBetweenPanics: timeBetweenPanics,
 	}
-	return &recoverer
 }
 
-func (p *PanicRecovererWithLimitImpl) WithCustomPanicRecovery(fn func(), customRecovery func()) func() error {
-	if time.Since(p.lastRecover) > p.timeBetweenPanics {
-		p.recovers = 0
-	}
-
-	p.recovers++
-	if p.recovers > p.maxRecovers {
-		return func() error {
-			return errors.NewErrorWithSuggestions(errors.InternalServerErrorMsg, "Run `confluent flink shell -vvv` to enable debug logs when starting the flink shell and report the output to the CLI team. Kindly share steps reproduce, if possible.\nPlease, restart the CLI.")
+func (p *PanicRecoveryWithLimit) WithCustomPanicRecovery(fn func(), customRecovery func()) error {
+	WithCustomPanicRecovery(fn, func() {
+		if time.Since(p.lastRecover) > p.timeBetweenPanics {
+			p.recovers = 0
 		}
-	}
+		p.recovers++
+		p.lastRecover = time.Now()
+		customRecovery()
+	})()
 
-	p.lastRecover = time.Now()
-	return func() error {
-		WithCustomPanicRecovery(fn, customRecovery)()
-		return nil
+	if p.recovers > p.maxRecovers {
+		return errors.NewErrorWithSuggestions(errors.InternalServerErrorMsg, "Run `confluent flink shell -vvv` to enable debug logs when starting the flink shell and report the output to the CLI team. Kindly share steps reproduce, if possible.\nPlease, restart the CLI.")
 	}
+	return nil
 }
 
 func WithPanicRecovery(fn func()) func() {


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Bug Fixes
- Fixes bug where `confluent flink shell` would crash if statements were executed too quickly

Checklist
---------
- [x] Leave this box unchecked if features are not yet available in production

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->
The panic recovery with limit also stopped the execution when the readEvalPrint function was called too quickly. However, it's only supposed to stop execution when there's an actual panic we recovered from

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
<!--
Has it been tested? How?
Copy and paste any instructions or steps that can save the reviewer time.
-->