### PR TITLE
[CLI-2908] Add plugin uninstall command

### DIFF
--- a/internal/plugin/command.go
+++ b/internal/plugin/command.go
@@ -64,6 +64,7 @@ Naming collisions with existing CLI commands and other plugins:
 	cmd.AddCommand(c.newInstallCommand())
 	cmd.AddCommand(c.newListCommand())
 	cmd.AddCommand(c.newSearchCommand())
+	cmd.AddCommand(c.newUninstallCommand())
 
 	return cmd
 }

--- a/internal/plugin/command_install.go
+++ b/internal/plugin/command_install.go
@@ -56,7 +56,7 @@ func (c *command) install(_ *cobra.Command, args []string) error {
 		return err
 	}
 
-	output.Printf(c.Config.EnableColor, "Installed plugin `%s`.\n", plugin.ToCommandName(manifest.Name))
+	output.Printf(c.Config.EnableColor, "Installed plugin `%s`.\n", plugin.ToCommandName(manifest.Id))
 
 	return nil
 }
@@ -86,7 +86,7 @@ func getPluginManifest(pluginName, dir string) (*Manifest, error) {
 		if err := yaml.Unmarshal(manifestFile, manifest); err != nil {
 			return nil, err
 		}
-		manifest.Name = file.Name()
+		manifest.Id = file.Name()
 
 		return manifest, nil
 	}
@@ -103,16 +103,16 @@ func installPlugin(manifest *Manifest, repositoryDir, installDir string) error {
 	var pluginInstaller plugin.PluginInstaller
 	switch language {
 	case "go":
-		pluginInstaller = &plugin.GoPluginInstaller{Name: manifest.Name}
+		pluginInstaller = &plugin.GoPluginInstaller{Name: manifest.Id}
 	case "python":
 		pluginInstaller = &plugin.PythonPluginInstaller{
-			Name:          manifest.Name,
+			Name:          manifest.Id,
 			RepositoryDir: repositoryDir,
 			InstallDir:    installDir,
 		}
 	case "bash":
 		pluginInstaller = &plugin.BashPluginInstaller{
-			Name:          manifest.Name,
+			Name:          manifest.Id,
 			RepositoryDir: repositoryDir,
 			InstallDir:    installDir,
 		}

--- a/internal/plugin/command_install.go
+++ b/internal/plugin/command_install.go
@@ -103,16 +103,16 @@ func installPlugin(manifest *Manifest, repositoryDir, installDir string) error {
 	var pluginInstaller plugin.PluginInstaller
 	switch language {
 	case "go":
-		pluginInstaller = &plugin.GoPluginInstaller{Name: manifest.Id}
+		pluginInstaller = &plugin.GoPluginInstaller{Id: manifest.Id}
 	case "python":
 		pluginInstaller = &plugin.PythonPluginInstaller{
-			Name:          manifest.Id,
+			Id:            manifest.Id,
 			RepositoryDir: repositoryDir,
 			InstallDir:    installDir,
 		}
 	case "bash":
 		pluginInstaller = &plugin.BashPluginInstaller{
-			Name:          manifest.Id,
+			Id:            manifest.Id,
 			RepositoryDir: repositoryDir,
 			InstallDir:    installDir,
 		}

--- a/internal/plugin/command_install_test.go
+++ b/internal/plugin/command_install_test.go
@@ -19,7 +19,7 @@ func TestGetPluginManifest(t *testing.T) {
 	assert.NoError(t, err)
 
 	referenceManifest := &Manifest{
-		Name:        "confluent-test_plugin",
+		Id:          "confluent-test_plugin",
 		Description: "Does nothing",
 		Dependencies: []Dependency{
 			{

--- a/internal/plugin/command_install_test.go
+++ b/internal/plugin/command_install_test.go
@@ -51,7 +51,7 @@ func TestInstallPythonPlugin(t *testing.T) {
 	defer os.RemoveAll(dir)
 
 	pluginInstaller := &plugin.PythonPluginInstaller{
-		Name:          "confluent-test_plugin",
+		Id:            "confluent-test_plugin",
 		RepositoryDir: filepath.Join("..", "..", "test", "fixtures", "input", "plugin"),
 		InstallDir:    dir,
 	}

--- a/internal/plugin/command_list.go
+++ b/internal/plugin/command_list.go
@@ -15,8 +15,8 @@ import (
 )
 
 type out struct {
-	PluginName string `human:"Plugin Name" serialized:"plugin_name"`
-	PluginId   string `human:"Plugin Id" serialized:"plugin_id"`
+	PluginName string `human:"Name" serialized:"plugin_name"`
+	PluginId   string `human:"ID" serialized:"plugin_id"`
 	FilePath   string `human:"File Path" serialized:"file_path"`
 }
 
@@ -52,15 +52,15 @@ func (c *command) list(cmd *cobra.Command, _ []string) error {
 
 	list := output.NewList(cmd)
 	var overshadowedPlugins, nameConflictPlugins []*out
-	for name, paths := range pluginMap {
+	for id, paths := range pluginMap {
 		path := paths[0]
 		if home != "" && strings.HasPrefix(path, home) {
 			path = filepath.Join("~", strings.TrimPrefix(path, home))
 		}
 
 		pluginInfo := &out{
-			PluginName: strings.ReplaceAll(strings.ReplaceAll(name, "-", " "), "_", "-"),
-			PluginId:   name,
+			PluginName: strings.ReplaceAll(strings.ReplaceAll(id, "-", " "), "_", "-"),
+			PluginId:   id,
 			FilePath:   path,
 		}
 

--- a/internal/plugin/command_list.go
+++ b/internal/plugin/command_list.go
@@ -59,7 +59,7 @@ func (c *command) list(cmd *cobra.Command, _ []string) error {
 		}
 
 		pluginInfo := &out{
-			PluginName: strings.ReplaceAll(strings.ReplaceAll(id, "-", " "), "_", "-"),
+			PluginName: plugin.ToCommandName(id),
 			PluginId:   id,
 			FilePath:   path,
 		}

--- a/internal/plugin/command_list.go
+++ b/internal/plugin/command_list.go
@@ -16,6 +16,7 @@ import (
 
 type out struct {
 	PluginName string `human:"Plugin Name" serialized:"plugin_name"`
+	PluginId   string `human:"Plugin Id" serialized:"plugin_id"`
 	FilePath   string `human:"File Path" serialized:"file_path"`
 }
 
@@ -59,6 +60,7 @@ func (c *command) list(cmd *cobra.Command, _ []string) error {
 
 		pluginInfo := &out{
 			PluginName: strings.ReplaceAll(strings.ReplaceAll(name, "-", " "), "_", "-"),
+			PluginId:   name,
 			FilePath:   path,
 		}
 

--- a/internal/plugin/command_search.go
+++ b/internal/plugin/command_search.go
@@ -16,12 +16,14 @@ import (
 )
 
 type ManifestOut struct {
+	Name         string `human:"Name" serialized:"Name"`
 	Id           string `human:"ID" serialized:"ID"`
 	Description  string `human:"Description" serialized:"description"`
 	Dependencies string `human:"Dependencies" serialized:"dependencies"`
 }
 
 type Manifest struct {
+	Name         string
 	Id           string
 	Description  string       `yaml:"description"`
 	Dependencies []Dependency `yaml:"dependencies"`
@@ -103,6 +105,7 @@ func getPluginManifests(dir string) ([]*ManifestOut, error) {
 				return nil, err
 			}
 			manifestOut := ManifestOut{
+				Name:         strings.ReplaceAll(strings.ReplaceAll(file.Name(), "-", " "), "_", "-"),
 				Id:           file.Name(),
 				Description:  manifest.Description,
 				Dependencies: strings.Join(dependenciesToStrings(manifest.Dependencies), ", "),

--- a/internal/plugin/command_search.go
+++ b/internal/plugin/command_search.go
@@ -2,7 +2,6 @@ package plugin
 
 import (
 	"fmt"
-	"github.com/confluentinc/cli/v3/pkg/plugin"
 	"os"
 	"path/filepath"
 	"strings"
@@ -13,6 +12,7 @@ import (
 
 	pcmd "github.com/confluentinc/cli/v3/pkg/cmd"
 	"github.com/confluentinc/cli/v3/pkg/output"
+	"github.com/confluentinc/cli/v3/pkg/plugin"
 	"github.com/confluentinc/cli/v3/pkg/utils"
 )
 

--- a/internal/plugin/command_search.go
+++ b/internal/plugin/command_search.go
@@ -16,13 +16,13 @@ import (
 )
 
 type ManifestOut struct {
-	Name         string `human:"Name" serialized:"name"`
+	Id           string `human:"Id" serialized:"name"`
 	Description  string `human:"Description" serialized:"description"`
 	Dependencies string `human:"Dependencies" serialized:"dependencies"`
 }
 
 type Manifest struct {
-	Name         string
+	Id           string
 	Description  string       `yaml:"description"`
 	Dependencies []Dependency `yaml:"dependencies"`
 }
@@ -103,7 +103,7 @@ func getPluginManifests(dir string) ([]*ManifestOut, error) {
 				return nil, err
 			}
 			manifestOut := ManifestOut{
-				Name:         file.Name(),
+				Id:           file.Name(),
 				Description:  manifest.Description,
 				Dependencies: strings.Join(dependenciesToStrings(manifest.Dependencies), ", "),
 			}

--- a/internal/plugin/command_search.go
+++ b/internal/plugin/command_search.go
@@ -16,7 +16,7 @@ import (
 )
 
 type ManifestOut struct {
-	Id           string `human:"Id" serialized:"name"`
+	Id           string `human:"ID" serialized:"ID"`
 	Description  string `human:"Description" serialized:"description"`
 	Dependencies string `human:"Dependencies" serialized:"dependencies"`
 }

--- a/internal/plugin/command_search.go
+++ b/internal/plugin/command_search.go
@@ -2,6 +2,7 @@ package plugin
 
 import (
 	"fmt"
+	"github.com/confluentinc/cli/v3/pkg/plugin"
 	"os"
 	"path/filepath"
 	"strings"
@@ -105,7 +106,7 @@ func getPluginManifests(dir string) ([]*ManifestOut, error) {
 				return nil, err
 			}
 			manifestOut := ManifestOut{
-				Name:         strings.ReplaceAll(strings.ReplaceAll(file.Name(), "-", " "), "_", "-"),
+				Name:         plugin.ToCommandName(file.Name()),
 				Id:           file.Name(),
 				Description:  manifest.Description,
 				Dependencies: strings.Join(dependenciesToStrings(manifest.Dependencies), ", "),

--- a/internal/plugin/command_search_test.go
+++ b/internal/plugin/command_search_test.go
@@ -86,6 +86,7 @@ func TestGetPluginManifests(t *testing.T) {
 	referenceManifests := []*ManifestOut{
 		{
 			Id:           "confluent-test_plugin",
+			Name:         "confluent test-plugin",
 			Description:  "Does nothing",
 			Dependencies: "Python 3",
 		},

--- a/internal/plugin/command_search_test.go
+++ b/internal/plugin/command_search_test.go
@@ -85,7 +85,7 @@ func TestGetPluginManifests(t *testing.T) {
 
 	referenceManifests := []*ManifestOut{
 		{
-			Name:         "confluent-test_plugin",
+			Id:           "confluent-test_plugin",
 			Description:  "Does nothing",
 			Dependencies: "Python 3",
 		},

--- a/internal/plugin/command_uninstall.go
+++ b/internal/plugin/command_uninstall.go
@@ -26,7 +26,7 @@ func (c *command) uninstall(cmd *cobra.Command, args []string) error {
 		return ok
 	}
 
-	if err := deletion.ValidateAndConfirmDeletionYesNo(cmd, args, existenceFunc, resource.Plugin); err != nil {
+	if err := deletion.ValidateAndConfirm(cmd, args, existenceFunc, resource.Plugin); err != nil {
 		return err
 	}
 

--- a/internal/plugin/command_uninstall.go
+++ b/internal/plugin/command_uninstall.go
@@ -1,12 +1,14 @@
 package plugin
 
 import (
+	"os"
+
+	"github.com/spf13/cobra"
+
 	pcmd "github.com/confluentinc/cli/v3/pkg/cmd"
 	"github.com/confluentinc/cli/v3/pkg/deletion"
 	"github.com/confluentinc/cli/v3/pkg/plugin"
 	"github.com/confluentinc/cli/v3/pkg/resource"
-	"github.com/spf13/cobra"
-	"os"
 )
 
 func (c *command) newUninstallCommand() *cobra.Command {

--- a/internal/plugin/command_uninstall.go
+++ b/internal/plugin/command_uninstall.go
@@ -13,7 +13,6 @@ func (c *command) newUninstallCommand() *cobra.Command {
 	return &cobra.Command{
 		Use:   "uninstall <plugin-id-1> [plugin-id-2] ... [plugin-id-n]",
 		Short: "Uninstall official Confluent CLI plugins.",
-		Long:  "Uninstall official Confluent CLI plugins from the confluentinc/cli-plugins repository.",
 		Args:  cobra.MinimumNArgs(1),
 		RunE:  c.uninstall,
 	}

--- a/internal/plugin/command_uninstall.go
+++ b/internal/plugin/command_uninstall.go
@@ -31,10 +31,7 @@ func (c *command) uninstall(cmd *cobra.Command, args []string) error {
 	}
 
 	deleteFunc := func(name string) error {
-		if err := os.Remove(pluginMap[name][0]); err != nil {
-			return err
-		}
-		return nil
+		return os.Remove(pluginMap[name][0])
 	}
 
 	_, err := deletion.Delete(args, deleteFunc, resource.Plugin)

--- a/internal/plugin/command_uninstall.go
+++ b/internal/plugin/command_uninstall.go
@@ -1,0 +1,43 @@
+package plugin
+
+import (
+	pcmd "github.com/confluentinc/cli/v3/pkg/cmd"
+	"github.com/confluentinc/cli/v3/pkg/deletion"
+	"github.com/confluentinc/cli/v3/pkg/plugin"
+	"github.com/confluentinc/cli/v3/pkg/resource"
+	"github.com/spf13/cobra"
+	"os"
+)
+
+func (c *command) newUninstallCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "uninstall <plugin-id-1> [plugin-id-2] ... [plugin-id-n]",
+		Short: "Uninstall official Confluent CLI plugins.",
+		Long:  "Uninstall official Confluent CLI plugins from the confluentinc/cli-plugins repository.",
+		Args:  cobra.MinimumNArgs(1),
+		RunE:  c.uninstall,
+	}
+}
+
+func (c *command) uninstall(cmd *cobra.Command, args []string) error {
+	pcmd.AddForceFlag(cmd)
+	pluginMap := plugin.SearchPath(c.cfg)
+	existenceFunc := func(name string) bool {
+		_, ok := pluginMap[name]
+		return ok
+	}
+
+	if err := deletion.ValidateAndConfirmDeletionYesNo(cmd, args, existenceFunc, resource.Plugin); err != nil {
+		return err
+	}
+
+	deleteFunc := func(name string) error {
+		if err := os.Remove(pluginMap[name][0]); err != nil {
+			return err
+		}
+		return nil
+	}
+
+	_, err := deletion.Delete(args, deleteFunc, resource.Plugin)
+	return err
+}

--- a/pkg/plugin/bash_plugin_installer.go
+++ b/pkg/plugin/bash_plugin_installer.go
@@ -12,7 +12,7 @@ import (
 )
 
 type BashPluginInstaller struct {
-	Name          string
+	Id            string
 	RepositoryDir string
 	InstallDir    string
 }
@@ -51,5 +51,5 @@ func (b *BashPluginInstaller) CheckVersion(ver *version.Version) error {
 }
 
 func (b *BashPluginInstaller) Install() error {
-	return installSimplePlugin(b.Name, b.RepositoryDir, b.InstallDir, "bash")
+	return installSimplePlugin(b.Id, b.RepositoryDir, b.InstallDir, "bash")
 }

--- a/pkg/plugin/go_plugin_installer.go
+++ b/pkg/plugin/go_plugin_installer.go
@@ -12,7 +12,7 @@ import (
 )
 
 type GoPluginInstaller struct {
-	Name string
+	Id string
 }
 
 func (g *GoPluginInstaller) IsVersion(word string) bool {
@@ -48,7 +48,7 @@ func (g *GoPluginInstaller) CheckVersion(ver *version.Version) error {
 }
 
 func (g *GoPluginInstaller) Install() error {
-	packageName := fmt.Sprintf("github.com/confluentinc/cli/v3-plugins/%s@latest", g.Name)
+	packageName := fmt.Sprintf("github.com/confluentinc/cli-plugins/%s@latest", g.Id)
 	installCmd := exec.NewCommand("go", "install", packageName)
 
 	if _, err := installCmd.Output(); err != nil {

--- a/pkg/plugin/python_plugin_installer.go
+++ b/pkg/plugin/python_plugin_installer.go
@@ -12,7 +12,7 @@ import (
 )
 
 type PythonPluginInstaller struct {
-	Name          string
+	Id            string
 	RepositoryDir string
 	InstallDir    string
 }
@@ -64,5 +64,5 @@ func (p *PythonPluginInstaller) CheckVersion(ver *version.Version) error {
 }
 
 func (p *PythonPluginInstaller) Install() error {
-	return installSimplePlugin(p.Name, p.RepositoryDir, p.InstallDir, "python")
+	return installSimplePlugin(p.Id, p.RepositoryDir, p.InstallDir, "python")
 }

--- a/pkg/resource/resource.go
+++ b/pkg/resource/resource.go
@@ -47,6 +47,7 @@ const (
 	NetworkLinkServiceAssociation   = "network link service association"
 	Organization                    = "organization"
 	Peering                         = "peering"
+	Plugin                          = "plugin"
 	PrivateLinkAccess               = "private link access"
 	PrivateLinkAttachment           = "private link attachment"
 	PrivateLinkAttachmentConnection = "private link attachment connection"

--- a/test/fixtures/output/plugin/help-onprem.golden
+++ b/test/fixtures/output/plugin/help-onprem.golden
@@ -42,6 +42,7 @@ Available Commands:
   install     Install or update official Confluent CLI plugins.
   list        List Confluent CLI plugins in $PATH.
   search      Search for Confluent CLI plugins.
+  uninstall   Uninstall official Confluent CLI plugins.
 
 Global Flags:
   -h, --help            Show help for this command.

--- a/test/fixtures/output/plugin/help.golden
+++ b/test/fixtures/output/plugin/help.golden
@@ -42,6 +42,7 @@ Available Commands:
   install     Install or update official Confluent CLI plugins.
   list        List Confluent CLI plugins in $PATH.
   search      Search for Confluent CLI plugins.
+  uninstall   Uninstall official Confluent CLI plugins.
 
 Global Flags:
   -h, --help            Show help for this command.

--- a/test/fixtures/output/plugin/list.golden
+++ b/test/fixtures/output/plugin/list.golden
@@ -1,14 +1,14 @@
-           Plugin Name           |                             File Path                               
----------------------------------+---------------------------------------------------------------------
-  confluent another-dash-test    | test/fixtures/input/plugin/confluent-another_dash_test-but_with.sh  
-  but-with                       |                                                                     
-  confluent can print to stderr  | test/fixtures/input/plugin/confluent-can-print-to-stderr.sh         
-  confluent cli command          | test/fixtures/input/plugin/confluent-cli-command                    
-  confluent dash-test            | test/fixtures/input/plugin/confluent-dash_test.sh                   
-  confluent foo bar baz boo far  | test/fixtures/input/plugin/confluent-foo-bar-baz-boo-far.sh         
-  confluent kafka something      | test/fixtures/input/plugin/confluent-kafka-something.sh             
-  confluent plugin1              | test/fixtures/input/plugin/confluent-plugin1.sh                     
-  confluent plugin2              | test/fixtures/input/plugin/confluent-plugin2.sh                     
-  confluent print args           | test/fixtures/input/plugin/confluent-print-args.sh                  
+           Plugin Name           |              Plugin Id               |                             File Path                               
+---------------------------------+--------------------------------------+---------------------------------------------------------------------
+  confluent another-dash-test    | confluent-another_dash_test-but_with | test/fixtures/input/plugin/confluent-another_dash_test-but_with.sh  
+  but-with                       |                                      |                                                                     
+  confluent can print to stderr  | confluent-can-print-to-stderr        | test/fixtures/input/plugin/confluent-can-print-to-stderr.sh         
+  confluent cli command          | confluent-cli-command                | test/fixtures/input/plugin/confluent-cli-command                    
+  confluent dash-test            | confluent-dash_test                  | test/fixtures/input/plugin/confluent-dash_test.sh                   
+  confluent foo bar baz boo far  | confluent-foo-bar-baz-boo-far        | test/fixtures/input/plugin/confluent-foo-bar-baz-boo-far.sh         
+  confluent kafka something      | confluent-kafka-something            | test/fixtures/input/plugin/confluent-kafka-something.sh             
+  confluent plugin1              | confluent-plugin1                    | test/fixtures/input/plugin/confluent-plugin1.sh                     
+  confluent plugin2              | confluent-plugin2                    | test/fixtures/input/plugin/confluent-plugin2.sh                     
+  confluent print args           | confluent-print-args                 | test/fixtures/input/plugin/confluent-print-args.sh                  
 [WARN] The built-in command `confluent version` will be run instead of the duplicate plugin at test/fixtures/input/plugin/confluent-version.
 [WARN] The command `confluent plugin2` will run the plugin listed above instead of the duplicate plugin at test/fixtures/input/plugin/test/confluent-plugin2.

--- a/test/fixtures/output/plugin/list.golden
+++ b/test/fixtures/output/plugin/list.golden
@@ -1,4 +1,4 @@
-           Plugin Name           |              Plugin Id               |                             File Path                               
+               Name              |                  ID                  |                             File Path                               
 ---------------------------------+--------------------------------------+---------------------------------------------------------------------
   confluent another-dash-test    | confluent-another_dash_test-but_with | test/fixtures/input/plugin/confluent-another_dash_test-but_with.sh  
   but-with                       |                                      |                                                                     

--- a/test/fixtures/output/plugin/uninstall-help-onprem.golden
+++ b/test/fixtures/output/plugin/uninstall-help-onprem.golden
@@ -1,4 +1,4 @@
-Uninstall official Confluent CLI plugins from the confluentinc/cli-plugins repository.
+Uninstall official Confluent CLI plugins.
 
 Usage:
   confluent plugin uninstall <plugin-id-1> [plugin-id-2] ... [plugin-id-n] [flags]

--- a/test/fixtures/output/plugin/uninstall-help-onprem.golden
+++ b/test/fixtures/output/plugin/uninstall-help-onprem.golden
@@ -1,0 +1,9 @@
+Uninstall official Confluent CLI plugins from the confluentinc/cli-plugins repository.
+
+Usage:
+  confluent plugin uninstall <plugin-id-1> [plugin-id-2] ... [plugin-id-n] [flags]
+
+Global Flags:
+  -h, --help            Show help for this command.
+      --unsafe-trace    Equivalent to -vvvv, but also log HTTP requests and responses which might contain plaintext secrets.
+  -v, --verbose count   Increase verbosity (-v for warn, -vv for info, -vvv for debug, -vvvv for trace).

--- a/test/fixtures/output/plugin/uninstall-help.golden
+++ b/test/fixtures/output/plugin/uninstall-help.golden
@@ -1,4 +1,4 @@
-Uninstall official Confluent CLI plugins from the confluentinc/cli-plugins repository.
+Uninstall official Confluent CLI plugins.
 
 Usage:
   confluent plugin uninstall <plugin-id-1> [plugin-id-2] ... [plugin-id-n] [flags]

--- a/test/fixtures/output/plugin/uninstall-help.golden
+++ b/test/fixtures/output/plugin/uninstall-help.golden
@@ -1,0 +1,9 @@
+Uninstall official Confluent CLI plugins from the confluentinc/cli-plugins repository.
+
+Usage:
+  confluent plugin uninstall <plugin-id-1> [plugin-id-2] ... [plugin-id-n] [flags]
+
+Global Flags:
+  -h, --help            Show help for this command.
+      --unsafe-trace    Equivalent to -vvvv, but also log HTTP requests and responses which might contain plaintext secrets.
+  -v, --verbose count   Increase verbosity (-v for warn, -vv for info, -vvv for debug, -vvvv for trace).

--- a/test/fixtures/output/plugin/uninstall.golden
+++ b/test/fixtures/output/plugin/uninstall.golden
@@ -1,0 +1,1 @@
+Are you sure you want to delete plugin "confluent-test-plugin-uninstall"? (y/n): Deleted plugin "confluent-test-plugin-uninstall".

--- a/test/plugin_test.go
+++ b/test/plugin_test.go
@@ -2,14 +2,13 @@ package test
 
 import (
 	"fmt"
+	"github.com/confluentinc/cli/v3/pkg/utils"
 	"io/fs"
 	"os"
 	"runtime"
 	"strings"
 
 	"github.com/stretchr/testify/require"
-
-	"github.com/confluentinc/cli/v3/pkg/utils"
 )
 
 func (s *CLITestSuite) TestPlugin() {
@@ -49,6 +48,8 @@ func (s *CLITestSuite) TestPluginUninstall() {
 	file, err := os.Create(filename)
 	req.NoError(err)
 	err = file.Chmod(fs.ModePerm)
+	req.NoError(err)
+	err = file.Close()
 	req.NoError(err)
 	defer func() {
 		if utils.FileExists(filename) {

--- a/test/plugin_test.go
+++ b/test/plugin_test.go
@@ -2,12 +2,14 @@ package test
 
 import (
 	"fmt"
-	"github.com/confluentinc/cli/v3/pkg/utils"
-	"github.com/stretchr/testify/require"
 	"io/fs"
 	"os"
 	"runtime"
 	"strings"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/confluentinc/cli/v3/pkg/utils"
 )
 
 func (s *CLITestSuite) TestPlugin() {

--- a/test/plugin_test.go
+++ b/test/plugin_test.go
@@ -2,13 +2,14 @@ package test
 
 import (
 	"fmt"
-	"github.com/confluentinc/cli/v3/pkg/utils"
 	"io/fs"
 	"os"
 	"runtime"
 	"strings"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/confluentinc/cli/v3/pkg/utils"
 )
 
 func (s *CLITestSuite) TestPlugin() {

--- a/test/plugin_test.go
+++ b/test/plugin_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"github.com/confluentinc/cli/v3/pkg/utils"
 	"github.com/stretchr/testify/require"
+	"io/fs"
 	"os"
 	"runtime"
 	"strings"
@@ -43,7 +44,9 @@ func (s *CLITestSuite) TestPlugin() {
 func (s *CLITestSuite) TestPluginUninstall() {
 	req := require.New(s.T())
 	filename := "test/fixtures/input/plugin/confluent-test-plugin-uninstall.sh"
-	_, err := os.OpenFile(filename, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0777)
+	file, err := os.Create(filename)
+	req.NoError(err)
+	err = file.Chmod(fs.ModePerm)
 	req.NoError(err)
 	defer func() {
 		if utils.FileExists(filename) {


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- The "name" field in in the `confluent plugin search` has been renamed to "id"; a new "name" field has been added in its place

New Features
- Added `confluent plugin uninstall` command for Confluent Platform

Checklist
---------
- [x] Leave this box unchecked if features are not yet available in production

What
----
Added plugin uninstall command to remove the plugins that are no longer needed for a user. Also added the ID for a particular plugin in the command plugin list (which can be used as the flag in uninstall) and changed the one of the column names in plugin search for the sake of consistency with list command
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->

References
----------
https://confluentinc.atlassian.net/browse/CLI-2908
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
Created a new function in the TestPluginUninstall in the plugin_test.go class to test the unistall functionality added. This involved creating a dummy plugin, uninstalling it and checking that the plugin list command gives the expected output after the uninstall.
For manual testing, added one of the plugins using the install. Verified it using plugin list command. Then uninstalled it using the plugin uninstall command and again verified the results using the plugin list command.
<!--
Has it been tested? How?
Copy and paste any instructions or steps that can save the reviewer time.
-->