### PR TITLE
Trim URL suffixes properly

### DIFF
--- a/internal/kafka/kafka_rest_onprem.go
+++ b/internal/kafka/kafka_rest_onprem.go
@@ -49,8 +49,8 @@ func initKafkaRest(c *pcmd.AuthenticatedCLICommand, cmd *cobra.Command) (*kafkar
 // Embedded KafkaRest uses /kafka/v3 and standalone uses /v3
 // Relying on users to include the /kafka in the url for embedded instances
 func SetServerURL(cmd *cobra.Command, client *kafkarestv3.APIClient, url string) {
-	url = strings.Trim(url, "/")   // localhost:8091/kafka/v3/ --> localhost:8091/kafka/v3
-	url = strings.Trim(url, "/v3") // localhost:8091/kafka/v3 --> localhost:8091/kafka
+	url = strings.TrimSuffix(url, "/")   // localhost:8091/kafka/v3/ --> localhost:8091/kafka/v3
+	url = strings.TrimSuffix(url, "/v3") // localhost:8091/kafka/v3 --> localhost:8091/kafka
 	protocolRgx := regexp.MustCompile(`(\w+)://`)
 	protocolMatch := protocolRgx.MatchString(url)
 	if !protocolMatch {
@@ -66,7 +66,7 @@ func SetServerURL(cmd *cobra.Command, client *kafkarestv3.APIClient, url string)
 			output.ErrPrintf(false, protocolMsg)
 		}
 	}
-	client.ChangeBasePath(strings.Trim(url, "/") + "/v3")
+	client.ChangeBasePath(strings.TrimSuffix(url, "/") + "/v3")
 }
 
 // getKafkaRestUrl tries to fetch the Kafka REST URL from the --url flag or from the CONFLUENT_REST_URL environment variable.

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -204,7 +204,7 @@ func generateCredentialName(username string) string {
 }
 
 func GetDataplaneToken(ctx *config.Context) (string, error) {
-	endpoint := strings.Trim(ctx.GetPlatformServer(), "/") + "/api/access_tokens"
+	endpoint := strings.TrimSuffix(ctx.GetPlatformServer(), "/") + "/api/access_tokens"
 
 	res := &struct {
 		Token string `json:"token"`

--- a/pkg/auth/sso/auth_state.go
+++ b/pkg/auth/sso/auth_state.go
@@ -89,7 +89,7 @@ func newState(authUrl string, noBrowser bool) (*authState, error) {
 	env := GetCCloudEnvFromBaseUrl(authUrl)
 
 	state := &authState{
-		SSOProviderCallbackUrl: authUrl + ssoProviderCallbackEndpoint,
+		SSOProviderCallbackUrl: strings.TrimSuffix(authUrl, "/") + ssoProviderCallbackEndpoint,
 		SSOProviderHost:        "https://" + ssoConfigs[env].ssoProviderDomain,
 		SSOProviderClientID:    GetAuth0CCloudClientIdFromBaseUrl(authUrl),
 		SSOProviderIdentifier:  ssoConfigs[env].ssoProviderIdentifier,

--- a/pkg/linter/command_rules.go
+++ b/pkg/linter/command_rules.go
@@ -238,7 +238,7 @@ func RequireValidExamples() CommandRule {
 			}
 
 			for _, match := range regexp.MustCompile(`--[a-z\-]+=`).FindAllString(example, -1) {
-				errs = multierror.Append(errs, fmt.Errorf("%s: flag `%s` must not use \"=\" in example %d", cmd.CommandPath(), strings.TrimRight(match, "="), i+1))
+				errs = multierror.Append(errs, fmt.Errorf("%s: flag `%s` must not use \"=\" in example %d", cmd.CommandPath(), strings.TrimSuffix(match, "="), i+1))
 			}
 		}
 


### PR DESCRIPTION
Release Notes
-------------
Bug Fixes
- Trim custom Kafka REST `--url` values properly

Checklist
---------
- [x] Leave this box unchecked if features are not yet available in production

What
----
Make sure URL suffixes are being trimmed properly.

Test & Review
-------------
Manually tested login with `--no-browser` and trailing "/"