### PR TITLE
refactor: KFS-2060 put new retention time behind feature flag

### DIFF
--- a/internal/flink/command_compute_pool_delete.go
+++ b/internal/flink/command_compute_pool_delete.go
@@ -7,8 +7,10 @@ import (
 	"github.com/spf13/cobra"
 
 	pcmd "github.com/confluentinc/cli/v3/pkg/cmd"
+	"github.com/confluentinc/cli/v3/pkg/config"
 	"github.com/confluentinc/cli/v3/pkg/deletion"
 	"github.com/confluentinc/cli/v3/pkg/errors"
+	"github.com/confluentinc/cli/v3/pkg/featureflags"
 	"github.com/confluentinc/cli/v3/pkg/resource"
 	"github.com/confluentinc/cli/v3/pkg/utils"
 )
@@ -49,7 +51,7 @@ func (c *command) computePoolDelete(cmd *cobra.Command, args []string) error {
 		return err == nil
 	}
 
-	if err := validateAndConfirmComputePoolDeletion(cmd, args, existenceFunc, resource.FlinkComputePool, computePool.Spec.GetDisplayName()); err != nil {
+	if err := c.validateAndConfirmComputePoolDeletion(cmd, args, existenceFunc, resource.FlinkComputePool, computePool.Spec.GetDisplayName()); err != nil {
 		return err
 	}
 
@@ -77,7 +79,11 @@ func confirmMultipleDeletionString(idList []string) string {
 		"After that, they will be permanently deleted. \n", utils.ArrayToCommaDelimitedString(idList, "and"))
 }
 
-func validateAndConfirmComputePoolDeletion(cmd *cobra.Command, args []string, checkExistence func(string) bool, resourceType, name string) error {
+func (c *command) validateAndConfirmComputePoolDeletion(cmd *cobra.Command, args []string, checkExistence func(string) bool, resourceType, name string) error {
+	if !featureflags.Manager.BoolVariation("flink.statement.30_days_retention_time", c.Context, config.CliLaunchDarklyClient, true, true) {
+		return deletion.ValidateAndConfirmDeletion(cmd, args, checkExistence, resourceType, name)
+	}
+
 	if err := resource.ValidatePrefixes(resourceType, args); err != nil {
 		return err
 	}


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Checklist
---------
- [x] Leave this box unchecked if features are not yet available in production

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->
We want to toggle the change with the new statement retention time message with a feature flag

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
<!--
Has it been tested? How?
Copy and paste any instructions or steps that can save the reviewer time.
-->