### PR TITLE
KFS-1706 Add missing keyboard shortcuts to flink shell

### DIFF
--- a/pkg/flink/internal/controller/input_controller.go
+++ b/pkg/flink/internal/controller/input_controller.go
@@ -222,16 +222,34 @@ func getUnixBindings() []prompt.Option {
 	return []prompt.Option{
 		prompt.OptionAddASCIICodeBind(
 			prompt.ASCIICodeBind{
-				ASCIICode: []byte{0x1b, 0x62}, // Alt/Option + Arrow Left
+				ASCIICode: []byte{0x1b, 0x62}, // Alt/Option + Arrow Left (ESC + b)
 				Fn:        prompt.GoLeftWord,
 			},
 			prompt.ASCIICodeBind{
-				ASCIICode: []byte{0x1b, 0x66}, // Alt/Option + Arrow Right
+				ASCIICode: []byte{0x1b, 0x66}, // Alt/Option + Arrow Right (ESC + f)
 				Fn:        prompt.GoRightWord,
 			},
 			prompt.ASCIICodeBind{
 				ASCIICode: []byte{0x1b, 0x7F}, // Alt/Option + Backspace
 				Fn:        prompt.DeleteWord,
+			},
+			prompt.ASCIICodeBind{
+				ASCIICode: []byte{0x1b, 0x64}, // ForwardDeleteWord (ESC + d)
+				Fn: func(buf *prompt.Buffer) {
+					buf.Delete(buf.Document().FindEndOfCurrentWordWithSpace())
+				},
+			},
+			prompt.ASCIICodeBind{
+				ASCIICode: []byte{0x1b, 0x75}, // UpCaseWord (Alt/Option + u)
+				Fn: func(buf *prompt.Buffer) {
+					buf.InsertText(strings.ToUpper(buf.Document().GetWordAfterCursorWithSpace()), true, true)
+				},
+			},
+			prompt.ASCIICodeBind{
+				ASCIICode: []byte{0x1b, 0x6c}, // DownCaseWord (Alt/Option + l)
+				Fn: func(buf *prompt.Buffer) {
+					buf.InsertText(strings.ToLower(buf.Document().GetWordAfterCursorWithSpace()), true, true)
+				},
 			},
 		),
 	}

--- a/pkg/flink/internal/controller/input_controller.go
+++ b/pkg/flink/internal/controller/input_controller.go
@@ -188,16 +188,6 @@ func (c *InputController) getKeyBindings() []prompt.Option {
 	return append(
 		[]prompt.Option{
 			prompt.OptionAddKeyBind(prompt.KeyBind{
-				Key: prompt.ControlD,
-				Fn: func(b *prompt.Buffer) {
-					if b.Text() != "" {
-						b.Delete(1)
-					} else {
-						c.shouldExit = true
-					}
-				},
-			}),
-			prompt.OptionAddKeyBind(prompt.KeyBind{
 				Key: prompt.ControlQ,
 				Fn: func(b *prompt.Buffer) {
 					c.shouldExit = true

--- a/pkg/flink/internal/controller/input_controller.go
+++ b/pkg/flink/internal/controller/input_controller.go
@@ -230,13 +230,13 @@ func getUnixBindings() []prompt.Option {
 				},
 			},
 			prompt.ASCIICodeBind{
-				ASCIICode: []byte{0x1b, 0x75}, // UpCaseWord (Alt/Option + u)
+				ASCIICode: []byte{0x1b, 0x75}, // UpCaseWord (ESC + u)
 				Fn: func(buf *prompt.Buffer) {
 					buf.InsertText(strings.ToUpper(buf.Document().GetWordAfterCursorWithSpace()), true, true)
 				},
 			},
 			prompt.ASCIICodeBind{
-				ASCIICode: []byte{0x1b, 0x6c}, // DownCaseWord (Alt/Option + l)
+				ASCIICode: []byte{0x1b, 0x6c}, // DownCaseWord (ESC + l)
 				Fn: func(buf *prompt.Buffer) {
 					buf.InsertText(strings.ToLower(buf.Document().GetWordAfterCursorWithSpace()), true, true)
 				},

--- a/pkg/flink/internal/controller/input_controller.go
+++ b/pkg/flink/internal/controller/input_controller.go
@@ -212,11 +212,11 @@ func getUnixBindings() []prompt.Option {
 	return []prompt.Option{
 		prompt.OptionAddASCIICodeBind(
 			prompt.ASCIICodeBind{
-				ASCIICode: []byte{0x1b, 0x62}, // Alt/Option + Arrow Left (ESC + b)
+				ASCIICode: []byte{0x1b, 0x62}, // Alt/Option + Arrow Left (sometimes Alt/Option + b)
 				Fn:        prompt.GoLeftWord,
 			},
 			prompt.ASCIICodeBind{
-				ASCIICode: []byte{0x1b, 0x66}, // Alt/Option + Arrow Right (ESC + f)
+				ASCIICode: []byte{0x1b, 0x66}, // Alt/Option + Arrow Right (sometimes Alt/Option + f)
 				Fn:        prompt.GoRightWord,
 			},
 			prompt.ASCIICodeBind{
@@ -224,19 +224,19 @@ func getUnixBindings() []prompt.Option {
 				Fn:        prompt.DeleteWord,
 			},
 			prompt.ASCIICodeBind{
-				ASCIICode: []byte{0x1b, 0x64}, // ForwardDeleteWord (ESC + d)
+				ASCIICode: []byte{0x1b, 0x64}, // ForwardDeleteWord (Alt/Option + d)
 				Fn: func(buf *prompt.Buffer) {
 					buf.Delete(buf.Document().FindEndOfCurrentWordWithSpace())
 				},
 			},
 			prompt.ASCIICodeBind{
-				ASCIICode: []byte{0x1b, 0x75}, // UpCaseWord (ESC + u)
+				ASCIICode: []byte{0x1b, 0x75}, // UpCaseWord (Alt/Option + u)
 				Fn: func(buf *prompt.Buffer) {
 					buf.InsertText(strings.ToUpper(buf.Document().GetWordAfterCursorWithSpace()), true, true)
 				},
 			},
 			prompt.ASCIICodeBind{
-				ASCIICode: []byte{0x1b, 0x6c}, // DownCaseWord (ESC + l)
+				ASCIICode: []byte{0x1b, 0x6c}, // DownCaseWord (Alt/Option + l)
 				Fn: func(buf *prompt.Buffer) {
 					buf.InsertText(strings.ToLower(buf.Document().GetWordAfterCursorWithSpace()), true, true)
 				},

--- a/pkg/flink/internal/controller/input_controller.go
+++ b/pkg/flink/internal/controller/input_controller.go
@@ -190,7 +190,11 @@ func (c *InputController) getKeyBindings() []prompt.Option {
 			prompt.OptionAddKeyBind(prompt.KeyBind{
 				Key: prompt.ControlD,
 				Fn: func(b *prompt.Buffer) {
-					c.shouldExit = true
+					if b.Text() != "" {
+						b.Delete(1)
+					} else {
+						c.shouldExit = true
+					}
 				},
 			}),
 			prompt.OptionAddKeyBind(prompt.KeyBind{


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

New Features
- Flink shell supports new keybindings
  - Ctrl-D deletes characters and only closes if the buffer is empty
  - Alt-D deletes words
  - Alt-L lowercases words
  - Alt-U uppercases words

Checklist
---------
- [X] Leave this box unchecked if features are not yet available in production

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->

https://github.com/confluentinc/cli/assets/13372091/e0629d3f-6802-4155-bc0d-199ec4818871

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
<!--
Has it been tested? How?
Copy and paste any instructions or steps that can save the reviewer time.
-->