### PR TITLE
Fix missing checks on command run requirements

### DIFF
--- a/pkg/cmd/prerunner.go
+++ b/pkg/cmd/prerunner.go
@@ -538,6 +538,12 @@ func (r *PreRun) createMDSClient(ctx *config.Context, ver *version.Version, unsa
 // Initializes a default KafkaRestClient
 func (r *PreRun) InitializeOnPremKafkaRest(command *AuthenticatedCLICommand) func(*cobra.Command, []string) error {
 	return func(cmd *cobra.Command, args []string) error {
+		// ErrIfMissingRunRequirement is called inside of AuthenticatedWithMDS but we don't return that error
+		// So call it in this func too to avoid skipping the annotation check
+		if err := ErrIfMissingRunRequirement(cmd, r.Config); err != nil {
+			return err
+		}
+
 		// pass mds token as bearer token otherwise use http basic auth
 		// no error means user is logged in with mds and has valid token; on an error we try http basic auth since mds is not needed for RP commands
 		err := r.AuthenticatedWithMDS(command)(cmd, args)

--- a/pkg/cmd/prerunner.go
+++ b/pkg/cmd/prerunner.go
@@ -32,10 +32,6 @@ import (
 
 const autoLoginMsg = "Successful auto-login with non-interactive credentials."
 
-var wrongLoginCommandsMap = map[string]string{
-	"confluent cluster": "confluent kafka cluster",
-}
-
 // PreRun is a helper class for automatically setting up Cobra PersistentPreRun commands
 type PreRunner interface {
 	Anonymous(command *CLICommand, willAuthenticate bool) func(*cobra.Command, []string) error
@@ -408,17 +404,6 @@ func (r *PreRun) AuthenticatedWithMDS(command *AuthenticatedCLICommand) func(*co
 
 		// Even if there was an error while setting the context, notify the user about any unmet run requirements first.
 		if err := ErrIfMissingRunRequirement(cmd, r.Config); err != nil {
-			if err == config.RunningOnPremCommandInCloudErr {
-				for topLevelCmd, suggestCmd := range wrongLoginCommandsMap {
-					if strings.HasPrefix(cmd.CommandPath(), topLevelCmd) {
-						suggestCmdPath := strings.Replace(cmd.CommandPath(), topLevelCmd, suggestCmd, 1)
-						return errors.NewErrorWithSuggestions(
-							fmt.Sprintf("`%s` is not a Confluent Cloud command. Did you mean `%s`?", cmd.CommandPath(), suggestCmdPath),
-							fmt.Sprintf("If you are a Confluent Cloud user, run `%s` instead.\nIf you are attempting to connect to Confluent Platform, login with `confluent login --url <mds-url>` to use `%s`.", suggestCmdPath, cmd.CommandPath()),
-						)
-					}
-				}
-			}
 			return err
 		}
 
@@ -538,15 +523,12 @@ func (r *PreRun) createMDSClient(ctx *config.Context, ver *version.Version, unsa
 // Initializes a default KafkaRestClient
 func (r *PreRun) InitializeOnPremKafkaRest(command *AuthenticatedCLICommand) func(*cobra.Command, []string) error {
 	return func(cmd *cobra.Command, args []string) error {
-		// ErrIfMissingRunRequirement is called inside of AuthenticatedWithMDS but we don't return that error
-		// So call it in this func too to avoid skipping the annotation check
-		if err := ErrIfMissingRunRequirement(cmd, r.Config); err != nil {
-			return err
-		}
-
 		// pass mds token as bearer token otherwise use http basic auth
 		// no error means user is logged in with mds and has valid token; on an error we try http basic auth since mds is not needed for RP commands
 		err := r.AuthenticatedWithMDS(command)(cmd, args)
+		if _, ok := err.(*errors.RunRequirementError); ok {
+			return err
+		}
 		useMdsToken := err == nil
 
 		provider := (KafkaRESTProvider)(func() (*KafkaREST, error) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -58,7 +58,7 @@ var (
 	}
 	RunningOnPremCommandInCloudErr = &errors.RunRequirementError{
 		ErrorMsg:       "this is not a Confluent Cloud command. You must log in to Confluent Platform to use this command",
-		SuggestionsMsg: "Log in to Confluent Platform with `confluent login --url <mds-url>`.\n" + "See available commands with `--help`.",
+		SuggestionsMsg: "Log in to Confluent Platform with `confluent login --url <mds-url>`.\nSee available commands with `--help`.",
 	}
 	RunningSimilarOnPremCommandInCloudErr = func(cmdPath, suggestedCmdPath string) errors.CLITypedError {
 		return &errors.RunRequirementError{

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -58,7 +58,7 @@ var (
 	}
 	RunningOnPremCommandInCloudErr = &errors.RunRequirementError{
 		ErrorMsg:       "this is not a Confluent Cloud command. You must log in to Confluent Platform to use this command",
-		SuggestionsMsg: "Log in to Confluent Platform with `confluent login --url <mds-url>`.\n" + `Use the "--help" flag to see available commands.`,
+		SuggestionsMsg: "Log in to Confluent Platform with `confluent login --url <mds-url>`.\n" + "See available commands with `--help`.",
 	}
 	RunningSimilarOnPremCommandInCloudErr = func(cmdPath, suggestedCmdPath string) errors.CLITypedError {
 		return &errors.RunRequirementError{

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -24,42 +24,48 @@ const emptyFieldIndicator = "EMPTY"
 const signupSuggestion = "If you need a Confluent Cloud account, sign up with `confluent cloud-signup`."
 
 var (
-	RequireCloudLoginErr = errors.NewErrorWithSuggestions(
-		"you must log in to Confluent Cloud to use this command",
-		"Log in with `confluent login`.\n"+signupSuggestion,
-	)
-	RequireCloudLoginOrgUnsuspendedErr = errors.NewErrorWithSuggestions(
-		"you must unsuspend your organization to use this command",
-		errors.SuspendedOrganizationSuggestions,
-	)
-	RequireCloudLoginFreeTrialEndedOrgUnsuspendedErr = errors.NewErrorWithSuggestions(
-		"you must unsuspend your organization to use this command",
-		errors.EndOfFreeTrialSuggestions,
-	)
-	RequireCloudLoginOrOnPremErr = errors.NewErrorWithSuggestions(
-		"you must log in to use this command",
-		"Log in with `confluent login`.\n"+signupSuggestion,
-	)
-	RequireNonAPIKeyCloudLoginErr = errors.NewErrorWithSuggestions(
-		"you must log in to Confluent Cloud with a username and password to use this command",
-		"Log in with `confluent login`.\n"+signupSuggestion,
-	)
-	RequireNonAPIKeyCloudLoginOrOnPremLoginErr = errors.NewErrorWithSuggestions(
-		"you must log in to Confluent Cloud with a username and password or log in to Confluent Platform to use this command",
-		"Log in with `confluent login` or `confluent login --url <mds-url>`.\n"+signupSuggestion,
-	)
-	RequireNonCloudLogin = errors.NewErrorWithSuggestions(
-		"you must log out of Confluent Cloud to use this command",
-		"Log out with `confluent logout`.\n",
-	)
-	RequireOnPremLoginErr = errors.NewErrorWithSuggestions(
-		"you must log in to Confluent Platform to use this command",
-		"Log in to Confluent Platform with `confluent login --url <mds-url>`.",
-	)
-	RunningOnPremCommandInCloudErr = errors.NewErrorWithSuggestions(
-		"this is not a Confluent Cloud command. You must log in to Confluent Platform to use this command",
-		"Log in to Confluent Platform with `confluent login --url <mds-url>`.\n"+`Use the "--help" flag to see available commands.`,
-	)
+	RequireCloudLoginErr = &errors.RunRequirementError{
+		ErrorMsg:       "you must log in to Confluent Cloud to use this command",
+		SuggestionsMsg: "Log in with `confluent login`.\n" + signupSuggestion,
+	}
+	RequireCloudLoginOrgUnsuspendedErr = &errors.RunRequirementError{
+		ErrorMsg:       "you must unsuspend your organization to use this command",
+		SuggestionsMsg: errors.SuspendedOrganizationSuggestions,
+	}
+	RequireCloudLoginFreeTrialEndedOrgUnsuspendedErr = &errors.RunRequirementError{
+		ErrorMsg:       "you must unsuspend your organization to use this command",
+		SuggestionsMsg: errors.EndOfFreeTrialSuggestions,
+	}
+	RequireCloudLoginOrOnPremErr = &errors.RunRequirementError{
+		ErrorMsg:       "you must log in to use this command",
+		SuggestionsMsg: "Log in with `confluent login`.\n" + signupSuggestion,
+	}
+	RequireNonAPIKeyCloudLoginErr = &errors.RunRequirementError{
+		ErrorMsg:       "you must log in to Confluent Cloud with a username and password to use this command",
+		SuggestionsMsg: "Log in with `confluent login`.\n" + signupSuggestion,
+	}
+	RequireNonAPIKeyCloudLoginOrOnPremLoginErr = &errors.RunRequirementError{
+		ErrorMsg:       "you must log in to Confluent Cloud with a username and password or log in to Confluent Platform to use this command",
+		SuggestionsMsg: "Log in with `confluent login` or `confluent login --url <mds-url>`.\n" + signupSuggestion,
+	}
+	RequireNonCloudLogin = &errors.RunRequirementError{
+		ErrorMsg:       "you must log out of Confluent Cloud to use this command",
+		SuggestionsMsg: "Log out with `confluent logout`.\n",
+	}
+	RequireOnPremLoginErr = &errors.RunRequirementError{
+		ErrorMsg:       "you must log in to Confluent Platform to use this command",
+		SuggestionsMsg: "Log in to Confluent Platform with `confluent login --url <mds-url>`.",
+	}
+	RunningOnPremCommandInCloudErr = &errors.RunRequirementError{
+		ErrorMsg:       "this is not a Confluent Cloud command. You must log in to Confluent Platform to use this command",
+		SuggestionsMsg: "Log in to Confluent Platform with `confluent login --url <mds-url>`.\n" + `Use the "--help" flag to see available commands.`,
+	}
+	RunningSimilarOnPremCommandInCloudErr = func(cmdPath, suggestedCmdPath string) errors.CLITypedError {
+		return &errors.RunRequirementError{
+			ErrorMsg:       fmt.Sprintf("`%s` is not a Confluent Cloud command. Did you mean `%s`?", cmdPath, suggestedCmdPath),
+			SuggestionsMsg: fmt.Sprintf("If you are a Confluent Cloud user, run `%s` instead.\nIf you are attempting to connect to Confluent Platform, login with `confluent login --url <mds-url>` to use `%s`.", suggestedCmdPath, cmdPath),
+		}
+	}
 )
 
 // Config represents the CLI configuration.

--- a/pkg/errors/typed.go
+++ b/pkg/errors/typed.go
@@ -206,3 +206,16 @@ func (e *MDSV2Alpha1ErrorType2Array) Error() string {
 func (e *MDSV2Alpha1ErrorType2Array) UserFacingError() error {
 	return fmt.Errorf(parsedGenericOpenApiErrorMsg, e.Error())
 }
+
+type RunRequirementError struct {
+	ErrorMsg       string
+	SuggestionsMsg string
+}
+
+func (e *RunRequirementError) Error() string {
+	return e.ErrorMsg
+}
+
+func (e *RunRequirementError) UserFacingError() error {
+	return NewErrorWithSuggestions(e.ErrorMsg, e.SuggestionsMsg)
+}

--- a/test/fixtures/output/kafka/broker/list-cloud-login.golden
+++ b/test/fixtures/output/kafka/broker/list-cloud-login.golden
@@ -2,4 +2,4 @@ Error: this is not a Confluent Cloud command. You must log in to Confluent Platf
 
 Suggestions:
     Log in to Confluent Platform with `confluent login --url <mds-url>`.
-    Use the "--help" flag to see available commands.
+    See available commands with `--help`.

--- a/test/fixtures/output/kafka/broker/list-cloud-login.golden
+++ b/test/fixtures/output/kafka/broker/list-cloud-login.golden
@@ -1,0 +1,5 @@
+Error: this is not a Confluent Cloud command. You must log in to Confluent Platform to use this command
+
+Suggestions:
+    Log in to Confluent Platform with `confluent login --url <mds-url>`.
+    Use the "--help" flag to see available commands.

--- a/test/fixtures/output/kafka/broker/list-not-logged-in.golden
+++ b/test/fixtures/output/kafka/broker/list-not-logged-in.golden
@@ -1,0 +1,4 @@
+Error: you must log in to Confluent Platform to use this command
+
+Suggestions:
+    Log in to Confluent Platform with `confluent login --url <mds-url>`.

--- a/test/kafka_test.go
+++ b/test/kafka_test.go
@@ -273,6 +273,15 @@ func (s *CLITestSuite) TestKafkaBrokerList() {
 		test.login = "onprem"
 		s.runIntegrationTest(test)
 	}
+
+	tests = []CLITest{
+		{args: "kafka broker list", fixture: "kafka/broker/list-not-logged-in.golden", exitCode: 1},
+		{args: "kafka broker list", login: "cloud", fixture: "kafka/broker/list-cloud-login.golden", exitCode: 1},
+	}
+
+	for _, test := range tests {
+		s.runIntegrationTest(test)
+	}
 }
 
 func (s *CLITestSuite) TestKafkaLink() {


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- PLACEHOLDER

New Features
- PLACEHOLDER

Bug Fixes
- PLACEHOLDER

Checklist
---------
- [x] Leave this box unchecked if features are not yet available in production

What
----
Some commands set `c.PersistentPreRunE = prerunner.InitializeOnPremKafkaRest(c.AuthenticatedCLICommand)`, which overwrites the usual `PersistentPreRunE`.

However, doing this causes the error from the call to `ErrIfMissingRunRequirement` in `AuthenticatedWithMDS` to not be returned. This means that using `InitializeOnPremKafkaRest` causes annotations to be ignored. This results in misleading errors or even panics if users try to run the commands that the annotations were supposed to prevent them from running.

As a quick fix, I've added the `ErrIfMissingRunRequirement` requirement check to `InitializeOnPremKafkaRest` itself.

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
Running `confluent kafka broker list` before the change (logged out or logged into Cloud):
```
confluent kafka broker list
Error: Kafka REST URL not found

Suggestions:
    Use the --url flag or set CONFLUENT_REST_URL.
```
And after the change (logged out):
```
confluent kafka broker list                                                     
Error: you must log in to Confluent Platform to use this command

Suggestions:
    Log in to Confluent Platform with confluent login --url <mds-url>.
```
After the change (logged into Cloud):
```
confluent kafka broker list      
Error: this is not a Confluent Cloud command. You must log in to Confluent Platform to use this command

Suggestions:
    Log in to Confluent Platform with confluent login --url <mds-url>.
    Use the "--help" flag to see available commands.
```