### PR TITLE
Feat/kfs 987 flinkcc 456 use upsert columns

### DIFF
--- a/pkg/flink/components/table_view_test.go
+++ b/pkg/flink/components/table_view_test.go
@@ -42,7 +42,7 @@ func (s *TableViewTestSuite) TestJumpUp() {
 }
 
 func getResultsExample(numRows int) *types.MaterializedStatementResults {
-	materializedStatementResults := types.NewMaterializedStatementResults([]string{"Count"}, 10)
+	materializedStatementResults := types.NewMaterializedStatementResults([]string{"Count"}, 10, nil)
 	for i := 0; i < numRows; i++ {
 		materializedStatementResults.Append(types.StatementResultRow{
 			Operation: types.Insert,

--- a/pkg/flink/internal/controller/basic_output_controller_test.go
+++ b/pkg/flink/internal/controller/basic_output_controller_test.go
@@ -34,7 +34,7 @@ func (s *BasicOutputControllerTestSuite) SetupTest() {
 }
 
 func (s *BasicOutputControllerTestSuite) TestVisualizeResultsShouldPrintNoRows() {
-	mat := types.NewMaterializedStatementResults([]string{}, 10)
+	mat := types.NewMaterializedStatementResults([]string{}, 10, nil)
 	s.resultFetcher.EXPECT().GetMaterializedStatementResults().Return(&mat)
 	s.resultFetcher.EXPECT().GetStatement().Return(types.ProcessedStatement{})
 	stdout := test.RunAndCaptureSTDOUT(s.T(), s.basicOutputController.VisualizeResults)
@@ -43,7 +43,7 @@ func (s *BasicOutputControllerTestSuite) TestVisualizeResultsShouldPrintNoRows()
 }
 
 func (s *BasicOutputControllerTestSuite) TestRunInteractiveInputShouldNotPrintNoRowsWhenStatusDetailAvailable() {
-	mat := types.NewMaterializedStatementResults([]string{}, 10)
+	mat := types.NewMaterializedStatementResults([]string{}, 10, nil)
 	s.resultFetcher.EXPECT().GetMaterializedStatementResults().Return(&mat)
 	s.resultFetcher.EXPECT().GetStatement().Return(types.ProcessedStatement{StatusDetail: "Created table 'test'"})
 	stdout := test.RunAndCaptureSTDOUT(s.T(), s.basicOutputController.VisualizeResults)
@@ -53,7 +53,7 @@ func (s *BasicOutputControllerTestSuite) TestRunInteractiveInputShouldNotPrintNo
 
 func (s *BasicOutputControllerTestSuite) TestVisualizeResultsShouldPrintTable() {
 	executedStatementWithResults := getStatementWithResultsExample()
-	mat := types.NewMaterializedStatementResults(executedStatementWithResults.StatementResults.GetHeaders(), 10)
+	mat := types.NewMaterializedStatementResults(executedStatementWithResults.StatementResults.GetHeaders(), 10, nil)
 	mat.Append(executedStatementWithResults.StatementResults.GetRows()...)
 	s.resultFetcher.EXPECT().GetMaterializedStatementResults().Return(&mat).Times(4)
 

--- a/pkg/flink/internal/controller/interactive_output_controller_test.go
+++ b/pkg/flink/internal/controller/interactive_output_controller_test.go
@@ -154,7 +154,7 @@ func (s *InteractiveOutputControllerTestSuite) TestOpenRowViewOnUserInput() {
 
 func getResultsExample() *types.MaterializedStatementResults {
 	executedStatementWithResults := getStatementWithResultsExample()
-	mat := types.NewMaterializedStatementResults(executedStatementWithResults.StatementResults.GetHeaders(), 10)
+	mat := types.NewMaterializedStatementResults(executedStatementWithResults.StatementResults.GetHeaders(), 10, nil)
 	mat.Append(executedStatementWithResults.StatementResults.GetRows()...)
 	return &mat
 }
@@ -229,7 +229,7 @@ func (s *InteractiveOutputControllerTestSuite) TestTableTitleDisplaysChangelogMo
 
 func (s *InteractiveOutputControllerTestSuite) TestTableTitleDisplaysPageSizeAndCacheSizeWithUnsafeTrace() {
 	executedStatementWithResults := getStatementWithResultsExample()
-	mat := types.NewMaterializedStatementResults(executedStatementWithResults.StatementResults.GetHeaders(), 10)
+	mat := types.NewMaterializedStatementResults(executedStatementWithResults.StatementResults.GetHeaders(), 10, nil)
 	mat.Append(executedStatementWithResults.StatementResults.GetRows()...)
 
 	s.resultFetcher.EXPECT().IsTableMode().Return(true)

--- a/pkg/flink/internal/results/materialized_results_test.go
+++ b/pkg/flink/internal/results/materialized_results_test.go
@@ -32,7 +32,7 @@ func (s *MaterializedStatementResultsTestSuite) TestChangelogMode() {
 		require.NoError(t, err)
 
 		// test if in changelog mode all the rows are there and in the correct order
-		materializedStatementResults := types.NewMaterializedStatementResults(convertedResults.GetHeaders(), 100)
+		materializedStatementResults := types.NewMaterializedStatementResults(convertedResults.GetHeaders(), 100, nil)
 		materializedStatementResults.SetTableMode(false)
 		materializedStatementResults.Append(convertedResults.GetRows()...)
 		// in changelog mode we have an additional column "Operation"
@@ -63,7 +63,7 @@ func (s *MaterializedStatementResultsTestSuite) TestTableMode() {
 			},
 		},
 	}
-	materializedStatementResults := types.NewMaterializedStatementResults(headers, 10000)
+	materializedStatementResults := types.NewMaterializedStatementResults(headers, 10000, nil)
 	materializedStatementResults.Append(previousRow)
 	require.Equal(s.T(), headers, materializedStatementResults.GetHeaders())
 	require.Equal(s.T(), 1, materializedStatementResults.GetTableSize())
@@ -102,7 +102,7 @@ func (s *MaterializedStatementResultsTestSuite) TestKeyCountIncreases() {
 
 		// object under test
 		headers := []string{"Key", "Count"}
-		materializedStatementResults := types.NewMaterializedStatementResults(headers, 10000)
+		materializedStatementResults := types.NewMaterializedStatementResults(headers, 10000, nil)
 
 		for _, key := range keys {
 			row := types.StatementResultRow{
@@ -193,7 +193,7 @@ func (s *MaterializedStatementResultsTestSuite) TestChangelogIsCleanedUpWhenOver
 	var expectedRows []types.StatementResultRow
 	expectedRows = append(expectedRows, previousRow)
 
-	materializedStatementResults := types.NewMaterializedStatementResults(headers, 3)
+	materializedStatementResults := types.NewMaterializedStatementResults(headers, 3, nil)
 	materializedStatementResults.Append(previousRow)
 	materializedStatementResults.SetTableMode(false)
 	for count := 1; count <= 10; count++ {
@@ -229,7 +229,7 @@ func (s *MaterializedStatementResultsTestSuite) TestTableIsCleanedUpWhenOverCapa
 	headers := []string{"Count"}
 	var expectedRows []types.StatementResultRow
 
-	materializedStatementResults := types.NewMaterializedStatementResults(headers, 3)
+	materializedStatementResults := types.NewMaterializedStatementResults(headers, 3, nil)
 	for count := 1; count <= 10; count++ {
 		row := types.StatementResultRow{
 			Operation: types.Insert,
@@ -265,7 +265,7 @@ func (s *MaterializedStatementResultsTestSuite) TestTableDoesNotCleanupEventsTha
 		},
 	}
 
-	materializedStatementResults := types.NewMaterializedStatementResults(headers, 2)
+	materializedStatementResults := types.NewMaterializedStatementResults(headers, 2, nil)
 	materializedStatementResults.Append(row)
 	for count := 0; count <= 10; count++ {
 		// add new row
@@ -307,7 +307,7 @@ func (s *MaterializedStatementResultsTestSuite) TestCleanup() {
 			},
 		},
 	}
-	materializedStatementResults := types.NewMaterializedStatementResults(headers, 1)
+	materializedStatementResults := types.NewMaterializedStatementResults(headers, 1, nil)
 	materializedStatementResults.Append(row)
 	iterator := materializedStatementResults.Iterator(false)
 	require.Equal(s.T(), row, *iterator.GetNext())
@@ -346,13 +346,13 @@ func (s *MaterializedStatementResultsTestSuite) TestOnlyAllowAppendWithSameSchem
 			},
 		},
 	}
-	materializedStatementResults := types.NewMaterializedStatementResults(invalidHeaders, 1)
+	materializedStatementResults := types.NewMaterializedStatementResults(invalidHeaders, 1, nil)
 	valuesInserted := materializedStatementResults.Append(row)
 	require.False(s.T(), valuesInserted)
 	require.Empty(s.T(), materializedStatementResults.GetTableSize())
 
 	validHeaders := []string{"Count", "Count2"}
-	materializedStatementResults = types.NewMaterializedStatementResults(validHeaders, 1)
+	materializedStatementResults = types.NewMaterializedStatementResults(validHeaders, 1, nil)
 	valuesInserted = materializedStatementResults.Append(row)
 	require.True(s.T(), valuesInserted)
 	require.Equal(s.T(), 1, materializedStatementResults.GetTableSize())
@@ -360,7 +360,7 @@ func (s *MaterializedStatementResultsTestSuite) TestOnlyAllowAppendWithSameSchem
 
 func (s *MaterializedStatementResultsTestSuite) TestIteratorForwardResetThenBackward() {
 	headers := []string{"Count"}
-	materializedStatementResults := types.NewMaterializedStatementResults(headers, 10)
+	materializedStatementResults := types.NewMaterializedStatementResults(headers, 10, nil)
 
 	for i := 0; i < 10; i++ {
 		materializedStatementResults.Append(types.StatementResultRow{
@@ -411,7 +411,7 @@ func (s *MaterializedStatementResultsTestSuite) TestIteratorForwardResetThenBack
 
 func (s *MaterializedStatementResultsTestSuite) TestIteratorForwardAndBackward() {
 	headers := []string{"Count"}
-	materializedStatementResults := types.NewMaterializedStatementResults(headers, 10)
+	materializedStatementResults := types.NewMaterializedStatementResults(headers, 10, nil)
 
 	for i := 0; i < 10; i++ {
 		materializedStatementResults.Append(types.StatementResultRow{
@@ -441,7 +441,7 @@ func (s *MaterializedStatementResultsTestSuite) TestIteratorForwardAndBackward()
 
 func (s *MaterializedStatementResultsTestSuite) TestIteratorMoveToEndThenMoveToStart() {
 	headers := []string{"Count"}
-	materializedStatementResults := types.NewMaterializedStatementResults(headers, 10)
+	materializedStatementResults := types.NewMaterializedStatementResults(headers, 10, nil)
 
 	for i := 0; i < 10; i++ {
 		materializedStatementResults.Append(types.StatementResultRow{
@@ -482,7 +482,7 @@ func (s *MaterializedStatementResultsTestSuite) TestIteratorMoveToEndThenMoveToS
 
 func (s *MaterializedStatementResultsTestSuite) TestIteratorMoveDoesNotWorkOnceEndWasReached() {
 	headers := []string{"Count"}
-	materializedStatementResults := types.NewMaterializedStatementResults(headers, 10)
+	materializedStatementResults := types.NewMaterializedStatementResults(headers, 10, nil)
 
 	for i := 0; i < 10; i++ {
 		materializedStatementResults.Append(types.StatementResultRow{
@@ -520,7 +520,7 @@ func (s *MaterializedStatementResultsTestSuite) TestIteratorMoveDoesNotWorkOnceE
 
 func (s *MaterializedStatementResultsTestSuite) TestForEach() {
 	headers := []string{"Count"}
-	materializedStatementResults := types.NewMaterializedStatementResults(headers, 10)
+	materializedStatementResults := types.NewMaterializedStatementResults(headers, 10, nil)
 
 	for i := 0; i < 10; i++ {
 		materializedStatementResults.Append(types.StatementResultRow{
@@ -554,7 +554,7 @@ func (s *MaterializedStatementResultsTestSuite) TestForEach() {
 
 func (s *MaterializedStatementResultsTestSuite) TestGetColumnWidths() {
 	headers := []string{"1234", "12"}
-	materializedStatementResults := types.NewMaterializedStatementResults(headers, 10)
+	materializedStatementResults := types.NewMaterializedStatementResults(headers, 10, nil)
 	materializedStatementResults.Append(types.StatementResultRow{
 		Operation: types.Insert,
 		Fields: []types.StatementResultField{
@@ -574,7 +574,7 @@ func (s *MaterializedStatementResultsTestSuite) TestGetColumnWidths() {
 
 func (s *MaterializedStatementResultsTestSuite) TestGetColumnWidthsWithMultiLineValues() {
 	headers := []string{"1234", "12"}
-	materializedStatementResults := types.NewMaterializedStatementResults(headers, 10)
+	materializedStatementResults := types.NewMaterializedStatementResults(headers, 10, nil)
 	materializedStatementResults.Append(types.StatementResultRow{
 		Operation: types.Insert,
 		Fields: []types.StatementResultField{
@@ -594,7 +594,7 @@ func (s *MaterializedStatementResultsTestSuite) TestGetColumnWidthsWithMultiLine
 
 func (s *MaterializedStatementResultsTestSuite) TestGetColumnWidthsChangelogMode() {
 	headers := []string{"1234", "12"}
-	materializedStatementResults := types.NewMaterializedStatementResults(headers, 10)
+	materializedStatementResults := types.NewMaterializedStatementResults(headers, 10, nil)
 	materializedStatementResults.SetTableMode(false)
 	materializedStatementResults.Append(types.StatementResultRow{
 		Operation: types.Insert,
@@ -615,7 +615,7 @@ func (s *MaterializedStatementResultsTestSuite) TestGetColumnWidthsChangelogMode
 
 func (s *MaterializedStatementResultsTestSuite) TestToggleTableMode() {
 	headers := []string{"column1", "column2"}
-	materializedStatementResults := types.NewMaterializedStatementResults(headers, 10)
+	materializedStatementResults := types.NewMaterializedStatementResults(headers, 10, nil)
 	materializedStatementResults.Append(types.StatementResultRow{
 		Operation: types.Delete,
 		Fields: []types.StatementResultField{
@@ -643,7 +643,7 @@ func (s *MaterializedStatementResultsTestSuite) TestToggleTableMode() {
 
 func (s *MaterializedStatementResultsTestSuite) TestRowKeysShouldNotCollide() {
 	headers := []string{"column1", "column2"}
-	materializedStatementResults := types.NewMaterializedStatementResults(headers, 10)
+	materializedStatementResults := types.NewMaterializedStatementResults(headers, 10, nil)
 	materializedStatementResults.Append(types.StatementResultRow{
 		Operation: types.Insert,
 		Fields: []types.StatementResultField{
@@ -696,4 +696,102 @@ func (s *MaterializedStatementResultsTestSuite) TestRowKeysShouldNotCollide() {
 	})
 
 	require.Equal(s.T(), expected, actual)
+}
+
+func (s *MaterializedStatementResultsTestSuite) TestUpsertColumns() {
+	headers := []string{"column1", "column2", "column3"}
+	materializedStatementResults := types.NewMaterializedStatementResults(headers, 10, &[]int32{0, 2})
+
+	// insert 2 rows
+	appendRow(&materializedStatementResults, types.Insert, types.Varchar, "key1", "1", "key2")
+	appendRow(&materializedStatementResults, types.Insert, types.Varchar, "key1", "2", "key1")
+	require.Equal(s.T(), [][]string{
+		{"key1", "1", "key2"},
+		{"key1", "2", "key1"},
+	}, toSlice(&materializedStatementResults))
+	// update before should nothing
+	appendRow(&materializedStatementResults, types.UpdateBefore, types.Varchar, "key1", "1", "key2")
+	appendRow(&materializedStatementResults, types.UpdateBefore, types.Varchar, "key1", "2", "key1")
+	require.Equal(s.T(), [][]string{
+		{"key1", "1", "key2"},
+		{"key1", "2", "key1"},
+	}, toSlice(&materializedStatementResults))
+
+	appendRow(&materializedStatementResults, types.UpdateAfter, types.Varchar, "key1", "2", "key2")
+	appendRow(&materializedStatementResults, types.UpdateAfter, types.Varchar, "key1", "3", "key1")
+	// another UpdateAfter will be ignored
+	appendRow(&materializedStatementResults, types.UpdateAfter, types.Varchar, "key1", "3", "key1")
+	require.Equal(s.T(), [][]string{
+		{"key1", "2", "key2"},
+		{"key1", "3", "key1"},
+	}, toSlice(&materializedStatementResults))
+
+	// row will be deleted regardless of the value, only the keys are important
+	appendRow(&materializedStatementResults, types.Delete, types.Varchar, "key1", "2", "key1")
+	require.Equal(s.T(), [][]string{
+		{"key1", "2", "key2"},
+	}, toSlice(&materializedStatementResults))
+}
+
+func (s *MaterializedStatementResultsTestSuite) TestFallbackToEntireRowAsKeyIfUpsertColumnsFail() {
+	headers := []string{"column1", "column2", "column3"}
+	// choose an upsert column idx that's out of range
+	materializedStatementResults := types.NewMaterializedStatementResults(headers, 10, &[]int32{0, 10})
+
+	// insert 2 rows
+	appendRow(&materializedStatementResults, types.Insert, types.Varchar, "key1", "1", "key2")
+	appendRow(&materializedStatementResults, types.Insert, types.Varchar, "key1", "2", "key1")
+	require.Equal(s.T(), [][]string{
+		{"key1", "1", "key2"},
+		{"key1", "2", "key1"},
+	}, toSlice(&materializedStatementResults))
+	// update before should delete both rows
+	appendRow(&materializedStatementResults, types.UpdateBefore, types.Varchar, "key1", "1", "key2")
+	appendRow(&materializedStatementResults, types.UpdateBefore, types.Varchar, "key1", "2", "key1")
+	require.Empty(s.T(), toSlice(&materializedStatementResults))
+
+	appendRow(&materializedStatementResults, types.UpdateAfter, types.Varchar, "key1", "2", "key2")
+	appendRow(&materializedStatementResults, types.UpdateAfter, types.Varchar, "key1", "3", "key1")
+	// another UpdateAfter will duplicate the row
+	appendRow(&materializedStatementResults, types.UpdateAfter, types.Varchar, "key1", "3", "key1")
+	require.Equal(s.T(), [][]string{
+		{"key1", "2", "key2"},
+		{"key1", "3", "key1"},
+		{"key1", "3", "key1"},
+	}, toSlice(&materializedStatementResults))
+
+	// Delete with wrong value will be ignored, because we can't find the row
+	appendRow(&materializedStatementResults, types.Delete, types.Varchar, "key1", "2", "key1")
+	// Delete with correct value will only delete one of the duplicates
+	appendRow(&materializedStatementResults, types.Delete, types.Varchar, "key1", "3", "key1")
+	require.Equal(s.T(), [][]string{
+		{"key1", "2", "key2"},
+		{"key1", "3", "key1"},
+	}, toSlice(&materializedStatementResults))
+}
+
+func appendRow(materializedStatementResults *types.MaterializedStatementResults, operation types.StatementResultOperation, typeOfValues types.StatementResultFieldType, rowValues ...string) {
+	fields := []types.StatementResultField{}
+	for _, value := range rowValues {
+		fields = append(fields, types.AtomicStatementResultField{
+			Type:  typeOfValues,
+			Value: value,
+		})
+	}
+	materializedStatementResults.Append(types.StatementResultRow{
+		Operation: operation,
+		Fields:    fields,
+	})
+}
+
+func toSlice(materializedStatementResults *types.MaterializedStatementResults) [][]string {
+	var actual [][]string
+	materializedStatementResults.ForEach(func(rowIdx int, row *types.StatementResultRow) {
+		var fields []string
+		for _, field := range row.GetFields() {
+			fields = append(fields, field.ToString())
+		}
+		actual = append(actual, fields)
+	})
+	return actual
 }

--- a/pkg/flink/internal/results/materialized_results_test.go
+++ b/pkg/flink/internal/results/materialized_results_test.go
@@ -42,7 +42,7 @@ func (s *MaterializedStatementResultsTestSuite) TestChangelogMode() {
 		for _, expectedRow := range convertedResults.GetRows() {
 			actualRow := iterator.GetNext()
 			operationField := types.AtomicStatementResultField{
-				Type:  "VARCHAR",
+				Type:  types.Varchar,
 				Value: expectedRow.Operation.String(),
 			}
 			require.Equal(t, expectedRow.Operation, actualRow.Operation)
@@ -54,7 +54,13 @@ func (s *MaterializedStatementResultsTestSuite) TestChangelogMode() {
 
 func (s *MaterializedStatementResultsTestSuite) TestTableMode() {
 	headers := []string{"Count"}
-	previousRow := types.StatementResultRow{
+	materializedStatementResults := types.NewMaterializedStatementResults(headers, 10000, nil)
+	appendRow(&materializedStatementResults, types.Insert, types.Integer, "0")
+	require.Equal(s.T(), headers, materializedStatementResults.GetHeaders())
+	require.Equal(s.T(), 1, materializedStatementResults.GetTableSize())
+
+	iterator := materializedStatementResults.Iterator(false)
+	require.Equal(s.T(), types.StatementResultRow{
 		Operation: types.Insert,
 		Fields: []types.StatementResultField{
 			types.AtomicStatementResultField{
@@ -62,22 +68,19 @@ func (s *MaterializedStatementResultsTestSuite) TestTableMode() {
 				Value: "0",
 			},
 		},
-	}
-	materializedStatementResults := types.NewMaterializedStatementResults(headers, 10000, nil)
-	materializedStatementResults.Append(previousRow)
-	require.Equal(s.T(), headers, materializedStatementResults.GetHeaders())
-	require.Equal(s.T(), 1, materializedStatementResults.GetTableSize())
-	iterator := materializedStatementResults.Iterator(false)
-	require.Equal(s.T(), previousRow, *iterator.GetNext())
+	}, *iterator.GetNext())
+
 	changelogSize := 1
 	for count := 1; count <= 10; count++ {
 		// remove previous row
-		previousRow.Operation = types.UpdateBefore
-		materializedStatementResults.Append(previousRow)
+		appendRow(&materializedStatementResults, types.UpdateBefore, types.Integer, strconv.Itoa(count-1))
 		require.Equal(s.T(), 0, materializedStatementResults.GetTableSize())
 
 		// add new row
-		previousRow = types.StatementResultRow{
+		appendRow(&materializedStatementResults, types.UpdateAfter, types.Integer, strconv.Itoa(count))
+		iterator = materializedStatementResults.Iterator(false)
+		require.Equal(s.T(), 1, materializedStatementResults.GetTableSize())
+		require.Equal(s.T(), types.StatementResultRow{
 			Operation: types.UpdateAfter,
 			Fields: []types.StatementResultField{
 				types.AtomicStatementResultField{
@@ -85,11 +88,7 @@ func (s *MaterializedStatementResultsTestSuite) TestTableMode() {
 					Value: strconv.Itoa(count),
 				},
 			},
-		}
-		materializedStatementResults.Append(previousRow)
-		iterator = materializedStatementResults.Iterator(false)
-		require.Equal(s.T(), 1, materializedStatementResults.GetTableSize())
-		require.Equal(s.T(), previousRow, *iterator.GetNext())
+		}, *iterator.GetNext())
 		changelogSize += 2
 	}
 
@@ -105,21 +104,8 @@ func (s *MaterializedStatementResultsTestSuite) TestKeyCountIncreases() {
 		materializedStatementResults := types.NewMaterializedStatementResults(headers, 10000, nil)
 
 		for _, key := range keys {
-			row := types.StatementResultRow{
-				Operation: types.Insert,
-				Fields: []types.StatementResultField{
-					types.AtomicStatementResultField{
-						Type:  types.Integer,
-						Value: strconv.Itoa(key),
-					},
-					types.AtomicStatementResultField{
-						Type:  types.Integer,
-						Value: strconv.Itoa(1),
-					},
-				},
-			}
-			materializedStatementResults.Append(row)
-			materializedStatementResults.Append(row)
+			appendRow(&materializedStatementResults, types.Insert, types.Integer, strconv.Itoa(key), strconv.Itoa(1))
+			appendRow(&materializedStatementResults, types.Insert, types.Integer, strconv.Itoa(key), strconv.Itoa(1))
 		}
 		// check if the number of keys is correct
 		require.Equal(t, 2*len(keys), materializedStatementResults.GetTableSize())
@@ -129,37 +115,8 @@ func (s *MaterializedStatementResultsTestSuite) TestKeyCountIncreases() {
 			// Updates to group by are sent the following way
 			// We get retraction for the previous groupby value
 			// Then we get an update for the new groupby value
-			row := types.StatementResultRow{
-				Operation: types.UpdateBefore,
-				Fields: []types.StatementResultField{
-					types.AtomicStatementResultField{
-						Type:  types.Integer,
-						Value: strconv.Itoa(key),
-					},
-					types.AtomicStatementResultField{
-						Type:  types.Integer,
-						Value: strconv.Itoa(1),
-					},
-				},
-			}
-
-			materializedStatementResults.Append(row)
-
-			row = types.StatementResultRow{
-				Operation: types.UpdateAfter,
-				Fields: []types.StatementResultField{
-					types.AtomicStatementResultField{
-						Type:  types.Integer,
-						Value: strconv.Itoa(key),
-					},
-					types.AtomicStatementResultField{
-						Type:  types.Integer,
-						Value: strconv.Itoa(0),
-					},
-				},
-			}
-
-			materializedStatementResults.Append(row)
+			appendRow(&materializedStatementResults, types.UpdateBefore, types.Integer, strconv.Itoa(key), strconv.Itoa(1))
+			appendRow(&materializedStatementResults, types.UpdateAfter, types.Integer, strconv.Itoa(key), strconv.Itoa(0))
 		}
 		// check if the number of keys is correct
 		require.Equal(t, 2*len(keys), materializedStatementResults.GetTableSize())
@@ -181,124 +138,55 @@ func (s *MaterializedStatementResultsTestSuite) TestKeyCountIncreases() {
 
 func (s *MaterializedStatementResultsTestSuite) TestChangelogIsCleanedUpWhenOverCapacity() {
 	headers := []string{"Count"}
-	previousRow := types.StatementResultRow{
-		Operation: types.Insert,
-		Fields: []types.StatementResultField{
-			types.AtomicStatementResultField{
-				Type:  types.Integer,
-				Value: "0",
-			},
-		},
-	}
-	var expectedRows []types.StatementResultRow
-	expectedRows = append(expectedRows, previousRow)
-
 	materializedStatementResults := types.NewMaterializedStatementResults(headers, 3, nil)
-	materializedStatementResults.Append(previousRow)
+	appendRow(&materializedStatementResults, types.Insert, types.Integer, "0")
 	materializedStatementResults.SetTableMode(false)
 	for count := 1; count <= 10; count++ {
 		// remove previous row
-		previousRow.Operation = types.UpdateBefore
-		materializedStatementResults.Append(previousRow)
-		expectedRows = append(expectedRows, previousRow)
-
+		appendRow(&materializedStatementResults, types.UpdateBefore, types.Integer, strconv.Itoa(count-1))
 		// add new row
-		previousRow = types.StatementResultRow{
-			Operation: types.UpdateAfter,
-			Fields: []types.StatementResultField{
-				types.AtomicStatementResultField{
-					Type:  types.Integer,
-					Value: strconv.Itoa(count),
-				},
-			},
-		}
-		materializedStatementResults.Append(previousRow)
-		expectedRows = append(expectedRows, previousRow)
+		appendRow(&materializedStatementResults, types.UpdateAfter, types.Integer, strconv.Itoa(count))
 	}
 
 	require.Equal(s.T(), 3, materializedStatementResults.GetChangelogSize())
-	expectedRows = expectedRows[len(expectedRows)-materializedStatementResults.GetChangelogSize():]
-	materializedStatementResults.ForEach(func(rowIdx int, row *types.StatementResultRow) {
-		expectedRow := &expectedRows[rowIdx]
-		require.Equal(s.T(), expectedRow.Operation, row.Operation)
-		require.Equal(s.T(), expectedRow.Fields, row.Fields[1:])
-	})
+	require.Equal(s.T(), [][]string{{"+U", "9"}, {"-U", "9"}, {"+U", "10"}}, toSlice(&materializedStatementResults))
 }
 
 func (s *MaterializedStatementResultsTestSuite) TestTableIsCleanedUpWhenOverCapacity() {
 	headers := []string{"Count"}
-	var expectedRows []types.StatementResultRow
-
 	materializedStatementResults := types.NewMaterializedStatementResults(headers, 3, nil)
 	for count := 1; count <= 10; count++ {
-		row := types.StatementResultRow{
-			Operation: types.Insert,
-			Fields: []types.StatementResultField{
-				types.AtomicStatementResultField{
-					Type:  types.Integer,
-					Value: strconv.Itoa(count),
-				},
-			},
-		}
-		materializedStatementResults.Append(row)
-		expectedRows = append(expectedRows, row)
+		appendRow(&materializedStatementResults, types.Insert, types.Integer, strconv.Itoa(count))
 	}
 
 	require.Equal(s.T(), 3, materializedStatementResults.GetTableSize())
-	expectedRows = expectedRows[len(expectedRows)-materializedStatementResults.GetTableSize():]
-	materializedStatementResults.ForEach(func(rowIdx int, row *types.StatementResultRow) {
-		expectedRow := &expectedRows[rowIdx]
-		require.Equal(s.T(), expectedRow.Operation, row.Operation)
-		require.Equal(s.T(), expectedRow.Fields, row.Fields)
-	})
+	require.Equal(s.T(), [][]string{{"8"}, {"9"}, {"10"}}, toSlice(&materializedStatementResults))
 }
 
 func (s *MaterializedStatementResultsTestSuite) TestTableDoesNotCleanupEventsThatWereRemovedFromChangelog() {
 	headers := []string{"Count"}
-	row := types.StatementResultRow{
-		Operation: types.Insert,
-		Fields: []types.StatementResultField{
-			types.AtomicStatementResultField{
-				Type:  types.Integer,
-				Value: "100",
-			},
-		},
-	}
-
 	materializedStatementResults := types.NewMaterializedStatementResults(headers, 2, nil)
-	materializedStatementResults.Append(row)
-	for count := 0; count <= 10; count++ {
-		// add new row
-		operation := types.UpdateAfter
-		if count == 0 {
-			operation = types.Insert
-		}
-		newRow := types.StatementResultRow{
-			Operation: operation,
-			Fields: []types.StatementResultField{
-				types.AtomicStatementResultField{
-					Type:  types.Integer,
-					Value: strconv.Itoa(count),
-				},
-			},
-		}
-		materializedStatementResults.Append(newRow)
-
+	appendRow(&materializedStatementResults, types.Insert, types.Integer, "100")
+	appendRow(&materializedStatementResults, types.Insert, types.Integer, "0")
+	for count := 1; count <= 10; count++ {
 		// remove previous row
-		newRow.Operation = types.UpdateBefore
-		materializedStatementResults.Append(newRow)
+		appendRow(&materializedStatementResults, types.UpdateBefore, types.Integer, strconv.Itoa(count-1))
+		// add new row
+		appendRow(&materializedStatementResults, types.UpdateAfter, types.Integer, strconv.Itoa(count))
 	}
+	// remove last row
+	appendRow(&materializedStatementResults, types.UpdateBefore, types.Integer, "10")
 
 	require.Equal(s.T(), 1, materializedStatementResults.GetTableSize())
-	materializedStatementResults.ForEach(func(rowIdx int, row *types.StatementResultRow) {
-		require.Equal(s.T(), row.Operation, row.Operation)
-		require.Equal(s.T(), row.Fields, row.Fields)
-	})
+	require.Equal(s.T(), [][]string{{"100"}}, toSlice(&materializedStatementResults))
 }
 
 func (s *MaterializedStatementResultsTestSuite) TestCleanup() {
 	headers := []string{"Count"}
-	row := types.StatementResultRow{
+	materializedStatementResults := types.NewMaterializedStatementResults(headers, 1, nil)
+	appendRow(&materializedStatementResults, types.Insert, types.Integer, "0")
+	iterator := materializedStatementResults.Iterator(false)
+	require.Equal(s.T(), types.StatementResultRow{
 		Operation: types.Insert,
 		Fields: []types.StatementResultField{
 			types.AtomicStatementResultField{
@@ -306,14 +194,14 @@ func (s *MaterializedStatementResultsTestSuite) TestCleanup() {
 				Value: "0",
 			},
 		},
-	}
-	materializedStatementResults := types.NewMaterializedStatementResults(headers, 1, nil)
-	materializedStatementResults.Append(row)
-	iterator := materializedStatementResults.Iterator(false)
-	require.Equal(s.T(), row, *iterator.GetNext())
+	}, *iterator.GetNext())
+
 	for count := 1; count <= 10; count++ {
 		// add new row
-		row = types.StatementResultRow{
+		appendRow(&materializedStatementResults, types.Insert, types.Integer, strconv.Itoa(count))
+		iterator = materializedStatementResults.Iterator(false)
+		require.Equal(s.T(), 1, materializedStatementResults.GetTableSize())
+		require.Equal(s.T(), types.StatementResultRow{
 			Operation: types.Insert,
 			Fields: []types.StatementResultField{
 				types.AtomicStatementResultField{
@@ -321,11 +209,7 @@ func (s *MaterializedStatementResultsTestSuite) TestCleanup() {
 					Value: strconv.Itoa(count),
 				},
 			},
-		}
-		materializedStatementResults.Append(row)
-		iterator = materializedStatementResults.Iterator(false)
-		require.Equal(s.T(), 1, materializedStatementResults.GetTableSize())
-		require.Equal(s.T(), row, *iterator.GetNext())
+		}, *iterator.GetNext())
 	}
 
 	require.Equal(s.T(), 1, materializedStatementResults.GetTableSize())
@@ -363,15 +247,7 @@ func (s *MaterializedStatementResultsTestSuite) TestIteratorForwardResetThenBack
 	materializedStatementResults := types.NewMaterializedStatementResults(headers, 10, nil)
 
 	for i := 0; i < 10; i++ {
-		materializedStatementResults.Append(types.StatementResultRow{
-			Operation: types.Insert,
-			Fields: []types.StatementResultField{
-				types.AtomicStatementResultField{
-					Type:  types.Integer,
-					Value: strconv.Itoa(i),
-				},
-			},
-		})
+		appendRow(&materializedStatementResults, types.Insert, types.Integer, strconv.Itoa(i))
 	}
 	require.Equal(s.T(), 10, materializedStatementResults.GetTableSize())
 
@@ -414,15 +290,7 @@ func (s *MaterializedStatementResultsTestSuite) TestIteratorForwardAndBackward()
 	materializedStatementResults := types.NewMaterializedStatementResults(headers, 10, nil)
 
 	for i := 0; i < 10; i++ {
-		materializedStatementResults.Append(types.StatementResultRow{
-			Operation: types.Insert,
-			Fields: []types.StatementResultField{
-				types.AtomicStatementResultField{
-					Type:  types.Integer,
-					Value: strconv.Itoa(i),
-				},
-			},
-		})
+		appendRow(&materializedStatementResults, types.Insert, types.Integer, strconv.Itoa(i))
 	}
 	require.Equal(s.T(), 10, materializedStatementResults.GetTableSize())
 
@@ -444,15 +312,7 @@ func (s *MaterializedStatementResultsTestSuite) TestIteratorMoveToEndThenMoveToS
 	materializedStatementResults := types.NewMaterializedStatementResults(headers, 10, nil)
 
 	for i := 0; i < 10; i++ {
-		materializedStatementResults.Append(types.StatementResultRow{
-			Operation: types.Insert,
-			Fields: []types.StatementResultField{
-				types.AtomicStatementResultField{
-					Type:  types.Integer,
-					Value: strconv.Itoa(i),
-				},
-			},
-		})
+		appendRow(&materializedStatementResults, types.Insert, types.Integer, strconv.Itoa(i))
 	}
 	require.Equal(s.T(), 10, materializedStatementResults.GetTableSize())
 
@@ -485,15 +345,7 @@ func (s *MaterializedStatementResultsTestSuite) TestIteratorMoveDoesNotWorkOnceE
 	materializedStatementResults := types.NewMaterializedStatementResults(headers, 10, nil)
 
 	for i := 0; i < 10; i++ {
-		materializedStatementResults.Append(types.StatementResultRow{
-			Operation: types.Insert,
-			Fields: []types.StatementResultField{
-				types.AtomicStatementResultField{
-					Type:  types.Integer,
-					Value: strconv.Itoa(i),
-				},
-			},
-		})
+		appendRow(&materializedStatementResults, types.Insert, types.Integer, strconv.Itoa(i))
 	}
 	require.Equal(s.T(), 10, materializedStatementResults.GetTableSize())
 
@@ -521,17 +373,8 @@ func (s *MaterializedStatementResultsTestSuite) TestIteratorMoveDoesNotWorkOnceE
 func (s *MaterializedStatementResultsTestSuite) TestForEach() {
 	headers := []string{"Count"}
 	materializedStatementResults := types.NewMaterializedStatementResults(headers, 10, nil)
-
 	for i := 0; i < 10; i++ {
-		materializedStatementResults.Append(types.StatementResultRow{
-			Operation: types.Insert,
-			Fields: []types.StatementResultField{
-				types.AtomicStatementResultField{
-					Type:  types.Integer,
-					Value: strconv.Itoa(i),
-				},
-			},
-		})
+		appendRow(&materializedStatementResults, types.Insert, types.Integer, strconv.Itoa(i))
 	}
 
 	idx := 0
@@ -555,40 +398,14 @@ func (s *MaterializedStatementResultsTestSuite) TestForEach() {
 func (s *MaterializedStatementResultsTestSuite) TestGetColumnWidths() {
 	headers := []string{"1234", "12"}
 	materializedStatementResults := types.NewMaterializedStatementResults(headers, 10, nil)
-	materializedStatementResults.Append(types.StatementResultRow{
-		Operation: types.Insert,
-		Fields: []types.StatementResultField{
-			types.AtomicStatementResultField{
-				Type:  types.Varchar,
-				Value: "12345",
-			},
-			types.AtomicStatementResultField{
-				Type:  types.Varchar,
-				Value: "1",
-			},
-		},
-	})
-
+	appendRow(&materializedStatementResults, types.Insert, types.Varchar, "12345", "1")
 	require.Equal(s.T(), []int{5, 2}, materializedStatementResults.GetMaxWidthPerColumn())
 }
 
 func (s *MaterializedStatementResultsTestSuite) TestGetColumnWidthsWithMultiLineValues() {
 	headers := []string{"1234", "12"}
 	materializedStatementResults := types.NewMaterializedStatementResults(headers, 10, nil)
-	materializedStatementResults.Append(types.StatementResultRow{
-		Operation: types.Insert,
-		Fields: []types.StatementResultField{
-			types.AtomicStatementResultField{
-				Type:  types.Varchar,
-				Value: "12345 \n 123456789",
-			},
-			types.AtomicStatementResultField{
-				Type:  types.Varchar,
-				Value: "1\n123",
-			},
-		},
-	})
-
+	appendRow(&materializedStatementResults, types.Insert, types.Varchar, "12345 \n 123456789", "1\n123")
 	require.Equal(s.T(), []int{10, 3}, materializedStatementResults.GetMaxWidthPerColumn())
 }
 
@@ -596,39 +413,14 @@ func (s *MaterializedStatementResultsTestSuite) TestGetColumnWidthsChangelogMode
 	headers := []string{"1234", "12"}
 	materializedStatementResults := types.NewMaterializedStatementResults(headers, 10, nil)
 	materializedStatementResults.SetTableMode(false)
-	materializedStatementResults.Append(types.StatementResultRow{
-		Operation: types.Insert,
-		Fields: []types.StatementResultField{
-			types.AtomicStatementResultField{
-				Type:  types.Varchar,
-				Value: "12345",
-			},
-			types.AtomicStatementResultField{
-				Type:  types.Varchar,
-				Value: "1",
-			},
-		},
-	})
-
+	appendRow(&materializedStatementResults, types.Insert, types.Varchar, "12345", "1")
 	require.Equal(s.T(), []int{len("Operation"), 5, 2}, materializedStatementResults.GetMaxWidthPerColumn())
 }
 
 func (s *MaterializedStatementResultsTestSuite) TestToggleTableMode() {
 	headers := []string{"column1", "column2"}
 	materializedStatementResults := types.NewMaterializedStatementResults(headers, 10, nil)
-	materializedStatementResults.Append(types.StatementResultRow{
-		Operation: types.Delete,
-		Fields: []types.StatementResultField{
-			types.AtomicStatementResultField{
-				Type:  types.Varchar,
-				Value: "12345",
-			},
-			types.AtomicStatementResultField{
-				Type:  types.Varchar,
-				Value: "1",
-			},
-		},
-	})
+	appendRow(&materializedStatementResults, types.Delete, types.Varchar, "12", "3")
 
 	require.True(s.T(), materializedStatementResults.IsTableMode())
 	require.Equal(s.T(), headers, materializedStatementResults.GetHeaders())
@@ -644,58 +436,11 @@ func (s *MaterializedStatementResultsTestSuite) TestToggleTableMode() {
 func (s *MaterializedStatementResultsTestSuite) TestRowKeysShouldNotCollide() {
 	headers := []string{"column1", "column2"}
 	materializedStatementResults := types.NewMaterializedStatementResults(headers, 10, nil)
-	materializedStatementResults.Append(types.StatementResultRow{
-		Operation: types.Insert,
-		Fields: []types.StatementResultField{
-			types.AtomicStatementResultField{
-				Type:  types.Varchar,
-				Value: "1",
-			},
-			types.AtomicStatementResultField{
-				Type:  types.Varchar,
-				Value: "23",
-			},
-		},
-	})
-	materializedStatementResults.Append(types.StatementResultRow{
-		Operation: types.Insert,
-		Fields: []types.StatementResultField{
-			types.AtomicStatementResultField{
-				Type:  types.Varchar,
-				Value: "12",
-			},
-			types.AtomicStatementResultField{
-				Type:  types.Varchar,
-				Value: "3",
-			},
-		},
-	})
-	materializedStatementResults.Append(types.StatementResultRow{
-		Operation: types.UpdateBefore,
-		Fields: []types.StatementResultField{
-			types.AtomicStatementResultField{
-				Type:  types.Varchar,
-				Value: "1",
-			},
-			types.AtomicStatementResultField{
-				Type:  types.Varchar,
-				Value: "23",
-			},
-		},
-	})
 
-	expected := [][]string{{"12", "3"}}
-
-	var actual [][]string
-	materializedStatementResults.ForEach(func(rowIdx int, row *types.StatementResultRow) {
-		var fields []string
-		for _, field := range row.GetFields() {
-			fields = append(fields, field.ToString())
-		}
-		actual = append(actual, fields)
-	})
-
-	require.Equal(s.T(), expected, actual)
+	appendRow(&materializedStatementResults, types.Insert, types.Varchar, "1", "23")
+	appendRow(&materializedStatementResults, types.Insert, types.Varchar, "12", "3")
+	appendRow(&materializedStatementResults, types.UpdateBefore, types.Varchar, "1", "23")
+	require.Equal(s.T(), [][]string{{"12", "3"}}, toSlice(&materializedStatementResults))
 }
 
 func (s *MaterializedStatementResultsTestSuite) TestUpsertColumns() {

--- a/pkg/flink/internal/results/result_fetcher.go
+++ b/pkg/flink/internal/results/result_fetcher.go
@@ -159,7 +159,7 @@ func (t *ResultFetcher) Init(statement types.ProcessedStatement) {
 	t.setStatement(statement)
 	t.setInitialRefreshState(statement)
 	headers := t.getResultHeadersOrCreateFromResultSchema(statement)
-	t.materializedStatementResults = types.NewMaterializedStatementResults(headers, MaxResultsCapacity)
+	t.materializedStatementResults = types.NewMaterializedStatementResults(headers, MaxResultsCapacity, statement.Traits.UpsertColumns)
 	t.materializedStatementResults.SetTableMode(true)
 	t.materializedStatementResults.Append(statement.StatementResults.GetRows()...)
 }

--- a/pkg/flink/types/materialized_results.go
+++ b/pkg/flink/types/materialized_results.go
@@ -4,6 +4,7 @@ import (
 	"sync"
 
 	"github.com/confluentinc/cli/v3/pkg/flink/internal/utils"
+	"github.com/confluentinc/cli/v3/pkg/log"
 )
 
 type MaterializedStatementResultsIterator struct {
@@ -72,23 +73,25 @@ func (i *MaterializedStatementResultsIterator) Move(stepsToMove int) *StatementR
 }
 
 type MaterializedStatementResults struct {
-	isTableMode bool
-	maxCapacity int
-	headers     []string
-	changelog   LinkedList[StatementResultRow]
-	table       LinkedList[StatementResultRow]
-	cache       map[string]*ListElement[StatementResultRow]
-	lock        sync.RWMutex
+	isTableMode   bool
+	maxCapacity   int
+	headers       []string
+	changelog     LinkedList[StatementResultRow]
+	table         LinkedList[StatementResultRow]
+	cache         map[string]*ListElement[StatementResultRow]
+	lock          sync.RWMutex
+	upsertColumns *[]int32
 }
 
-func NewMaterializedStatementResults(headers []string, maxCapacity int) MaterializedStatementResults {
+func NewMaterializedStatementResults(headers []string, maxCapacity int, upsertColumns *[]int32) MaterializedStatementResults {
 	return MaterializedStatementResults{
-		isTableMode: true,
-		maxCapacity: maxCapacity,
-		headers:     headers,
-		changelog:   NewLinkedList[StatementResultRow](),
-		table:       NewLinkedList[StatementResultRow](),
-		cache:       map[string]*ListElement[StatementResultRow]{},
+		isTableMode:   true,
+		maxCapacity:   maxCapacity,
+		headers:       headers,
+		changelog:     NewLinkedList[StatementResultRow](),
+		table:         NewLinkedList[StatementResultRow](),
+		cache:         map[string]*ListElement[StatementResultRow]{},
+		upsertColumns: upsertColumns,
 	}
 }
 
@@ -123,7 +126,7 @@ func (s *MaterializedStatementResults) cleanup() {
 
 	if s.table.Len() > s.maxCapacity {
 		removedRow := s.table.RemoveFront()
-		removedRowKey := removedRow.GetRowKey()
+		removedRowKey, _ := removedRow.GetRowKey(s.upsertColumns)
 		delete(s.cache, removedRowKey)
 	}
 }
@@ -140,22 +143,56 @@ func (s *MaterializedStatementResults) Append(rows ...StatementResultRow) bool {
 		}
 		s.changelog.PushBack(row)
 
-		rowKey := row.GetRowKey()
-		if row.Operation.IsInsertOperation() {
-			listPtr := s.table.PushBack(row)
-			s.cache[rowKey] = listPtr
+		if rowKey, hasUpsertColumns := row.GetRowKey(s.upsertColumns); hasUpsertColumns {
+			s.processRowWithUpsertColumns(row, rowKey)
 		} else {
-			listPtr, ok := s.cache[rowKey]
-			if ok {
-				s.table.Remove(listPtr)
-				delete(s.cache, rowKey)
-			}
+			s.processRowWithoutUpsertColumns(row, rowKey)
 		}
 
 		// if we are now over the capacity we need to remove some records
 		s.cleanup()
 	}
 	return allValuesInserted
+}
+
+func (s *MaterializedStatementResults) processRowWithUpsertColumns(row StatementResultRow, rowKey string) {
+	switch row.Operation {
+	case Insert:
+		listPtr := s.table.PushBack(row)
+		s.cache[rowKey] = listPtr
+	case UpdateBefore:
+		// ignore update before, when using upsert columns
+		return
+	case UpdateAfter:
+		listPtr, ok := s.cache[rowKey]
+		if ok {
+			listPtr.element.Value = row
+		}
+	case Delete:
+		listPtr, ok := s.cache[rowKey]
+		if ok {
+			s.table.Remove(listPtr)
+			delete(s.cache, rowKey)
+		}
+	default:
+		log.CliLogger.Warnf("unknown operation received: %f\n", row.Operation)
+	}
+}
+
+func (s *MaterializedStatementResults) processRowWithoutUpsertColumns(row StatementResultRow, rowKey string) {
+	// insert row at the end
+	if row.Operation.IsInsertOperation() {
+		listPtr := s.table.PushBack(row)
+		s.cache[rowKey] = listPtr
+		return
+	}
+
+	// delete row
+	listPtr, ok := s.cache[rowKey]
+	if ok {
+		s.table.Remove(listPtr)
+		delete(s.cache, rowKey)
+	}
 }
 
 func (s *MaterializedStatementResults) Size() int {


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

New Features
- `confluent flink shell` uses the `upsertColumns` property now when its available, which makes results in table mode more stable

Checklist
---------
- [x] Leave this box unchecked if features are not yet available in production

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->

When upsertColumns are availabe, we can find previously inserted rows by their upsert keys and update them in place instead of deleting the whole row when a -U comes in and appending at the end. 

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
<!--
Has it been tested? How?
Copy and paste any instructions or steps that can save the reviewer time.
-->



https://github.com/confluentinc/cli/assets/37211050/2d376876-7410-4c0c-9e42-19cdcc40c730


