### PR TITLE
Fix `--headers` flag bug in `local kafka topic produce`

### DIFF
--- a/internal/kafka/command_topic.go
+++ b/internal/kafka/command_topic.go
@@ -237,7 +237,7 @@ func ProduceToTopic(cmd *cobra.Command, keyMetaInfo []byte, valueMetaInfo []byte
 			break
 		}
 
-		message, err := GetProduceMessage(cmd, keyMetaInfo, valueMetaInfo, topic, data, keySerializer, valueSerializer)
+		message, err := getProduceMessage(cmd, keyMetaInfo, valueMetaInfo, topic, data, keySerializer, valueSerializer)
 		if err != nil {
 			return err
 		}

--- a/internal/kafka/command_topic_produce.go
+++ b/internal/kafka/command_topic_produce.go
@@ -433,6 +433,7 @@ func getProduceMessage(cmd *cobra.Command, keyMetaInfo, valueMetaInfo []byte, to
 		Value: value,
 	}
 
+	// This error is intentionally ignored because `confluent local kafka topic produce` does not define this flag
 	headers, _ := cmd.Flags().GetStringSlice("headers")
 	if headers != nil {
 		parsedHeaders, err := parseHeaders(headers, delimiter)

--- a/internal/kafka/command_topic_produce.go
+++ b/internal/kafka/command_topic_produce.go
@@ -408,23 +408,13 @@ func PrepareInputChannel(scanErr *error) (chan string, func()) {
 	}
 }
 
-func GetProduceMessage(cmd *cobra.Command, keyMetaInfo, valueMetaInfo []byte, topic, data string, keySerializer, valueSerializer serdes.SerializationProvider) (*ckafka.Message, error) {
+func getProduceMessage(cmd *cobra.Command, keyMetaInfo, valueMetaInfo []byte, topic, data string, keySerializer, valueSerializer serdes.SerializationProvider) (*ckafka.Message, error) {
 	parseKey, err := cmd.Flags().GetBool("parse-key")
 	if err != nil {
 		return nil, err
 	}
 
 	delimiter, err := cmd.Flags().GetString("delimiter")
-	if err != nil {
-		return nil, err
-	}
-
-	headers, err := cmd.Flags().GetStringSlice("headers")
-	if err != nil {
-		return nil, err
-	}
-
-	parsedHeaders, err := parseHeaders(headers, delimiter)
 	if err != nil {
 		return nil, err
 	}
@@ -439,9 +429,17 @@ func GetProduceMessage(cmd *cobra.Command, keyMetaInfo, valueMetaInfo []byte, to
 			Topic:     &topic,
 			Partition: ckafka.PartitionAny,
 		},
-		Key:     key,
-		Value:   value,
-		Headers: parsedHeaders,
+		Key:   key,
+		Value: value,
+	}
+
+	headers, _ := cmd.Flags().GetStringSlice("headers")
+	if headers != nil {
+		parsedHeaders, err := parseHeaders(headers, delimiter)
+		if err != nil {
+			return nil, err
+		}
+		message.Headers = parsedHeaders
 	}
 
 	return message, nil


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- PLACEHOLDER

New Features
- PLACEHOLDER

Bug Fixes
- Fix missing `--headers` flag error in `confluent local kafka topic produce`

Checklist
---------
- [ ] Leave this box unchecked if features are not yet available in production

What
----
The `--headers` flag was missing in `confluent local kafka topic produce` but trying to be accessed due to the changes from #2775. Ignore this flag if it is not specified.

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
Manually tested