### PR TITLE
[CLI-2622] Update flags for `schema-registry schema compatibility validate`

### DIFF
--- a/internal/schema-registry/command_schema_compatibility_validate.go
+++ b/internal/schema-registry/command_schema_compatibility_validate.go
@@ -53,7 +53,9 @@ func (c *command) newSchemaCompatibilityValidateCommand(cfg *config.Config) *cob
 	cobra.CheckErr(cmd.MarkFlagFilename("references", "json"))
 
 	cobra.CheckErr(cmd.MarkFlagRequired("subject"))
-	cobra.CheckErr(cmd.MarkFlagRequired("type"))
+	if cfg.IsCloudLogin() {
+		cobra.CheckErr(cmd.MarkFlagRequired("type"))
+	}
 
 	return cmd
 }

--- a/internal/schema-registry/command_schema_compatibility_validate.go
+++ b/internal/schema-registry/command_schema_compatibility_validate.go
@@ -37,8 +37,8 @@ func (c *command) newSchemaCompatibilityValidateCommand(cfg *config.Config) *cob
 	}
 	cmd.Example = examples.BuildExampleString(example)
 
-	pcmd.AddSchemaTypeFlag(cmd)
 	cmd.Flags().String("subject", "", subjectUsage)
+	pcmd.AddSchemaTypeFlag(cmd)
 	cmd.Flags().String("version", "", `Version of the schema. Can be a specific version or "latest".`)
 	cmd.Flags().String("references", "", "The path to the references file.")
 	pcmd.AddContextFlag(cmd, c.CLICommand)

--- a/internal/schema-registry/command_schema_compatibility_validate.go
+++ b/internal/schema-registry/command_schema_compatibility_validate.go
@@ -21,7 +21,7 @@ type validateOut struct {
 
 func (c *command) newSchemaCompatibilityValidateCommand(cfg *config.Config) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "validate <schema-file>",
+		Use:   "validate <schema-path>",
 		Short: "Validate a schema with a subject version.",
 		Long:  "Validate that a schema is compatible against a given subject version.",
 		Args:  cobra.ExactArgs(1),

--- a/internal/schema-registry/command_schema_compatibility_validate.go
+++ b/internal/schema-registry/command_schema_compatibility_validate.go
@@ -21,10 +21,10 @@ type validateOut struct {
 
 func (c *command) newSchemaCompatibilityValidateCommand(cfg *config.Config) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "validate",
+		Use:   "validate <schema-file>",
 		Short: "Validate a schema with a subject version.",
 		Long:  "Validate that a schema is compatible against a given subject version.",
-		Args:  cobra.NoArgs,
+		Args:  cobra.ExactArgs(1),
 		RunE:  c.compatibilityValidate,
 	}
 
@@ -37,7 +37,6 @@ func (c *command) newSchemaCompatibilityValidateCommand(cfg *config.Config) *cob
 	}
 	cmd.Example = examples.BuildExampleString(example)
 
-	cmd.Flags().String("schema", "", "The path to the schema file.")
 	pcmd.AddSchemaTypeFlag(cmd)
 	cmd.Flags().String("subject", "", subjectUsage)
 	cmd.Flags().String("version", "", `Version of the schema. Can be a specific version or "latest".`)
@@ -51,13 +50,15 @@ func (c *command) newSchemaCompatibilityValidateCommand(cfg *config.Config) *cob
 	}
 	pcmd.AddOutputFlag(cmd)
 
-	cobra.CheckErr(cmd.MarkFlagFilename("schema", "avsc", "json", "proto"))
 	cobra.CheckErr(cmd.MarkFlagFilename("references", "json"))
+
+	cobra.CheckErr(cmd.MarkFlagRequired("subject"))
+	cobra.CheckErr(cmd.MarkFlagRequired("type"))
 
 	return cmd
 }
 
-func (c *command) compatibilityValidate(cmd *cobra.Command, _ []string) error {
+func (c *command) compatibilityValidate(cmd *cobra.Command, args []string) error {
 	subject, err := cmd.Flags().GetString("subject")
 	if err != nil {
 		return err
@@ -68,18 +69,13 @@ func (c *command) compatibilityValidate(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	schemaPath, err := cmd.Flags().GetString("schema")
-	if err != nil {
-		return err
-	}
-
 	schemaType, err := cmd.Flags().GetString("type")
 	if err != nil {
 		return err
 	}
 	schemaType = strings.ToUpper(schemaType)
 
-	schema, err := os.ReadFile(schemaPath)
+	schema, err := os.ReadFile(args[0])
 	if err != nil {
 		return err
 	}

--- a/internal/schema-registry/command_schema_compatibility_validate.go
+++ b/internal/schema-registry/command_schema_compatibility_validate.go
@@ -30,7 +30,7 @@ func (c *command) newSchemaCompatibilityValidateCommand(cfg *config.Config) *cob
 
 	example := examples.Example{
 		Text: `Validate the compatibility of schema "payments" against the latest version of subject "records".`,
-		Code: "confluent schema-registry schema compatibility validate --schema payments.avsc --type avro --subject records --version latest",
+		Code: "confluent schema-registry schema compatibility validate payments.avsc --type avro --subject records --version latest",
 	}
 	if cfg.IsOnPremLogin() {
 		example.Code += " " + onPremAuthenticationMsg

--- a/test/fixtures/output/schema-registry/schema/compatibility/validate-help-onprem.golden
+++ b/test/fixtures/output/schema-registry/schema/compatibility/validate-help-onprem.golden
@@ -1,7 +1,7 @@
 Validate that a schema is compatible against a given subject version.
 
 Usage:
-  confluent schema-registry schema compatibility validate <schema-file> [flags]
+  confluent schema-registry schema compatibility validate <schema-path> [flags]
 
 Examples:
 Validate the compatibility of schema "payments" against the latest version of subject "records".

--- a/test/fixtures/output/schema-registry/schema/compatibility/validate-help-onprem.golden
+++ b/test/fixtures/output/schema-registry/schema/compatibility/validate-help-onprem.golden
@@ -6,7 +6,7 @@ Usage:
 Examples:
 Validate the compatibility of schema "payments" against the latest version of subject "records".
 
-  $ confluent schema-registry schema compatibility validate --schema payments.avsc --type avro --subject records --version latest --ca-location <ca-file-location> --schema-registry-endpoint <schema-registry-endpoint>
+  $ confluent schema-registry schema compatibility validate payments.avsc --type avro --subject records --version latest --ca-location <ca-file-location> --schema-registry-endpoint <schema-registry-endpoint>
 
 Flags:
       --subject string                    REQUIRED: Subject of the schema.

--- a/test/fixtures/output/schema-registry/schema/compatibility/validate-help-onprem.golden
+++ b/test/fixtures/output/schema-registry/schema/compatibility/validate-help-onprem.golden
@@ -1,7 +1,7 @@
 Validate that a schema is compatible against a given subject version.
 
 Usage:
-  confluent schema-registry schema compatibility validate [flags]
+  confluent schema-registry schema compatibility validate <schema-file> [flags]
 
 Examples:
 Validate the compatibility of schema "payments" against the latest version of subject "records".
@@ -9,9 +9,8 @@ Validate the compatibility of schema "payments" against the latest version of su
   $ confluent schema-registry schema compatibility validate --schema payments.avsc --type avro --subject records --version latest --ca-location <ca-file-location> --schema-registry-endpoint <schema-registry-endpoint>
 
 Flags:
-      --schema string                     The path to the schema file.
-      --type string                       Specify the schema type as "avro", "json", or "protobuf".
-      --subject string                    Subject of the schema.
+      --type string                       REQUIRED: Specify the schema type as "avro", "json", or "protobuf".
+      --subject string                    REQUIRED: Subject of the schema.
       --version string                    Version of the schema. Can be a specific version or "latest".
       --references string                 The path to the references file.
       --context string                    CLI context name.

--- a/test/fixtures/output/schema-registry/schema/compatibility/validate-help-onprem.golden
+++ b/test/fixtures/output/schema-registry/schema/compatibility/validate-help-onprem.golden
@@ -9,7 +9,7 @@ Validate the compatibility of schema "payments" against the latest version of su
   $ confluent schema-registry schema compatibility validate --schema payments.avsc --type avro --subject records --version latest --ca-location <ca-file-location> --schema-registry-endpoint <schema-registry-endpoint>
 
 Flags:
-      --type string                       REQUIRED: Specify the schema type as "avro", "json", or "protobuf".
+      --type string                       Specify the schema type as "avro", "json", or "protobuf".
       --subject string                    REQUIRED: Subject of the schema.
       --version string                    Version of the schema. Can be a specific version or "latest".
       --references string                 The path to the references file.

--- a/test/fixtures/output/schema-registry/schema/compatibility/validate-help-onprem.golden
+++ b/test/fixtures/output/schema-registry/schema/compatibility/validate-help-onprem.golden
@@ -9,8 +9,8 @@ Validate the compatibility of schema "payments" against the latest version of su
   $ confluent schema-registry schema compatibility validate --schema payments.avsc --type avro --subject records --version latest --ca-location <ca-file-location> --schema-registry-endpoint <schema-registry-endpoint>
 
 Flags:
-      --type string                       Specify the schema type as "avro", "json", or "protobuf".
       --subject string                    REQUIRED: Subject of the schema.
+      --type string                       Specify the schema type as "avro", "json", or "protobuf".
       --version string                    Version of the schema. Can be a specific version or "latest".
       --references string                 The path to the references file.
       --context string                    CLI context name.

--- a/test/fixtures/output/schema-registry/schema/compatibility/validate-help.golden
+++ b/test/fixtures/output/schema-registry/schema/compatibility/validate-help.golden
@@ -1,7 +1,7 @@
 Validate that a schema is compatible against a given subject version.
 
 Usage:
-  confluent schema-registry schema compatibility validate <schema-file> [flags]
+  confluent schema-registry schema compatibility validate <schema-path> [flags]
 
 Examples:
 Validate the compatibility of schema "payments" against the latest version of subject "records".

--- a/test/fixtures/output/schema-registry/schema/compatibility/validate-help.golden
+++ b/test/fixtures/output/schema-registry/schema/compatibility/validate-help.golden
@@ -1,7 +1,7 @@
 Validate that a schema is compatible against a given subject version.
 
 Usage:
-  confluent schema-registry schema compatibility validate [flags]
+  confluent schema-registry schema compatibility validate <schema-file> [flags]
 
 Examples:
 Validate the compatibility of schema "payments" against the latest version of subject "records".
@@ -9,9 +9,8 @@ Validate the compatibility of schema "payments" against the latest version of su
   $ confluent schema-registry schema compatibility validate --schema payments.avsc --type avro --subject records --version latest
 
 Flags:
-      --schema string        The path to the schema file.
-      --type string          Specify the schema type as "avro", "json", or "protobuf".
-      --subject string       Subject of the schema.
+      --type string          REQUIRED: Specify the schema type as "avro", "json", or "protobuf".
+      --subject string       REQUIRED: Subject of the schema.
       --version string       Version of the schema. Can be a specific version or "latest".
       --references string    The path to the references file.
       --context string       CLI context name.

--- a/test/fixtures/output/schema-registry/schema/compatibility/validate-help.golden
+++ b/test/fixtures/output/schema-registry/schema/compatibility/validate-help.golden
@@ -9,8 +9,8 @@ Validate the compatibility of schema "payments" against the latest version of su
   $ confluent schema-registry schema compatibility validate --schema payments.avsc --type avro --subject records --version latest
 
 Flags:
-      --type string          REQUIRED: Specify the schema type as "avro", "json", or "protobuf".
       --subject string       REQUIRED: Subject of the schema.
+      --type string          REQUIRED: Specify the schema type as "avro", "json", or "protobuf".
       --version string       Version of the schema. Can be a specific version or "latest".
       --references string    The path to the references file.
       --context string       CLI context name.

--- a/test/fixtures/output/schema-registry/schema/compatibility/validate-help.golden
+++ b/test/fixtures/output/schema-registry/schema/compatibility/validate-help.golden
@@ -6,7 +6,7 @@ Usage:
 Examples:
 Validate the compatibility of schema "payments" against the latest version of subject "records".
 
-  $ confluent schema-registry schema compatibility validate --schema payments.avsc --type avro --subject records --version latest
+  $ confluent schema-registry schema compatibility validate payments.avsc --type avro --subject records --version latest
 
 Flags:
       --subject string       REQUIRED: Subject of the schema.

--- a/test/schema_registry_test.go
+++ b/test/schema_registry_test.go
@@ -28,9 +28,9 @@ func (s *CLITestSuite) TestSchemaRegistryCluster() {
 
 func (s *CLITestSuite) TestSchemaRegistryCompatibilityValidate() {
 	tests := []CLITest{
-		{args: fmt.Sprintf("schema-registry schema compatibility validate --subject payments --version 1 --schema %s --environment %s", schemaPath, testserver.SRApiEnvId), fixture: "schema-registry/schema/compatibility/validate.golden"},
-		{args: fmt.Sprintf("schema-registry schema compatibility validate --subject payments --version 1 --schema %s --environment %s -o json", schemaPath, testserver.SRApiEnvId), fixture: "schema-registry/schema/compatibility/validate-json.golden"},
-		{args: fmt.Sprintf("schema-registry schema compatibility validate --subject payments --version 1 --schema %s --environment %s -o yaml", schemaPath, testserver.SRApiEnvId), fixture: "schema-registry/schema/compatibility/validate-yaml.golden"},
+		{args: fmt.Sprintf("schema-registry schema compatibility validate %s --type json --subject payments --version 1 --environment %s", schemaPath, testserver.SRApiEnvId), fixture: "schema-registry/schema/compatibility/validate.golden"},
+		{args: fmt.Sprintf("schema-registry schema compatibility validate %s --type json --subject payments --version 1 --environment %s -o json", schemaPath, testserver.SRApiEnvId), fixture: "schema-registry/schema/compatibility/validate-json.golden"},
+		{args: fmt.Sprintf("schema-registry schema compatibility validate %s --type json --subject payments --version 1 --environment %s -o yaml", schemaPath, testserver.SRApiEnvId), fixture: "schema-registry/schema/compatibility/validate-yaml.golden"},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- The `--schema` flag for `confluent schema-registry schema compatibility validate` has been replaced with a required argument
- The `--subject` flag is now required for `confluent schema-registry schema compatibility validate`; the `--type` flag is additionally required for the Cloud version of this command

New Features
- PLACEHOLDER

Bug Fixes
- PLACEHOLDER

Checklist
---------
- [x] Leave this box unchecked if features are not yet available in production

What
----
- Make `--schema` a required argument instead of a flag
- Make `--subject` required
- Make `--type` required for Cloud

The Cloud backend returns an unprocessable entity error when the `--type` isn't specified. Schema type is optional for on-prem according to the on-prem API docs, though (since it defaults to AVRO).

The ticket also mentions making `--version` default to latest, but I think we'll lose functionality this way. Omitting `--version` calls `POST /compatibility/subjects/(string: subject)/versions`, which checks compatibility against all versions.

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
<!--
Has it been tested? How?
Copy and paste any instructions or steps that can save the reviewer time.
-->