### PR TITLE
[CLI-3110] Error on `kafka consumer group lag` commands when cluster is not dedicated

### DIFF
--- a/internal/kafka/command_cluster_describe.go
+++ b/internal/kafka/command_cluster_describe.go
@@ -90,12 +90,12 @@ func (c *clusterCommand) getLkcForDescribe(args []string) (string, error) {
 		return args[0], nil
 	}
 
-	lkc := c.Context.KafkaClusterContext.GetActiveKafkaClusterId()
-	if lkc == "" {
+	clusterId := c.Context.KafkaClusterContext.GetActiveKafkaClusterId()
+	if clusterId == "" {
 		return "", errors.NewErrorWithSuggestions(errors.NoKafkaSelectedErrorMsg, errors.NoKafkaForDescribeSuggestions)
 	}
 
-	return lkc, nil
+	return clusterId, nil
 }
 
 func (c *clusterCommand) outputKafkaClusterDescription(cmd *cobra.Command, cluster *cmkv2.CmkV2Cluster, getTopicCount bool) error {

--- a/internal/kafka/command_consumer_group_lag.go
+++ b/internal/kafka/command_consumer_group_lag.go
@@ -57,8 +57,7 @@ func (c *consumerCommand) checkIsDedicated() error {
 		return errors.CatchKafkaNotFoundError(err, clusterId, httpResp)
 	}
 
-	if !isDedicated(&cluster) {
-		clusterType := getCmkClusterType(&cluster)
+	if clusterType := getCmkClusterType(&cluster); clusterType != "DEDICATED" {
 		return fmt.Errorf(`Kafka cluster "%s" is type "%s" but must be type "DEDICATED"`, clusterId, clusterType)
 	}
 

--- a/internal/kafka/command_consumer_group_lag.go
+++ b/internal/kafka/command_consumer_group_lag.go
@@ -1,9 +1,12 @@
 package kafka
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
 
 	"github.com/confluentinc/cli/v3/pkg/config"
+	"github.com/confluentinc/cli/v3/pkg/errors"
 )
 
 type lagOut struct {
@@ -36,4 +39,28 @@ func (c *consumerCommand) newLagCommand(cfg *config.Config) *cobra.Command {
 	}
 
 	return cmd
+}
+
+func (c *consumerCommand) checkIsDedicated() error {
+	clusterId := c.Context.KafkaClusterContext.GetActiveKafkaClusterId()
+	if clusterId == "" {
+		return errors.NewErrorWithSuggestions(errors.NoKafkaSelectedErrorMsg, errors.NoKafkaForDescribeSuggestions)
+	}
+
+	environmentId, err := c.Context.EnvironmentId()
+	if err != nil {
+		return err
+	}
+
+	cluster, httpResp, err := c.V2Client.DescribeKafkaCluster(clusterId, environmentId)
+	if err != nil {
+		return errors.CatchKafkaNotFoundError(err, clusterId, httpResp)
+	}
+
+	if !isDedicated(&cluster) {
+		clusterType := getCmkClusterType(&cluster)
+		return fmt.Errorf(`Kafka cluster "%s" is type "%s" but must be type "DEDICATED"`, clusterId, clusterType)
+	}
+
+	return nil
 }

--- a/internal/kafka/command_consumer_group_lag_describe.go
+++ b/internal/kafka/command_consumer_group_lag_describe.go
@@ -38,6 +38,10 @@ func (c *consumerCommand) newLagDescribeCommand() *cobra.Command {
 }
 
 func (c *consumerCommand) groupLagDescribe(cmd *cobra.Command, args []string) error {
+	if err := c.checkIsDedicated(); err != nil {
+		return err
+	}
+
 	topic, err := cmd.Flags().GetString("topic")
 	if err != nil {
 		return err

--- a/internal/kafka/command_consumer_group_lag_list.go
+++ b/internal/kafka/command_consumer_group_lag_list.go
@@ -32,6 +32,10 @@ func (c *consumerCommand) newLagListCommand() *cobra.Command {
 }
 
 func (c *consumerCommand) groupLagList(cmd *cobra.Command, args []string) error {
+	if err := c.checkIsDedicated(); err != nil {
+		return err
+	}
+
 	kafkaREST, err := c.GetKafkaREST()
 	if err != nil {
 		return err

--- a/internal/kafka/command_consumer_group_lag_summarize.go
+++ b/internal/kafka/command_consumer_group_lag_summarize.go
@@ -37,6 +37,10 @@ func (c *consumerCommand) newLagSummarizeCommand() *cobra.Command {
 }
 
 func (c *consumerCommand) groupLagSummarize(cmd *cobra.Command, args []string) error {
+	if err := c.checkIsDedicated(); err != nil {
+		return err
+	}
+
 	kafkaREST, err := c.GetKafkaREST()
 	if err != nil {
 		return err

--- a/test/fixtures/output/kafka/consumer/group/lag/basic.golden
+++ b/test/fixtures/output/kafka/consumer/group/lag/basic.golden
@@ -1,0 +1,1 @@
+Error: Kafka cluster "lkc-basic" is type "BASIC" but must be type "DEDICATED"

--- a/test/fixtures/output/kafka/consumer/group/lag/describe-json.golden
+++ b/test/fixtures/output/kafka/consumer/group/lag/describe-json.golden
@@ -1,5 +1,5 @@
 {
-  "cluster_id": "lkc-1234",
+  "cluster_id": "lkc-describe-dedicated",
   "consumer_group_id": "consumer-group-1",
   "lag": 100,
   "log_end_offset": 101,

--- a/test/fixtures/output/kafka/consumer/group/lag/describe.golden
+++ b/test/fixtures/output/kafka/consumer/group/lag/describe.golden
@@ -1,12 +1,12 @@
-+----------------+------------------+
-| Cluster        | lkc-1234         |
-| Consumer Group | consumer-group-1 |
-| Lag            | 100              |
-| Log End Offset | 101              |
-| Current Offset | 1                |
-| Consumer       | consumer-1       |
-| Instance       | instance-1       |
-| Client         | client-1         |
-| Topic          | topic-1          |
-| Partition      | 1                |
-+----------------+------------------+
++----------------+------------------------+
+| Cluster        | lkc-describe-dedicated |
+| Consumer Group | consumer-group-1       |
+| Lag            | 100                    |
+| Log End Offset | 101                    |
+| Current Offset | 1                      |
+| Consumer       | consumer-1             |
+| Instance       | instance-1             |
+| Client         | client-1               |
+| Topic          | topic-1                |
+| Partition      | 1                      |
++----------------+------------------------+

--- a/test/fixtures/output/kafka/consumer/group/lag/list-json.golden
+++ b/test/fixtures/output/kafka/consumer/group/lag/list-json.golden
@@ -1,6 +1,6 @@
 [
   {
-    "cluster_id": "lkc-1234",
+    "cluster_id": "lkc-describe-dedicated",
     "consumer_group_id": "consumer-group-1",
     "lag": 10,
     "log_end_offset": 11,
@@ -12,7 +12,7 @@
     "partition_id": 2
   },
   {
-    "cluster_id": "lkc-1234",
+    "cluster_id": "lkc-describe-dedicated",
     "consumer_group_id": "consumer-group-1",
     "lag": 100,
     "log_end_offset": 101,

--- a/test/fixtures/output/kafka/consumer/group/lag/list.golden
+++ b/test/fixtures/output/kafka/consumer/group/lag/list.golden
@@ -1,4 +1,4 @@
-  Cluster  |  Consumer Group  | Lag | Log End Offset | Current Offset |  Consumer  |  Instance  |  Client  |  Topic  | Partition  
------------+------------------+-----+----------------+----------------+------------+------------+----------+---------+------------
-  lkc-1234 | consumer-group-1 |  10 |             11 |              1 | consumer-2 | instance-2 | client-2 | topic-1 |         2  
-  lkc-1234 | consumer-group-1 | 100 |            101 |              1 | consumer-1 | instance-1 | client-1 | topic-1 |         1  
+         Cluster         |  Consumer Group  | Lag | Log End Offset | Current Offset |  Consumer  |  Instance  |  Client  |  Topic  | Partition  
+-------------------------+------------------+-----+----------------+----------------+------------+------------+----------+---------+------------
+  lkc-describe-dedicated | consumer-group-1 |  10 |             11 |              1 | consumer-2 | instance-2 | client-2 | topic-1 |         2  
+  lkc-describe-dedicated | consumer-group-1 | 100 |            101 |              1 | consumer-1 | instance-1 | client-1 | topic-1 |         1  

--- a/test/fixtures/output/kafka/consumer/group/lag/summarize-json.golden
+++ b/test/fixtures/output/kafka/consumer/group/lag/summarize-json.golden
@@ -1,5 +1,5 @@
 {
-  "cluster_id": "lkc-1234",
+  "cluster_id": "lkc-describe-dedicated",
   "consumer_group_id": "consumer-group-1",
   "total_lag": 110,
   "max_lag": 100,

--- a/test/fixtures/output/kafka/consumer/group/lag/summarize.golden
+++ b/test/fixtures/output/kafka/consumer/group/lag/summarize.golden
@@ -1,11 +1,11 @@
-+-------------------+------------------+
-| Cluster           | lkc-1234         |
-| Consumer Group    | consumer-group-1 |
-| Total Lag         | 110              |
-| Max Lag           | 100              |
-| Max Lag Consumer  | consumer-1       |
-| Max Lag Instance  | instance-1       |
-| Max Lag Client    | client-1         |
-| Max Lag Topic     | topic-1          |
-| Max Lag Partition | 1                |
-+-------------------+------------------+
++-------------------+------------------------+
+| Cluster           | lkc-describe-dedicated |
+| Consumer Group    | consumer-group-1       |
+| Total Lag         | 110                    |
+| Max Lag           | 100                    |
+| Max Lag Consumer  | consumer-1             |
+| Max Lag Instance  | instance-1             |
+| Max Lag Client    | client-1               |
+| Max Lag Topic     | topic-1                |
+| Max Lag Partition | 1                      |
++-------------------+------------------------+

--- a/test/kafka_test.go
+++ b/test/kafka_test.go
@@ -590,21 +590,25 @@ func (s *CLITestSuite) TestKafkaConsumerGroup() {
 
 func (s *CLITestSuite) TestKafkaConsumerGroupLag() {
 	tests := []CLITest{
-		{args: "kafka consumer group lag describe consumer-group-1 --cluster lkc-1234 --topic topic-1 --partition 1", fixture: "kafka/consumer/group/lag/describe.golden"},
-		{args: "kafka consumer group lag describe consumer-group-1 --cluster lkc-1234 --topic topic-1 --partition 1 -o json", fixture: "kafka/consumer/group/lag/describe-json.golden"},
-		{args: "kafka consumer group lag list consumer-group-1 --cluster lkc-1234", fixture: "kafka/consumer/group/lag/list.golden"},
-		{args: "kafka consumer group lag list consumer-group-1 --cluster lkc-1234 -o json", fixture: "kafka/consumer/group/lag/list-json.golden"},
-		{args: "kafka consumer group lag summarize consumer-group-1 --cluster lkc-1234", fixture: "kafka/consumer/group/lag/summarize.golden"},
-		{args: "kafka consumer group lag summarize consumer-group-1 --cluster lkc-1234 -o json", fixture: "kafka/consumer/group/lag/summarize-json.golden"},
+		{args: "kafka consumer group lag describe consumer-group-1 --cluster lkc-describe-dedicated --topic topic-1 --partition 1", fixture: "kafka/consumer/group/lag/describe.golden"},
+		{args: "kafka consumer group lag describe consumer-group-1 --cluster lkc-describe-dedicated --topic topic-1 --partition 1 -o json", fixture: "kafka/consumer/group/lag/describe-json.golden"},
+		{args: "kafka consumer group lag describe consumer-group-1 --cluster lkc-basic --topic topic-1 --partition 1", fixture: "kafka/consumer/group/lag/basic.golden", exitCode: 1},
+		{args: "kafka consumer group lag list consumer-group-1 --cluster lkc-describe-dedicated", fixture: "kafka/consumer/group/lag/list.golden"},
+		{args: "kafka consumer group lag list consumer-group-1 --cluster lkc-describe-dedicated -o json", fixture: "kafka/consumer/group/lag/list-json.golden"},
+		{args: "kafka consumer group lag list consumer-group-1 --cluster lkc-basic", fixture: "kafka/consumer/group/lag/basic.golden", exitCode: 1},
+		{args: "kafka consumer group lag summarize consumer-group-1 --cluster lkc-describe-dedicated", fixture: "kafka/consumer/group/lag/summarize.golden"},
+		{args: "kafka consumer group lag summarize consumer-group-1 --cluster lkc-describe-dedicated -o json", fixture: "kafka/consumer/group/lag/summarize-json.golden"},
+		{args: "kafka consumer group lag summarize consumer-group-1 --cluster lkc-basic", fixture: "kafka/consumer/group/lag/basic.golden", exitCode: 1},
 	}
 
 	for _, test := range tests {
 		test.login = "cloud"
 		s.runIntegrationTest(test)
 	}
+}
 
-	kafkaRestURL := s.TestBackend.GetKafkaRestUrl()
-	tests = []CLITest{
+func (s *CLITestSuite) TestKafkaConsumerGroupLag_OnPrem() {
+	tests := []CLITest{
 		{args: "kafka consumer group lag describe consumer-group-1 --topic topic-1 --partition 1", fixture: "kafka/consumer/group/lag/describe-onprem.golden"},
 		{args: "kafka consumer group lag list consumer-group-1", fixture: "kafka/consumer/group/lag/list-onprem.golden"},
 		{args: "kafka consumer group lag summarize consumer-group-1", fixture: "kafka/consumer/group/lag/summarize-onprem.golden"},
@@ -612,7 +616,7 @@ func (s *CLITestSuite) TestKafkaConsumerGroupLag() {
 
 	for _, test := range tests {
 		test.login = "onprem"
-		test.env = []string{"CONFLUENT_REST_URL=" + kafkaRestURL}
+		test.env = []string{"CONFLUENT_REST_URL=" + s.TestBackend.GetKafkaRestUrl()}
 		s.runIntegrationTest(test)
 	}
 }


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- PLACEHOLDER

New Features
- Improve error message when running `confluent kafka consumer group lag` commands without a dedicated Kafka cluster

Bug Fixes
- PLACEHOLDER

Checklist
---------
- [x] Leave this box unchecked if features are not yet available in production

What
----
Look up if Kafka cluster is dedicated before running consumer group lag commands

Test & Review
-------------
Integration tests