### PR TITLE
Revert "Add confluent/api to CLI's CODEOWNERS"

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
-*                             @confluentinc/cli @confluentinc/api
+*                             @confluentinc/cli
 pkg/flink/                    @confluentinc/cloud-surfaces
 pkg/ccloudv2/flink_gateway.go @confluentinc/cloud-surfaces


### PR DESCRIPTION
Reverts confluentinc/cli#2648

@confluentinc/api has the same member list as @confluentinc/cli now