### PR TITLE
CLI-3124: Print role bindings with deleted resources

### DIFF
--- a/internal/iam/command_rbac_role_binding_list.go
+++ b/internal/iam/command_rbac_role_binding_list.go
@@ -501,20 +501,17 @@ func (c *roleBindingCommand) ccloudListRolePrincipals(cmd *cobra.Command, listRo
 		if user, ok := principalToUser[principal]; ok {
 			row.Email = user.GetEmail()
 			row.Name = user.GetFullName()
-			list.Add(row)
 		}
 		if name, ok := serviceAccountToNameMap[principal]; ok {
 			row.Name = name
-			list.Add(row)
 		}
 		if name, ok := poolToNameMap[principal]; ok {
 			row.Name = name
-			list.Add(row)
 		}
 		if name, ok := groupMappingToNameMap[principal]; ok {
 			row.Name = name
-			list.Add(row)
 		}
+		list.Add(row)
 	}
 
 	return list.Print()

--- a/test/fixtures/output/iam/rbac/role-binding/list-user-orgadmin-cloud.golden
+++ b/test/fixtures/output/iam/rbac/role-binding/list-user-orgadmin-cloud.golden
@@ -3,4 +3,5 @@
   User:group-abc  | another-group-mapping |                       
   User:pool-12345 | identity-pool         |                       
   User:sa-12345   | service-account       |                       
+  User:u-11111    |                       |                       
   User:u-11aaa    | 11 Aaa                | u-11aaa@confluent.io  

--- a/test/test-server/iam_handlers.go
+++ b/test/test-server/iam_handlers.go
@@ -26,6 +26,8 @@ var (
 			"crn://confluent.cloud/organization=abc-123/identity-provider="+identityProviderId),
 		buildRoleBinding("rb-11aaa", "u-11aaa", "OrganizationAdmin",
 			"crn://confluent.cloud/organization=abc-123"),
+		buildRoleBinding("rb-11111", "u-11111", "OrganizationAdmin",
+			"crn://confluent.cloud/organization=abc-123"),
 		buildRoleBinding("rb-12345", "sa-12345", "OrganizationAdmin",
 			"crn://confluent.cloud/organization=abc-123"),
 		buildRoleBinding("rb-123ab", "group-abc", "OrganizationAdmin",


### PR DESCRIPTION
Checklist
---------
- [x] Leave this box unchecked if features are not yet available in production

What
----
It's possible for the role binding API to return a specific role binding even though its resource has been deleted. We want to align with the UI and print the role binding in that case.

Test & Review
-------------
Added integration test, will manually test before merging.