### PR TITLE
Add "Properties" and "Principal" fields to `flink statement describe`

### DIFF
--- a/internal/flink/command_statement_describe.go
+++ b/internal/flink/command_statement_describe.go
@@ -1,11 +1,24 @@
 package flink
 
 import (
+	"time"
+
 	"github.com/spf13/cobra"
 
 	pcmd "github.com/confluentinc/cli/v3/pkg/cmd"
 	"github.com/confluentinc/cli/v3/pkg/output"
 )
+
+type describeStatementOut struct {
+	CreationDate time.Time         `human:"Creation Date" serialized:"creation_date"`
+	Name         string            `human:"Name" serialized:"name"`
+	Statement    string            `human:"Statement" serialized:"statement"`
+	ComputePool  string            `human:"Compute Pool" serialized:"compute_pool"`
+	Status       string            `human:"Status" serialized:"status"`
+	StatusDetail string            `human:"Status Detail,omitempty" serialized:"status_detail,omitempty"`
+	Properties   map[string]string `human:"Properties" serialized:"properties"`
+	Principal    string            `human:"Principal" serialized:"principal"`
+}
 
 func (c *command) newStatementDescribeCommand() *cobra.Command {
 	cmd := &cobra.Command{
@@ -42,13 +55,15 @@ func (c *command) statementDescribe(cmd *cobra.Command, args []string) error {
 	}
 
 	table := output.NewTable(cmd)
-	table.Add(&statementOut{
+	table.Add(&describeStatementOut{
 		CreationDate: statement.Metadata.GetCreatedAt(),
 		Name:         statement.GetName(),
 		Statement:    statement.Spec.GetStatement(),
 		ComputePool:  statement.Spec.GetComputePoolId(),
 		Status:       statement.Status.GetPhase(),
 		StatusDetail: statement.Status.GetDetail(),
+		Properties:   statement.Spec.GetProperties(),
+		Principal:    statement.Spec.GetPrincipal(),
 	})
 	return table.Print()
 }

--- a/pkg/output/table.go
+++ b/pkg/output/table.go
@@ -232,6 +232,7 @@ func getTableValueString(value reflect.Value) string {
 		for i, k := range value.MapKeys() {
 			s[i] = fmt.Sprintf("%s=%s", k.String(), value.MapIndex(k).String())
 		}
+		sort.Strings(s)
 		return strings.Join(s, "\n")
 	default:
 		return fmt.Sprint(value)

--- a/pkg/output/table.go
+++ b/pkg/output/table.go
@@ -189,7 +189,7 @@ func (t *Table) printCore(writer io.Writer, auto bool) error {
 				tag := strings.Split(reflect.TypeOf(object).Elem().Field(i).Tag.Get(t.format.String()), ",")
 				if !slices.Contains(tag, "-") {
 					val := reflect.ValueOf(object).Elem().Field(i)
-					row = append(row, getValueAsString(val, tag))
+					row = append(row, getListValueString(val, tag))
 				}
 			}
 			w.Append(row)
@@ -203,7 +203,7 @@ func (t *Table) printCore(writer io.Writer, auto bool) error {
 			tag := strings.Split(reflect.TypeOf(t.objects[0]).Elem().Field(i).Tag.Get(t.format.String()), ",")
 			val := reflect.ValueOf(t.objects[0]).Elem().Field(i)
 			if !slices.Contains(tag, "-") && !(slices.Contains(tag, "omitempty") && val.IsZero()) {
-				w.Append([]string{tag[0], fmt.Sprint(val)})
+				w.Append([]string{tag[0], getTableValueString(val)})
 			}
 		}
 	}
@@ -213,15 +213,29 @@ func (t *Table) printCore(writer io.Writer, auto bool) error {
 	return nil
 }
 
-func getValueAsString(val reflect.Value, tag []string) string {
+func getListValueString(value reflect.Value, tag []string) string {
 	if slices.Contains(tag, "Current") {
-		if val.Bool() {
+		if value.Bool() {
 			return "*"
 		} else {
 			return " "
 		}
 	}
-	return fmt.Sprint(val)
+
+	return getTableValueString(value)
+}
+
+func getTableValueString(value reflect.Value) string {
+	switch value.Kind() {
+	case reflect.Map:
+		s := make([]string, len(value.MapKeys()))
+		for i, k := range value.MapKeys() {
+			s[i] = fmt.Sprintf("%s=%s", k.String(), value.MapIndex(k).String())
+		}
+		return strings.Join(s, "\n")
+	default:
+		return fmt.Sprint(value)
+	}
 }
 
 func (t *Table) isMap() bool {

--- a/test/fixtures/output/flink/statement/describe-yaml.golden
+++ b/test/fixtures/output/flink/statement/describe-yaml.golden
@@ -4,3 +4,7 @@ statement: CREATE TABLE test;
 compute_pool: pool-123456
 status: COMPLETED
 status_detail: SQL statement is completed
+properties:
+    sql.current-catalog: default
+    sql.current-database: my-cluster
+principal: u-123456

--- a/test/fixtures/output/flink/statement/describe.golden
+++ b/test/fixtures/output/flink/statement/describe.golden
@@ -5,7 +5,7 @@
 | Compute Pool  | pool-123456                     |
 | Status        | COMPLETED                       |
 | Status Detail | SQL statement is completed      |
-| Properties    | sql.current-database=my-cluster |
-|               | sql.current-catalog=default     |
+| Properties    | sql.current-catalog=default     |
+|               | sql.current-database=my-cluster |
 | Principal     | u-123456                        |
 +---------------+---------------------------------+

--- a/test/fixtures/output/flink/statement/describe.golden
+++ b/test/fixtures/output/flink/statement/describe.golden
@@ -1,8 +1,11 @@
-+---------------+-------------------------------+
-| Creation Date | 2022-01-01 00:00:00 +0000 UTC |
-| Name          | my-statement                  |
-| Statement     | CREATE TABLE test;            |
-| Compute Pool  | pool-123456                   |
-| Status        | COMPLETED                     |
-| Status Detail | SQL statement is completed    |
-+---------------+-------------------------------+
++---------------+---------------------------------+
+| Creation Date | 2022-01-01 00:00:00 +0000 UTC   |
+| Name          | my-statement                    |
+| Statement     | CREATE TABLE test;              |
+| Compute Pool  | pool-123456                     |
+| Status        | COMPLETED                       |
+| Status Detail | SQL statement is completed      |
+| Properties    | sql.current-database=my-cluster |
+|               | sql.current-catalog=default     |
+| Principal     | u-123456                        |
++---------------+---------------------------------+

--- a/test/test-server/flink_gateway_router.go
+++ b/test/test-server/flink_gateway_router.go
@@ -98,8 +98,13 @@ func handleSqlEnvironmentsEnvironmentStatementsStatement(t *testing.T) http.Hand
 		statement := flinkgatewayv1.SqlV1Statement{
 			Name: flinkgatewayv1.PtrString(mux.Vars(r)["statement"]),
 			Spec: &flinkgatewayv1.SqlV1StatementSpec{
-				Statement:     flinkgatewayv1.PtrString("CREATE TABLE test;"),
+				Statement: flinkgatewayv1.PtrString("CREATE TABLE test;"),
+				Properties: &map[string]string{
+					"sql.current-catalog":  "default",
+					"sql.current-database": "my-cluster",
+				},
 				ComputePoolId: flinkgatewayv1.PtrString("pool-123456"),
+				Principal:     flinkgatewayv1.PtrString("u-123456"),
 			},
 			Status: &flinkgatewayv1.SqlV1StatementStatus{
 				Phase:  "COMPLETED",


### PR DESCRIPTION
Release Notes
-------------
Breaking Changes
- PLACEHOLDER

New Features
- [Early Access] Add "Properties" and "Principal" fields to `confluent flink statement describe`

Bug Fixes
- PLACEHOLDER

Checklist
---------
- [x] Leave this box unchecked if features are not yet available in production

What
----
Add both fields and wrote a map printer, to be added to other commands in v4.

References
----------
https://confluentinc.atlassian.net/browse/CLI-3115

Test & Review
-------------
Integration tests