### PR TITLE
Fix Alpine dockerfile build issue

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -30,6 +30,6 @@ RUN chown $USER:$USER /etc
 # This symbolic link exists for backwards compatibility reasons
 RUN ln -s /bin/confluent /confluent
 
-RUN mkdir -p /etc/bash_completion.d && confluent completion bash > /etc/bash_completion.d/confluent
+RUN mkdir -p /etc/bash_completion.d/ && confluent completion bash > /etc/bash_completion.d/confluent
 
 USER $USER

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -30,6 +30,6 @@ RUN chown $USER:$USER /etc
 # This symbolic link exists for backwards compatibility reasons
 RUN ln -s /bin/confluent /confluent
 
-RUN mkdir /etc/bash_completion.d && confluent completion bash > /etc/bash_completion.d/confluent
+RUN mkdir -p /etc/bash_completion.d && confluent completion bash > /etc/bash_completion.d/confluent
 
 USER $USER


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- PLACEHOLDER

New Features
- PLACEHOLDER

Bug Fixes
- PLACEHOLDER

Checklist
---------
- [x] Leave this box unchecked if features are not yet available in production

What
----
Installing bash and/or bash-completions in the latest version of the `alpine` dockerfile now creates `/etc/bash_completion.d`, which causes `mkdir -p /etc/bash_completion.d` to fail.

Fix is to add `-p` so that mkdir doesn't error if the folder already exists.

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
Tested manually with dry run.