### PR TITLE
Add kafka message headers with --headers flag

### DIFF
--- a/internal/kafka/command_topic_produce.go
+++ b/internal/kafka/command_topic_produce.go
@@ -658,7 +658,11 @@ func parseHeaders(headers []string, delimiter string) ([]ckafka.Header, error) {
 		}
 
 		if len(parts) == 2 {
-			kafkaHeaders = append(kafkaHeaders, ckafka.Header{Key: key, Value: []byte(strings.TrimSpace(parts[1]))})
+			kafkaHeader := ckafka.Header{
+				Key:   key,
+				Value: []byte(strings.TrimSpace(parts[1])),
+			}
+			kafkaHeaders = append(kafkaHeaders, kafkaHeader)
 		}
 	}
 	return kafkaHeaders, nil

--- a/internal/kafka/command_topic_produce.go
+++ b/internal/kafka/command_topic_produce.go
@@ -656,13 +656,11 @@ func parseHeaders(headers []string, delimiter string) ([]ckafka.Header, error) {
 			return nil, fmt.Errorf(invalidHeadersErrorMsg, delimiter)
 		}
 
-		if len(parts) == 2 {
-			kafkaHeader := ckafka.Header{
-				Key:   strings.TrimSpace(parts[0]),
-				Value: []byte(strings.TrimSpace(parts[1])),
-			}
-			kafkaHeaders = append(kafkaHeaders, kafkaHeader)
+		kafkaHeader := ckafka.Header{
+			Key:   strings.TrimSpace(parts[0]),
+			Value: []byte(strings.TrimSpace(parts[1])),
 		}
+		kafkaHeaders = append(kafkaHeaders, kafkaHeader)
 	}
 	return kafkaHeaders, nil
 }

--- a/internal/kafka/command_topic_produce.go
+++ b/internal/kafka/command_topic_produce.go
@@ -61,7 +61,7 @@ func (c *command) newProduceCommand() *cobra.Command {
 	cmd.Flags().StringSlice("config", nil, `A comma-separated list of configuration overrides ("key=value") for the producer client. For a full list, see https://docs.confluent.io/platform/current/clients/librdkafka/html/md_CONFIGURATION.html`)
 	pcmd.AddProducerConfigFileFlag(cmd)
 	cmd.Flags().String("schema-registry-endpoint", "", "Endpoint for Schema Registry cluster.")
-	cmd.Flags().StringSlice("headers", nil, `A comma-separated list of headers ("key:value") for the message. Example: "key:value,key1:value1"`)
+	cmd.Flags().StringSlice("headers", nil, `A comma-separated list of headers formatted as "key:value".`)
 
 	// cloud-only flags
 	cmd.Flags().String("key-references", "", "The path to the message key schema references file.")

--- a/internal/kafka/command_topic_produce.go
+++ b/internal/kafka/command_topic_produce.go
@@ -38,7 +38,7 @@ func (c *command) newProduceCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "produce <topic>",
 		Short:             "Produce messages to a Kafka topic.",
-		Long:              "Produce messages to a Kafka topic.\n\nWhen using this command, you can specify the message header using the \"--headers\" flag.",
+		Long:              "Produce messages to a Kafka topic.\n\nWhen using this command, you can specify the message header using the `--headers` flag.",
 		Args:              cobra.ExactArgs(1),
 		ValidArgsFunction: pcmd.NewValidArgsFunction(c.validArgs),
 		RunE:              c.produce,

--- a/internal/kafka/command_topic_produce.go
+++ b/internal/kafka/command_topic_produce.go
@@ -647,20 +647,20 @@ func setSchemaPathRef(schemaString srsdk.SchemaString, dir, subject string, sche
 }
 
 func parseHeaders(headers []string, delimiter string) ([]ckafka.Header, error) {
-	var kafkaHeaders []ckafka.Header
+	kafkaHeaders := make([]ckafka.Header, len(headers))
 
-	for _, header := range headers {
+	for i, header := range headers {
 		parts := strings.SplitN(header, delimiter, 2)
 
 		if len(parts) < 2 || strings.TrimSpace(parts[0]) == "" {
 			return nil, fmt.Errorf(invalidHeadersErrorMsg, delimiter)
 		}
 
-		kafkaHeader := ckafka.Header{
+		kafkaHeaders[i] = ckafka.Header{
 			Key:   strings.TrimSpace(parts[0]),
 			Value: []byte(strings.TrimSpace(parts[1])),
 		}
-		kafkaHeaders = append(kafkaHeaders, kafkaHeader)
 	}
+	
 	return kafkaHeaders, nil
 }

--- a/internal/kafka/command_topic_produce.go
+++ b/internal/kafka/command_topic_produce.go
@@ -31,7 +31,6 @@ import (
 const (
 	missingKeyOrValueErrorMsg     = "missing key or value in message"
 	missingOrMalformedKeyErrorMsg = "missing or malformed key in message"
-	missingHeadersErrorMsg        = "missing headers, please specify comma-separated headers (key%svalue)"
 	invalidHeadersErrorMsg        = "invalid header format, headers should be in the format (key%svalue)"
 )
 
@@ -648,10 +647,6 @@ func setSchemaPathRef(schemaString srsdk.SchemaString, dir, subject string, sche
 }
 
 func parseHeaders(headers []string, delimiter string) ([]ckafka.Header, error) {
-	if len(headers) == 0 {
-		return nil, fmt.Errorf(missingHeadersErrorMsg, delimiter)
-	}
-
 	var kafkaHeaders []ckafka.Header
 
 	for _, header := range headers {

--- a/internal/kafka/command_topic_produce.go
+++ b/internal/kafka/command_topic_produce.go
@@ -652,14 +652,13 @@ func parseHeaders(headers []string, delimiter string) ([]ckafka.Header, error) {
 	for _, header := range headers {
 		parts := strings.SplitN(header, delimiter, 2)
 
-		key := strings.TrimSpace(parts[0])
-		if key == "" {
+		if len(parts) < 2 || strings.TrimSpace(parts[0]) == "" {
 			return nil, fmt.Errorf(invalidHeadersErrorMsg, delimiter)
 		}
 
 		if len(parts) == 2 {
 			kafkaHeader := ckafka.Header{
-				Key:   key,
+				Key:   strings.TrimSpace(parts[0]),
 				Value: []byte(strings.TrimSpace(parts[1])),
 			}
 			kafkaHeaders = append(kafkaHeaders, kafkaHeader)

--- a/internal/kafka/command_topic_produce.go
+++ b/internal/kafka/command_topic_produce.go
@@ -661,6 +661,5 @@ func parseHeaders(headers []string, delimiter string) ([]ckafka.Header, error) {
 			Value: []byte(strings.TrimSpace(parts[1])),
 		}
 	}
-	
 	return kafkaHeaders, nil
 }

--- a/internal/kafka/command_topic_produce.go
+++ b/internal/kafka/command_topic_produce.go
@@ -38,7 +38,7 @@ func (c *command) newProduceCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "produce <topic>",
 		Short:             "Produce messages to a Kafka topic.",
-		Long:              "Produce messages to a Kafka topic.\n\nWhen using this command, you can specify the message header using the --header flag.",
+		Long:              "Produce messages to a Kafka topic.\n\nWhen using this command, you can specify the message header using the \"--headers\" flag.",
 		Args:              cobra.ExactArgs(1),
 		ValidArgsFunction: pcmd.NewValidArgsFunction(c.validArgs),
 		RunE:              c.produce,

--- a/internal/kafka/command_topic_produce.go
+++ b/internal/kafka/command_topic_produce.go
@@ -660,7 +660,6 @@ func parseHeaders(headers []string, delimiter string) ([]ckafka.Header, error) {
 		if len(parts) == 2 {
 			kafkaHeaders = append(kafkaHeaders, ckafka.Header{Key: key, Value: []byte(strings.TrimSpace(parts[1]))})
 		}
-
 	}
 	return kafkaHeaders, nil
 }

--- a/internal/kafka/command_topic_produce_test.go
+++ b/internal/kafka/command_topic_produce_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	ckafka "github.com/confluentinc/confluent-kafka-go/kafka"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -104,7 +105,7 @@ func TestGetMetaInfoFromSchemaId(t *testing.T) {
 }
 
 func TestHeaders(t *testing.T) {
-	t.Run("It should return valid kafka headers", func(t *testing.T) {
+	t.Run("It should return valid Kafka headers", func(t *testing.T) {
 		headers := []string{"contenttype:application/json", "x-request-id:12345"}
 
 		expected := []ckafka.Header{
@@ -113,7 +114,6 @@ func TestHeaders(t *testing.T) {
 		}
 
 		parsedHeaders, err := parseHeaders(headers, ":")
-
 		assert.Equal(t, parsedHeaders, expected)
 		assert.NoError(t, err)
 	})

--- a/internal/kafka/command_topic_produce_test.go
+++ b/internal/kafka/command_topic_produce_test.go
@@ -118,8 +118,19 @@ func TestHeaders(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
-	t.Run("It should return an invalid headers error", func(t *testing.T) {
-		headers := []string{"", ":valueOnly"}
+	t.Run("It should return an invalid headers error when key is missing", func(t *testing.T) {
+		headers := []string{":valueOnly"}
+
+		parsedHeaders, err := parseHeaders(headers, ":")
+		expectedErrorMsg := fmt.Sprintf(invalidHeadersErrorMsg, ":")
+
+		assert.Error(t, err)
+		assert.Equal(t, err.Error(), expectedErrorMsg)
+		assert.Nil(t, parsedHeaders)
+	})
+
+	t.Run("It should return an invalid headers error when delimiter is incorrect", func(t *testing.T) {
+		headers := []string{"asdasdas:valueOnly", "sadsad=sdsadasd"}
 
 		parsedHeaders, err := parseHeaders(headers, ":")
 		expectedErrorMsg := fmt.Sprintf(invalidHeadersErrorMsg, ":")

--- a/internal/kafka/command_topic_produce_test.go
+++ b/internal/kafka/command_topic_produce_test.go
@@ -118,7 +118,7 @@ func TestHeaders(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
-	t.Run("It should return Invalid headers error", func(t *testing.T) {
+	t.Run("It should return an invalid headers error", func(t *testing.T) {
 		headers := []string{"", ":valueOnly"}
 
 		parsedHeaders, err := parseHeaders(headers, ":")

--- a/internal/kafka/command_topic_produce_test.go
+++ b/internal/kafka/command_topic_produce_test.go
@@ -118,17 +118,6 @@ func TestHeaders(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
-	t.Run("It should return missing headers error", func(t *testing.T) {
-		headers := []string{}
-
-		parsedHeaders, err := parseHeaders(headers, ":")
-		expectedErrorMsg := fmt.Sprintf(missingHeadersErrorMsg, ":")
-
-		assert.Error(t, err)
-		assert.Equal(t, err.Error(), expectedErrorMsg)
-		assert.Nil(t, parsedHeaders)
-	})
-
 	t.Run("It should return Invalid headers error", func(t *testing.T) {
 		headers := []string{"", ":valueOnly"}
 

--- a/internal/kafka/command_topic_produce_test.go
+++ b/internal/kafka/command_topic_produce_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	
 	ckafka "github.com/confluentinc/confluent-kafka-go/kafka"
 )
 

--- a/internal/kafka/command_topic_produce_test.go
+++ b/internal/kafka/command_topic_produce_test.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 	"testing"
 
-	ckafka "github.com/confluentinc/confluent-kafka-go/kafka"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	
+	ckafka "github.com/confluentinc/confluent-kafka-go/kafka"
 )
 
 type splitTest struct {

--- a/internal/kafka/command_topic_produce_test.go
+++ b/internal/kafka/command_topic_produce_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	ckafka "github.com/confluentinc/confluent-kafka-go/kafka"
 )
 

--- a/internal/kafka/command_topic_produce_test.go
+++ b/internal/kafka/command_topic_produce_test.go
@@ -1,8 +1,10 @@
 package kafka
 
 import (
+	"fmt"
 	"testing"
 
+	ckafka "github.com/confluentinc/confluent-kafka-go/kafka"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -99,4 +101,42 @@ func TestGetKeyAndValue_Fail(t *testing.T) {
 func TestGetMetaInfoFromSchemaId(t *testing.T) {
 	metaInfo := getMetaInfoFromSchemaId(100004)
 	require.Equal(t, []byte{0x0, 0x0, 0x1, 0x86, 0xa4}, metaInfo)
+}
+
+func TestHeaders(t *testing.T) {
+	t.Run("It should return valid kafka headers", func(t *testing.T) {
+		headers := []string{"contenttype:application/json", "x-request-id:12345"}
+
+		expected := []ckafka.Header{
+			{Key: "contenttype", Value: []byte("application/json")},
+			{Key: "x-request-id", Value: []byte("12345")},
+		}
+
+		parsedHeaders, err := parseHeaders(headers, ":")
+
+		assert.Equal(t, parsedHeaders, expected)
+		assert.NoError(t, err)
+	})
+
+	t.Run("It should return missing headers error", func(t *testing.T) {
+		headers := []string{}
+
+		parsedHeaders, err := parseHeaders(headers, ":")
+		expectedErrorMsg := fmt.Sprintf(missingHeadersErrorMsg, ":")
+
+		assert.Error(t, err)
+		assert.Equal(t, err.Error(), expectedErrorMsg)
+		assert.Nil(t, parsedHeaders)
+	})
+
+	t.Run("It should return Invalid headers error", func(t *testing.T) {
+		headers := []string{"", ":valueOnly"}
+
+		parsedHeaders, err := parseHeaders(headers, ":")
+		expectedErrorMsg := fmt.Sprintf(invalidHeadersErrorMsg, ":")
+
+		assert.Error(t, err)
+		assert.Equal(t, err.Error(), expectedErrorMsg)
+		assert.Nil(t, parsedHeaders)
+	})
 }

--- a/test/fixtures/output/kafka/topic/produce-help-onprem.golden
+++ b/test/fixtures/output/kafka/topic/produce-help-onprem.golden
@@ -1,6 +1,6 @@
 Produce messages to a Kafka topic.
 
-When using this command, you cannot modify the message header, and the message header will not be printed out.
+When using this command, you can specify the message header using the --header flag.
 
 Usage:
   confluent kafka topic produce <topic> [flags]
@@ -22,6 +22,7 @@ Flags:
       --config strings                      A comma-separated list of configuration overrides ("key=value") for the producer client. For a full list, see https://docs.confluent.io/platform/current/clients/librdkafka/html/md_CONFIGURATION.html
       --config-file string                  The path to the configuration file for the producer client, in JSON or Avro format.
       --schema-registry-endpoint string     Endpoint for Schema Registry cluster.
+      --headers strings                     A comma-separated list of headers ("key:value") for the message. Example: "key:value,key1:value1"
       --key-references string               The path to the message key schema references file.
       --api-key string                      API key.
       --api-secret string                   API secret.

--- a/test/fixtures/output/kafka/topic/produce-help-onprem.golden
+++ b/test/fixtures/output/kafka/topic/produce-help-onprem.golden
@@ -22,7 +22,7 @@ Flags:
       --config strings                      A comma-separated list of configuration overrides ("key=value") for the producer client. For a full list, see https://docs.confluent.io/platform/current/clients/librdkafka/html/md_CONFIGURATION.html
       --config-file string                  The path to the configuration file for the producer client, in JSON or Avro format.
       --schema-registry-endpoint string     Endpoint for Schema Registry cluster.
-      --headers strings                     A comma-separated list of headers ("key:value") for the message. Example: "key:value,key1:value1"
+      --headers strings                     A comma-separated list of headers formatted as "key:value".
       --key-references string               The path to the message key schema references file.
       --api-key string                      API key.
       --api-secret string                   API secret.

--- a/test/fixtures/output/kafka/topic/produce-help-onprem.golden
+++ b/test/fixtures/output/kafka/topic/produce-help-onprem.golden
@@ -1,6 +1,6 @@
 Produce messages to a Kafka topic.
 
-When using this command, you can specify the message header using the --header flag.
+When using this command, you can specify the message header using the "--headers" flag.
 
 Usage:
   confluent kafka topic produce <topic> [flags]

--- a/test/fixtures/output/kafka/topic/produce-help-onprem.golden
+++ b/test/fixtures/output/kafka/topic/produce-help-onprem.golden
@@ -1,6 +1,6 @@
 Produce messages to a Kafka topic.
 
-When using this command, you can specify the message header using the "--headers" flag.
+When using this command, you can specify the message header using the `--headers` flag.
 
 Usage:
   confluent kafka topic produce <topic> [flags]

--- a/test/fixtures/output/kafka/topic/produce-help.golden
+++ b/test/fixtures/output/kafka/topic/produce-help.golden
@@ -1,6 +1,6 @@
 Produce messages to a Kafka topic.
 
-When using this command, you cannot modify the message header, and the message header will not be printed out.
+When using this command, you can specify the message header using the --header flag.
 
 Usage:
   confluent kafka topic produce <topic> [flags]
@@ -22,6 +22,7 @@ Flags:
       --config strings                      A comma-separated list of configuration overrides ("key=value") for the producer client. For a full list, see https://docs.confluent.io/platform/current/clients/librdkafka/html/md_CONFIGURATION.html
       --config-file string                  The path to the configuration file for the producer client, in JSON or Avro format.
       --schema-registry-endpoint string     Endpoint for Schema Registry cluster.
+      --headers strings                     A comma-separated list of headers ("key:value") for the message. Example: "key:value,key1:value1"
       --key-references string               The path to the message key schema references file.
       --api-key string                      API key.
       --api-secret string                   API secret.

--- a/test/fixtures/output/kafka/topic/produce-help.golden
+++ b/test/fixtures/output/kafka/topic/produce-help.golden
@@ -22,7 +22,7 @@ Flags:
       --config strings                      A comma-separated list of configuration overrides ("key=value") for the producer client. For a full list, see https://docs.confluent.io/platform/current/clients/librdkafka/html/md_CONFIGURATION.html
       --config-file string                  The path to the configuration file for the producer client, in JSON or Avro format.
       --schema-registry-endpoint string     Endpoint for Schema Registry cluster.
-      --headers strings                     A comma-separated list of headers ("key:value") for the message. Example: "key:value,key1:value1"
+      --headers strings                     A comma-separated list of headers formatted as "key:value".
       --key-references string               The path to the message key schema references file.
       --api-key string                      API key.
       --api-secret string                   API secret.

--- a/test/fixtures/output/kafka/topic/produce-help.golden
+++ b/test/fixtures/output/kafka/topic/produce-help.golden
@@ -1,6 +1,6 @@
 Produce messages to a Kafka topic.
 
-When using this command, you can specify the message header using the --header flag.
+When using this command, you can specify the message header using the "--headers" flag.
 
 Usage:
   confluent kafka topic produce <topic> [flags]

--- a/test/fixtures/output/kafka/topic/produce-help.golden
+++ b/test/fixtures/output/kafka/topic/produce-help.golden
@@ -1,6 +1,6 @@
 Produce messages to a Kafka topic.
 
-When using this command, you can specify the message header using the "--headers" flag.
+When using this command, you can specify the message header using the `--headers` flag.
 
 Usage:
   confluent kafka topic produce <topic> [flags]


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

New Features
- Add `--headers` to `confluent kafka topic produce` for specifying headers manually when producing messages

Checklist
---------
- [x] Leave this box unchecked if features are not yet available in production

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->

What?
The `confluent kafka topic produce` command has been changed to accept the `--headers` flag to specify the headers manually in the below format `key1:value1,key2:value2`.

The headers values are then parsed to the Kafka headers type.

Why?
When the messages are produced from CLI, currently it is not possible to set the headers and this changes allows it.

References
----------
Resolves #2768 

Test & Review
-------------
Currently, it has been tested with local build of Confluent CLI together with the [confluentinc/cp-server](https://hub.docker.com/r/confluentinc/cp-kafka) & [confluentinc/cp-kafka-rest](https://hub.docker.com/r/confluentinc/cp-kafka-rest)

To test this functionality locally:

1. Run the docker with the provided [docker-compose.yml](https://github.com/confluentinc/cp-all-in-one/blob/7.5.0-post/cp-all-in-one/docker-compose.yml) file. Only required: `cp-server` & `cp-kafka-rest`.
2. create the topic
3. Produce the message with headers
4. Consume the messages to check printed headers

### Screenshots

**Producer:**

<img width="939" alt="producer" src="https://github.com/confluentinc/cli/assets/18111862/6e8b1c7a-2d34-4125-b8a3-56c145b89561">

**Consumer:**

<img width="940" alt="consumer" src="https://github.com/confluentinc/cli/assets/18111862/410489d7-2d33-49ea-bb22-ed297d50b8cd">
