### PR TITLE
[CLI-2996] Enable CLI color by default

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -127,6 +127,7 @@ func New() *Config {
 		ContextStates:    make(map[string]*ContextState),
 		SavedCredentials: make(map[string]*LoginCredential),
 		Version:          new(pversion.Version),
+		EnableColor:      true,
 	}
 }
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -236,6 +236,7 @@ func TestConfig_Load(t *testing.T) {
 				Filename:           "test_json/load_disable_update.json",
 				DisableUpdates:     true,
 				DisableUpdateCheck: true,
+				EnableColor:        true,
 				Platforms:          map[string]*Platform{},
 				Credentials:        map[string]*Credential{},
 				Contexts:           map[string]*Context{},

--- a/test/cli_test.go
+++ b/test/cli_test.go
@@ -239,6 +239,7 @@ func resetConfiguration(t *testing.T, arePluginsEnabled bool) {
 	// probably don't really want to do this or devs will get mad
 	cfg := config.New()
 	cfg.DisablePlugins = !arePluginsEnabled
+	cfg.EnableColor = false
 	err := cfg.Save()
 	require.NoError(t, err)
 }


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- CLI text highlighting is now enabled by default for new users

New Features
- PLACEHOLDER

Bug Fixes
- PLACEHOLDER

Checklist
---------
- [x] Leave this box unchecked if features are not yet available in production

What
----
Set text highlighting to true by default instead of false. This doesn't affect existing users (unless they delete their config file for some reason)

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
Manual testing:
- checked that this change doesn't have an effect if `enable_color: false` is already set
- deleted my config file to start over and checked that text highlighting was enabled without having to use `confluent configuration update enable_color true`