### PR TITLE
fix: treat Insert and UpdateAfter both as upsert events

### DIFF
--- a/pkg/flink/internal/results/materialized_results_test.go
+++ b/pkg/flink/internal/results/materialized_results_test.go
@@ -447,9 +447,9 @@ func (s *MaterializedStatementResultsTestSuite) TestUpsertColumns() {
 	headers := []string{"column1", "column2", "column3"}
 	materializedStatementResults := types.NewMaterializedStatementResults(headers, 10, &[]int32{0, 2})
 
-	// insert 2 rows
+	// insert 2 rows, update after should be treated the same as insert
 	appendRow(&materializedStatementResults, types.Insert, types.Varchar, "key1", "1", "key2")
-	appendRow(&materializedStatementResults, types.Insert, types.Varchar, "key1", "2", "key1")
+	appendRow(&materializedStatementResults, types.UpdateAfter, types.Varchar, "key1", "2", "key1")
 	require.Equal(s.T(), [][]string{
 		{"key1", "1", "key2"},
 		{"key1", "2", "key1"},


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Checklist
---------
- [x] Leave this box unchecked if features are not yet available in production

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->
This seems more resilient, since we could still recover from cases where we missed the initial insert event for some reason. The subsequent UpdateAfter events, would lead to the row being inserted eventually.


References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
<!--
Has it been tested? How?
Copy and paste any instructions or steps that can save the reviewer time.
-->