### PR TITLE
feat/KFS-1891 KFS-1881 warning and new retention for compute pool deletion msg

### DIFF
--- a/internal/flink/command_compute_pool_delete.go
+++ b/internal/flink/command_compute_pool_delete.go
@@ -65,20 +65,16 @@ func (c *command) computePoolDelete(cmd *cobra.Command, args []string) error {
 }
 
 func confirmDeletionString(name, id string) string {
-	deletionString := fmt.Sprintf("Are you sure you want to delete the compute pool \"%s\"?"+
+	return fmt.Sprintf("Are you sure you want to delete the compute pool \"%s\"?"+
 		" All statements leveraging the compute pool will be STOPPED immediately and be available for 30 days in the statement list history.\n"+
 		"After that, they will be permanently deleted. \n"+
 		"To confirm, type \"%s\". To cancel, press Ctrl-C", id, name)
-
-	return deletionString
 }
 
 func confirmMultipleDeletionString(idList []string) string {
-	deletionString := fmt.Sprintf("Are you sure you want to delete compute pools %s?"+
+	return fmt.Sprintf("Are you sure you want to delete compute pools %s?"+
 		" All statements leveraging the compute pools will be STOPPED immediately and be available for 30 days in the statement list history.\n"+
 		"After that, they will be permanently deleted. \n", utils.ArrayToCommaDelimitedString(idList, "and"))
-
-	return deletionString
 }
 
 func validateAndConfirmComputePoolDeletion(cmd *cobra.Command, args []string, checkExistence func(string) bool, resourceType, name string) error {

--- a/test/fixtures/output/flink/compute-pool/delete-multiple-refuse.golden
+++ b/test/fixtures/output/flink/compute-pool/delete-multiple-refuse.golden
@@ -1,1 +1,3 @@
-Are you sure you want to delete Flink compute pools "lfcp-123456" and "lfcp-222222"? (y/n): 
+Are you sure you want to delete compute pools "lfcp-123456" and "lfcp-222222"? All statements leveraging the compute pools will be STOPPED immediately and be available for 30 days in the statement list history.
+After that, they will be permanently deleted. 
+ (y/n): 

--- a/test/fixtures/output/flink/compute-pool/delete-multiple-success.golden
+++ b/test/fixtures/output/flink/compute-pool/delete-multiple-success.golden
@@ -1,1 +1,3 @@
-Are you sure you want to delete Flink compute pools "lfcp-123456" and "lfcp-222222"? (y/n): Deleted Flink compute pools "lfcp-123456" and "lfcp-222222".
+Are you sure you want to delete compute pools "lfcp-123456" and "lfcp-222222"? All statements leveraging the compute pools will be STOPPED immediately and be available for 30 days in the statement list history.
+After that, they will be permanently deleted. 
+ (y/n): Deleted Flink compute pools "lfcp-123456" and "lfcp-222222".


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

New Features
- Added warning with statement retention time for `confluent flink compute-pool delete`

Checklist
---------
- [x] Leave this box unchecked if features are not yet available in production

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
<!--
Has it been tested? How?
Copy and paste any instructions or steps that can save the reviewer time.
-->