### PR TITLE
[CLI-3126] Fix panic in Connect offset commands

### DIFF
--- a/internal/connect/command_offset_status_describe.go
+++ b/internal/connect/command_offset_status_describe.go
@@ -94,7 +94,7 @@ func (c *offsetCommand) statusDescribe(cmd *cobra.Command, args []string) error 
 
 func printHumanDescribeOffsetStatus(cmd *cobra.Command, offsetStatus connectv1.ConnectV1AlterOffsetStatus, id string) error {
 	var appliedAt string
-	if offsetStatus.AppliedAt.IsSet() {
+	if offsetStatus.AppliedAt.Get() != nil {
 		appliedAt = offsetStatus.AppliedAt.Get().String()
 	}
 
@@ -147,7 +147,7 @@ func printHumanDescribeOffsetStatus(cmd *cobra.Command, offsetStatus connectv1.C
 
 func printSerializedDescribeOffsetStatus(cmd *cobra.Command, offsetStatus connectv1.ConnectV1AlterOffsetStatus, id string) error {
 	var appliedAt string
-	if offsetStatus.AppliedAt.IsSet() {
+	if offsetStatus.AppliedAt.Get() != nil {
 		appliedAt = offsetStatus.AppliedAt.Get().String()
 	}
 


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- PLACEHOLDER

New Features
- PLACEHOLDER

Bug Fixes
- Prevent `confluent connect offset delete`, `confluent connect offset update`, and `confluent connect offset status describe` from crashing

Checklist
---------
- [x] Leave this box unchecked if features are not yet available in production

What
----
`IsSet()` in ccloud-sdk-go-v2 doesn't guarantee that a nullable field is actually non-nil, so we need to check directly that it isn't nil.

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
<!--
Has it been tested? How?
Copy and paste any instructions or steps that can save the reviewer time.
-->