### PR TITLE
[CLI-2853] Remove `environment` and `context` flags from various `use` commands

### DIFF
--- a/internal/environment/command_use.go
+++ b/internal/environment/command_use.go
@@ -21,8 +21,6 @@ func (c *command) newUseCommand() *cobra.Command {
 		RunE:              c.use,
 	}
 
-	pcmd.AddContextFlag(cmd, c.CLICommand)
-
 	return cmd
 }
 

--- a/internal/flink/command_region_use.go
+++ b/internal/flink/command_region_use.go
@@ -31,8 +31,6 @@ func (c *command) newRegionUseCommand() *cobra.Command {
 
 	pcmd.AddCloudFlag(cmd)
 	pcmd.AddRegionFlagFlink(cmd, c.AuthenticatedCLICommand)
-	pcmd.AddEnvironmentFlag(cmd, c.AuthenticatedCLICommand)
-	pcmd.AddContextFlag(cmd, c.CLICommand)
 
 	cobra.CheckErr(cmd.MarkFlagRequired("cloud"))
 	cobra.CheckErr(cmd.MarkFlagRequired("region"))

--- a/internal/iam/command_service_account_use.go
+++ b/internal/iam/command_service_account_use.go
@@ -19,8 +19,6 @@ func (c *serviceAccountCommand) newUseCommand() *cobra.Command {
 		RunE:              c.use,
 	}
 
-	pcmd.AddContextFlag(cmd, c.CLICommand)
-
 	return cmd
 }
 

--- a/internal/kafka/command_cluster_use.go
+++ b/internal/kafka/command_cluster_use.go
@@ -22,9 +22,6 @@ func (c *clusterCommand) newUseCommand() *cobra.Command {
 		Annotations:       map[string]string{pcmd.RunRequirement: pcmd.RequireNonAPIKeyCloudLogin},
 	}
 
-	pcmd.AddContextFlag(cmd, c.CLICommand)
-	pcmd.AddEnvironmentFlag(cmd, c.AuthenticatedCLICommand)
-
 	return cmd
 }
 

--- a/test/fixtures/output/environment/use-help.golden
+++ b/test/fixtures/output/environment/use-help.golden
@@ -3,9 +3,6 @@ Choose a Confluent Cloud environment to be used in subsequent commands which sup
 Usage:
   confluent environment use <id> [flags]
 
-Flags:
-      --context string   CLI context name.
-
 Global Flags:
   -h, --help            Show help for this command.
       --unsafe-trace    Equivalent to -vvvv, but also log HTTP requests and responses which might contain plaintext secrets.

--- a/test/fixtures/output/flink/region/use-help.golden
+++ b/test/fixtures/output/flink/region/use-help.golden
@@ -9,10 +9,8 @@ Select region "N. Virginia (us-east-1)" for use in subsequent Flink commands.
   $ confluent flink region use --cloud aws --region us-east-1
 
 Flags:
-      --cloud string         REQUIRED: Specify the cloud provider as "aws", "azure", or "gcp".
-      --region string        REQUIRED: Cloud region for Flink (use "confluent flink region list" to see all).
-      --environment string   Environment ID.
-      --context string       CLI context name.
+      --cloud string    REQUIRED: Specify the cloud provider as "aws", "azure", or "gcp".
+      --region string   REQUIRED: Cloud region for Flink (use "confluent flink region list" to see all).
 
 Global Flags:
   -h, --help            Show help for this command.

--- a/test/fixtures/output/iam/service-account/use-help.golden
+++ b/test/fixtures/output/iam/service-account/use-help.golden
@@ -3,9 +3,6 @@ Choose a service account to be used in subsequent commands which support passing
 Usage:
   confluent iam service-account use <id> [flags]
 
-Flags:
-      --context string   CLI context name.
-
 Global Flags:
   -h, --help            Show help for this command.
       --unsafe-trace    Equivalent to -vvvv, but also log HTTP requests and responses which might contain plaintext secrets.

--- a/test/fixtures/output/kafka/cluster/use-help.golden
+++ b/test/fixtures/output/kafka/cluster/use-help.golden
@@ -3,10 +3,6 @@ Choose a Kafka cluster to be used in subsequent commands which support passing a
 Usage:
   confluent kafka cluster use <id> [flags]
 
-Flags:
-      --context string       CLI context name.
-      --environment string   Environment ID.
-
 Global Flags:
   -h, --help            Show help for this command.
       --unsafe-trace    Equivalent to -vvvv, but also log HTTP requests and responses which might contain plaintext secrets.


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- The `--context` flag has been removed from `confluent environment use`, `confluent flink region use`, `confluent service-account use`, and `confluent kafka cluster use`
- The `--environment` flag has been removed from `confluent flink region use` and `confluent kafka cluster use`

New Features
- PLACEHOLDER

Bug Fixes
- PLACEHOLDER

Checklist
---------
- [x] Leave this box unchecked if features are not yet available in production

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
<!--
Has it been tested? How?
Copy and paste any instructions or steps that can save the reviewer time.
-->