### PR TITLE
[CLI-2851] `kafka region list` output should match `flink region list`

### DIFF
--- a/internal/kafka/command_region_list.go
+++ b/internal/kafka/command_region_list.go
@@ -1,8 +1,6 @@
 package kafka
 
 import (
-	"strings"
-
 	"github.com/spf13/cobra"
 
 	pcmd "github.com/confluentinc/cli/v3/pkg/cmd"
@@ -44,7 +42,7 @@ func (c *regionCommand) list(cmd *cobra.Command, _ []string) error {
 	list := output.NewList(cmd)
 	for _, region := range regions {
 		out := &regionOut{
-			Cloud:  strings.ToUpper(region.CloudId),
+			Cloud:  region.CloudId,
 			Region: region.RegionId,
 			Name:   region.RegionName,
 		}

--- a/internal/kafka/command_region_list.go
+++ b/internal/kafka/command_region_list.go
@@ -1,12 +1,20 @@
 package kafka
 
 import (
+	"strings"
+
 	"github.com/spf13/cobra"
 
 	pcmd "github.com/confluentinc/cli/v3/pkg/cmd"
 	"github.com/confluentinc/cli/v3/pkg/kafka"
 	"github.com/confluentinc/cli/v3/pkg/output"
 )
+
+type regionOut struct {
+	Name   string `human:"Name" serialized:"name"`
+	Cloud  string `human:"Cloud" serialized:"cloud"`
+	Region string `human:"Region" serialized:"region"`
+}
 
 func (c *regionCommand) newListCommand() *cobra.Command {
 	cmd := &cobra.Command{
@@ -35,7 +43,12 @@ func (c *regionCommand) list(cmd *cobra.Command, _ []string) error {
 
 	list := output.NewList(cmd)
 	for _, region := range regions {
-		list.Add(region)
+		out := &regionOut{
+			Cloud:  strings.ToUpper(region.CloudId),
+			Region: region.RegionId,
+			Name:   region.RegionName,
+		}
+		list.Add(out)
 	}
 	return list.Print()
 }

--- a/test/fixtures/output/kafka/10.golden
+++ b/test/fixtures/output/kafka/10.golden
@@ -1,4 +1,4 @@
-  Cloud ID |     Cloud Name      |   Region ID    |       Region Name        
------------+---------------------+----------------+--------------------------
-  aws      | Amazon Web Services | ap-northeast-1 | ap-northeast-1 (Tokyo)   
-  aws      | Amazon Web Services | us-east-1      | us-east-1 (N. Virginia)  
+           Name           | Cloud |     Region      
+--------------------------+-------+-----------------
+  ap-northeast-1 (Tokyo)  | AWS   | ap-northeast-1  
+  us-east-1 (N. Virginia) | AWS   | us-east-1       

--- a/test/fixtures/output/kafka/10.golden
+++ b/test/fixtures/output/kafka/10.golden
@@ -1,4 +1,4 @@
            Name           | Cloud |     Region      
 --------------------------+-------+-----------------
-  ap-northeast-1 (Tokyo)  | AWS   | ap-northeast-1  
-  us-east-1 (N. Virginia) | AWS   | us-east-1       
+  ap-northeast-1 (Tokyo)  | aws   | ap-northeast-1  
+  us-east-1 (N. Virginia) | aws   | us-east-1       

--- a/test/fixtures/output/kafka/11.golden
+++ b/test/fixtures/output/kafka/11.golden
@@ -1,3 +1,3 @@
             Name            | Cloud |    Region      
 ----------------------------+-------+----------------
-  southeastasia (Singapore) | AZURE | southeastasia  
+  southeastasia (Singapore) | azure | southeastasia  

--- a/test/fixtures/output/kafka/11.golden
+++ b/test/fixtures/output/kafka/11.golden
@@ -1,3 +1,3 @@
-  Cloud ID | Cloud Name |   Region ID   |        Region Name         
------------+------------+---------------+----------------------------
-  azure    | Azure      | southeastasia | southeastasia (Singapore)  
+            Name            | Cloud |    Region      
+----------------------------+-------+----------------
+  southeastasia (Singapore) | AZURE | southeastasia  

--- a/test/fixtures/output/kafka/14.golden
+++ b/test/fixtures/output/kafka/14.golden
@@ -1,7 +1,7 @@
              Name             | Cloud |     Region       
 ------------------------------+-------+------------------
-  ap-northeast-1 (Tokyo)      | AWS   | ap-northeast-1   
-  asia-east2 (Hong Kong)      | GCP   | asia-east2       
-  asia-southeast1 (Singapore) | GCP   | asia-southeast1  
-  southeastasia (Singapore)   | AZURE | southeastasia    
-  us-east-1 (N. Virginia)     | AWS   | us-east-1        
+  ap-northeast-1 (Tokyo)      | aws   | ap-northeast-1   
+  asia-east2 (Hong Kong)      | gcp   | asia-east2       
+  asia-southeast1 (Singapore) | gcp   | asia-southeast1  
+  southeastasia (Singapore)   | azure | southeastasia    
+  us-east-1 (N. Virginia)     | aws   | us-east-1        

--- a/test/fixtures/output/kafka/14.golden
+++ b/test/fixtures/output/kafka/14.golden
@@ -1,7 +1,7 @@
-  Cloud ID |      Cloud Name       |    Region ID    |         Region Name          
------------+-----------------------+-----------------+------------------------------
-  aws      | Amazon Web Services   | ap-northeast-1  | ap-northeast-1 (Tokyo)       
-  aws      | Amazon Web Services   | us-east-1       | us-east-1 (N. Virginia)      
-  azure    | Azure                 | southeastasia   | southeastasia (Singapore)    
-  gcp      | Google Cloud Platform | asia-east2      | asia-east2 (Hong Kong)       
-  gcp      | Google Cloud Platform | asia-southeast1 | asia-southeast1 (Singapore)  
+             Name             | Cloud |     Region       
+------------------------------+-------+------------------
+  ap-northeast-1 (Tokyo)      | AWS   | ap-northeast-1   
+  asia-east2 (Hong Kong)      | GCP   | asia-east2       
+  asia-southeast1 (Singapore) | GCP   | asia-southeast1  
+  southeastasia (Singapore)   | AZURE | southeastasia    
+  us-east-1 (N. Virginia)     | AWS   | us-east-1        

--- a/test/fixtures/output/kafka/15.golden
+++ b/test/fixtures/output/kafka/15.golden
@@ -1,27 +1,27 @@
 [
   {
     "name": "ap-northeast-1 (Tokyo)",
-    "cloud": "AWS",
+    "cloud": "aws",
     "region": "ap-northeast-1"
   },
   {
     "name": "asia-east2 (Hong Kong)",
-    "cloud": "GCP",
+    "cloud": "gcp",
     "region": "asia-east2"
   },
   {
     "name": "asia-southeast1 (Singapore)",
-    "cloud": "GCP",
+    "cloud": "gcp",
     "region": "asia-southeast1"
   },
   {
     "name": "southeastasia (Singapore)",
-    "cloud": "AZURE",
+    "cloud": "azure",
     "region": "southeastasia"
   },
   {
     "name": "us-east-1 (N. Virginia)",
-    "cloud": "AWS",
+    "cloud": "aws",
     "region": "us-east-1"
   }
 ]

--- a/test/fixtures/output/kafka/15.golden
+++ b/test/fixtures/output/kafka/15.golden
@@ -1,32 +1,27 @@
 [
   {
-    "cloud_id": "aws",
-    "cloud_name": "Amazon Web Services",
-    "region_id": "ap-northeast-1",
-    "region_name": "ap-northeast-1 (Tokyo)"
+    "name": "ap-northeast-1 (Tokyo)",
+    "cloud": "AWS",
+    "region": "ap-northeast-1"
   },
   {
-    "cloud_id": "aws",
-    "cloud_name": "Amazon Web Services",
-    "region_id": "us-east-1",
-    "region_name": "us-east-1 (N. Virginia)"
+    "name": "asia-east2 (Hong Kong)",
+    "cloud": "GCP",
+    "region": "asia-east2"
   },
   {
-    "cloud_id": "azure",
-    "cloud_name": "Azure",
-    "region_id": "southeastasia",
-    "region_name": "southeastasia (Singapore)"
+    "name": "asia-southeast1 (Singapore)",
+    "cloud": "GCP",
+    "region": "asia-southeast1"
   },
   {
-    "cloud_id": "gcp",
-    "cloud_name": "Google Cloud Platform",
-    "region_id": "asia-east2",
-    "region_name": "asia-east2 (Hong Kong)"
+    "name": "southeastasia (Singapore)",
+    "cloud": "AZURE",
+    "region": "southeastasia"
   },
   {
-    "cloud_id": "gcp",
-    "cloud_name": "Google Cloud Platform",
-    "region_id": "asia-southeast1",
-    "region_name": "asia-southeast1 (Singapore)"
+    "name": "us-east-1 (N. Virginia)",
+    "cloud": "AWS",
+    "region": "us-east-1"
   }
 ]

--- a/test/fixtures/output/kafka/16.golden
+++ b/test/fixtures/output/kafka/16.golden
@@ -1,27 +1,27 @@
 [
   {
     "name": "ap-northeast-1 (Tokyo)",
-    "cloud": "AWS",
+    "cloud": "aws",
     "region": "ap-northeast-1"
   },
   {
     "name": "asia-east2 (Hong Kong)",
-    "cloud": "GCP",
+    "cloud": "gcp",
     "region": "asia-east2"
   },
   {
     "name": "asia-southeast1 (Singapore)",
-    "cloud": "GCP",
+    "cloud": "gcp",
     "region": "asia-southeast1"
   },
   {
     "name": "southeastasia (Singapore)",
-    "cloud": "AZURE",
+    "cloud": "azure",
     "region": "southeastasia"
   },
   {
     "name": "us-east-1 (N. Virginia)",
-    "cloud": "AWS",
+    "cloud": "aws",
     "region": "us-east-1"
   }
 ]

--- a/test/fixtures/output/kafka/16.golden
+++ b/test/fixtures/output/kafka/16.golden
@@ -1,32 +1,27 @@
 [
   {
-    "cloud_id": "aws",
-    "cloud_name": "Amazon Web Services",
-    "region_id": "ap-northeast-1",
-    "region_name": "ap-northeast-1 (Tokyo)"
+    "name": "ap-northeast-1 (Tokyo)",
+    "cloud": "AWS",
+    "region": "ap-northeast-1"
   },
   {
-    "cloud_id": "aws",
-    "cloud_name": "Amazon Web Services",
-    "region_id": "us-east-1",
-    "region_name": "us-east-1 (N. Virginia)"
+    "name": "asia-east2 (Hong Kong)",
+    "cloud": "GCP",
+    "region": "asia-east2"
   },
   {
-    "cloud_id": "azure",
-    "cloud_name": "Azure",
-    "region_id": "southeastasia",
-    "region_name": "southeastasia (Singapore)"
+    "name": "asia-southeast1 (Singapore)",
+    "cloud": "GCP",
+    "region": "asia-southeast1"
   },
   {
-    "cloud_id": "gcp",
-    "cloud_name": "Google Cloud Platform",
-    "region_id": "asia-east2",
-    "region_name": "asia-east2 (Hong Kong)"
+    "name": "southeastasia (Singapore)",
+    "cloud": "AZURE",
+    "region": "southeastasia"
   },
   {
-    "cloud_id": "gcp",
-    "cloud_name": "Google Cloud Platform",
-    "region_id": "asia-southeast1",
-    "region_name": "asia-southeast1 (Singapore)"
+    "name": "us-east-1 (N. Virginia)",
+    "cloud": "AWS",
+    "region": "us-east-1"
   }
 ]

--- a/test/fixtures/output/kafka/9.golden
+++ b/test/fixtures/output/kafka/9.golden
@@ -1,4 +1,4 @@
-  Cloud ID |      Cloud Name       |    Region ID    |         Region Name          
------------+-----------------------+-----------------+------------------------------
-  gcp      | Google Cloud Platform | asia-east2      | asia-east2 (Hong Kong)       
-  gcp      | Google Cloud Platform | asia-southeast1 | asia-southeast1 (Singapore)  
+             Name             | Cloud |     Region       
+------------------------------+-------+------------------
+  asia-east2 (Hong Kong)      | GCP   | asia-east2       
+  asia-southeast1 (Singapore) | GCP   | asia-southeast1  

--- a/test/fixtures/output/kafka/9.golden
+++ b/test/fixtures/output/kafka/9.golden
@@ -1,4 +1,4 @@
              Name             | Cloud |     Region       
 ------------------------------+-------+------------------
-  asia-east2 (Hong Kong)      | GCP   | asia-east2       
-  asia-southeast1 (Singapore) | GCP   | asia-southeast1  
+  asia-east2 (Hong Kong)      | gcp   | asia-east2       
+  asia-southeast1 (Singapore) | gcp   | asia-southeast1  


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- Changed column "Region Name" to "Name", "Cloud ID" to "Cloud ", "Region ID" to "Region" and removed "Cloud Name" in the output of `confluent kafka region list`

Checklist
---------
- [x] Leave this box unchecked if features are not yet available in production

What
----
`kafka region list` output should match `flink region list`

References
----------
https://confluentinc.atlassian.net/browse/CLI-2851

Test & Review
-------------
Updated Integration tests.