### PR TITLE
fix: wait for statements properly

### DIFF
--- a/pkg/flink/internal/controller/.snapshots/TestStatementControllerTestSuite-TestExecuteStatementWaitsForCompletedState
+++ b/pkg/flink/internal/controller/.snapshots/TestStatementControllerTestSuite-TestExecuteStatementWaitsForCompletedState
@@ -1,0 +1,6 @@
+Statement successfully submitted.
+Waiting for statement to be ready. Statement phase is PENDING.
+Statement phase is RUNNING.
+Listening for execution errors. Press Enter to detach.
+Statement phase is COMPLETED.
+

--- a/pkg/flink/internal/controller/.snapshots/TestStatementControllerTestSuite-TestExecuteStatementWaitsForFailedState
+++ b/pkg/flink/internal/controller/.snapshots/TestStatementControllerTestSuite-TestExecuteStatementWaitsForFailedState
@@ -1,0 +1,6 @@
+Statement successfully submitted.
+Waiting for statement to be ready. Statement phase is PENDING.
+Statement phase is RUNNING.
+Listening for execution errors. Press Enter to detach.
+Statement phase is FAILED.
+

--- a/pkg/flink/internal/controller/.snapshots/TestStatementControllerTestSuite-TestExecuteStatementWaitsForNonEmptyPageToken
+++ b/pkg/flink/internal/controller/.snapshots/TestStatementControllerTestSuite-TestExecuteStatementWaitsForNonEmptyPageToken
@@ -1,0 +1,6 @@
+Statement successfully submitted.
+Waiting for statement to be ready. Statement phase is PENDING.
+Statement phase is RUNNING.
+Listening for execution errors. Press Enter to detach.
+Statement phase is RUNNING.
+

--- a/pkg/flink/internal/controller/.snapshots/TestStatementControllerTestSuite-TestExecuteStatementWaitsForNonEmptyPageToken
+++ b/pkg/flink/internal/controller/.snapshots/TestStatementControllerTestSuite-TestExecuteStatementWaitsForNonEmptyPageToken
@@ -1,6 +1,4 @@
 Statement successfully submitted.
 Waiting for statement to be ready. Statement phase is PENDING.
 Statement phase is RUNNING.
-Listening for execution errors. Press Enter to detach.
-Statement phase is RUNNING.
 

--- a/pkg/flink/internal/controller/statement_controller_test.go
+++ b/pkg/flink/internal/controller/statement_controller_test.go
@@ -228,7 +228,7 @@ func (s *StatementControllerTestSuite) TestExecuteStatementPrintsNoWarningForSta
 }
 
 func (s *StatementControllerTestSuite) TestExecuteStatementWaitsForCompletedState() {
-	statementToExecute := "select 1;"
+	statementToExecute := "insert into users values ('test');"
 	processedStatement := types.ProcessedStatement{Status: types.PENDING, Principal: "sa-123"}
 	runningStatement := types.ProcessedStatement{Status: types.RUNNING}
 	completedStatement := types.ProcessedStatement{Status: types.COMPLETED}
@@ -248,7 +248,7 @@ func (s *StatementControllerTestSuite) TestExecuteStatementWaitsForCompletedStat
 }
 
 func (s *StatementControllerTestSuite) TestExecuteStatementWaitsForFailedState() {
-	statementToExecute := "select 1;"
+	statementToExecute := "insert into users values ('test');"
 	processedStatement := types.ProcessedStatement{Status: types.PENDING, Principal: "sa-123"}
 	runningStatement := types.ProcessedStatement{Status: types.RUNNING}
 	failedStatement := types.ProcessedStatement{Status: types.FAILED}
@@ -270,25 +270,23 @@ func (s *StatementControllerTestSuite) TestExecuteStatementWaitsForFailedState()
 func (s *StatementControllerTestSuite) TestExecuteStatementWaitsForNonEmptyPageToken() {
 	statementToExecute := "select 1;"
 	processedStatement := types.ProcessedStatement{Status: types.PENDING, Principal: "sa-123"}
-	runningStatement := types.ProcessedStatement{Status: types.RUNNING}
-	runningStatementWithNextPage := types.ProcessedStatement{Status: types.RUNNING, PageToken: "not-empty"}
+	runningStatement := types.ProcessedStatement{Status: types.RUNNING, PageToken: "not-empty"}
 	s.store.EXPECT().ProcessStatement(statementToExecute).Return(&processedStatement, nil)
 	s.consoleParser.EXPECT().Read().Return(nil, nil).AnyTimes()
 	s.store.EXPECT().WaitPendingStatement(gomock.Any(), processedStatement).Return(&runningStatement, nil)
 	s.store.EXPECT().FetchStatementResults(runningStatement).Return(&runningStatement, nil)
-	s.store.EXPECT().WaitForTerminalStatementState(gomock.Any(), runningStatement).Return(&runningStatementWithNextPage, nil)
 
 	stdout := testUtils.RunAndCaptureSTDOUT(s.T(), func() {
 		returnedStatement, err := s.statementController.ExecuteStatement(statementToExecute)
 		require.Nil(s.T(), err)
-		require.Equal(s.T(), &runningStatementWithNextPage, returnedStatement)
+		require.Equal(s.T(), &runningStatement, returnedStatement)
 	})
 
 	cupaloy.SnapshotT(s.T(), stdout)
 }
 
 func (s *StatementControllerTestSuite) TestExecuteStatementReturnsWhenUserDetaches() {
-	statementToExecute := "select 1;"
+	statementToExecute := "insert into users values ('test');"
 	processedStatement := types.ProcessedStatement{Status: types.PENDING, Principal: "sa-123"}
 	runningStatement := types.ProcessedStatement{Status: types.RUNNING}
 	s.store.EXPECT().ProcessStatement(statementToExecute).Return(&processedStatement, nil)

--- a/pkg/flink/internal/store/store_test.go
+++ b/pkg/flink/internal/store/store_test.go
@@ -1656,47 +1656,6 @@ func createStatementWithSqlKind(sqlKind string) flinkgatewayv1.SqlV1Statement {
 	}
 }
 
-func (s *StoreTestSuite) TestIsBackgroundStatement() {
-	tests := []struct {
-		name                  string
-		statement             flinkgatewayv1.SqlV1Statement
-		isBackgroundStatement bool
-	}{
-		{
-			name:                  "insert_into lowercase",
-			statement:             createStatementWithSqlKind("insert_into"),
-			isBackgroundStatement: true,
-		},
-		{
-			name:                  "insert_into uppercase",
-			statement:             createStatementWithSqlKind("INSERT_INTO"),
-			isBackgroundStatement: true,
-		},
-		{
-			name:                  "insert_into random case",
-			statement:             createStatementWithSqlKind("iNsErt_inTo"),
-			isBackgroundStatement: true,
-		},
-		{
-			name:                  "leading and trailing white space",
-			statement:             createStatementWithSqlKind("   INSERT_INTO   "),
-			isBackgroundStatement: false,
-		},
-		{
-			name:                  "missing last char",
-			statement:             createStatementWithSqlKind("INSERT_INT"),
-			isBackgroundStatement: false,
-		},
-	}
-
-	for _, testCase := range tests {
-		s.T().Run(testCase.name, func(t *testing.T) {
-			processedStatement := types.NewProcessedStatement(testCase.statement)
-			require.Equal(t, testCase.isBackgroundStatement, processedStatement.IsBackgroundStatement())
-		})
-	}
-}
-
 func TestWaitForTerminalStateDoesNotStartWhenAlreadyInTerminalState(t *testing.T) {
 	client := mock.NewMockGatewayClientInterface(gomock.NewController(t))
 	appOptions := types.ApplicationOptions{

--- a/pkg/flink/internal/store/store_test.go
+++ b/pkg/flink/internal/store/store_test.go
@@ -1636,6 +1636,14 @@ func (s *StoreTestSuite) TestIsSelectStatement() {
 			statement:         createStatementWithSqlKind("selec"),
 			isSelectStatement: false,
 		},
+		{
+			name: "select random case without trait",
+			statement: flinkgatewayv1.SqlV1Statement{
+				Spec: &flinkgatewayv1.SqlV1StatementSpec{
+					Statement: flinkgatewayv1.PtrString("SeLeCt"),
+				}},
+			isSelectStatement: true,
+		},
 	}
 
 	for _, testCase := range tests {

--- a/pkg/flink/types/processed_statement.go
+++ b/pkg/flink/types/processed_statement.go
@@ -95,5 +95,6 @@ func (s ProcessedStatement) IsTerminalState() bool {
 }
 
 func (s ProcessedStatement) IsSelectStatement() bool {
-	return strings.EqualFold(s.Traits.GetSqlKind(), "SELECT")
+	return strings.EqualFold(s.Traits.GetSqlKind(), "SELECT") ||
+		strings.HasPrefix(strings.ToUpper(s.Statement), "SELECT")
 }

--- a/pkg/flink/types/processed_statement.go
+++ b/pkg/flink/types/processed_statement.go
@@ -89,8 +89,9 @@ func (s ProcessedStatement) PrintStatementDoneStatus() {
 }
 
 func (s ProcessedStatement) IsTerminalState() bool {
-	isRunningAndHasResults := s.Status == RUNNING && s.PageToken != ""
-	return s.Status == COMPLETED || s.Status == FAILED || isRunningAndHasResults
+	isRunningAndHasNextPage := s.Status == RUNNING && s.PageToken != ""
+	hasResults := len(s.StatementResults.GetRows()) > 1
+	return s.Status == COMPLETED || s.Status == FAILED || isRunningAndHasNextPage || hasResults
 }
 
 func (s ProcessedStatement) IsSelectStatement() bool {

--- a/pkg/flink/types/processed_statement.go
+++ b/pkg/flink/types/processed_statement.go
@@ -96,7 +96,3 @@ func (s ProcessedStatement) IsTerminalState() bool {
 func (s ProcessedStatement) IsSelectStatement() bool {
 	return strings.EqualFold(s.Traits.GetSqlKind(), "SELECT")
 }
-
-func (s ProcessedStatement) IsBackgroundStatement() bool {
-	return strings.EqualFold(s.Traits.GetSqlKind(), "INSERT_INTO")
-}


### PR DESCRIPTION
Checklist
---------
- [x] Leave this box unchecked if features are not yet available in production

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->
- We should use the "listening for execution errors" flow for all statements that are RUNNING but don't have results
- We should also still check the statement prefix in case sqlTraits are not available

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
<!--
Has it been tested? How?
Copy and paste any instructions or steps that can save the reviewer time.
-->