### PR TITLE
fix: set timezone to UTC for flink shell tests

### DIFF
--- a/test/flink_test.go
+++ b/test/flink_test.go
@@ -226,7 +226,7 @@ func (s *CLITestSuite) setupFlinkShellTests() {
 	require.NoError(s.T(), err)
 
 	// Fake the timezone, to ensure CI and local run with the same default timezone.
-	// We use UTC to avoid TZ differences due to daylight savings time.
+	// We use UTC to avoid time zone differences due to daylight savings time.
 	err = os.Setenv(timezoneEnvVar, "UTC")
 	require.NoError(s.T(), err)
 }

--- a/test/flink_test.go
+++ b/test/flink_test.go
@@ -225,8 +225,9 @@ func (s *CLITestSuite) setupFlinkShellTests() {
 	err := os.Setenv(prompt.EnvVarInputFile, flinkShellInputStreamFile)
 	require.NoError(s.T(), err)
 
-	// Fake the timezone, to ensure CI and local run with the same default timezone
-	err = os.Setenv(timezoneEnvVar, "Europe/London")
+	// Fake the timezone, to ensure CI and local run with the same default timezone.
+	// We use UTC to avoid TZ differences due to daylight savings time.
+	err = os.Setenv(timezoneEnvVar, "UTC")
 	require.NoError(s.T(), err)
 }
 


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Checklist
---------
- [x] Leave this box unchecked if features are not yet available in production

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->
Tests are broken because of daylight savings time. To avoid this, we set the TZ to be UTC. This should unblock https://github.com/confluentinc/cli/pull/2699

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
<!--
Has it been tested? How?
Copy and paste any instructions or steps that can save the reviewer time.
-->