### PR TITLE
[CLI-2696] In `schema-registry schema list`, rename "Schema ID" to "ID"

### DIFF
--- a/internal/schema-registry/command_schema_list.go
+++ b/internal/schema-registry/command_schema_list.go
@@ -10,9 +10,9 @@ import (
 )
 
 type row struct {
-	SchemaId int32  `human:"Schema ID" serialized:"schema_id"`
-	Subject  string `human:"Subject" serialized:"subject"`
-	Version  int32  `human:"Version" serialized:"version"`
+	Id      int32  `human:"ID" serialized:"id"`
+	Subject string `human:"Subject" serialized:"subject"`
+	Version int32  `human:"Version" serialized:"version"`
 }
 
 func (c *command) newSchemaListCommand(cfg *config.Config) *cobra.Command {
@@ -80,9 +80,9 @@ func (c *command) schemaList(cmd *cobra.Command, _ []string) error {
 	list := output.NewList(cmd)
 	for _, schema := range schemas {
 		list.Add(&row{
-			SchemaId: schema.GetId(),
-			Subject:  schema.GetSubject(),
-			Version:  schema.GetVersion(),
+			Id:      schema.GetId(),
+			Subject: schema.GetSubject(),
+			Version: schema.GetVersion(),
 		})
 	}
 	return list.Print()

--- a/test/fixtures/output/schema-registry/schema/list-schemas-default.golden
+++ b/test/fixtures/output/schema-registry/schema/list-schemas-default.golden
@@ -1,5 +1,5 @@
-  Schema ID |   Subject   | Version  
-------------+-------------+----------
-     100001 | mysubject-1 |       1  
-     100002 | mysubject-1 |       2  
-     100003 | mysubject-2 |       1  
+    ID   |   Subject   | Version  
+---------+-------------+----------
+  100001 | mysubject-1 |       1  
+  100002 | mysubject-1 |       2  
+  100003 | mysubject-2 |       1  

--- a/test/fixtures/output/schema-registry/schema/list-schemas-subject.golden
+++ b/test/fixtures/output/schema-registry/schema/list-schemas-subject.golden
@@ -1,4 +1,4 @@
-  Schema ID |   Subject   | Version  
-------------+-------------+----------
-     100001 | mysubject-1 |       1  
-     100002 | mysubject-1 |       2  
+    ID   |   Subject   | Version  
+---------+-------------+----------
+  100001 | mysubject-1 |       1  
+  100002 | mysubject-1 |       2  


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- Renamed `Schema ID` to `ID` in `schema-registry schema list`

Checklist
---------
- [x] Leave this box unchecked if features are not yet available in production

What
----
Renamed `Schema ID` to `ID` in `schema-registry schema list`

References
----------
https://confluentinc.atlassian.net/browse/CLI-2696

Test & Review
-------------
Updated integration tests