### PR TITLE
SCP-2653-update-flink-artifact-with-runtime_lang-arg

### DIFF
--- a/internal/flink/command_artifact.go
+++ b/internal/flink/command_artifact.go
@@ -1,7 +1,9 @@
 package flink
 
 import (
+	"github.com/confluentinc/cli/v3/pkg/ccloudv2"
 	"github.com/spf13/cobra"
+	"strings"
 
 	connectcustompluginv1 "github.com/confluentinc/ccloud-sdk-go-v2/connect-custom-plugin/v1"
 
@@ -14,6 +16,7 @@ type flinkArtifactOut struct {
 	PluginId      string `human:"Plugin ID" serialized:"plugin_id" `
 	VersionId     string `human:"Version ID" serialized:"version_id" `
 	ContentFormat string `human:"Content Format" serialized:"content_format" `
+	RuntimeLang   string `human:"Runtime Language" serialized:"runtime_language" `
 }
 
 func (c *command) newArtifactCommand() *cobra.Command {
@@ -31,13 +34,26 @@ func (c *command) newArtifactCommand() *cobra.Command {
 	return cmd
 }
 
+func getRuntimeLangAndName(displayName string, suffixes map[string]string) (string, string) {
+	for suffix, lang := range suffixes {
+		if strings.HasSuffix(displayName, suffix) {
+			return lang, strings.TrimSuffix(displayName, suffix)
+		}
+	}
+	return "java", displayName // default values
+}
+
 func printTable(cmd *cobra.Command, plugin connectcustompluginv1.ConnectV1CustomConnectorPlugin) error {
+	displayName := plugin.GetDisplayName()
+	runtimeLang, name := getRuntimeLangAndName(displayName, ccloudv2.FlinkArtifactRuntimeSuffixes)
+
 	table := output.NewTable(cmd)
 	table.Add(&flinkArtifactOut{
-		Name:          plugin.GetDisplayName(),
+		Name:          name,
 		PluginId:      plugin.GetId(),
 		VersionId:     plugin.GetConnectorClass(),
 		ContentFormat: plugin.GetContentFormat(),
+		RuntimeLang:   runtimeLang,
 	})
 
 	return table.Print()

--- a/internal/flink/command_artifact_list.go
+++ b/internal/flink/command_artifact_list.go
@@ -1,6 +1,7 @@
 package flink
 
 import (
+	"github.com/confluentinc/cli/v3/pkg/ccloudv2"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -10,8 +11,9 @@ import (
 )
 
 type customPluginOutList struct {
-	Id   string `human:"ID" serialized:"id"`
-	Name string `human:"Name" serialized:"name"`
+	Id          string `human:"ID" serialized:"id"`
+	Name        string `human:"Name" serialized:"name"`
+	RuntimeLang string `human:"Runtime Language" serialized:"runtime_language"`
 }
 
 func (c *command) newListCommand() *cobra.Command {
@@ -37,9 +39,12 @@ func (c *command) list(cmd *cobra.Command, _ []string) error {
 	list := output.NewList(cmd)
 	for _, plugin := range plugins {
 		if strings.HasPrefix(plugin.GetConnectorType(), "flink") {
+			displayName := plugin.GetDisplayName()
+			runtimeLang, name := getRuntimeLangAndName(displayName, ccloudv2.FlinkArtifactRuntimeSuffixes)
 			list.Add(&customPluginOutList{
-				Name: plugin.GetDisplayName(),
-				Id:   plugin.GetId(),
+				Name:        name,
+				Id:          plugin.GetId(),
+				RuntimeLang: runtimeLang,
 			})
 		}
 	}

--- a/pkg/ccloudv2/utils.go
+++ b/pkg/ccloudv2/utils.go
@@ -24,7 +24,12 @@ const (
 )
 
 var (
-	ByocSupportClouds = []string{"aws", "azure"}
+	ByocSupportClouds            = []string{"aws", "azure"}
+	SupportFlinkArtifactRuntime  = []string{"java", "python"}
+	FlinkArtifactRuntimeSuffixes = map[string]string{
+		"_java": "java",
+		"_py":   "python",
+	}
 )
 
 type NullableString interface {

--- a/test/fixtures/output/flink/artifact/create-mismatch-artifact-extension-and-runtime-lang.golden
+++ b/test/fixtures/output/flink/artifact/create-mismatch-artifact-extension-and-runtime-lang.golden
@@ -1,0 +1,1 @@
+Error: only "java" runtime language is allowed for ".jar" artifacts

--- a/test/fixtures/output/flink/artifact/create-missing-runtime-lang.golden
+++ b/test/fixtures/output/flink/artifact/create-missing-runtime-lang.golden
@@ -1,5 +1,4 @@
-Create a Flink UDF artifact.
-
+Error: required flag(s) "runtime-language" not set
 Usage:
   confluent flink artifact create <name> [flags]
 
@@ -19,3 +18,4 @@ Global Flags:
   -h, --help            Show help for this command.
       --unsafe-trace    Equivalent to -vvvv, but also log HTTP requests and responses which might contain plaintext secrets.
   -v, --verbose count   Increase verbosity (-v for warn, -vv for info, -vvv for debug, -vvvv for trace).
+

--- a/test/fixtures/output/flink/artifact/create.golden
+++ b/test/fixtures/output/flink/artifact/create.golden
@@ -1,6 +1,7 @@
-+----------------+------------------+
-| Name           | my-custom-plugin |
-| Plugin ID      | ccp-123456       |
-| Version ID     | ver-123456       |
-| Content Format | JAR              |
-+----------------+------------------+
++------------------+------------------+
+| Name             | my-custom-plugin |
+| Plugin ID        | ccp-123456       |
+| Version ID       | ver-123456       |
+| Content Format   | JAR              |
+| Runtime Language | java             |
++------------------+------------------+

--- a/test/fixtures/output/flink/artifact/describe.golden
+++ b/test/fixtures/output/flink/artifact/describe.golden
@@ -1,6 +1,7 @@
-+----------------+---------------+
-| Name           | CliPluginTest |
-| Plugin ID      | ccp-789013    |
-| Version ID     | ver-123456    |
-| Content Format | JAR           |
-+----------------+---------------+
++------------------+---------------+
+| Name             | CliPluginTest |
+| Plugin ID        | ccp-789013    |
+| Version ID       | ver-123456    |
+| Content Format   | JAR           |
+| Runtime Language | java          |
++------------------+---------------+

--- a/test/fixtures/output/flink/artifact/list.golden
+++ b/test/fixtures/output/flink/artifact/list.golden
@@ -1,3 +1,4 @@
-      ID     |      Name       
--------------+-----------------
-  ccp-789013 | CliPluginTest3  
+      ID     |      Name      | Runtime Language  
+-------------+----------------+-------------------
+  ccp-789013 | CliPluginTest3 | java              
+  ccp-789014 | CliPluginTest4 | python            

--- a/test/flink_test.go
+++ b/test/flink_test.go
@@ -34,8 +34,10 @@ type flinkShellTest struct {
 
 func (s *CLITestSuite) TestFlinkArtifact() {
 	tests := []CLITest{
-		{args: "flink artifact create my-flink-artifact --artifact-file test/fixtures/input/flink/java-udf-examples-3.0.jar", fixture: "flink/artifact/create.golden"},
-		{args: "flink artifact create my-flink-artifact --artifact-file test/fixtures/input/flink/java-udf-examples-3.0.jar --description cliPluginTest", fixture: "flink/artifact/create.golden"},
+		{args: "flink artifact create my-flink-artifact --artifact-file test/fixtures/input/flink/java-udf-examples-3.0.jar --runtime-language java", fixture: "flink/artifact/create.golden"},
+		{args: "flink artifact create my-flink-artifact --artifact-file test/fixtures/input/flink/java-udf-examples-3.0.jar --runtime-language java --description cliPluginTest", fixture: "flink/artifact/create.golden"},
+		{args: "flink artifact create my-flink-artifact --artifact-file test/fixtures/input/flink/java-udf-examples-3.0.jar", fixture: "flink/artifact/create-missing-runtime-lang.golden", exitCode: 1},
+		{args: "flink artifact create my-flink-artifact --artifact-file test/fixtures/input/flink/java-udf-examples-3.0.jar --runtime-language python", fixture: "flink/artifact/create-mismatch-artifact-extension-and-runtime-lang.golden", exitCode: 1},
 		{args: "flink artifact describe ccp-789013", fixture: "flink/artifact/describe.golden"},
 		{args: "flink artifact list", fixture: "flink/artifact/list.golden"},
 		{args: "flink artifact delete ccp-123456 --force", fixture: "flink/artifact/delete.golden"},

--- a/test/test-server/connect_handler.go
+++ b/test/test-server/connect_handler.go
@@ -387,13 +387,21 @@ func handleCustomConnectorPlugins(t *testing.T) http.HandlerFunc {
 			}
 			plugin3 := connectcustompluginv1.ConnectV1CustomConnectorPlugin{
 				Id:             connectcustompluginv1.PtrString("ccp-789013"),
-				DisplayName:    connectcustompluginv1.PtrString("CliPluginTest3"),
+				DisplayName:    connectcustompluginv1.PtrString("CliPluginTest3_java"),
 				ConnectorType:  connectcustompluginv1.PtrString("flink_udf"),
 				Cloud:          connectcustompluginv1.PtrString("AWS"),
 				ConnectorClass: connectcustompluginv1.PtrString("ver_123456"),
 				ContentFormat:  connectcustompluginv1.PtrString("JAR"),
 			}
-			err := json.NewEncoder(w).Encode(connectcustompluginv1.ConnectV1CustomConnectorPluginList{Data: []connectcustompluginv1.ConnectV1CustomConnectorPlugin{plugin1, plugin2, plugin3}})
+			plugin4 := connectcustompluginv1.ConnectV1CustomConnectorPlugin{
+				Id:             connectcustompluginv1.PtrString("ccp-789014"),
+				DisplayName:    connectcustompluginv1.PtrString("CliPluginTest4_py"),
+				ConnectorType:  connectcustompluginv1.PtrString("flink_udf"),
+				Cloud:          connectcustompluginv1.PtrString("AWS"),
+				ConnectorClass: connectcustompluginv1.PtrString("ver_123456"),
+				ContentFormat:  connectcustompluginv1.PtrString("ZIP"),
+			}
+			err := json.NewEncoder(w).Encode(connectcustompluginv1.ConnectV1CustomConnectorPluginList{Data: []connectcustompluginv1.ConnectV1CustomConnectorPlugin{plugin1, plugin2, plugin3, plugin4}})
 			require.NoError(t, err)
 		}
 	}


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->



New Features
- add REQUIRED attribute `runtime-language` for flink artifact, only two choices: python or java

more detailed explanation:
1. input runtime-language: java/python is not case sensitive, code will use toLower() and we store as lowercase in backend. cli will return lowercase type.
2. .zip only allowed for python runtime, .jar only allowed for java runtime



Checklist
---------
- [ ] Leave this box unchecked if features are not yet available in production

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
<!--
Has it been tested? How?
Copy and paste any instructions or steps that can save the reviewer time.
-->