### PR TITLE
feat: add function to parse app options from slices

### DIFF
--- a/pkg/flink/types/application_options.go
+++ b/pkg/flink/types/application_options.go
@@ -1,7 +1,13 @@
 package types
 
 import (
+	"fmt"
+	"reflect"
+	"strconv"
+	"strings"
+
 	"github.com/confluentinc/cli/v3/pkg/config"
+	"github.com/confluentinc/cli/v3/pkg/errors"
 )
 
 type ApplicationOptions struct {
@@ -15,7 +21,96 @@ type ApplicationOptions struct {
 	ServiceAccountId string
 	Verbose          bool
 	LSPBaseUrl       string
+	GatewayURL       string
 	Context          *config.Context
+}
+
+func ParseApplicationOptionsFromSlices(
+	configKeys, configValues []string,
+) (*ApplicationOptions, error) {
+	if len(configKeys) != len(configValues) {
+		return nil, errors.NewErrorWithSuggestions(
+			fmt.Sprintf(
+				"number of config keys %d and config values %d don't match",
+				len(configKeys),
+				len(configValues),
+			),
+			"please provide the same number of config keys and values",
+		)
+	}
+	availabaleFields := getAvailableConfigFields()
+
+	// use reflections to find the fields in ApplicationOptions and assign the right value type to them
+	appOptions := &ApplicationOptions{}
+	appOptionsReflection := reflect.ValueOf(appOptions).Elem()
+	for i, configKey := range configKeys {
+		configValue := configValues[i]
+
+		// find the field by name
+		field := appOptionsReflection.FieldByName(configKey)
+		if !field.IsValid() {
+			return nil, errors.NewErrorWithSuggestions(
+				fmt.Sprintf("config-key %s not found in ApplicationOptions", configKey),
+				fmt.Sprintf(
+					"double check the provided config-keys match the available fields %s",
+					strings.Join(availabaleFields, ", "),
+				),
+			)
+		}
+
+		// convert the field value to the appropriate type
+		switch field.Kind() {
+		case reflect.Bool:
+			value, err := strconv.ParseBool(configValue)
+			if err != nil {
+				return nil, fmt.Errorf("config-value %s cannot be parsed to bool", configValue)
+			}
+			field.SetBool(value)
+		case reflect.String:
+			field.SetString(configValue)
+		default:
+			return nil, fmt.Errorf(
+				"field type %v of config-key %s is unsupported",
+				field.Kind(),
+				configKey,
+			)
+		}
+	}
+
+	return appOptions, nil
+}
+
+func getAvailableConfigFields() []string {
+	appOptionsType := reflect.TypeOf(ApplicationOptions{})
+	var availabaleFields []string
+	for i := 0; i < appOptionsType.NumField(); i++ {
+		field := appOptionsType.Field(i)
+		// only allow string or bool fields
+		if field.Type.Kind() == reflect.String || field.Type.Kind() == reflect.Bool {
+			availabaleFields = append(availabaleFields, field.Name)
+		}
+	}
+	return availabaleFields
+}
+
+func (a *ApplicationOptions) Validate() error {
+	var missingOptions []string
+	if a.GetEnvironmentId() == "" {
+		missingOptions = append(missingOptions, "EnvironmentId")
+	}
+	if a.GetOrganizationId() == "" {
+		missingOptions = append(missingOptions, "OrganizationId")
+	}
+	if a.GetComputePoolId() == "" {
+		missingOptions = append(missingOptions, "ComputePoolId")
+	}
+	if a.GetGatewayURL() == "" {
+		missingOptions = append(missingOptions, "GatewayURL")
+	}
+	if len(missingOptions) > 0 {
+		return fmt.Errorf("missing required config options: %s", strings.Join(missingOptions, ", "))
+	}
+	return nil
 }
 
 func (a *ApplicationOptions) GetUnsafeTrace() bool {
@@ -91,6 +186,13 @@ func (a *ApplicationOptions) GetContext() *config.Context {
 func (a *ApplicationOptions) GetLSPBaseUrl() string {
 	if a != nil {
 		return a.LSPBaseUrl
+	}
+	return ""
+}
+
+func (a *ApplicationOptions) GetGatewayURL() string {
+	if a != nil {
+		return a.GatewayURL
 	}
 	return ""
 }

--- a/pkg/flink/types/application_options_test.go
+++ b/pkg/flink/types/application_options_test.go
@@ -1,0 +1,75 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseApplicationOptionsFromSlices(t *testing.T) {
+	tests := []struct {
+		name               string
+		configKeys         []string
+		configValues       []string
+		expectedAppOptions *ApplicationOptions
+		expectedError      bool
+	}{
+		{
+			name:          "TestUnequalSliceLengths",
+			configKeys:    []string{"key1"},
+			configValues:  []string{},
+			expectedError: true,
+		},
+		{
+			name:          "TestInvalidKey",
+			configKeys:    []string{"key1"},
+			configValues:  []string{"value1"},
+			expectedError: true,
+		},
+		{
+			name:          "TestUnsupportedType",
+			configKeys:    []string{"Context"},
+			configValues:  []string{"unsupportedType"},
+			expectedError: true,
+		},
+		{
+			name:          "TestBoolParsingError",
+			configKeys:    []string{"UnsafeTrace"},
+			configValues:  []string{"notABool"},
+			expectedError: true,
+		},
+		{
+			name:         "TestParseAppOptionsSuccessfully",
+			configKeys:   []string{"UnsafeTrace", "UserAgent", "EnvironmentId", "EnvironmentName", "OrganizationId", "Database", "ComputePoolId", "ServiceAccountId", "Verbose", "LSPBaseUrl", "GatewayURL"},
+			configValues: []string{"true", "test", "env-123", "test-env", "org-123", "test-database", "lfcp-123", "sa-123", "true", "localhost:8080", "localhost:8000"},
+			expectedAppOptions: &ApplicationOptions{
+				UnsafeTrace:      true,
+				UserAgent:        "test",
+				EnvironmentId:    "env-123",
+				EnvironmentName:  "test-env",
+				OrganizationId:   "org-123",
+				Database:         "test-database",
+				ComputePoolId:    "lfcp-123",
+				ServiceAccountId: "sa-123",
+				Verbose:          true,
+				LSPBaseUrl:       "localhost:8080",
+				GatewayURL:       "localhost:8000",
+			},
+			expectedError: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			appOptions, err := ParseApplicationOptionsFromSlices(test.configKeys, test.configValues)
+
+			if test.expectedError {
+				require.Nil(t, appOptions)
+				require.Error(t, err)
+			} else {
+				require.Equal(t, test.expectedAppOptions, appOptions)
+				require.Nil(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Checklist
---------
- [x] Leave this box unchecked if features are not yet available in production

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->
Adds a function to parse app options from slices using reflections. This will enable us to overwrite the ApplicationOptions with special config flags that will only be available behind a feature flag. We can then use this to run the CLI against a local k8s instance of the flink system

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
<!--
Has it been tested? How?
Copy and paste any instructions or steps that can save the reviewer time.
-->