### PR TITLE
fix: stop printing status detail of terminal statement twice

### DIFF
--- a/pkg/flink/internal/store/store.go
+++ b/pkg/flink/internal/store/store.go
@@ -371,12 +371,15 @@ func (s *Store) WaitForTerminalStatementState(ctx context.Context, statement typ
 				}
 			}
 
+			statement.Status = types.PHASE(statementObj.Status.GetPhase())
+			statement.StatusDetail = statusDetail
+			if statement.IsTerminalState() {
+				break
+			}
+
 			if statusDetail != "" {
 				output.Println(false, statusDetail)
 			}
-
-			statement.Status = types.PHASE(statementObj.Status.GetPhase())
-			statement.StatusDetail = statusDetail
 
 			time.Sleep(time.Second)
 		}


### PR DESCRIPTION
Checklist
---------
- [x] Leave this box unchecked if features are not yet available in production

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->
We will print the status detail field twice, if the statement transitions to a terminal state.

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
<!--
Has it been tested? How?
Copy and paste any instructions or steps that can save the reviewer time.
-->