### PR TITLE
[CLI-3075] Prevent panic in `confluent context update`

### DIFF
--- a/pkg/kafka/cluster.go
+++ b/pkg/kafka/cluster.go
@@ -51,7 +51,7 @@ func FindCluster(client *ccloudv2.Client, ctx *config.Context, clusterId string)
 	}
 
 	if client == nil {
-		return nil, fmt.Errorf(errors.KafkaClusterNotFoundErrorMsg, clusterId)
+		return nil, errors.NewErrorWithSuggestions(fmt.Sprintf(errors.KafkaClusterNotFoundErrorMsg, clusterId), "You can set the active Kafka cluster with `confluent kafka cluster use`.")
 	}
 
 	cluster, httpResp, err := client.DescribeKafkaCluster(clusterId, environmentId)

--- a/pkg/kafka/cluster.go
+++ b/pkg/kafka/cluster.go
@@ -50,6 +50,10 @@ func FindCluster(client *ccloudv2.Client, ctx *config.Context, clusterId string)
 		return nil, err
 	}
 
+	if client == nil {
+		return nil, fmt.Errorf(errors.KafkaClusterNotFoundErrorMsg, clusterId)
+	}
+
 	cluster, httpResp, err := client.DescribeKafkaCluster(clusterId, environmentId)
 	if err != nil {
 		return nil, errors.CatchKafkaNotFoundError(err, clusterId, httpResp)


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- PLACEHOLDER

New Features
- PLACEHOLDER

Bug Fixes
- Fix a panic in `confluent context update --kafka-cluster`

Checklist
---------
- [x] Leave this box unchecked if features are not yet available in production

What
----
The context update command sends a `nil` client to `FindCluster`, which causes a panic if the cluster isn't found in the user's Kafka Cluster context.

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
<!--
Has it been tested? How?
Copy and paste any instructions or steps that can save the reviewer time.
-->