### PR TITLE
CLI-3118: Print warning when Cloud URL is passed to CP Kafka REST

### DIFF
--- a/internal/kafka/kafka_rest_onprem.go
+++ b/internal/kafka/kafka_rest_onprem.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/confluentinc/kafka-rest-sdk-go/kafkarestv3"
 
+	"github.com/confluentinc/cli/v3/pkg/ccloudv2"
 	pcmd "github.com/confluentinc/cli/v3/pkg/cmd"
 	"github.com/confluentinc/cli/v3/pkg/errors"
 	"github.com/confluentinc/cli/v3/pkg/kafkarest"
@@ -22,7 +23,7 @@ func initKafkaRest(c *pcmd.AuthenticatedCLICommand, cmd *cobra.Command) (*kafkar
 		return nil, nil, "", err
 	}
 
-	if strings.Contains(url, "confluent.cloud") {
+	if ccloudv2.IsCCloudURL(url, c.Config.IsTest) {
 		output.ErrPrintf(c.Config.EnableColor, "[WARN] This is a Confluent Platform command. Confluent Cloud URLs are not supported.\n")
 	}
 

--- a/internal/kafka/kafka_rest_onprem.go
+++ b/internal/kafka/kafka_rest_onprem.go
@@ -21,6 +21,11 @@ func initKafkaRest(c *pcmd.AuthenticatedCLICommand, cmd *cobra.Command) (*kafkar
 	if err != nil { // require the flag
 		return nil, nil, "", err
 	}
+
+	if strings.Contains(url, "confluent.cloud") {
+		output.ErrPrintf(c.Config.EnableColor, "[WARN] This is a Confluent Platform command. Confluent Cloud URLs are not supported.\n")
+	}
+
 	kafkaREST, err := c.GetKafkaREST()
 	if err != nil {
 		return nil, nil, "", err

--- a/test/fixtures/output/kafka/broker/list-warning-cloud-url.golden
+++ b/test/fixtures/output/kafka/broker/list-warning-cloud-url.golden
@@ -1,0 +1,2 @@
+[WARN] This is a Confluent Platform command. Confluent Cloud URLs are not supported.
+Error: unable to establish Kafka REST connection: https://pkc-12345.us-west-2.aws.confluent.cloud:44/v3: dial tcp: lookup pkc-12345.us-west-2.aws.confluent.cloud: no such host

--- a/test/fixtures/output/kafka/broker/list-warning-cloud-url.golden
+++ b/test/fixtures/output/kafka/broker/list-warning-cloud-url.golden
@@ -1,2 +1,5 @@
 [WARN] This is a Confluent Platform command. Confluent Cloud URLs are not supported.
-Error: unable to establish Kafka REST connection: https://pkc-12345.us-west-2.aws.confluent.cloud:44/v3: dial tcp: lookup pkc-12345.us-west-2.aws.confluent.cloud: no such host
+Error: Kafka REST request failed: GET http://127.0.0.1:1024/v3/clusters: 404 Not Found
+
+Suggestions:
+    Please check the status of your Kafka cluster or submit a support ticket.

--- a/test/kafka_test.go
+++ b/test/kafka_test.go
@@ -227,10 +227,6 @@ func getCreateBidirectionalLinkConfigFile() string {
 func (s *CLITestSuite) TestKafkaBroker() {
 	kafkaRestURL := s.TestBackend.GetKafkaRestUrl()
 	tests := []CLITest{
-		{args: "kafka broker list", fixture: "kafka/broker/list.golden"},
-		{args: "kafka broker list -o json", fixture: "kafka/broker/list-json.golden"},
-		{args: "kafka broker list -o yaml", fixture: "kafka/broker/list-yaml.golden"},
-
 		{args: "kafka broker describe 1", fixture: "kafka/broker/describe-1.golden"},
 		{args: "kafka broker describe 1 -o json", fixture: "kafka/broker/describe-1-json.golden"},
 		{args: "kafka broker describe 1 -o yaml", fixture: "kafka/broker/describe-1-yaml.golden"},
@@ -261,6 +257,20 @@ func (s *CLITestSuite) TestKafkaBroker() {
 	for _, test := range tests {
 		test.login = "onprem"
 		test.env = []string{"CONFLUENT_REST_URL=" + kafkaRestURL}
+		s.runIntegrationTest(test)
+	}
+}
+
+func (s *CLITestSuite) TestKafkaBrokerList() {
+	tests := []CLITest{
+		{args: fmt.Sprintf("kafka broker list --url %s", s.TestBackend.GetKafkaRestUrl()), fixture: "kafka/broker/list.golden"},
+		{args: "kafka broker list --url https://pkc-12345.us-west-2.aws.confluent.cloud:443", fixture: "kafka/broker/list-warning-cloud-url.golden", exitCode: 1},
+		{args: fmt.Sprintf("kafka broker list --url %s -o json", s.TestBackend.GetKafkaRestUrl()), fixture: "kafka/broker/list-json.golden"},
+		{args: fmt.Sprintf("kafka broker list --url %s -o yaml", s.TestBackend.GetKafkaRestUrl()), fixture: "kafka/broker/list-yaml.golden"},
+	}
+
+	for _, test := range tests {
+		test.login = "onprem"
 		s.runIntegrationTest(test)
 	}
 }

--- a/test/kafka_test.go
+++ b/test/kafka_test.go
@@ -264,7 +264,7 @@ func (s *CLITestSuite) TestKafkaBroker() {
 func (s *CLITestSuite) TestKafkaBrokerList() {
 	tests := []CLITest{
 		{args: fmt.Sprintf("kafka broker list --url %s", s.TestBackend.GetKafkaRestUrl()), fixture: "kafka/broker/list.golden"},
-		{args: "kafka broker list --url https://pkc-12345.us-west-2.aws.confluent.cloud:443", fixture: "kafka/broker/list-warning-cloud-url.golden", exitCode: 1},
+		{args: fmt.Sprintf("kafka broker list --url %s", s.TestBackend.GetCloudUrl()), fixture: "kafka/broker/list-warning-cloud-url.golden", exitCode: 1},
 		{args: fmt.Sprintf("kafka broker list --url %s -o json", s.TestBackend.GetKafkaRestUrl()), fixture: "kafka/broker/list-json.golden"},
 		{args: fmt.Sprintf("kafka broker list --url %s -o yaml", s.TestBackend.GetKafkaRestUrl()), fixture: "kafka/broker/list-yaml.golden"},
 	}


### PR DESCRIPTION
Release Notes
-------------
New Features
- Print a warning when a Confluent Cloud Kafka REST URL is passed to Confluent Platform Kafka REST

Checklist
---------
- [x] Leave this box unchecked if features are not yet available in production

What
----
Warn on bad URLs such as `confluent kafka broker list --url https://pkc-12345.us-west-2.aws.confluent.cloud:443`

Test & Review
-------------
Added integration test