### PR TITLE
[CLI-3048] Remove login requirement for `confluent connect plugin install`

### DIFF
--- a/internal/connect/command.go
+++ b/internal/connect/command.go
@@ -17,9 +17,8 @@ type connectOut struct {
 
 func New(cfg *config.Config, prerunner pcmd.PreRunner) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:         "connect",
-		Short:       "Manage Kafka Connect.",
-		Annotations: map[string]string{pcmd.RunRequirement: pcmd.RequireNonAPIKeyCloudLoginOrOnPremLogin},
+		Use:   "connect",
+		Short: "Manage Kafka Connect.",
 	}
 
 	cmd.AddCommand(newClusterCommand(cfg, prerunner))

--- a/internal/connect/command_plugin.go
+++ b/internal/connect/command_plugin.go
@@ -25,13 +25,11 @@ func newPluginCommand(cfg *config.Config, prerunner pcmd.PreRunner) *cobra.Comma
 	if cfg.IsCloudLogin() {
 		c.AuthenticatedCLICommand = pcmd.NewAuthenticatedCLICommand(cmd, prerunner)
 
+		cmd.AddCommand(c.newDescribeCommand())
 		cmd.AddCommand(c.newListCommand())
 	} else {
-		c.AuthenticatedCLICommand = pcmd.NewAuthenticatedWithMDSCLICommand(cmd, prerunner)
-		cmd.AddCommand(c.newInstallCommand())
+		cmd.AddCommand(newInstallCommand(prerunner))
 	}
-
-	cmd.AddCommand(c.newDescribeCommand())
 
 	return cmd
 }

--- a/internal/connect/command_plugin_install.go
+++ b/internal/connect/command_plugin_install.go
@@ -62,9 +62,7 @@ func newInstallCommand(prerunner pcmd.PreRunner) *cobra.Command {
 
 	cobra.CheckErr(cmd.MarkFlagDirname("plugin-directory"))
 
-	c := &pluginInstallCommand{
-		CLICommand: pcmd.NewAnonymousCLICommand(cmd, prerunner),
-	}
+	c := &pluginInstallCommand{pcmd.NewAnonymousCLICommand(cmd, prerunner)}
 	cmd.RunE = c.install
 
 	return cmd

--- a/pkg/cmd/authenticated_cli_command.go
+++ b/pkg/cmd/authenticated_cli_command.go
@@ -17,7 +17,6 @@ import (
 	"github.com/confluentinc/cli/v3/pkg/ccloudv2"
 	"github.com/confluentinc/cli/v3/pkg/config"
 	"github.com/confluentinc/cli/v3/pkg/errors"
-	"github.com/confluentinc/cli/v3/pkg/hub"
 	"github.com/confluentinc/cli/v3/pkg/schemaregistry"
 	"github.com/confluentinc/cli/v3/pkg/utils"
 	testserver "github.com/confluentinc/cli/v3/test/test-server"
@@ -33,7 +32,6 @@ type AuthenticatedCLICommand struct {
 	V2Client          *ccloudv2.Client
 
 	flinkGatewayClient   *ccloudv2.FlinkGatewayClient
-	hubClient            *hub.Client
 	metricsClient        *ccloudv2.MetricsClient
 	schemaRegistryClient *schemaregistry.Client
 
@@ -133,19 +131,6 @@ func (c *AuthenticatedCLICommand) getGatewayUrlForRegion(provider, region string
 	u.Path = ""
 
 	return u.String(), nil
-}
-
-func (c *AuthenticatedCLICommand) GetHubClient() (*hub.Client, error) {
-	if c.hubClient == nil {
-		unsafeTrace, err := c.Flags().GetBool("unsafe-trace")
-		if err != nil {
-			return nil, err
-		}
-
-		c.hubClient = hub.NewClient(c.Config.Version.UserAgent, c.Config.IsTest, unsafeTrace)
-	}
-
-	return c.hubClient, nil
 }
 
 func (c *AuthenticatedCLICommand) GetKafkaREST() (*KafkaREST, error) {


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- PLACEHOLDER

New Features
- `confluent connect plugin install` no longer requires users to log in

Bug Fixes
- PLACEHOLDER

Checklist
---------
- [x] Leave this box unchecked if features are not yet available in production

What
----
Not all on-premises users have MDS set up. This PR removes the login requirement so all on-premises users can use this command.

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
Manual testing: checked that this command can be used when logged out and when logged in to on-prem.