### PR TITLE
[KFS-2043] Allow CLI SET statements to contain equal signs inside key…

### DIFF
--- a/pkg/flink/internal/store/store_test.go
+++ b/pkg/flink/internal/store/store_test.go
@@ -528,7 +528,7 @@ func (s *StoreTestSuite) TestParseSetStatementError() {
 
 	_, _, err = parseSetStatement("SET key=value=as")
 	assert.Equal(s.T(), &types.StatementError{
-		Message: `"=" should only appear once`,
+		Message: `key and value must be enclosed by single quotes (')`,
 		Usage:   []string{"SET 'key'='value'"},
 	}, err)
 
@@ -540,14 +540,14 @@ func (s *StoreTestSuite) TestParseSetStatementError() {
 
 	_, _, err = parseSetStatement(`set ''key'''=''value''`)
 	assert.Equal(s.T(), &types.StatementError{
-		Message:    "key contains unescaped single quotes (')",
+		Message:    "key or value contains unescaped single quotes (')",
 		Usage:      []string{"SET 'key'='value'"},
 		Suggestion: `please escape all single quotes with another single quote "''key''"`,
 	}, err)
 
 	_, _, err = parseSetStatement(`set 'key'=''value''`)
 	assert.Equal(s.T(), &types.StatementError{
-		Message:    "value contains unescaped single quotes (')",
+		Message:    "key or value contains unescaped single quotes (')",
 		Usage:      []string{"SET 'key'='value'"},
 		Suggestion: `please escape all single quotes with another single quote "''key''"`,
 	}, err)

--- a/pkg/flink/internal/store/store_utils_test.go
+++ b/pkg/flink/internal/store/store_utils_test.go
@@ -111,6 +111,18 @@ func TestProcessSetStatement(t *testing.T) {
 		assert.Nil(t, err)
 		assert.EqualValues(t, true, result.IsSensitiveStatement)
 	})
+
+	t.Run("should parse set statements with equal signs in the value", func(t *testing.T) {
+		result, err := s.processSetStatement("set 'sql.secrets.openai' = 'b64encodedABCD=='")
+		assert.Nil(t, err)
+		assert.EqualValues(t, true, result.IsSensitiveStatement)
+	})
+
+	t.Run("should parse set statements with equal signs in the key", func(t *testing.T) {
+		result, err := s.processSetStatement("set 'sql.secrets.openai==' = 'b64encodedABCD=='")
+		assert.Nil(t, err)
+		assert.EqualValues(t, true, result.IsSensitiveStatement)
+	})
 }
 
 func TestProcessResetStatement(t *testing.T) {


### PR DESCRIPTION
Allow CLI SET statements to contain equal signs inside keys and values.

Allows values to be b64 encoded strings, which often end in '=='.

Switched the parsing to use regexes for robustness.

Release Notes
-------------
Bug Fixes
- Flink CLI SQL SET commands are allowed to contain equal signs in the keys and values.

Checklist
---------
- [ ] Leave this box unchecked if features are not yet available in production

What
----
Allow CLI SET statements to contain equal signs inside keys and values. B64 encoded strings often include equal signs, which would have previously not been allowed.

Test & Review
-------------
Covered by unittests