### PR TITLE
[CLI-2826] Use array for `principals` in serialized output of `confluent kafka quota` commands

### DIFF
--- a/internal/kafka/command_quota.go
+++ b/internal/kafka/command_quota.go
@@ -87,7 +87,7 @@ func printTable(cmd *cobra.Command, quota kafkaquotasv1.KafkaQuotasV1ClientQuota
 }
 
 func principalsToStringSlice(principals []kafkaquotasv1.GlobalObjectReference) []string {
-	principalIds := make([]string, len(principals))
+	ids := make([]string, len(principals))
 	for i, principal := range principals {
 		principalIds[i] = principal.GetId()
 	}

--- a/internal/kafka/command_quota.go
+++ b/internal/kafka/command_quota.go
@@ -35,57 +35,64 @@ func newQuotaCommand(prerunner pcmd.PreRunner) *cobra.Command {
 	return cmd
 }
 
-type quotaOut struct {
-	Id          string `human:"ID" serialized:"id"`
-	DisplayName string `human:"Name" serialized:"name"`
-	Description string `human:"Description" serialized:"description"`
-	Ingress     string `human:"Ingress" serialized:"ingress"`
-	Egress      string `human:"Egress" serialized:"egress"`
-	Principals  string `human:"Principals" serialized:"principals"`
-	Cluster     string `human:"Cluster" serialized:"cluster"`
-	Environment string `human:"Environment" serialized:"environment"`
+type quotaHumanOut struct {
+	Id          string `human:"ID"`
+	DisplayName string `human:"Name"`
+	Description string `human:"Description"`
+	Ingress     string `human:"Ingress (B/s)"`
+	Egress      string `human:"Egress (B/s)"`
+	Principals  string `human:"Principals"`
+	Cluster     string `human:"Cluster"`
+	Environment string `human:"Environment"`
 }
 
-func quotaToPrintable(quota kafkaquotasv1.KafkaQuotasV1ClientQuota, format output.Format) *quotaOut {
-	out := &quotaOut{
-		Id:          quota.GetId(),
-		DisplayName: quota.Spec.GetDisplayName(),
-		Description: quota.Spec.GetDescription(),
-		Ingress:     quota.Spec.Throughput.GetIngressByteRate(),
-		Egress:      quota.Spec.Throughput.GetEgressByteRate(),
-		Principals:  principalsToString(quota.Spec.GetPrincipals()),
-		Cluster:     quota.Spec.Cluster.GetId(),
-		Environment: quota.Spec.Environment.GetId(),
-	}
+type quotaSerializedOut struct {
+	Id          string   `serialized:"id"`
+	DisplayName string   `serialized:"name"`
+	Description string   `serialized:"description"`
+	Ingress     string   `serialized:"ingress"`
+	Egress      string   `serialized:"egress"`
+	Principals  []string `serialized:"principals"`
+	Cluster     string   `serialized:"cluster"`
+	Environment string   `serialized:"environment"`
+}
 
-	if format == output.Human {
-		out.Ingress += " B/s"
-		out.Egress += " B/s"
+func printTable(cmd *cobra.Command, quota kafkaquotasv1.KafkaQuotasV1ClientQuota) error {
+	table := output.NewTable(cmd)
+	if output.GetFormat(cmd) == output.Human {
+		table.Add(&quotaHumanOut{
+			Id:          quota.GetId(),
+			DisplayName: quota.Spec.GetDisplayName(),
+			Description: quota.Spec.GetDescription(),
+			Ingress:     quota.Spec.Throughput.GetIngressByteRate(),
+			Egress:      quota.Spec.Throughput.GetEgressByteRate(),
+			Principals:  strings.Join(principalsToStringSlice(quota.Spec.GetPrincipals()), ", "),
+			Cluster:     quota.Spec.Cluster.GetId(),
+			Environment: quota.Spec.Environment.GetId(),
+		})
 	} else {
-		// TODO: Serialize array instead of string in next major version
-		out.Principals = principalsToStringSerialized(quota.Spec.GetPrincipals())
+		table.Add(&quotaSerializedOut{
+			Id:          quota.GetId(),
+			DisplayName: quota.Spec.GetDisplayName(),
+			Description: quota.Spec.GetDescription(),
+			Ingress:     quota.Spec.Throughput.GetIngressByteRate(),
+			Egress:      quota.Spec.Throughput.GetEgressByteRate(),
+			Principals:  principalsToStringSlice(quota.Spec.GetPrincipals()),
+			Cluster:     quota.Spec.Cluster.GetId(),
+			Environment: quota.Spec.Environment.GetId(),
+		})
 	}
 
-	return out
+	return table.Print()
 }
 
-func principalsToString(principals []kafkaquotasv1.GlobalObjectReference) string {
-	ids := make([]string, len(principals))
+func principalsToStringSlice(principals []kafkaquotasv1.GlobalObjectReference) []string {
+	principalIds := make([]string, len(principals))
 	for i, principal := range principals {
-		ids[i] = principal.GetId()
+		principalIds[i] = principal.GetId()
 	}
-	return strings.Join(ids, ", ")
-}
 
-func principalsToStringSerialized(principals []kafkaquotasv1.GlobalObjectReference) string {
-	principalStr := ""
-	for i, principal := range principals {
-		principalStr += principal.Id
-		if i < len(principals)-1 {
-			principalStr += ","
-		}
-	}
-	return principalStr
+	return principalIds
 }
 
 func (c *quotaCommand) validArgs(cmd *cobra.Command, args []string) []string {

--- a/internal/kafka/command_quota.go
+++ b/internal/kafka/command_quota.go
@@ -89,10 +89,10 @@ func printTable(cmd *cobra.Command, quota kafkaquotasv1.KafkaQuotasV1ClientQuota
 func principalsToStringSlice(principals []kafkaquotasv1.GlobalObjectReference) []string {
 	ids := make([]string, len(principals))
 	for i, principal := range principals {
-		principalIds[i] = principal.GetId()
+		ids[i] = principal.GetId()
 	}
 
-	return principalIds
+	return ids
 }
 
 func (c *quotaCommand) validArgs(cmd *cobra.Command, args []string) []string {

--- a/internal/kafka/command_quota_create.go
+++ b/internal/kafka/command_quota_create.go
@@ -8,7 +8,6 @@ import (
 	pcmd "github.com/confluentinc/cli/v3/pkg/cmd"
 	"github.com/confluentinc/cli/v3/pkg/examples"
 	"github.com/confluentinc/cli/v3/pkg/kafka"
-	"github.com/confluentinc/cli/v3/pkg/output"
 )
 
 func (c *quotaCommand) newCreateCommand() *cobra.Command {
@@ -92,10 +91,7 @@ func (c *quotaCommand) create(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	table := output.NewTable(cmd)
-	format := output.GetFormat(cmd)
-	table.Add(quotaToPrintable(quota, format))
-	return table.Print()
+	return printTable(cmd, quota)
 }
 
 func sliceToObjRefArray(accounts []string) *[]kafkaquotasv1.GlobalObjectReference {

--- a/internal/kafka/command_quota_describe.go
+++ b/internal/kafka/command_quota_describe.go
@@ -4,7 +4,6 @@ import (
 	"github.com/spf13/cobra"
 
 	pcmd "github.com/confluentinc/cli/v3/pkg/cmd"
-	"github.com/confluentinc/cli/v3/pkg/output"
 )
 
 func (c *quotaCommand) newDescribeCommand() *cobra.Command {
@@ -29,8 +28,5 @@ func (c *quotaCommand) describe(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	table := output.NewTable(cmd)
-	format := output.GetFormat(cmd)
-	table.Add(quotaToPrintable(quota, format))
-	return table.Print()
+	return printTable(cmd, quota)
 }

--- a/internal/kafka/command_quota_list.go
+++ b/internal/kafka/command_quota_list.go
@@ -1,6 +1,8 @@
 package kafka
 
 import (
+	"strings"
+
 	"github.com/spf13/cobra"
 
 	kafkaquotasv1 "github.com/confluentinc/ccloud-sdk-go-v2/kafka-quotas/v1"
@@ -45,9 +47,30 @@ func (c *quotaCommand) list(cmd *cobra.Command, _ []string) error {
 	}
 
 	list := output.NewList(cmd)
-	format := output.GetFormat(cmd)
 	for _, quota := range quotas {
-		list.Add(quotaToPrintable(quota, format))
+		if output.GetFormat(cmd) == output.Human {
+			list.Add(&quotaHumanOut{
+				Id:          quota.GetId(),
+				DisplayName: quota.Spec.GetDisplayName(),
+				Description: quota.Spec.GetDescription(),
+				Ingress:     quota.Spec.Throughput.GetIngressByteRate(),
+				Egress:      quota.Spec.Throughput.GetEgressByteRate(),
+				Principals:  strings.Join(principalsToStringSlice(quota.Spec.GetPrincipals()), ", "),
+				Cluster:     quota.Spec.Cluster.GetId(),
+				Environment: quota.Spec.Environment.GetId(),
+			})
+		} else {
+			list.Add(&quotaSerializedOut{
+				Id:          quota.GetId(),
+				DisplayName: quota.Spec.GetDisplayName(),
+				Description: quota.Spec.GetDescription(),
+				Ingress:     quota.Spec.Throughput.GetIngressByteRate(),
+				Egress:      quota.Spec.Throughput.GetEgressByteRate(),
+				Principals:  principalsToStringSlice(quota.Spec.GetPrincipals()),
+				Cluster:     quota.Spec.Cluster.GetId(),
+				Environment: quota.Spec.Environment.GetId(),
+			})
+		}
 	}
 	return list.Print()
 }

--- a/internal/kafka/command_quota_update.go
+++ b/internal/kafka/command_quota_update.go
@@ -7,7 +7,6 @@ import (
 
 	pcmd "github.com/confluentinc/cli/v3/pkg/cmd"
 	"github.com/confluentinc/cli/v3/pkg/examples"
-	"github.com/confluentinc/cli/v3/pkg/output"
 	"github.com/confluentinc/cli/v3/pkg/types"
 )
 
@@ -77,10 +76,7 @@ func (c *quotaCommand) update(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	table := output.NewTable(cmd)
-	format := output.GetFormat(cmd)
-	table.Add(quotaToPrintable(updatedQuota, format))
-	return table.Print()
+	return printTable(cmd, updatedQuota)
 }
 
 func (c *quotaCommand) getUpdatedPrincipals(cmd *cobra.Command, updatePrincipals []kafkaquotasv1.GlobalObjectReference) (*[]kafkaquotasv1.GlobalObjectReference, error) {

--- a/test/fixtures/output/kafka/quota/create-default-yaml.golden
+++ b/test/fixtures/output/kafka/quota/create-default-yaml.golden
@@ -3,6 +3,7 @@ name: clientQuota
 description: ""
 ingress: "500"
 egress: "100"
-principals: <default>
+principals:
+    - <default>
 cluster: lkc-1234
 environment: env-596

--- a/test/fixtures/output/kafka/quota/create.golden
+++ b/test/fixtures/output/kafka/quota/create.golden
@@ -1,10 +1,10 @@
-+-------------+------------------+
-| ID          | cq-1234          |
-| Name        | clientQuota      |
-| Description | description      |
-| Ingress     | 500 B/s          |
-| Egress      | 100 B/s          |
-| Principals  | sa-1234, sa-5678 |
-| Cluster     | lkc-1234         |
-| Environment | env-596          |
-+-------------+------------------+
++---------------+------------------+
+| ID            | cq-1234          |
+| Name          | clientQuota      |
+| Description   | description      |
+| Ingress (B/s) | 500              |
+| Egress (B/s)  | 100              |
+| Principals    | sa-1234, sa-5678 |
+| Cluster       | lkc-1234         |
+| Environment   | env-596          |
++---------------+------------------+

--- a/test/fixtures/output/kafka/quota/describe-json.golden
+++ b/test/fixtures/output/kafka/quota/describe-json.golden
@@ -4,7 +4,7 @@
   "description": "quota description",
   "ingress": "2000",
   "egress": "5000",
-  "principals": "sa-1234,sa-5678",
+  "principals": ["sa-1234", "sa-5678"],
   "cluster": "lkc-1234",
   "environment": "env-1234"
 }

--- a/test/fixtures/output/kafka/quota/describe.golden
+++ b/test/fixtures/output/kafka/quota/describe.golden
@@ -1,10 +1,10 @@
-+-------------+-------------------+
-| ID          | cq-1234           |
-| Name        | quotaName         |
-| Description | quota description |
-| Ingress     | 2000 B/s          |
-| Egress      | 5000 B/s          |
-| Principals  | sa-1234, sa-5678  |
-| Cluster     | lkc-1234          |
-| Environment | env-1234          |
-+-------------+-------------------+
++---------------+-------------------+
+| ID            | cq-1234           |
+| Name          | quotaName         |
+| Description   | quota description |
+| Ingress (B/s) | 2000              |
+| Egress (B/s)  | 5000              |
+| Principals    | sa-1234, sa-5678  |
+| Cluster       | lkc-1234          |
+| Environment   | env-1234          |
++---------------+-------------------+

--- a/test/fixtures/output/kafka/quota/list-json.golden
+++ b/test/fixtures/output/kafka/quota/list-json.golden
@@ -5,7 +5,7 @@
     "description": "quota description",
     "ingress": "2000",
     "egress": "5000",
-    "principals": "sa-1234,sa-5678",
+    "principals": ["sa-1234", "sa-5678"],
     "cluster": "lkc-1234",
     "environment": "env-1234"
   }

--- a/test/fixtures/output/kafka/quota/list-yaml.golden
+++ b/test/fixtures/output/kafka/quota/list-yaml.golden
@@ -3,7 +3,9 @@
   description: quota description
   ingress: "2000"
   egress: "5000"
-  principals: sa-1234,sa-5678
+  principals:
+    - sa-1234
+    - sa-5678
   cluster: lkc-1234
   environment: env-1234
 - id: cq-4321
@@ -11,6 +13,7 @@
   description: quota description
   ingress: "2000"
   egress: "5000"
-  principals: sa-4321
+  principals:
+    - sa-4321
   cluster: lkc-1234
   environment: env-1234

--- a/test/fixtures/output/kafka/quota/list.golden
+++ b/test/fixtures/output/kafka/quota/list.golden
@@ -1,4 +1,4 @@
-    ID    |   Name    |    Description    | Ingress  |  Egress  |    Principals    | Cluster  | Environment  
-----------+-----------+-------------------+----------+----------+------------------+----------+--------------
-  cq-1234 | quotaName | quota description | 2000 B/s | 5000 B/s | sa-1234, sa-5678 | lkc-1234 | env-1234     
-  cq-4321 | quota2    | quota description | 2000 B/s | 5000 B/s | sa-4321          | lkc-1234 | env-1234     
+    ID    |   Name    |    Description    | Ingress (B/s) | Egress (B/s) |    Principals    | Cluster  | Environment  
+----------+-----------+-------------------+---------------+--------------+------------------+----------+--------------
+  cq-1234 | quotaName | quota description | 2000          | 5000         | sa-1234, sa-5678 | lkc-1234 | env-1234     
+  cq-4321 | quota2    | quota description | 2000          | 5000         | sa-4321          | lkc-1234 | env-1234     

--- a/test/fixtures/output/kafka/quota/update.golden
+++ b/test/fixtures/output/kafka/quota/update.golden
@@ -1,10 +1,10 @@
-+-------------+-------------------+
-| ID          | cq-1234           |
-| Name        | newName           |
-| Description | quota description |
-| Ingress     | 100 B/s           |
-| Egress      | 100 B/s           |
-| Principals  | sa-5678, sa-4321  |
-| Cluster     | lkc-1234          |
-| Environment | env-1234          |
-+-------------+-------------------+
++---------------+-------------------+
+| ID            | cq-1234           |
+| Name          | newName           |
+| Description   | quota description |
+| Ingress (B/s) | 100               |
+| Egress (B/s)  | 100               |
+| Principals    | sa-5678, sa-4321  |
+| Cluster       | lkc-1234          |
+| Environment   | env-1234          |
++---------------+-------------------+


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- The serialized field `principals` in `confluent kafka quota` commands is now an array

New Features
- PLACEHOLDER

Bug Fixes
- PLACEHOLDER

Checklist
---------
- [x] Leave this box unchecked if features are not yet available in production

What
----
I also moved the `B/s` bit in the human output from the value to the field label.

This makes it easier to remove the code duplication when https://confluentinc.atlassian.net/browse/CLI-3013 is done.

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
<!--
Has it been tested? How?
Copy and paste any instructions or steps that can save the reviewer time.
-->