### PR TITLE
fix/ KFS-1705 USE now works with multibyte chars

### DIFF
--- a/pkg/flink/internal/store/store_utils.go
+++ b/pkg/flink/internal/store/store_utils.go
@@ -282,7 +282,7 @@ func TokenizeSQL(statement string) []string {
 
 	// Iterate over each character in the input string
 	for i := 0; i < len(input); i++ {
-		c := rune(input[i])
+		c := input[i]
 
 		// Ignore whitespace
 		if unicode.IsSpace(c) && !inBacktick {

--- a/pkg/flink/internal/store/store_utils.go
+++ b/pkg/flink/internal/store/store_utils.go
@@ -274,10 +274,11 @@ func parseSetStatement(statement string) (string, string, error) {
 	return key, value, nil
 }
 
-func TokenizeSQL(input string) []string {
+func TokenizeSQL(statement string) []string {
 	var tokens []string
 	var buffer bytes.Buffer
 	var inBacktick bool
+	input := []rune(statement)
 
 	// Iterate over each character in the input string
 	for i := 0; i < len(input); i++ {

--- a/pkg/flink/internal/store/store_utils_test.go
+++ b/pkg/flink/internal/store/store_utils_test.go
@@ -470,3 +470,15 @@ func TestTokenizeSQL(t *testing.T) {
 	expected = []string{"`"}
 	require.Equal(expected, TokenizeSQL(input))
 }
+
+func TestTokenizeSQLSpecialCharacters(t *testing.T) {
+	require := require.New(t)
+
+	input := "my clusté€r"
+	expected := []string{"my", "clusté€r"}
+	require.Equal(expected, TokenizeSQL(input))
+
+	input = "my cluster αβγбвг汉字あア한😀"
+	expected = []string{"my", "cluster", "αβγбвг汉字あア한😀"}
+	require.Equal(expected, TokenizeSQL(input))
+}


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Bug Fixes
- USE supports multibyte characters like `éüöбвг汉` in `confluent flink shell`.

Checklist
---------
- [x] Leave this box unchecked if features are not yet available in production

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->
Kafka clusters can contain multibyte characters on their names and that's why this needs to be fixed.

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
<!--
Has it been tested? How?
Copy and paste any instructions or steps that can save the reviewer time.
-->
Unit test.