### PR TITLE
Set Dependabot PR limit to a large number

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
   - directory: "/"
     ignore:
       - dependency-name: "github.com/confluentinc/*"
-    open-pull-requests-limit: 0
+    open-pull-requests-limit: 100
     package-ecosystem: "gomod"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
What
----
I realized we haven't seen Dependabot PRs in over a month. Turns out I misread the documentation and 0 does not signify infinity. Instead, replace with a large number.

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
<!--
Has it been tested? How?
Copy and paste any instructions or steps that can save the reviewer time.
-->