### PR TITLE
[CLI-3140] Allow multiple onprem SSO login refresh

### DIFF
--- a/pkg/auth/auth_token_handler.go
+++ b/pkg/auth/auth_token_handler.go
@@ -150,7 +150,7 @@ func (a *AuthTokenHandlerImpl) GetConfluentToken(mdsClient *mdsv1.APIClient, cre
 	if credentials.IsSSO {
 		if credentials.AuthRefreshToken != "" {
 			if authToken, err := refreshConfluentToken(mdsClient, credentials); err == nil {
-				return authToken, "", nil
+				return authToken, credentials.AuthRefreshToken, nil
 			}
 		}
 


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- PLACEHOLDER

New Features
- PLACEHOLDER

Bug Fixes
- Fix an issue preventing on-premises users from refreshing SSO logins more than once

Checklist
---------
- [x] Leave this box unchecked if features are not yet available in production

What
----
On-prem refresh tokens remain valid after login extension requests. They still expire, and their expiration is set on the IDP side.

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
TODO: manual testing