### PR TITLE
[CLI-2566] Make human and serialized field names consistent in link describe/list

### DIFF
--- a/internal/kafka/command_link_describe.go
+++ b/internal/kafka/command_link_describe.go
@@ -12,9 +12,9 @@ import (
 type describeOut struct {
 	Name                 string `human:"Name" serialized:"link_name"`
 	TopicName            string `human:"Topic Name" serialized:"topic_name"`
-	SourceClusterId      string `human:"Source Cluster" serialized:"source_cluster_id"`
-	DestinationClusterId string `human:"Destination Cluster" serialized:"destination_cluster_id"`
-	RemoteClusterId      string `human:"Remote Cluster" serialized:"remote_cluster_id"`
+	SourceClusterId      string `human:"Source Cluster" serialized:"source_cluster"`
+	DestinationClusterId string `human:"Destination Cluster" serialized:"destination_cluster"`
+	RemoteClusterId      string `human:"Remote Cluster" serialized:"remote_cluster"`
 	State                string `human:"State" serialized:"state"`
 	Error                string `human:"Error,omitempty" serialized:"error,omitempty"`
 	ErrorMessage         string `human:"Error Message,omitempty" serialized:"error_message,omitempty"`

--- a/internal/kafka/command_link_list.go
+++ b/internal/kafka/command_link_list.go
@@ -14,9 +14,9 @@ const includeTopicsFlagName = "include-topics"
 type listOut struct {
 	Name                 string `human:"Name" serialized:"link_name"`
 	TopicName            string `human:"Topic Name" serialized:"topic_name"`
-	SourceClusterId      string `human:"Source Cluster" serialized:"source_cluster_id"`
-	DestinationClusterId string `human:"Destination Cluster" serialized:"destination_cluster_id"`
-	RemoteClusterId      string `human:"Remote Cluster" serialized:"remote_cluster_id"`
+	SourceClusterId      string `human:"Source Cluster" serialized:"source_cluster"`
+	DestinationClusterId string `human:"Destination Cluster" serialized:"destination_cluster"`
+	RemoteClusterId      string `human:"Remote Cluster" serialized:"remote_cluster"`
 	State                string `human:"State" serialized:"state"`
 	Error                string `human:"Error" serialized:"error"`
 	ErrorMessage         string `human:"Error Message" serialized:"error_message"`

--- a/test/fixtures/output/kafka/link/describe-json.golden
+++ b/test/fixtures/output/kafka/link/describe-json.golden
@@ -1,7 +1,7 @@
 {
   "link_name": "link-1",
-  "source_cluster_id": "lkc-describe-topic",
-  "destination_cluster_id": "",
-  "remote_cluster_id": "",
+  "source_cluster": "lkc-describe-topic",
+  "destination_cluster": "",
+  "remote_cluster": "",
   "state": "AVAILABLE"
 }

--- a/test/fixtures/output/kafka/link/list-link-json.golden
+++ b/test/fixtures/output/kafka/link/list-link-json.golden
@@ -1,45 +1,45 @@
 [
   {
     "link_name": "link-1",
-    "source_cluster_id": "cluster-1",
-    "destination_cluster_id": "cluster-2",
-    "remote_cluster_id": "",
+    "source_cluster": "cluster-1",
+    "destination_cluster": "cluster-2",
+    "remote_cluster": "",
     "state": "",
     "error": "",
     "error_message": ""
   },
   {
     "link_name": "link-2",
-    "source_cluster_id": "cluster-1",
-    "destination_cluster_id": "cluster-2",
-    "remote_cluster_id": "",
+    "source_cluster": "cluster-1",
+    "destination_cluster": "cluster-2",
+    "remote_cluster": "",
     "state": "AVAILABLE",
     "error": "",
     "error_message": ""
   },
   {
     "link_name": "link-3",
-    "source_cluster_id": "cluster-1",
-    "destination_cluster_id": "cluster-2",
-    "remote_cluster_id": "",
+    "source_cluster": "cluster-1",
+    "destination_cluster": "cluster-2",
+    "remote_cluster": "",
     "state": "UNAVAILABLE",
     "error": "AUTHENTICATION_ERROR",
     "error_message": "Please check your API key and secret."
   },
   {
     "link_name": "link-4",
-    "source_cluster_id": "",
-    "destination_cluster_id": "",
-    "remote_cluster_id": "cluster-2",
+    "source_cluster": "",
+    "destination_cluster": "",
+    "remote_cluster": "cluster-2",
     "state": "",
     "error": "",
     "error_message": ""
   },
   {
     "link_name": "link-5",
-    "source_cluster_id": "",
-    "destination_cluster_id": "",
-    "remote_cluster_id": "cluster-2",
+    "source_cluster": "",
+    "destination_cluster": "",
+    "remote_cluster": "cluster-2",
     "state": "",
     "error": "",
     "error_message": ""

--- a/test/fixtures/output/kafka/link/list-link-yaml.golden
+++ b/test/fixtures/output/kafka/link/list-link-yaml.golden
@@ -1,35 +1,35 @@
 - link_name: link-1
-  source_cluster_id: cluster-1
-  destination_cluster_id: cluster-2
-  remote_cluster_id: ""
+  source_cluster: cluster-1
+  destination_cluster: cluster-2
+  remote_cluster: ""
   state: ""
   error: ""
   error_message: ""
 - link_name: link-2
-  source_cluster_id: cluster-1
-  destination_cluster_id: cluster-2
-  remote_cluster_id: ""
+  source_cluster: cluster-1
+  destination_cluster: cluster-2
+  remote_cluster: ""
   state: AVAILABLE
   error: ""
   error_message: ""
 - link_name: link-3
-  source_cluster_id: cluster-1
-  destination_cluster_id: cluster-2
-  remote_cluster_id: ""
+  source_cluster: cluster-1
+  destination_cluster: cluster-2
+  remote_cluster: ""
   state: UNAVAILABLE
   error: AUTHENTICATION_ERROR
   error_message: Please check your API key and secret.
 - link_name: link-4
-  source_cluster_id: ""
-  destination_cluster_id: ""
-  remote_cluster_id: cluster-2
+  source_cluster: ""
+  destination_cluster: ""
+  remote_cluster: cluster-2
   state: ""
   error: ""
   error_message: ""
 - link_name: link-5
-  source_cluster_id: ""
-  destination_cluster_id: ""
-  remote_cluster_id: cluster-2
+  source_cluster: ""
+  destination_cluster: ""
+  remote_cluster: cluster-2
   state: ""
   error: ""
   error_message: ""


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- serialized `source_cluster_id` changed to `source_cluster`, `destination_cluster_id` changed to `destination_cluster`, `remote_cluster_id` changed to `remote_cluster` in `kafka link describe` and `kafka link list` commands

Checklist
---------
- [ ] Leave this box unchecked if features are not yet available in production

What
----
Make human and serialized field names consistent in link describe/list

References
----------
https://confluentinc.atlassian.net/browse/CLI-2566

Test & Review
-------------
Integration tests updated.