### PR TITLE
[CLI-2690, CLI-2711] Disable updates by default in CP

### DIFF
--- a/debian/Makefile
+++ b/debian/Makefile
@@ -60,7 +60,7 @@ install: apply-patches
 		mkdir -p $${dir}; \
 		ext=""; if [[ $${dir} =~ windows_.+ ]]; then ext=".exe"; fi; \
 		filepath=$${dir}/confluent$${ext}; \
-		curl -f -s https://s3-us-west-2.amazonaws.com/confluent.cloud/confluent-cli/binaries/$(CLI_VERSION)/confluent_$(CLI_VERSION)_$${dir}$${ext} -o $${filepath}; \
+		curl -f -s https://s3-us-west-2.amazonaws.com/confluent.cloud/confluent-cli/binaries/$(CLI_VERSION)/confluent-disableupdates_$(CLI_VERSION)_$${dir}$${ext} -o $${filepath}; \
 		chmod 755 $${filepath}; \
 	done
 

--- a/debian/patches/standard_build_layout.patch
+++ b/debian/patches/standard_build_layout.patch
@@ -1,5 +1,10 @@
+<<<<<<< Updated upstream
 --- cli/Makefile	2024-05-01 15:38:42.760440968 -0700
 +++ debian/Makefile	2024-04-19 15:12:44.087477824 -0700
+=======
+--- cli/Makefile	2024-06-07 08:55:44.538238893 -0700
++++ debian/Makefile	2024-06-07 13:26:32.169421105 -0700
+>>>>>>> Stashed changes
 @@ -1,149 +1,144 @@
 -SHELL := /bin/bash
 -GORELEASER_VERSION := v1.21.2
@@ -194,7 +199,7 @@
 +		mkdir -p $${dir}; \
 +		ext=""; if [[ $${dir} =~ windows_.+ ]]; then ext=".exe"; fi; \
 +		filepath=$${dir}/confluent$${ext}; \
-+		curl -f -s https://s3-us-west-2.amazonaws.com/confluent.cloud/confluent-cli/binaries/$(CLI_VERSION)/confluent_$(CLI_VERSION)_$${dir}$${ext} -o $${filepath}; \
++		curl -f -s https://s3-us-west-2.amazonaws.com/confluent.cloud/confluent-cli/binaries/$(CLI_VERSION)/confluent-disableupdates_$(CLI_VERSION)_$${dir}$${ext} -o $${filepath}; \
 +		chmod 755 $${filepath}; \
 +	done
 +


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- PLACEHOLDER

New Features
- PLACEHOLDER

Bug Fixes
- PLACEHOLDER

Checklist
---------
- [ ] Leave this box unchecked if features are not yet available in production

What
----
Binaries packaged with CP should not be updatable. Users can download the CLI separately if they wish to update it.

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
<!--
Has it been tested? How?
Copy and paste any instructions or steps that can save the reviewer time.
-->