### PR TITLE
[KFS-1863] add local mode to flink shell

### DIFF
--- a/internal/flink/command_shell.go
+++ b/internal/flink/command_shell.go
@@ -160,7 +160,7 @@ func (c *command) startFlinkSqlClient(prerunner pcmd.PreRunner, cmd *cobra.Comma
 		ComputePoolId:    computePool,
 		ServiceAccountId: serviceAccount,
 		Verbose:          verbose > 0,
-		LSPBaseURL:       lspBaseUrl,
+		LSPBaseUrl:       lspBaseUrl,
 	}
 
 	return client.StartApp(flinkGatewayClient, c.authenticated(prerunner.Authenticated(c.AuthenticatedCLICommand), cmd, jwtValidator), opts, reportUsage(cmd, c.Config, unsafeTrace))
@@ -188,7 +188,7 @@ func (c *command) startWithLocalMode(cmd *cobra.Command) error {
 		return err
 	}
 
-	gatewayClient := ccloudv2.NewFlinkGatewayClient(appOptions.GetGatewayURL(), c.Version.UserAgent, appOptions.GetUnsafeTrace(), "authToken")
+	gatewayClient := ccloudv2.NewFlinkGatewayClient(appOptions.GetGatewayUrl(), c.Version.UserAgent, appOptions.GetUnsafeTrace(), "authToken")
 
 	appOptions.Context = c.Context
 	return client.StartApp(gatewayClient, func() error { return nil }, *appOptions, func() {})

--- a/internal/flink/command_shell.go
+++ b/internal/flink/command_shell.go
@@ -11,15 +11,12 @@ import (
 	pcmd "github.com/confluentinc/cli/v3/pkg/cmd"
 	"github.com/confluentinc/cli/v3/pkg/config"
 	"github.com/confluentinc/cli/v3/pkg/errors"
+	"github.com/confluentinc/cli/v3/pkg/featureflags"
 	client "github.com/confluentinc/cli/v3/pkg/flink/app"
-	"github.com/confluentinc/cli/v3/pkg/flink/test/mock"
 	"github.com/confluentinc/cli/v3/pkg/flink/types"
 	"github.com/confluentinc/cli/v3/pkg/log"
 	ppanic "github.com/confluentinc/cli/v3/pkg/panic-recovery"
 )
-
-// If we set this const useFakeGateway to true, we start the client with a simulated gateway client that returns fake data. This is used for debugging.
-const useFakeGateway = false
 
 func (c *command) newShellCommand(prerunner pcmd.PreRunner) *cobra.Command {
 	cmd := &cobra.Command{
@@ -35,6 +32,11 @@ func (c *command) newShellCommand(prerunner pcmd.PreRunner) *cobra.Command {
 	c.addDatabaseFlag(cmd)
 	pcmd.AddEnvironmentFlag(cmd, c.AuthenticatedCLICommand)
 	pcmd.AddContextFlag(cmd, c.CLICommand)
+
+	if featureflags.Manager.BoolVariation("cli.flink.internal", c.Context, config.CliLaunchDarklyClient, true, false) {
+		cmd.Flags().StringSlice("config-key", []string{}, "app option keys for local mode")
+		cmd.Flags().StringSlice("config-value", []string{}, "app option values for local mode")
+	}
 
 	return cmd
 }
@@ -70,14 +72,10 @@ func (c *command) authenticated(authenticated func(*cobra.Command, []string) err
 }
 
 func (c *command) startFlinkSqlClient(prerunner pcmd.PreRunner, cmd *cobra.Command) error {
-	if useFakeGateway {
-		return client.StartApp(
-			mock.NewFakeFlinkGatewayClient(),
-			func() error { return nil },
-			types.ApplicationOptions{
-				Context:   c.Context,
-				UserAgent: c.Version.UserAgent,
-			}, func() {})
+	// if config-keys were passed, we should enter local mode
+	configKeys, _ := cmd.Flags().GetStringSlice("config-key")
+	if len(configKeys) > 0 {
+		return c.startWithLocalMode(cmd)
 	}
 
 	environmentId, err := cmd.Flags().GetString("environment")
@@ -162,10 +160,38 @@ func (c *command) startFlinkSqlClient(prerunner pcmd.PreRunner, cmd *cobra.Comma
 		ComputePoolId:    computePool,
 		ServiceAccountId: serviceAccount,
 		Verbose:          verbose > 0,
-		LSPBaseUrl:       lspBaseUrl,
+		LSPBaseURL:       lspBaseUrl,
 	}
 
 	return client.StartApp(flinkGatewayClient, c.authenticated(prerunner.Authenticated(c.AuthenticatedCLICommand), cmd, jwtValidator), opts, reportUsage(cmd, c.Config, unsafeTrace))
+}
+
+func (c *command) startWithLocalMode(cmd *cobra.Command) error {
+	// get config keys and values from flags
+	configKeys, err := cmd.Flags().GetStringSlice("config-key")
+	if err != nil {
+		return err
+	}
+	configValues, err := cmd.Flags().GetStringSlice("config-value")
+	if err != nil {
+		return err
+	}
+
+	// parse app options from given flags
+	appOptions, err := types.ParseApplicationOptionsFromSlices(configKeys, configValues)
+	if err != nil {
+		return err
+	}
+
+	// validate app options
+	if err := appOptions.Validate(); err != nil {
+		return err
+	}
+
+	gatewayClient := ccloudv2.NewFlinkGatewayClient(appOptions.GetGatewayURL(), c.Version.UserAgent, appOptions.GetUnsafeTrace(), "authToken")
+
+	appOptions.Context = c.Context
+	return client.StartApp(gatewayClient, func() error { return nil }, *appOptions, func() {})
 }
 
 func (c *command) getFlinkLanguageServiceUrl(gatewayClient *ccloudv2.FlinkGatewayClient) (string, error) {

--- a/internal/flink/command_shell.go
+++ b/internal/flink/command_shell.go
@@ -72,10 +72,15 @@ func (c *command) authenticated(authenticated func(*cobra.Command, []string) err
 }
 
 func (c *command) startFlinkSqlClient(prerunner pcmd.PreRunner, cmd *cobra.Command) error {
-	// if config-keys were passed, we should enter local mode
-	configKeys, _ := cmd.Flags().GetStringSlice("config-key")
-	if len(configKeys) > 0 {
-		return c.startWithLocalMode(cmd)
+	if featureflags.Manager.BoolVariation("cli.flink.internal", c.Context, config.CliLaunchDarklyClient, true, false) {
+		configKeys, err := cmd.Flags().GetStringSlice("config-key")
+		if err != nil {
+			return err
+		}
+		// if config-keys were passed, we should enter local mode
+		if len(configKeys) > 0 {
+			return c.startWithLocalMode(cmd)
+		}
 	}
 
 	environmentId, err := cmd.Flags().GetString("environment")

--- a/internal/flink/command_shell.go
+++ b/internal/flink/command_shell.go
@@ -34,8 +34,8 @@ func (c *command) newShellCommand(prerunner pcmd.PreRunner) *cobra.Command {
 	pcmd.AddContextFlag(cmd, c.CLICommand)
 
 	if featureflags.Manager.BoolVariation("cli.flink.internal", c.Context, config.CliLaunchDarklyClient, true, false) {
-		cmd.Flags().StringSlice("config-key", []string{}, "app option keys for local mode")
-		cmd.Flags().StringSlice("config-value", []string{}, "app option values for local mode")
+		cmd.Flags().StringSlice("config-key", []string{}, "App option keys for local mode.")
+		cmd.Flags().StringSlice("config-value", []string{}, "App option values for local mode.")
 	}
 
 	return cmd

--- a/pkg/flink/app/application.go
+++ b/pkg/flink/app/application.go
@@ -62,8 +62,8 @@ func StartApp(gatewayClient ccloudv2.GatewayClientInterface, tokenRefreshFunc fu
 	dataStore := store.NewStore(gatewayClient, appController.ExitApplication, &appOptions, synchronizedTokenRefreshFunc)
 	resultFetcher := results.NewResultFetcher(dataStore)
 
-	// Instantiate lsp
-	lspClient := lsp.NewLSPClientWS(getAuthToken, appOptions.GetLSPBaseUrl(), appOptions.GetOrganizationId(), appOptions.GetEnvironmentId())
+	// Instantiate LSP
+	lspClient := lsp.NewClientWs(getAuthToken, appOptions.GetLSPBaseUrl(), appOptions.GetOrganizationId(), appOptions.GetEnvironmentId())
 
 	stdinBefore := utils.GetStdin()
 	consoleParser, err := utils.GetConsoleParser()

--- a/pkg/flink/app/application.go
+++ b/pkg/flink/app/application.go
@@ -63,7 +63,7 @@ func StartApp(gatewayClient ccloudv2.GatewayClientInterface, tokenRefreshFunc fu
 	resultFetcher := results.NewResultFetcher(dataStore)
 
 	// Instantiate lsp
-	lspClient := lsp.NewLSPClientWS(getAuthToken, appOptions.GetLSPBaseUrl(), appOptions.GetOrganizationId(), appOptions.GetEnvironmentId())
+	lspClient := lsp.NewLSPClientWS(getAuthToken, appOptions.GetLSPBaseURL(), appOptions.GetOrganizationId(), appOptions.GetEnvironmentId())
 
 	stdinBefore := utils.GetStdin()
 	consoleParser, err := utils.GetConsoleParser()

--- a/pkg/flink/app/application.go
+++ b/pkg/flink/app/application.go
@@ -63,7 +63,7 @@ func StartApp(gatewayClient ccloudv2.GatewayClientInterface, tokenRefreshFunc fu
 	resultFetcher := results.NewResultFetcher(dataStore)
 
 	// Instantiate lsp
-	lspClient := lsp.NewLSPClientWS(getAuthToken, appOptions.GetLSPBaseURL(), appOptions.GetOrganizationId(), appOptions.GetEnvironmentId())
+	lspClient := lsp.NewLSPClientWS(getAuthToken, appOptions.GetLSPBaseUrl(), appOptions.GetOrganizationId(), appOptions.GetEnvironmentId())
 
 	stdinBefore := utils.GetStdin()
 	consoleParser, err := utils.GetConsoleParser()

--- a/pkg/flink/app/application.go
+++ b/pkg/flink/app/application.go
@@ -63,7 +63,7 @@ func StartApp(gatewayClient ccloudv2.GatewayClientInterface, tokenRefreshFunc fu
 	resultFetcher := results.NewResultFetcher(dataStore)
 
 	// Instantiate LSP
-	lspClient := lsp.NewClientWs(getAuthToken, appOptions.GetLSPBaseUrl(), appOptions.GetOrganizationId(), appOptions.GetEnvironmentId())
+	lspClient := lsp.NewWebsocketClient(getAuthToken, appOptions.GetLSPBaseUrl(), appOptions.GetOrganizationId(), appOptions.GetEnvironmentId())
 
 	stdinBefore := utils.GetStdin()
 	consoleParser, err := utils.GetConsoleParser()

--- a/pkg/flink/lsp/lsp_completer_ws.go
+++ b/pkg/flink/lsp/lsp_completer_ws.go
@@ -80,7 +80,7 @@ func (w *WebsocketLSPClient) refreshWebsocketConnection() {
 	}
 }
 
-func NewLSPClientWS(getAuthToken func() string, baseUrl, organizationId, environmentId string) LspInterface {
+func NewClientWs(getAuthToken func() string, baseUrl, organizationId, environmentId string) LspInterface {
 	lspClient, conn, err := newLSPConnection(baseUrl, getAuthToken(), organizationId, environmentId)
 	if err != nil {
 		return nil

--- a/pkg/flink/lsp/lsp_completer_ws.go
+++ b/pkg/flink/lsp/lsp_completer_ws.go
@@ -80,7 +80,7 @@ func (w *WebsocketLSPClient) refreshWebsocketConnection() {
 	}
 }
 
-func NewClientWs(getAuthToken func() string, baseUrl, organizationId, environmentId string) LspInterface {
+func NewWebsocketClient(getAuthToken func() string, baseUrl, organizationId, environmentId string) LspInterface {
 	lspClient, conn, err := newLSPConnection(baseUrl, getAuthToken(), organizationId, environmentId)
 	if err != nil {
 		return nil

--- a/pkg/flink/types/application_options.go
+++ b/pkg/flink/types/application_options.go
@@ -20,7 +20,7 @@ type ApplicationOptions struct {
 	ComputePoolId    string
 	ServiceAccountId string
 	Verbose          bool
-	LSPBaseUrl       string
+	LSPBaseURL       string
 	GatewayURL       string
 	Context          *config.Context
 }
@@ -183,9 +183,9 @@ func (a *ApplicationOptions) GetContext() *config.Context {
 	return nil
 }
 
-func (a *ApplicationOptions) GetLSPBaseUrl() string {
+func (a *ApplicationOptions) GetLSPBaseURL() string {
 	if a != nil {
-		return a.LSPBaseUrl
+		return a.LSPBaseURL
 	}
 	return ""
 }

--- a/pkg/flink/types/application_options.go
+++ b/pkg/flink/types/application_options.go
@@ -20,8 +20,8 @@ type ApplicationOptions struct {
 	ComputePoolId    string
 	ServiceAccountId string
 	Verbose          bool
-	LSPBaseURL       string
-	GatewayURL       string
+	LSPBaseUrl       string
+	GatewayUrl       string
 	Context          *config.Context
 }
 
@@ -104,7 +104,7 @@ func (a *ApplicationOptions) Validate() error {
 	if a.GetComputePoolId() == "" {
 		missingOptions = append(missingOptions, "ComputePoolId")
 	}
-	if a.GetGatewayURL() == "" {
+	if a.GetGatewayUrl() == "" {
 		missingOptions = append(missingOptions, "GatewayURL")
 	}
 	if len(missingOptions) > 0 {
@@ -183,16 +183,16 @@ func (a *ApplicationOptions) GetContext() *config.Context {
 	return nil
 }
 
-func (a *ApplicationOptions) GetLSPBaseURL() string {
+func (a *ApplicationOptions) GetLSPBaseUrl() string {
 	if a != nil {
-		return a.LSPBaseURL
+		return a.LSPBaseUrl
 	}
 	return ""
 }
 
-func (a *ApplicationOptions) GetGatewayURL() string {
+func (a *ApplicationOptions) GetGatewayUrl() string {
 	if a != nil {
-		return a.GatewayURL
+		return a.GatewayUrl
 	}
 	return ""
 }

--- a/pkg/flink/types/application_options_test.go
+++ b/pkg/flink/types/application_options_test.go
@@ -40,7 +40,7 @@ func TestParseApplicationOptionsFromSlices(t *testing.T) {
 		},
 		{
 			name:         "TestParseAppOptionsSuccessfully",
-			configKeys:   []string{"UnsafeTrace", "UserAgent", "EnvironmentId", "EnvironmentName", "OrganizationId", "Database", "ComputePoolId", "ServiceAccountId", "Verbose", "LSPBaseUrl", "GatewayURL"},
+			configKeys:   []string{"UnsafeTrace", "UserAgent", "EnvironmentId", "EnvironmentName", "OrganizationId", "Database", "ComputePoolId", "ServiceAccountId", "Verbose", "LSPBaseURL", "GatewayURL"},
 			configValues: []string{"true", "test", "env-123", "test-env", "org-123", "test-database", "lfcp-123", "sa-123", "true", "localhost:8080", "localhost:8000"},
 			expectedAppOptions: &ApplicationOptions{
 				UnsafeTrace:      true,
@@ -52,7 +52,7 @@ func TestParseApplicationOptionsFromSlices(t *testing.T) {
 				ComputePoolId:    "lfcp-123",
 				ServiceAccountId: "sa-123",
 				Verbose:          true,
-				LSPBaseUrl:       "localhost:8080",
+				LSPBaseURL:       "localhost:8080",
 				GatewayURL:       "localhost:8000",
 			},
 			expectedError: false,

--- a/pkg/flink/types/application_options_test.go
+++ b/pkg/flink/types/application_options_test.go
@@ -40,7 +40,7 @@ func TestParseApplicationOptionsFromSlices(t *testing.T) {
 		},
 		{
 			name:         "TestParseAppOptionsSuccessfully",
-			configKeys:   []string{"UnsafeTrace", "UserAgent", "EnvironmentId", "EnvironmentName", "OrganizationId", "Database", "ComputePoolId", "ServiceAccountId", "Verbose", "LSPBaseURL", "GatewayURL"},
+			configKeys:   []string{"UnsafeTrace", "UserAgent", "EnvironmentId", "EnvironmentName", "OrganizationId", "Database", "ComputePoolId", "ServiceAccountId", "Verbose", "LSPBaseUrl", "GatewayUrl"},
 			configValues: []string{"true", "test", "env-123", "test-env", "org-123", "test-database", "lfcp-123", "sa-123", "true", "localhost:8080", "localhost:8000"},
 			expectedAppOptions: &ApplicationOptions{
 				UnsafeTrace:      true,
@@ -52,8 +52,8 @@ func TestParseApplicationOptionsFromSlices(t *testing.T) {
 				ComputePoolId:    "lfcp-123",
 				ServiceAccountId: "sa-123",
 				Verbose:          true,
-				LSPBaseURL:       "localhost:8080",
-				GatewayURL:       "localhost:8000",
+				LSPBaseUrl:       "localhost:8080",
+				GatewayUrl:       "localhost:8000",
 			},
 			expectedError: false,
 		},


### PR DESCRIPTION
Checklist
---------
- [x] Leave this box unchecked if features are not yet available in production

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->
This adds two flags behind a feature flag which will only be enabled for internal orgs. With these flags we can overwrite the ApplicationOptions the shell uses. This enables us to run the flink shell with a local instance of the Flink system.

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
<!--
Has it been tested? How?
Copy and paste any instructions or steps that can save the reviewer time.
-->