### PR TITLE
Fix on-prem kafka rest bug

### DIFF
--- a/internal/connect/command_plugin_install.go
+++ b/internal/connect/command_plugin_install.go
@@ -51,7 +51,7 @@ func newInstallCommand(prerunner pcmd.PreRunner) *cobra.Command {
 				Code: "confluent connect plugin install confluentinc/kafka-connect-datagen:latest --plugin-directory $CONFLUENT_HOME/plugins --worker-configurations $CONFLUENT_HOME/etc/kafka/connect-distributed.properties",
 			},
 		),
-		Annotations: map[string]string{pcmd.RunRequirement: pcmd.RequireNonCloudLogin},
+		Annotations: map[string]string{pcmd.RunRequirement: pcmd.RequireNotCloudLogin},
 	}
 
 	cmd.Flags().String("plugin-directory", "", "The plugin installation directory. If not specified, a default will be selected based on your Confluent Platform installation.")

--- a/internal/connect/command_plugin_install.go
+++ b/internal/connect/command_plugin_install.go
@@ -51,7 +51,7 @@ func newInstallCommand(prerunner pcmd.PreRunner) *cobra.Command {
 				Code: "confluent connect plugin install confluentinc/kafka-connect-datagen:latest --plugin-directory $CONFLUENT_HOME/plugins --worker-configurations $CONFLUENT_HOME/etc/kafka/connect-distributed.properties",
 			},
 		),
-		Annotations: map[string]string{pcmd.RunRequirement: pcmd.RequireNotCloudLogin},
+		Annotations: map[string]string{pcmd.RunRequirement: pcmd.RequireCloudLogout},
 	}
 
 	cmd.Flags().String("plugin-directory", "", "The plugin installation directory. If not specified, a default will be selected based on your Confluent Platform installation.")

--- a/internal/kafka/command_broker.go
+++ b/internal/kafka/command_broker.go
@@ -14,7 +14,7 @@ func newBrokerCommand(prerunner pcmd.PreRunner) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:         "broker",
 		Short:       "Manage Kafka brokers.",
-		Annotations: map[string]string{pcmd.RunRequirement: pcmd.RequireOnPremLogin},
+		Annotations: map[string]string{pcmd.RunRequirement: pcmd.RequireNonCloudLogin},
 	}
 
 	c := &brokerCommand{pcmd.NewAuthenticatedWithMDSCLICommand(cmd, prerunner)}

--- a/internal/kafka/command_broker.go
+++ b/internal/kafka/command_broker.go
@@ -14,7 +14,7 @@ func newBrokerCommand(prerunner pcmd.PreRunner) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:         "broker",
 		Short:       "Manage Kafka brokers.",
-		Annotations: map[string]string{pcmd.RunRequirement: pcmd.RequireNotCloudLogin},
+		Annotations: map[string]string{pcmd.RunRequirement: pcmd.RequireCloudLogout},
 	}
 
 	c := &brokerCommand{pcmd.NewAuthenticatedWithMDSCLICommand(cmd, prerunner)}

--- a/internal/kafka/command_broker.go
+++ b/internal/kafka/command_broker.go
@@ -14,7 +14,7 @@ func newBrokerCommand(prerunner pcmd.PreRunner) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:         "broker",
 		Short:       "Manage Kafka brokers.",
-		Annotations: map[string]string{pcmd.RunRequirement: pcmd.RequireNonCloudLogin},
+		Annotations: map[string]string{pcmd.RunRequirement: pcmd.RequireNotCloudLogin},
 	}
 
 	c := &brokerCommand{pcmd.NewAuthenticatedWithMDSCLICommand(cmd, prerunner)}

--- a/internal/kafka/command_consumer.go
+++ b/internal/kafka/command_consumer.go
@@ -20,9 +20,8 @@ type consumerOut struct {
 
 func newConsumerCommand(cfg *config.Config, prerunner pcmd.PreRunner) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:         "consumer",
-		Short:       "Manage Kafka consumers.",
-		Annotations: map[string]string{pcmd.RunRequirement: pcmd.RequireNonAPIKeyCloudLoginOrOnPremLogin},
+		Use:   "consumer",
+		Short: "Manage Kafka consumers.",
 	}
 
 	c := &consumerCommand{}

--- a/internal/kafka/command_link.go
+++ b/internal/kafka/command_link.go
@@ -20,9 +20,8 @@ type linkCommand struct {
 
 func newLinkCommand(cfg *config.Config, prerunner pcmd.PreRunner) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:         "link",
-		Short:       "Manage inter-cluster links.",
-		Annotations: map[string]string{pcmd.RunRequirement: pcmd.RequireNonAPIKeyCloudLoginOrOnPremLogin},
+		Use:   "link",
+		Short: "Manage inter-cluster links.",
 	}
 
 	c := &linkCommand{}
@@ -30,7 +29,6 @@ func newLinkCommand(cfg *config.Config, prerunner pcmd.PreRunner) *cobra.Command
 	if cfg.IsCloudLogin() {
 		c.AuthenticatedCLICommand = pcmd.NewAuthenticatedCLICommand(cmd, prerunner)
 
-		cmd.AddCommand(c.newConfigurationCommand(cfg))
 		cmd.AddCommand(c.newCreateCommand())
 		cmd.AddCommand(c.newDeleteCommand())
 		cmd.AddCommand(c.newDescribeCommand())
@@ -40,13 +38,13 @@ func newLinkCommand(cfg *config.Config, prerunner pcmd.PreRunner) *cobra.Command
 		c.AuthenticatedCLICommand = pcmd.NewAuthenticatedWithMDSCLICommand(cmd, prerunner)
 		c.PersistentPreRunE = prerunner.InitializeOnPremKafkaRest(c.AuthenticatedCLICommand)
 
-		cmd.AddCommand(c.newConfigurationCommand(cfg))
 		cmd.AddCommand(c.newCreateCommandOnPrem())
 		cmd.AddCommand(c.newDeleteCommandOnPrem())
 		cmd.AddCommand(c.newDescribeCommandOnPrem())
 		cmd.AddCommand(c.newListCommandOnPrem())
 		cmd.AddCommand(c.newTaskCommandOnPrem())
 	}
+	cmd.AddCommand(c.newConfigurationCommand(cfg))
 
 	return cmd
 }

--- a/internal/kafka/command_partition.go
+++ b/internal/kafka/command_partition.go
@@ -16,9 +16,8 @@ type partitionCommand struct {
 
 func newPartitionCommand(cfg *config.Config, prerunner pcmd.PreRunner) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:         "partition",
-		Short:       "Manage Kafka partitions.",
-		Annotations: map[string]string{pcmd.RunRequirement: pcmd.RequireNonAPIKeyCloudLoginOrOnPremLogin},
+		Use:   "partition",
+		Short: "Manage Kafka partitions.",
 	}
 
 	c := &partitionCommand{}

--- a/internal/kafka/command_replica.go
+++ b/internal/kafka/command_replica.go
@@ -14,7 +14,7 @@ func newReplicaCommand(prerunner pcmd.PreRunner) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:         "replica",
 		Short:       "Manage Kafka replicas.",
-		Annotations: map[string]string{pcmd.RunRequirement: pcmd.RequireNotCloudLogin},
+		Annotations: map[string]string{pcmd.RunRequirement: pcmd.RequireCloudLogout},
 	}
 
 	c := &replicaCommand{pcmd.NewAuthenticatedWithMDSCLICommand(cmd, prerunner)}

--- a/internal/kafka/command_replica.go
+++ b/internal/kafka/command_replica.go
@@ -14,7 +14,7 @@ func newReplicaCommand(prerunner pcmd.PreRunner) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:         "replica",
 		Short:       "Manage Kafka replicas.",
-		Annotations: map[string]string{pcmd.RunRequirement: pcmd.RequireNonCloudLogin},
+		Annotations: map[string]string{pcmd.RunRequirement: pcmd.RequireNotCloudLogin},
 	}
 
 	c := &replicaCommand{pcmd.NewAuthenticatedWithMDSCLICommand(cmd, prerunner)}

--- a/internal/kafka/command_replica.go
+++ b/internal/kafka/command_replica.go
@@ -14,7 +14,7 @@ func newReplicaCommand(prerunner pcmd.PreRunner) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:         "replica",
 		Short:       "Manage Kafka replicas.",
-		Annotations: map[string]string{pcmd.RunRequirement: pcmd.RequireOnPremLogin},
+		Annotations: map[string]string{pcmd.RunRequirement: pcmd.RequireNonCloudLogin},
 	}
 
 	c := &replicaCommand{pcmd.NewAuthenticatedWithMDSCLICommand(cmd, prerunner)}

--- a/internal/secret/command.go
+++ b/internal/secret/command.go
@@ -17,7 +17,7 @@ func New(prerunner pcmd.PreRunner, flagResolver pcmd.FlagResolver, plugin secret
 	cmd := &cobra.Command{
 		Use:         "secret",
 		Short:       "Manage secrets for Confluent Platform.",
-		Annotations: map[string]string{pcmd.RunRequirement: pcmd.RequireNotCloudLogin},
+		Annotations: map[string]string{pcmd.RunRequirement: pcmd.RequireCloudLogout},
 	}
 
 	c := &command{

--- a/internal/secret/command.go
+++ b/internal/secret/command.go
@@ -17,7 +17,7 @@ func New(prerunner pcmd.PreRunner, flagResolver pcmd.FlagResolver, plugin secret
 	cmd := &cobra.Command{
 		Use:         "secret",
 		Short:       "Manage secrets for Confluent Platform.",
-		Annotations: map[string]string{pcmd.RunRequirement: pcmd.RequireNonCloudLogin},
+		Annotations: map[string]string{pcmd.RunRequirement: pcmd.RequireNotCloudLogin},
 	}
 
 	c := &command{

--- a/pkg/cmd/run_requirements.go
+++ b/pkg/cmd/run_requirements.go
@@ -16,7 +16,7 @@ const (
 	RequireCloudLoginOrOnPremLogin          = "cloud-login-or-on-prem-login"
 	RequireNonAPIKeyCloudLogin              = "non-api-key-cloud-login"
 	RequireNonAPIKeyCloudLoginOrOnPremLogin = "non-api-key-cloud-login-or-on-prem-login"
-	RequireNotCloudLogin                    = "not-cloud-login"
+	RequireCloudLogout                      = "cloud-logout"
 	RequireOnPremLogin                      = "on-prem-login"
 )
 
@@ -45,8 +45,8 @@ func ErrIfMissingRunRequirement(cmd *cobra.Command, cfg *config.Config) error {
 			f = cfg.CheckIsNonAPIKeyCloudLogin
 		case RequireNonAPIKeyCloudLoginOrOnPremLogin:
 			f = cfg.CheckIsNonAPIKeyCloudLoginOrOnPremLogin
-		case RequireNotCloudLogin:
-			f = cfg.CheckIsNotCloudLogin
+		case RequireCloudLogout:
+			f = cfg.CheckIsCloudLogout
 		case RequireOnPremLogin:
 			f = cfg.CheckIsOnPremLogin
 		}

--- a/pkg/cmd/run_requirements.go
+++ b/pkg/cmd/run_requirements.go
@@ -16,7 +16,7 @@ const (
 	RequireCloudLoginOrOnPremLogin          = "cloud-login-or-on-prem-login"
 	RequireNonAPIKeyCloudLogin              = "non-api-key-cloud-login"
 	RequireNonAPIKeyCloudLoginOrOnPremLogin = "non-api-key-cloud-login-or-on-prem-login"
-	RequireNonCloudLogin                    = "non-cloud-login"
+	RequireNotCloudLogin                    = "not-cloud-login"
 	RequireOnPremLogin                      = "on-prem-login"
 )
 
@@ -45,8 +45,8 @@ func ErrIfMissingRunRequirement(cmd *cobra.Command, cfg *config.Config) error {
 			f = cfg.CheckIsNonAPIKeyCloudLogin
 		case RequireNonAPIKeyCloudLoginOrOnPremLogin:
 			f = cfg.CheckIsNonAPIKeyCloudLoginOrOnPremLogin
-		case RequireNonCloudLogin:
-			f = cfg.CheckIsNonCloudLogin
+		case RequireNotCloudLogin:
+			f = cfg.CheckIsNotCloudLogin
 		case RequireOnPremLogin:
 			f = cfg.CheckIsOnPremLogin
 		}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -48,7 +48,7 @@ var (
 		ErrorMsg:       "you must log in to Confluent Cloud with a username and password or log in to Confluent Platform to use this command",
 		SuggestionsMsg: "Log in with `confluent login` or `confluent login --url <mds-url>`.\n" + signupSuggestion,
 	}
-	RequireNonCloudLogin = &errors.RunRequirementError{
+	RequireNotCloudLogin = &errors.RunRequirementError{
 		ErrorMsg:       "you must log out of Confluent Cloud to use this command",
 		SuggestionsMsg: "Log out with `confluent logout`.\n",
 	}
@@ -710,9 +710,9 @@ func (c *Config) CheckIsNonAPIKeyCloudLoginOrOnPremLogin() error {
 	return nil
 }
 
-func (c *Config) CheckIsNonCloudLogin() error {
+func (c *Config) CheckIsNotCloudLogin() error {
 	if c.isCloud() {
-		return RequireNonCloudLogin
+		return RequireNotCloudLogin
 	}
 	return nil
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -48,7 +48,7 @@ var (
 		ErrorMsg:       "you must log in to Confluent Cloud with a username and password or log in to Confluent Platform to use this command",
 		SuggestionsMsg: "Log in with `confluent login` or `confluent login --url <mds-url>`.\n" + signupSuggestion,
 	}
-	RequireNotCloudLogin = &errors.RunRequirementError{
+	RequireCloudLogout = &errors.RunRequirementError{
 		ErrorMsg:       "you must log out of Confluent Cloud to use this command",
 		SuggestionsMsg: "Log out with `confluent logout`.\n",
 	}
@@ -710,9 +710,9 @@ func (c *Config) CheckIsNonAPIKeyCloudLoginOrOnPremLogin() error {
 	return nil
 }
 
-func (c *Config) CheckIsNotCloudLogin() error {
+func (c *Config) CheckIsCloudLogout() error {
 	if c.isCloud() {
-		return RequireNotCloudLogin
+		return RequireCloudLogout
 	}
 	return nil
 }

--- a/test/fixtures/output/kafka/broker/list-cloud-login.golden
+++ b/test/fixtures/output/kafka/broker/list-cloud-login.golden
@@ -1,5 +1,5 @@
-Error: this is not a Confluent Cloud command. You must log in to Confluent Platform to use this command
+Error: you must log out of Confluent Cloud to use this command
 
 Suggestions:
-    Log in to Confluent Platform with `confluent login --url <mds-url>`.
-    See available commands with `--help`.
+    Log out with `confluent logout`.
+    

--- a/test/fixtures/output/kafka/broker/list-not-logged-in.golden
+++ b/test/fixtures/output/kafka/broker/list-not-logged-in.golden
@@ -1,4 +1,4 @@
-Error: you must log in to Confluent Platform to use this command
+Error: Kafka REST URL not found
 
 Suggestions:
-    Log in to Confluent Platform with `confluent login --url <mds-url>`.
+    Use the `--url` flag or set `CONFLUENT_REST_URL`.


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- PLACEHOLDER

New Features
- PLACEHOLDER

Bug Fixes
- Fix a bug requiring an on-premises login to use the on-premises `confluent kafka` commands

Checklist
---------
- [x] Leave this box unchecked if features are not yet available in production

What
----
Fixing the run requirement bug where `InitializeOnPremKafkaRest` caused all run requirements to be ignored surfaced this issue, where incorrect run requirements were put on various on-prem kafka commands.

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
<!--
Has it been tested? How?
Copy and paste any instructions or steps that can save the reviewer time.
-->