### PR TITLE
[CLI-2351] Remove deprecated env vars

### DIFF
--- a/internal/cluster/command_describe.go
+++ b/internal/cluster/command_describe.go
@@ -2,6 +2,7 @@ package cluster
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/spf13/cobra"
 
@@ -83,7 +84,7 @@ func getURL(cmd *cobra.Command) (string, error) {
 		return url, err
 	}
 
-	if url := pauth.GetEnvWithFallback(pauth.ConfluentPlatformMDSURL, pauth.DeprecatedConfluentPlatformMDSURL); url != "" {
+	if url := os.Getenv(pauth.ConfluentPlatformMDSURL); url != "" {
 		return url, nil
 	}
 
@@ -96,7 +97,7 @@ func getCACertPath(cmd *cobra.Command) (string, error) {
 		return caCertPath, err
 	}
 
-	return pauth.GetEnvWithFallback(pauth.ConfluentPlatformCACertPath, pauth.DeprecatedConfluentPlatformCACertPath), nil
+	return os.Getenv(pauth.ConfluentPlatformCACertPath), nil
 }
 
 func printDescribe(cmd *cobra.Command, meta *ScopedId) error {

--- a/internal/login/command.go
+++ b/internal/login/command.go
@@ -3,6 +3,7 @@ package login
 import (
 	"context"
 	"fmt"
+	"os"
 	"path/filepath"
 	"regexp"
 	"runtime"
@@ -299,7 +300,7 @@ func (c *command) getCaCertPath(cmd *cobra.Command, username, url string) (strin
 	}
 
 	if caCertPath == "" {
-		caCertPath = pauth.GetEnvWithFallback(pauth.ConfluentPlatformCACertPath, pauth.DeprecatedConfluentPlatformCACertPath)
+		caCertPath = os.Getenv(pauth.ConfluentPlatformCACertPath)
 	}
 
 	var isLegacyContext bool
@@ -396,7 +397,7 @@ func (c *command) getURL(cmd *cobra.Command) (string, error) {
 		return "https://confluentgov.com", nil
 	}
 
-	if url := pauth.GetEnvWithFallback(pauth.ConfluentPlatformMDSURL, pauth.DeprecatedConfluentPlatformMDSURL); url != "" {
+	if url := os.Getenv(pauth.ConfluentPlatformMDSURL); url != "" {
 		return url, nil
 	}
 

--- a/internal/logout/command_test.go
+++ b/internal/logout/command_test.go
@@ -1,7 +1,6 @@
 package logout
 
 import (
-	"os"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -44,7 +43,6 @@ var (
 
 func TestLogout(t *testing.T) {
 	req := require.New(t)
-	clearCCloudDeprecatedEnvVar(req)
 	cfg := config.AuthenticatedCloudConfigMock()
 	contextName := cfg.Context().Name
 	logoutCmd, cfg := newLogoutCmd(cfg)
@@ -63,8 +61,4 @@ func verifyLoggedOutState(t *testing.T, cfg *config.Config, loggedOutContext str
 	state := cfg.Contexts[loggedOutContext].State
 	req.Empty(state.AuthToken)
 	req.Empty(state.Auth)
-}
-
-func clearCCloudDeprecatedEnvVar(req *require.Assertions) {
-	req.NoError(os.Unsetenv(pauth.DeprecatedConfluentCloudEmail))
 }

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -14,7 +14,6 @@ import (
 	"github.com/confluentinc/cli/v3/pkg/errors"
 	"github.com/confluentinc/cli/v3/pkg/jwt"
 	"github.com/confluentinc/cli/v3/pkg/keychain"
-	"github.com/confluentinc/cli/v3/pkg/output"
 	"github.com/confluentinc/cli/v3/pkg/secret"
 )
 
@@ -29,28 +28,7 @@ const (
 	ConfluentPlatformMDSURL      = "CONFLUENT_PLATFORM_MDS_URL"
 	ConfluentPlatformCACertPath  = "CONFLUENT_PLATFORM_CA_CERT_PATH"
 	ConfluentPlatformSSO         = "CONFLUENT_PLATFORM_SSO"
-
-	DeprecatedConfluentCloudEmail         = "CCLOUD_EMAIL"
-	DeprecatedConfluentCloudPassword      = "CCLOUD_PASSWORD"
-	DeprecatedConfluentPlatformUsername   = "CONFLUENT_USERNAME"
-	DeprecatedConfluentPlatformPassword   = "CONFLUENT_PASSWORD"
-	DeprecatedConfluentPlatformMDSURL     = "CONFLUENT_MDS_URL"
-	DeprecatedConfluentPlatformCACertPath = "CONFLUENT_CA_CERT_PATH"
 )
-
-// GetEnvWithFallback calls os.GetEnv() twice, once for the current var and once for the deprecated var.
-func GetEnvWithFallback(current, deprecated string) string {
-	if val := os.Getenv(current); val != "" {
-		return val
-	}
-
-	if val := os.Getenv(deprecated); val != "" {
-		output.ErrPrintf(false, errors.DeprecatedEnvVarWarningMsg, deprecated, current)
-		return val
-	}
-
-	return ""
-}
 
 func IsOnPremSSOEnv() bool {
 	return strings.ToLower(os.Getenv(ConfluentPlatformSSO)) == "true"

--- a/pkg/auth/login_credentials_manager.go
+++ b/pkg/auth/login_credentials_manager.go
@@ -44,10 +44,8 @@ func (c *Credentials) IsFullSet() bool {
 }
 
 type environmentVariables struct {
-	username           string
-	password           string
-	deprecatedUsername string
-	deprecatedPassword string
+	username string
+	password string
 }
 
 // Get login credentials using the functions from LoginCredentialsManager
@@ -99,10 +97,8 @@ func NewLoginCredentialsManager(prompt form.Prompt, client *ccloudv1.Client) Log
 
 func (h *LoginCredentialsManagerImpl) GetCloudCredentialsFromEnvVar(organizationId string) func() (*Credentials, error) {
 	envVars := environmentVariables{
-		username:           ConfluentCloudEmail,
-		password:           ConfluentCloudPassword,
-		deprecatedUsername: DeprecatedConfluentCloudEmail,
-		deprecatedPassword: DeprecatedConfluentCloudPassword,
+		username: ConfluentCloudEmail,
+		password: ConfluentCloudPassword,
 	}
 	return h.getCredentialsFromEnvVarFunc(envVars, organizationId)
 }
@@ -113,16 +109,6 @@ func (h *LoginCredentialsManagerImpl) getCredentialsFromEnvVarFunc(envVars envir
 		if h.isSSOUser(email, organizationId) {
 			log.CliLogger.Debugf("%s=%s belongs to an SSO user.", ConfluentCloudEmail, email)
 			return &Credentials{Username: email, IsSSO: true}, nil
-		}
-
-		if email == "" {
-			email, password = h.getEnvVarCredentials(envVars.deprecatedUsername, envVars.deprecatedPassword)
-			if email != "" {
-				output.ErrPrintf(false, errors.DeprecatedEnvVarWarningMsg, envVars.deprecatedUsername, envVars.username)
-			}
-			if password != "" {
-				output.ErrPrintf(false, errors.DeprecatedEnvVarWarningMsg, envVars.deprecatedPassword, envVars.password)
-			}
 		}
 
 		if password == "" {
@@ -149,10 +135,8 @@ func (h *LoginCredentialsManagerImpl) getEnvVarCredentials(userEnvVar, passwordE
 
 func (h *LoginCredentialsManagerImpl) GetOnPremCredentialsFromEnvVar() func() (*Credentials, error) {
 	envVars := environmentVariables{
-		username:           ConfluentPlatformUsername,
-		password:           ConfluentPlatformPassword,
-		deprecatedUsername: DeprecatedConfluentPlatformUsername,
-		deprecatedPassword: DeprecatedConfluentPlatformPassword,
+		username: ConfluentPlatformUsername,
+		password: ConfluentPlatformPassword,
 	}
 	return h.getCredentialsFromEnvVarFunc(envVars, "")
 }
@@ -360,16 +344,14 @@ func (h *LoginCredentialsManagerImpl) isOnPremSSOUser(url, caCertPath string, un
 // URL and ca-cert-path (if exists) are returned in addition to username and password
 func (h *LoginCredentialsManagerImpl) GetOnPremPrerunCredentialsFromEnvVar() func() (*Credentials, error) {
 	return func() (*Credentials, error) {
-		url := GetEnvWithFallback(ConfluentPlatformMDSURL, DeprecatedConfluentPlatformMDSURL)
+		url := os.Getenv(ConfluentPlatformMDSURL)
 		if url == "" {
 			return nil, fmt.Errorf(errors.NoUrlEnvVarErrorMsg)
 		}
 
 		envVars := environmentVariables{
-			username:           ConfluentPlatformUsername,
-			password:           ConfluentPlatformPassword,
-			deprecatedUsername: DeprecatedConfluentPlatformUsername,
-			deprecatedPassword: DeprecatedConfluentPlatformPassword,
+			username: ConfluentPlatformUsername,
+			password: ConfluentPlatformPassword,
 		}
 
 		creds, _ := h.getCredentialsFromEnvVarFunc(envVars, "")()
@@ -377,7 +359,7 @@ func (h *LoginCredentialsManagerImpl) GetOnPremPrerunCredentialsFromEnvVar() fun
 			return nil, fmt.Errorf(errors.NoCredentialsFoundErrorMsg)
 		}
 		creds.PrerunLoginURL = url
-		creds.PrerunLoginCaCertPath = GetEnvWithFallback(ConfluentPlatformCACertPath, DeprecatedConfluentPlatformCACertPath)
+		creds.PrerunLoginCaCertPath = os.Getenv(ConfluentPlatformCACertPath)
 
 		return creds, nil
 	}

--- a/pkg/auth/login_credentials_manager_test.go
+++ b/pkg/auth/login_credentials_manager_test.go
@@ -35,10 +35,6 @@ var (
 		Username: envUsername,
 		Password: envPassword,
 	}
-	deprecateEnvCredentials = &Credentials{
-		Username: deprecatedEnvUser,
-		Password: deprecatedEnvPassword,
-	}
 	promptCredentials = &Credentials{
 		Username: promptUsername,
 		Password: promptPassword,

--- a/pkg/auth/login_credentials_manager_test.go
+++ b/pkg/auth/login_credentials_manager_test.go
@@ -117,22 +117,8 @@ func (suite *LoginCredentialsManagerTestSuite) TestGetCCloudCredentialsFromEnvVa
 	suite.compareCredentials(envCredentials, creds)
 }
 
-func (suite *LoginCredentialsManagerTestSuite) TestGetCCloudCredentialsFromDeprecatedEnvVar() {
-	// incomplete credentials, setting on username but not password
-	suite.require.NoError(os.Setenv(DeprecatedConfluentCloudEmail, deprecatedEnvUser))
-	creds, err := suite.loginCredentialsManager.GetCloudCredentialsFromEnvVar("")()
-	suite.require.NoError(err)
-	suite.require.Nil(creds)
-
-	suite.setDeprecatedCCEnvVars()
-	creds, err = suite.loginCredentialsManager.GetCloudCredentialsFromEnvVar("")()
-	suite.require.NoError(err)
-	suite.compareCredentials(deprecateEnvCredentials, creds)
-}
-
 func (suite *LoginCredentialsManagerTestSuite) TestGetCCloudCredentialsFromEnvVarOrderOfPrecedence() {
 	suite.setCCEnvVars()
-	suite.setDeprecatedCCEnvVars()
 	creds, err := suite.loginCredentialsManager.GetCloudCredentialsFromEnvVar("")()
 	suite.require.NoError(err)
 	suite.compareCredentials(envCredentials, creds)
@@ -151,22 +137,8 @@ func (suite *LoginCredentialsManagerTestSuite) TestGetConfluentTokenAndCredentia
 	suite.compareCredentials(envCredentials, creds)
 }
 
-func (suite *LoginCredentialsManagerTestSuite) TestGetConfluentCredentialsFromDeprecatedEnvVar() {
-	// incomplete credentials, setting on username but not password
-	suite.require.NoError(os.Setenv(DeprecatedConfluentPlatformUsername, deprecatedEnvUser))
-	creds, err := suite.loginCredentialsManager.GetOnPremCredentialsFromEnvVar()()
-	suite.require.NoError(err)
-	suite.require.Nil(creds)
-
-	suite.setDeprecatedCPEnvVars()
-	creds, err = suite.loginCredentialsManager.GetOnPremCredentialsFromEnvVar()()
-	suite.require.NoError(err)
-	suite.compareCredentials(deprecateEnvCredentials, creds)
-}
-
 func (suite *LoginCredentialsManagerTestSuite) TestGetConfluentCredentialsFromEnvVarOrderOfPrecedence() {
 	suite.setCPEnvVars()
-	suite.setDeprecatedCPEnvVars()
 	creds, err := suite.loginCredentialsManager.GetOnPremCredentialsFromEnvVar()()
 	suite.require.NoError(err)
 	suite.compareCredentials(envCredentials, creds)
@@ -259,16 +231,9 @@ func (suite *LoginCredentialsManagerTestSuite) setCCEnvVars() {
 	suite.require.NoError(os.Setenv(ConfluentCloudPassword, envPassword))
 }
 
-func (suite *LoginCredentialsManagerTestSuite) setDeprecatedCCEnvVars() {
-	suite.require.NoError(os.Setenv(DeprecatedConfluentCloudEmail, deprecatedEnvUser))
-	suite.require.NoError(os.Setenv(DeprecatedConfluentCloudPassword, deprecatedEnvPassword))
-}
-
 func (suite *LoginCredentialsManagerTestSuite) clearCCEnvVars() {
 	suite.require.NoError(os.Unsetenv(ConfluentCloudEmail))
 	suite.require.NoError(os.Unsetenv(ConfluentCloudPassword))
-	suite.require.NoError(os.Unsetenv(DeprecatedConfluentCloudEmail))
-	suite.require.NoError(os.Unsetenv(DeprecatedConfluentCloudPassword))
 }
 
 func (suite *LoginCredentialsManagerTestSuite) setCPEnvVars() {
@@ -276,16 +241,9 @@ func (suite *LoginCredentialsManagerTestSuite) setCPEnvVars() {
 	suite.require.NoError(os.Setenv(ConfluentPlatformPassword, envPassword))
 }
 
-func (suite *LoginCredentialsManagerTestSuite) setDeprecatedCPEnvVars() {
-	suite.require.NoError(os.Setenv(DeprecatedConfluentPlatformUsername, deprecatedEnvUser))
-	suite.require.NoError(os.Setenv(DeprecatedConfluentPlatformPassword, deprecatedEnvPassword))
-}
-
 func (suite *LoginCredentialsManagerTestSuite) clearCPEnvVars() {
 	suite.require.NoError(os.Unsetenv(ConfluentPlatformUsername))
 	suite.require.NoError(os.Unsetenv(ConfluentPlatformPassword))
-	suite.require.NoError(os.Unsetenv(DeprecatedConfluentPlatformUsername))
-	suite.require.NoError(os.Unsetenv(DeprecatedConfluentPlatformPassword))
 }
 
 func TestLoginCredentialsManager(t *testing.T) {

--- a/pkg/cmd/authenticated_cli_command.go
+++ b/pkg/cmd/authenticated_cli_command.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"net/url"
+	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -193,7 +194,7 @@ func (c *AuthenticatedCLICommand) GetSchemaRegistryClient(cmd *cobra.Command) (*
 				return nil, err
 			}
 			if caLocation == "" {
-				caLocation = auth.GetEnvWithFallback(auth.ConfluentPlatformCACertPath, auth.DeprecatedConfluentPlatformCACertPath)
+				caLocation = os.Getenv(auth.ConfluentPlatformCACertPath)
 			}
 			if caLocation != "" {
 				caClient, err := utils.GetCAClient(caLocation)

--- a/pkg/cmd/prerunner.go
+++ b/pkg/cmd/prerunner.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"os"
 	"slices"
 	"strings"
 
@@ -133,7 +134,7 @@ func isOnPremLoginCmd(command *CLICommand, isTest bool) bool {
 	if command.CommandPath() != "confluent login" {
 		return false
 	}
-	mdsEnvUrl := pauth.GetEnvWithFallback(pauth.ConfluentPlatformMDSURL, pauth.DeprecatedConfluentPlatformMDSURL)
+	mdsEnvUrl := os.Getenv(pauth.ConfluentPlatformMDSURL)
 	url, _ := command.Flags().GetString("url")
 	return (url == "" && mdsEnvUrl != "") || !ccloudv2.IsCCloudURL(url, isTest)
 }
@@ -142,7 +143,7 @@ func isCloudLoginCmd(command *CLICommand, isTest bool) bool {
 	if command.CommandPath() != "confluent login" {
 		return false
 	}
-	mdsEnvUrl := pauth.GetEnvWithFallback(pauth.ConfluentPlatformMDSURL, pauth.DeprecatedConfluentPlatformMDSURL)
+	mdsEnvUrl := os.Getenv(pauth.ConfluentPlatformMDSURL)
 	url, _ := command.Flags().GetString("url")
 	return (url == "" && mdsEnvUrl == "") || ccloudv2.IsCCloudURL(url, isTest)
 }
@@ -610,7 +611,7 @@ func resolveOnPremKafkaRestFlags(cmd *cobra.Command) (*onPremKafkaRestFlagValues
 
 func createOnPremKafkaRestClient(ctx *config.Context, caCertPath, clientCertPath, clientKeyPath string, logger *log.Logger) (*http.Client, error) {
 	if caCertPath == "" {
-		caCertPath = pauth.GetEnvWithFallback(pauth.ConfluentPlatformCACertPath, pauth.DeprecatedConfluentPlatformCACertPath)
+		caCertPath = os.Getenv(pauth.ConfluentPlatformCACertPath)
 		logger.Debugf("Found CA cert path: %s", caCertPath)
 	}
 	// use cert path flag or env var if it was passed

--- a/pkg/errors/warning_message.go
+++ b/pkg/errors/warning_message.go
@@ -4,9 +4,6 @@ const (
 	// secret commands
 	SaveTheMasterKeyMsg = "Save the master key. It cannot be retrieved later."
 
-	// login command
-	DeprecatedEnvVarWarningMsg = "`%s` has been deprecated and replaced by `%s`.\n"
-
 	// audit log migration
 	OtherCategoryWarning = "\\“Other\\” Category Warning: The OTHER event category rule from the route %q " +
 		"for cluster %q has been dropped because it contains a MANAGEMENT event category. The OTHER event " +


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- The following deprecated environment variables are no longer supported: "CCLOUD_EMAIL", "CCLOUD_PASSWORD", "CONFLUENT_USERNAME", "CONFLUENT_PASSWORD", "CONFLUENT_MDS_URL", and "CONFLUENT_CA_CERT_PATH"

New Features
- PLACEHOLDER

Bug Fixes
- PLACEHOLDER

Checklist
---------
- [x] Leave this box unchecked if features are not yet available in production

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
<!--
Has it been tested? How?
Copy and paste any instructions or steps that can save the reviewer time.
-->