### PR TITLE
Do not pass `""` to backend if `--algorithm` is unspecified

### DIFF
--- a/internal/schema-registry/command_dek_create.go
+++ b/internal/schema-registry/command_dek_create.go
@@ -77,16 +77,13 @@ func (c *command) dekCreate(cmd *cobra.Command, _ []string) error {
 	}
 
 	createReq := srsdk.CreateDekRequest{
-		Subject: srsdk.PtrString(subject),
-		Version: srsdk.PtrInt32(version),
+		Subject:              srsdk.PtrString(subject),
+		Version:              srsdk.PtrInt32(version),
+		EncryptedKeyMaterial: srsdk.PtrString(encryptedKeyMaterial),
 	}
 
 	if cmd.Flags().Changed("algorithm") {
 		createReq.Algorithm = srsdk.PtrString(algorithm)
-	}
-
-	if cmd.Flags().Changed("encrypted-key-material") {
-		createReq.EncryptedKeyMaterial = srsdk.PtrString(encryptedKeyMaterial)
 	}
 
 	dek, err := client.CreateDek(kekName, createReq)

--- a/internal/schema-registry/command_dek_create.go
+++ b/internal/schema-registry/command_dek_create.go
@@ -51,7 +51,7 @@ func (c *command) dekCreate(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	name, err := cmd.Flags().GetString("kek-name")
+	kekName, err := cmd.Flags().GetString("kek-name")
 	if err != nil {
 		return err
 	}
@@ -77,13 +77,19 @@ func (c *command) dekCreate(cmd *cobra.Command, _ []string) error {
 	}
 
 	createReq := srsdk.CreateDekRequest{
-		Subject:              srsdk.PtrString(subject),
-		Version:              srsdk.PtrInt32(version),
-		Algorithm:            srsdk.PtrString(algorithm),
-		EncryptedKeyMaterial: srsdk.PtrString(encryptedKeyMaterial),
+		Subject: srsdk.PtrString(subject),
+		Version: srsdk.PtrInt32(version),
 	}
 
-	dek, err := client.CreateDek(name, createReq)
+	if cmd.Flags().Changed("algorithm") {
+		createReq.Algorithm = srsdk.PtrString(algorithm)
+	}
+
+	if cmd.Flags().Changed("encrypted-key-material") {
+		createReq.EncryptedKeyMaterial = srsdk.PtrString(encryptedKeyMaterial)
+	}
+
+	dek, err := client.CreateDek(kekName, createReq)
 	if err != nil {
 		return err
 	}

--- a/internal/schema-registry/command_dek_delete.go
+++ b/internal/schema-registry/command_dek_delete.go
@@ -46,7 +46,7 @@ func (c *command) dekDelete(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	name, err := cmd.Flags().GetString("kek-name")
+	kekName, err := cmd.Flags().GetString("kek-name")
 	if err != nil {
 		return err
 	}
@@ -77,9 +77,9 @@ func (c *command) dekDelete(cmd *cobra.Command, _ []string) error {
 	}
 
 	if version == "" {
-		err = client.DeleteDekVersions(name, subject, algorithm, permanent)
+		err = client.DeleteDekVersions(kekName, subject, algorithm, permanent)
 	} else {
-		err = client.DeleteDekVersion(name, subject, version, algorithm, permanent)
+		err = client.DeleteDekVersion(kekName, subject, version, algorithm, permanent)
 	}
 	if err != nil {
 		return err

--- a/internal/schema-registry/command_dek_describe.go
+++ b/internal/schema-registry/command_dek_describe.go
@@ -41,7 +41,7 @@ func (c *command) dekDescribe(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	name, err := cmd.Flags().GetString("kek-name")
+	kekName, err := cmd.Flags().GetString("kek-name")
 	if err != nil {
 		return err
 	}
@@ -66,7 +66,7 @@ func (c *command) dekDescribe(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	dek, err := client.GetDekByVersion(name, subject, version, algorithm, all)
+	dek, err := client.GetDekByVersion(kekName, subject, version, algorithm, all)
 	if err != nil {
 		return err
 	}

--- a/internal/schema-registry/command_dek_subject_list.go
+++ b/internal/schema-registry/command_dek_subject_list.go
@@ -43,12 +43,12 @@ func (c *command) dekSubjectList(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	name, err := cmd.Flags().GetString("kek-name")
+	kekName, err := cmd.Flags().GetString("kek-name")
 	if err != nil {
 		return err
 	}
 
-	subjects, err := client.GetDekSubjects(name)
+	subjects, err := client.GetDekSubjects(kekName)
 	if err != nil {
 		return err
 	}

--- a/internal/schema-registry/command_dek_undelete.go
+++ b/internal/schema-registry/command_dek_undelete.go
@@ -41,7 +41,7 @@ func (c *command) dekUndelete(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	name, err := cmd.Flags().GetString("kek-name")
+	kekName, err := cmd.Flags().GetString("kek-name")
 	if err != nil {
 		return err
 	}
@@ -62,9 +62,9 @@ func (c *command) dekUndelete(cmd *cobra.Command, _ []string) error {
 	}
 
 	if version == "" {
-		err = client.UndeleteDekVersions(name, subject, algorithm)
+		err = client.UndeleteDekVersions(kekName, subject, algorithm)
 	} else {
-		err = client.UndeleteDekVersion(name, subject, version, algorithm)
+		err = client.UndeleteDekVersion(kekName, subject, version, algorithm)
 	}
 	if err != nil {
 		return err

--- a/internal/schema-registry/command_dek_version_list.go
+++ b/internal/schema-registry/command_dek_version_list.go
@@ -38,7 +38,7 @@ func (c *command) dekVersionList(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	name, err := cmd.Flags().GetString("kek-name")
+	kekName, err := cmd.Flags().GetString("kek-name")
 	if err != nil {
 		return err
 	}
@@ -58,7 +58,7 @@ func (c *command) dekVersionList(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	versions, err := client.GetDeKVersions(name, subject, algorithm, all)
+	versions, err := client.GetDeKVersions(kekName, subject, algorithm, all)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- PLACEHOLDER

New Features
- PLACEHOLDER

Bug Fixes
- Allow `confluent schema-registry dek create` to be called without specifying `--algorithm`

Checklist
---------
- [x] Leave this box unchecked if features are not yet available in production

What
----
If `--algorithm` was omitted, we previously would pass `""` to the backend which resulted in:
```
Error: Cannot coerce empty String ("") to `DekFormat` value (but could if coercion was enabled using `CoercionConfig`)
```
Now, we do not pass that field.

Test & Review
-------------
Manually tested