### PR TITLE
Feat/KFS-2159 don't store secrets to history

### DIFF
--- a/pkg/flink/config/local_statements.go
+++ b/pkg/flink/config/local_statements.go
@@ -17,7 +17,7 @@ const (
 	KeyCatalog        = "sql.current-catalog"
 	KeyDatabase       = "sql.current-database"
 	KeyLocalTimeZone  = "sql.local-time-zone"
-	KeyOpenaiSecret   = "sql.secrets.openai"
+	KeySqlSecrets     = "sql.secrets."
 	KeyResultsTimeout = "client.results-timeout"
 	KeyServiceAccount = "client.service-account"
 	KeyStatementName  = "client.statement-name"
@@ -30,5 +30,3 @@ const (
 	OutputFormatStandard  OutputFormat = "standard"
 	OutputFormatPlainText OutputFormat = "plain-text"
 )
-
-var SensitiveKeys = []string{KeyOpenaiSecret}

--- a/pkg/flink/internal/store/store_utils.go
+++ b/pkg/flink/internal/store/store_utils.go
@@ -450,7 +450,7 @@ func hasSensitiveKey(key string) bool {
 	return distance <= 2
 }
 
-func getSubstUpToSecondDot(s string) string {
+func getSubstringUpToSecondDot(s string) string {
 	firstDot := strings.Index(s, ".")
 	if firstDot == -1 {
 		return ""

--- a/pkg/flink/internal/store/store_utils.go
+++ b/pkg/flink/internal/store/store_utils.go
@@ -439,7 +439,7 @@ func parseResetStatement(statement string) (string, error) {
 }
 
 func hasSensitiveKey(key string) bool {
-	secretsPrefix := getSubstUpToSecondDot(key)
+	secretsPrefix := getSubstringUpToSecondDot(key)
 	if secretsPrefix == "" {
 		return false
 	}

--- a/pkg/flink/internal/store/store_utils_test.go
+++ b/pkg/flink/internal/store/store_utils_test.go
@@ -507,7 +507,7 @@ func TestTokenizeSQLSpecialCharacters(t *testing.T) {
 	require.Equal(expected, TokenizeSQL(input))
 }
 
-func TestGetSubstUpToSecondDot(t *testing.T) {
+func TestGetSubstringUpToSecondDot(t *testing.T) {
 	tests := []struct {
 		name     string
 		input    string
@@ -567,7 +567,7 @@ func TestGetSubstUpToSecondDot(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := getSubstUpToSecondDot(tt.input)
+			result := getSubstringUpToSecondDot(tt.input)
 			require.Equal(t, tt.expected, result)
 		})
 	}

--- a/pkg/flink/internal/store/store_utils_test.go
+++ b/pkg/flink/internal/store/store_utils_test.go
@@ -285,64 +285,68 @@ func hoursToSeconds(hours float32) int {
 }
 
 func TestIsUserSecretKey(t *testing.T) {
-	require.True(t, isKeySimilarToSensitiveKey(config.KeyOpenaiSecret, "sql.secrets.openai"))
-	require.True(t, isKeySimilarToSensitiveKey(config.KeyOpenaiSecret, "sql.secrets.openai"))
-	require.True(t, isKeySimilarToSensitiveKey(config.KeyOpenaiSecret, "sql.secrets.penaik"))
-	require.True(t, isKeySimilarToSensitiveKey(config.KeyOpenaiSecret, "sql.secrets.oopenai"))
-	require.True(t, isKeySimilarToSensitiveKey(config.KeyOpenaiSecret, "sql.secrets.oenaik"))
-	require.True(t, isKeySimilarToSensitiveKey(config.KeyOpenaiSecret, "sql.secrets.oppenai"))
-	require.True(t, isKeySimilarToSensitiveKey(config.KeyOpenaiSecret, "sql.secrets.opnai"))
-	require.True(t, isKeySimilarToSensitiveKey(config.KeyOpenaiSecret, "sql.secrets.opeenai"))
-	require.True(t, isKeySimilarToSensitiveKey(config.KeyOpenaiSecret, "sql.secrets.opeai"))
-	require.True(t, isKeySimilarToSensitiveKey(config.KeyOpenaiSecret, "sql.secrets.opennai"))
-	require.True(t, isKeySimilarToSensitiveKey(config.KeyOpenaiSecret, "sql.secrets.openi"))
-	require.True(t, isKeySimilarToSensitiveKey(config.KeyOpenaiSecret, "sql.secrets.openaai"))
-	require.True(t, isKeySimilarToSensitiveKey(config.KeyOpenaiSecret, "sql.secrets.opena"))
-	require.True(t, isKeySimilarToSensitiveKey(config.KeyOpenaiSecret, "sql.secrets.openaii"))
-	require.True(t, isKeySimilarToSensitiveKey(config.KeyOpenaiSecret, "sql.secrets.openaiii"))
+	require.True(t, hasSensitiveKey("sql.secrets.openai"))
+	require.True(t, hasSensitiveKey("sql.secrets.openai"))
+	require.True(t, hasSensitiveKey("sql.secrets.penaik"))
+	require.True(t, hasSensitiveKey("sql.secrets.oopenai"))
+	require.True(t, hasSensitiveKey("sql.secrets.oenaik"))
+	require.True(t, hasSensitiveKey("sql.secrets.oppenai"))
+	require.True(t, hasSensitiveKey("sql.secrets.opnai"))
+	require.True(t, hasSensitiveKey("sql.secrets.opeenai"))
+	require.True(t, hasSensitiveKey("sql.secrets.opeai"))
+	require.True(t, hasSensitiveKey("sql.secrets.opennai"))
+	require.True(t, hasSensitiveKey("sql.secrets.openi"))
+	require.True(t, hasSensitiveKey("sql.secrets.openaai"))
+	require.True(t, hasSensitiveKey("sql.secrets.opena"))
+	require.True(t, hasSensitiveKey("sql.secrets.openaii"))
+	require.True(t, hasSensitiveKey("sql.secrets.openaiii"))
 
-	require.True(t, isKeySimilarToSensitiveKey(config.KeyOpenaiSecret, "SQL.SECRETS.openai"))
-	require.True(t, isKeySimilarToSensitiveKey(config.KeyOpenaiSecret, "SQL.SECRETS.openai"))
-	require.True(t, isKeySimilarToSensitiveKey(config.KeyOpenaiSecret, "SQL.SECRETS.penaik"))
-	require.True(t, isKeySimilarToSensitiveKey(config.KeyOpenaiSecret, "SQL.SECRETS.oopenai"))
-	require.True(t, isKeySimilarToSensitiveKey(config.KeyOpenaiSecret, "SQL.SECRETS.oenaik"))
-	require.True(t, isKeySimilarToSensitiveKey(config.KeyOpenaiSecret, "SQL.SECRETS.oppenai"))
-	require.True(t, isKeySimilarToSensitiveKey(config.KeyOpenaiSecret, "SQL.SECRETS.opnai"))
-	require.True(t, isKeySimilarToSensitiveKey(config.KeyOpenaiSecret, "SQL.SECRETS.opeenai"))
-	require.True(t, isKeySimilarToSensitiveKey(config.KeyOpenaiSecret, "SQL.SECRETS.opeai"))
-	require.True(t, isKeySimilarToSensitiveKey(config.KeyOpenaiSecret, "SQL.SECRETS.opennai"))
-	require.True(t, isKeySimilarToSensitiveKey(config.KeyOpenaiSecret, "SQL.SECRETS.openi"))
-	require.True(t, isKeySimilarToSensitiveKey(config.KeyOpenaiSecret, "SQL.SECRETS.openaai"))
-	require.True(t, isKeySimilarToSensitiveKey(config.KeyOpenaiSecret, "SQL.SECRETS.opena"))
-	require.True(t, isKeySimilarToSensitiveKey(config.KeyOpenaiSecret, "SQL.SECRETS.openaii"))
-	require.True(t, isKeySimilarToSensitiveKey(config.KeyOpenaiSecret, "SQL.SECRETS.openaiii"))
+	require.True(t, hasSensitiveKey("SQL.SECRETS.openai"))
+	require.True(t, hasSensitiveKey("SQL.SECRETS.openai"))
+	require.True(t, hasSensitiveKey("SQL.SECRETS.penaik"))
+	require.True(t, hasSensitiveKey("SQL.SECRETS.oopenai"))
+	require.True(t, hasSensitiveKey("SQL.SECRETS.oenaik"))
+	require.True(t, hasSensitiveKey("SQL.SECRETS.oppenai"))
+	require.True(t, hasSensitiveKey("SQL.SECRETS.opnai"))
+	require.True(t, hasSensitiveKey("SQL.SECRETS.opeenai"))
+	require.True(t, hasSensitiveKey("SQL.SECRETS.opeai"))
+	require.True(t, hasSensitiveKey("SQL.SECRETS.opennai"))
+	require.True(t, hasSensitiveKey("SQL.SECRETS.openi"))
+	require.True(t, hasSensitiveKey("SQL.SECRETS.openaai"))
+	require.True(t, hasSensitiveKey("SQL.SECRETS.opena"))
+	require.True(t, hasSensitiveKey("SQL.SECRETS.openaii"))
+	require.True(t, hasSensitiveKey("SQL.SECRETS.openaiii"))
 
-	require.True(t, isKeySimilarToSensitiveKey(config.KeyOpenaiSecret, "SQL.SECRETS.OPENAI"))
-	require.True(t, isKeySimilarToSensitiveKey(config.KeyOpenaiSecret, "SQL.SECRETS.OPENAI"))
-	require.True(t, isKeySimilarToSensitiveKey(config.KeyOpenaiSecret, "SQL.SECRETS.PENAIK"))
-	require.True(t, isKeySimilarToSensitiveKey(config.KeyOpenaiSecret, "SQL.SECRETS.OOPENAI"))
-	require.True(t, isKeySimilarToSensitiveKey(config.KeyOpenaiSecret, "SQL.SECRETS.OENAIK"))
-	require.True(t, isKeySimilarToSensitiveKey(config.KeyOpenaiSecret, "SQL.SECRETS.OPPENAI"))
-	require.True(t, isKeySimilarToSensitiveKey(config.KeyOpenaiSecret, "SQL.SECRETS.OPNAI"))
-	require.True(t, isKeySimilarToSensitiveKey(config.KeyOpenaiSecret, "SQL.SECRETS.OPEENAI"))
-	require.True(t, isKeySimilarToSensitiveKey(config.KeyOpenaiSecret, "SQL.SECRETS.OPEAI"))
-	require.True(t, isKeySimilarToSensitiveKey(config.KeyOpenaiSecret, "SQL.SECRETS.OPENNAI"))
-	require.True(t, isKeySimilarToSensitiveKey(config.KeyOpenaiSecret, "SQL.SECRETS.OPENI"))
-	require.True(t, isKeySimilarToSensitiveKey(config.KeyOpenaiSecret, "SQL.SECRETS.OPENAAI"))
-	require.True(t, isKeySimilarToSensitiveKey(config.KeyOpenaiSecret, "SQL.SECRETS.OPENA"))
-	require.True(t, isKeySimilarToSensitiveKey(config.KeyOpenaiSecret, "SQL.SECRETS.OPENAII"))
-	require.True(t, isKeySimilarToSensitiveKey(config.KeyOpenaiSecret, "SQL.SECRETS.OPENAIII"))
+	require.True(t, hasSensitiveKey("SQL.SECRETS.OPENAI"))
+	require.True(t, hasSensitiveKey("SQL.SECRETS.OPENAI"))
+	require.True(t, hasSensitiveKey("SQL.SECRETS.PENAIK"))
+	require.True(t, hasSensitiveKey("SQL.SECRETS.OOPENAI"))
+	require.True(t, hasSensitiveKey("SQL.SECRETS.OENAIK"))
+	require.True(t, hasSensitiveKey("SQL.SECRETS.OPPENAI"))
+	require.True(t, hasSensitiveKey("SQL.SECRETS.OPNAI"))
+	require.True(t, hasSensitiveKey("SQL.SECRETS.OPEENAI"))
+	require.True(t, hasSensitiveKey("SQL.SECRETS.OPEAI"))
+	require.True(t, hasSensitiveKey("SQL.SECRETS.OPENNAI"))
+	require.True(t, hasSensitiveKey("SQL.SECRETS.OPENI"))
+	require.True(t, hasSensitiveKey("SQL.SECRETS.OPENAAI"))
+	require.True(t, hasSensitiveKey("SQL.SECRETS.OPENA"))
+	require.True(t, hasSensitiveKey("SQL.SECRETS.OPENAII"))
+	require.True(t, hasSensitiveKey("SQL.SECRETS.OPENAIII"))
+	require.True(t, hasSensitiveKey("SQL.SECRETS.NAME"))
+	require.True(t, hasSensitiveKey("SQL.SECRETS.SCERECETASDT"))
+	require.True(t, hasSensitiveKey("SQL.SECRETS.SECCCCCCCCRET"))
 
-	require.False(t, isKeySimilarToSensitiveKey(config.KeyOpenaiSecret, ""))
-	require.False(t, isKeySimilarToSensitiveKey(config.KeyOpenaiSecret, "gustavo"))
-	require.False(t, isKeySimilarToSensitiveKey(config.KeyOpenaiSecret, "sql.current-catalog"))
-	require.False(t, isKeySimilarToSensitiveKey(config.KeyOpenaiSecret, "client.results-timeout"))
-	require.False(t, isKeySimilarToSensitiveKey(config.KeyOpenaiSecret, "OPENAPI.KEY"))
-	require.False(t, isKeySimilarToSensitiveKey(config.KeyOpenaiSecret, "SQL.SECRETS.NAME"))
-	require.False(t, isKeySimilarToSensitiveKey(config.KeyOpenaiSecret, "SQL.SECRETS.SCERECETASDT"))
-	require.False(t, isKeySimilarToSensitiveKey(config.KeyOpenaiSecret, "SQL.SECRETS.SECCCCCCCCRET"))
-	require.False(t, isKeySimilarToSensitiveKey(config.KeyOpenaiSecret, "SEEEEECRET.OPENAPI.KEY"))
-	require.False(t, isKeySimilarToSensitiveKey(config.KeyOpenaiSecret, "SECRET.OPENAPI.KEY"))
+	require.False(t, hasSensitiveKey(""))
+	require.False(t, hasSensitiveKey("gustavo"))
+	require.False(t, hasSensitiveKey("sql.current-catalog"))
+	require.False(t, hasSensitiveKey("client.results-timeout"))
+	require.False(t, hasSensitiveKey("OPENAPI.KEY"))
+	require.False(t, hasSensitiveKey("SEEEEECRET.OPENAPI.KEY"))
+	require.False(t, hasSensitiveKey("SECRET.OPENAPI.KEY"))
+}
+
+func TestIsUserSecretKey2(t *testing.T) {
+	require.True(t, hasSensitiveKey("sql.secrets.mysecret"))
 }
 
 func TestFormatUTCOffsetToTimezone(t *testing.T) {
@@ -501,4 +505,70 @@ func TestTokenizeSQLSpecialCharacters(t *testing.T) {
 	input = "my cluster αβγбвг汉字あア한😀"
 	expected = []string{"my", "cluster", "αβγбвг汉字あア한😀"}
 	require.Equal(expected, TokenizeSQL(input))
+}
+
+func TestGetSubstUpToSecondDot(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "normal case with two dots",
+			input:    "sql.secrets.mysecret",
+			expected: "sql.secrets.",
+		},
+		{
+			name:     "normal case with two dots",
+			input:    "sql.secretxx.mysecret",
+			expected: "sql.secretxx.",
+		},
+		{
+			name:     "normal case with two dots",
+			input:    "x.y.z",
+			expected: "x.y.",
+		},
+		{
+			name:     "only one dot",
+			input:    "x.y",
+			expected: "",
+		},
+		{
+			name:     "no dots",
+			input:    "xyz",
+			expected: "",
+		},
+		{
+			name:     "more than two dots",
+			input:    "x.y.z.a",
+			expected: "x.y.",
+		},
+		{
+			name:     "dots at start",
+			input:    ".x.y.z",
+			expected: ".x.",
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "dots only",
+			input:    "...",
+			expected: "..",
+		},
+		{
+			name:     "space between dots",
+			input:    "x. .z",
+			expected: "x. .",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := getSubstUpToSecondDot(tt.input)
+			require.Equal(t, tt.expected, result)
+		})
+	}
 }


### PR DESCRIPTION
Release Notes
-------------
Bug fix
- [Early Access] Prevent persistent user secret in CLI history

<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->


Checklist
---------
- [x] Leave this box unchecked if features are not yet available in production

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->
We don't want to store any secrets set using 'sql.secrets.*' to history . Same as https://github.com/confluentinc/cli/pull/2776 but that PR has branch naming issue. Can't have `'` in the branch name. https://confluent.slack.com/archives/C09EP1SS3/p1716916913343059

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
<!--
Has it been tested? How?
Copy and paste any instructions or steps that can save the reviewer time.
-->
unit tests