### PR TITLE
[CLI-3081] Call UpdateDefaultPaymentMethod in `admin payment update` to match UI

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -212,3 +212,7 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
+
+replace (
+    github.com/confluentinc/ccloud-sdk-go-v1-public => ../ccloud-sdk-go-v1-public
+)

--- a/internal/admin/command_payment_update.go
+++ b/internal/admin/command_payment_update.go
@@ -18,8 +18,6 @@ func (c *command) newUpdateCommand() *cobra.Command {
 }
 
 func (c *command) update(_ *cobra.Command, _ []string) error {
-	output.Println(c.Config.EnableColor, "Edit credit card")
-
 	f := form.New(
 		form.Field{ID: "card number", Prompt: "Card number", Regex: `^(?:\d[ -]*?){13,19}$`},
 		form.Field{ID: "expiration", Prompt: "MM/YY", Regex: `^\d{2}/\d{2}$`},

--- a/internal/admin/command_payment_update.go
+++ b/internal/admin/command_payment_update.go
@@ -41,7 +41,7 @@ func (c *command) update(_ *cobra.Command, _ []string) error {
 		return err
 	}
 
-	if err := c.Client.Billing.UpdatePaymentInfo(user.GetOrganization(), stripeToken.ID); err != nil {
+	if err := c.Client.Billing.UpdateDefaultPaymentMethod(user.GetOrganization(), stripeToken.ID); err != nil {
 		return err
 	}
 

--- a/test/fixtures/output/admin/payment/update-retry.golden
+++ b/test/fixtures/output/admin/payment/update-retry.golden
@@ -1,4 +1,3 @@
-Edit credit card
 Card number: Error: "bad card number" is not of valid format for field "card number"
 Card number: MM/YY: Error: "bad expiration" is not of valid format for field "expiration"
 MM/YY: CVC: Error: "bad cvc" is not of valid format for field "cvc"

--- a/test/fixtures/output/admin/payment/update.golden
+++ b/test/fixtures/output/admin/payment/update.golden
@@ -1,2 +1,1 @@
-Edit credit card
 Card number: MM/YY: CVC: Cardholder name: Updated.

--- a/test/test-server/ccloud_handlers.go
+++ b/test/test-server/ccloud_handlers.go
@@ -159,41 +159,34 @@ func handleLoginRealm(t *testing.T) http.HandlerFunc {
 
 // Handler for: "/api/organizations/{id}/payment_info"
 func handlePaymentInfo(t *testing.T) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		switch r.Method {
-		case http.MethodGet: // admin payment describe
-			res := ccloudv1.GetPaymentInfoReply{
-				Card: &ccloudv1.Card{
-					Cardholder: "Miles Todzo",
-					Brand:      "Visa",
-					Last4:      "4242",
-					ExpMonth:   "01",
-					ExpYear:    "99",
-				},
-				Organization: &ccloudv1.Organization{Id: 0},
-			}
-			data, err := json.Marshal(res)
-			require.NoError(t, err)
-			_, err = w.Write(data)
-			require.NoError(t, err)
+	return func(w http.ResponseWriter, _ *http.Request) {
+		res := ccloudv1.GetPaymentInfoReply{
+			Card: &ccloudv1.Card{
+				Cardholder: "Miles Todzo",
+				Brand:      "Visa",
+				Last4:      "4242",
+				ExpMonth:   "01",
+				ExpYear:    "99",
+			},
+			Organization: &ccloudv1.Organization{},
 		}
+		data, err := json.Marshal(res)
+		require.NoError(t, err)
+		_, err = w.Write(data)
+		require.NoError(t, err)
 	}
 }
 
 // Handler for: "/api/organizations/%d/update_default_payment_method"
 func handleUpdateDefaultPaymentMethod(t *testing.T) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		switch r.Method {
-		case http.MethodPost: // admin payment update
-			req := &ccloudv1.UpdateDefaultPaymentMethodRequest{}
-			err := ccstructs.UnmarshalJSON(r.Body, req)
-			require.NoError(t, err)
-			require.NotEmpty(t, req.PaymentMethodId)
-
-			res := &ccloudv1.UpdateDefaultPaymentMethodReply{}
-			err = json.NewEncoder(w).Encode(res)
-			require.NoError(t, err)
-		}
+		req := &ccloudv1.UpdateDefaultPaymentMethodRequest{}
+		err := ccstructs.UnmarshalJSON(r.Body, req)
+		require.NoError(t, err)
+		require.NotEmpty(t, req.PaymentMethodId)
+		res := &ccloudv1.UpdateDefaultPaymentMethodReply{}
+		err = json.NewEncoder(w).Encode(res)
+		require.NoError(t, err)
 	}
 }
 

--- a/test/test-server/ccloud_handlers.go
+++ b/test/test-server/ccloud_handlers.go
@@ -161,15 +161,6 @@ func handleLoginRealm(t *testing.T) http.HandlerFunc {
 func handlePaymentInfo(t *testing.T) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		switch r.Method {
-		case http.MethodPost: // admin payment update
-			req := &ccloudv1.UpdatePaymentInfoRequest{}
-			err := ccstructs.UnmarshalJSON(r.Body, req)
-			require.NoError(t, err)
-			require.NotEmpty(t, req.StripeToken)
-
-			res := &ccloudv1.UpdatePaymentInfoReply{}
-			err = json.NewEncoder(w).Encode(res)
-			require.NoError(t, err)
 		case http.MethodGet: // admin payment describe
 			res := ccloudv1.GetPaymentInfoReply{
 				Card: &ccloudv1.Card{
@@ -184,6 +175,23 @@ func handlePaymentInfo(t *testing.T) http.HandlerFunc {
 			data, err := json.Marshal(res)
 			require.NoError(t, err)
 			_, err = w.Write(data)
+			require.NoError(t, err)
+		}
+	}
+}
+
+// Handler for: "/api/organizations/%d/update_default_payment_method"
+func handleUpdateDefaultPaymentMethod(t *testing.T) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodPost: // admin payment update
+			req := &ccloudv1.UpdateDefaultPaymentMethodRequest{}
+			err := ccstructs.UnmarshalJSON(r.Body, req)
+			require.NoError(t, err)
+			require.NotEmpty(t, req.PaymentMethodId)
+
+			res := &ccloudv1.UpdateDefaultPaymentMethodReply{}
+			err = json.NewEncoder(w).Encode(res)
 			require.NoError(t, err)
 		}
 	}

--- a/test/test-server/ccloud_router.go
+++ b/test/test-server/ccloud_router.go
@@ -16,6 +16,7 @@ var ccloudHandlers = []route{
 	{"/api/login/realm", handleLoginRealm},
 	{"/api/metadata/security/v2alpha1/authenticate", handleV2Authenticate},
 	{"/api/organizations/{id}/payment_info", handlePaymentInfo},
+	{"/api/organizations/{id}/update_default_payment_method", handleUpdateDefaultPaymentMethod},
 	{"/api/organizations/{id}/price_table", handlePriceTable},
 	{"/api/organizations/{id}/promo_code_claims", handlePromoCodeClaims},
 	{"/api/schema_registries", handleSchemaRegistries},


### PR DESCRIPTION
Release Notes
-------------
Breaking Changes
- PLACEHOLDER

New Features
- PLACEHOLDER

Bug Fixes
- Update the default payment method when running `confluent admin payment update`

Checklist
---------
- [x] Leave this box unchecked if features are not yet available in production

What
----
Match the UX of the UI

References
----------
* https://confluentinc.atlassian.net/browse/CLI-3081
* https://confluentinc.atlassian.net/wiki/spaces/CS/pages/3347972454/Unify+Payment+Update+Behavior+For+Confluent+UI+and+Confluent+CLI

Test & Review
-------------
Integration tested, but seeing a 500 in the staging environment. Marking as draft until this is fixed.