### PR TITLE
Block dependabot updates for confluentinc dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,10 @@
 
 version: 2
 updates:
-  - package-ecosystem: "gomod"
-    directory: "/"
+  - directory: "/"
+    ignore:
+      - dependency-name: "github.com/confluentinc/*"
+    open-pull-requests-limit: 0
+    package-ecosystem: "gomod"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
What
----
When dependabot opens PRs for confluentinc/ccloud-sdk-go-v2 and other similar repositories, a PR usually already exists for integrating the updates, or a team plans to integrate them soon.