### PR TITLE
[KFS-2294] set correct key/value pairs in USE catalog.database cmd

### DIFF
--- a/pkg/flink/internal/store/store_utils.go
+++ b/pkg/flink/internal/store/store_utils.go
@@ -155,8 +155,8 @@ func (s *Store) processUseStatement(statement string) (*types.ProcessedStatement
 
 		// "USE `catalog_name`.`database_name`" statement
 	} else if catalog != "" && database != "" {
-		s.Properties.Set(catalog, database)
-		s.Properties.Set(catalog, database)
+		s.Properties.Set(config.KeyCatalog, catalog)
+		s.Properties.Set(config.KeyDatabase, database)
 		addedConfig = append(addedConfig, []string{config.KeyCatalog, catalog})
 		addedConfig = append(addedConfig, []string{config.KeyDatabase, database})
 	} else {

--- a/pkg/flink/internal/store/store_utils_test.go
+++ b/pkg/flink/internal/store/store_utils_test.go
@@ -221,6 +221,7 @@ func TestProcessUseStatement(t *testing.T) {
 		require.Equal(t, "configuration updated successfully", result.StatusDetail)
 		expectedResult := createStatementResults([]string{"Key", "Value"}, [][]string{{config.KeyDatabase, "db1"}})
 		assert.Equal(t, expectedResult, result.StatementResults)
+		assert.Equal(t, "db1", s.Properties.Get(config.KeyDatabase))
 	})
 
 	t.Run("should return an error message if catalog name is missing", func(t *testing.T) {
@@ -236,6 +237,22 @@ func TestProcessUseStatement(t *testing.T) {
 		require.Equal(t, "configuration updated successfully", result.StatusDetail)
 		expectedResult := createStatementResults([]string{"Key", "Value"}, [][]string{{config.KeyCatalog, "metadata"}})
 		assert.Equal(t, expectedResult, result.StatementResults)
+		assert.Equal(t, "metadata", s.Properties.Get(config.KeyCatalog))
+	})
+
+	t.Run("should update the catalog and database name in config", func(t *testing.T) {
+		result, err := s.processUseStatement("USE `my catalog`.`my database`")
+		require.Nil(t, err)
+		require.Equal(t, config.OpUse, result.Kind)
+		require.EqualValues(t, types.COMPLETED, result.Status)
+		require.Equal(t, "configuration updated successfully", result.StatusDetail)
+		expectedResult := createStatementResults([]string{"Key", "Value"}, [][]string{
+			{config.KeyCatalog, "my catalog"},
+			{config.KeyDatabase, "my database"},
+		})
+		assert.Equal(t, expectedResult, result.StatementResults)
+		assert.Equal(t, "my catalog", s.Properties.Get(config.KeyCatalog))
+		assert.Equal(t, "my database", s.Properties.Get(config.KeyDatabase))
 	})
 
 	t.Run("should return an error message for invalid syntax", func(t *testing.T) {


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Bug Fixes
- `confluent flink shell`: The `USE <catalog>.<database>` command previously set an incorrect key/value pair in the config (`catalog: database`). Now it sets the proper key/value pairs (`sql.current-catalog: catalog, sql.current-database: database`)

Checklist
---------
- [x] Leave this box unchecked if features are not yet available in production

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->
We were setting the wrong key in the config

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
<!--
Has it been tested? How?
Copy and paste any instructions or steps that can save the reviewer time.
-->