### PR TITLE
chore: consistent usage of regions across tests

### DIFF
--- a/test/fixtures/output/flink/compute-pool/create-region-autocomplete.golden
+++ b/test/fixtures/output/flink/compute-pool/create-region-autocomplete.golden
@@ -1,3 +1,4 @@
 eu-west-1
+eu-west-2
 :4
 Completion ended with directive: ShellCompDirectiveNoFileComp

--- a/test/fixtures/output/flink/compute-pool/describe-after-use.golden
+++ b/test/fixtures/output/flink/compute-pool/describe-after-use.golden
@@ -6,6 +6,6 @@
 | Current CFU | 0                 |
 | Max CFU     | 1                 |
 | Cloud       | AWS               |
-| Region      | us-west-2         |
+| Region      | eu-west-1         |
 | Status      | PROVISIONED       |
 +-------------+-------------------+

--- a/test/fixtures/output/flink/compute-pool/describe.golden
+++ b/test/fixtures/output/flink/compute-pool/describe.golden
@@ -6,6 +6,6 @@
 | Current CFU | 0                 |
 | Max CFU     | 1                 |
 | Cloud       | AWS               |
-| Region      | us-west-2         |
+| Region      | eu-west-1         |
 | Status      | PROVISIONED       |
 +-------------+-------------------+

--- a/test/fixtures/output/flink/compute-pool/list-after-use.golden
+++ b/test/fixtures/output/flink/compute-pool/list-after-use.golden
@@ -1,4 +1,4 @@
   Current |     ID      |       Name        | Environment | Current CFU | Max CFU | Cloud |  Region   |   Status     
 ----------+-------------+-------------------+-------------+-------------+---------+-------+-----------+--------------
-  *       | lfcp-123456 | my-compute-pool-1 | env-123     |           0 |       1 | AWS   | us-west-1 | PROVISIONED  
-          | lfcp-222222 | my-compute-pool-2 | env-456     |           0 |       2 | AWS   | us-west-2 | PROVISIONED  
+  *       | lfcp-123456 | my-compute-pool-1 | env-123     |           0 |       1 | AWS   | eu-west-1 | PROVISIONED  
+          | lfcp-222222 | my-compute-pool-2 | env-456     |           0 |       2 | AWS   | eu-west-2 | PROVISIONED  

--- a/test/fixtures/output/flink/compute-pool/list-region-autocomplete.golden
+++ b/test/fixtures/output/flink/compute-pool/list-region-autocomplete.golden
@@ -1,4 +1,5 @@
 eu-west-1
+eu-west-2
 europe-west3-a
 :4
 Completion ended with directive: ShellCompDirectiveNoFileComp

--- a/test/fixtures/output/flink/compute-pool/list-region.golden
+++ b/test/fixtures/output/flink/compute-pool/list-region.golden
@@ -1,3 +1,3 @@
   Current |     ID      |       Name        | Environment | Current CFU | Max CFU | Cloud |  Region   |   Status     
 ----------+-------------+-------------------+-------------+-------------+---------+-------+-----------+--------------
-          | lfcp-222222 | my-compute-pool-2 | env-456     |           0 |       2 | AWS   | us-west-2 | PROVISIONED  
+          | lfcp-222222 | my-compute-pool-2 | env-456     |           0 |       2 | AWS   | eu-west-2 | PROVISIONED  

--- a/test/fixtures/output/flink/compute-pool/list.golden
+++ b/test/fixtures/output/flink/compute-pool/list.golden
@@ -1,4 +1,4 @@
   Current |     ID      |       Name        | Environment | Current CFU | Max CFU | Cloud |  Region   |   Status     
 ----------+-------------+-------------------+-------------+-------------+---------+-------+-----------+--------------
-          | lfcp-123456 | my-compute-pool-1 | env-123     |           0 |       1 | AWS   | us-west-1 | PROVISIONED  
-          | lfcp-222222 | my-compute-pool-2 | env-456     |           0 |       2 | AWS   | us-west-2 | PROVISIONED  
+          | lfcp-123456 | my-compute-pool-1 | env-123     |           0 |       1 | AWS   | eu-west-1 | PROVISIONED  
+          | lfcp-222222 | my-compute-pool-2 | env-456     |           0 |       2 | AWS   | eu-west-2 | PROVISIONED  

--- a/test/fixtures/output/flink/compute-pool/update-after-use.golden
+++ b/test/fixtures/output/flink/compute-pool/update-after-use.golden
@@ -6,6 +6,6 @@
 | Current CFU | 0                 |
 | Max CFU     | 5                 |
 | Cloud       | AWS               |
-| Region      | us-west-2         |
+| Region      | eu-west-1         |
 | Status      | PROVISIONED       |
 +-------------+-------------------+

--- a/test/fixtures/output/flink/compute-pool/update.golden
+++ b/test/fixtures/output/flink/compute-pool/update.golden
@@ -6,6 +6,6 @@
 | Current CFU | 0                 |
 | Max CFU     | 5                 |
 | Cloud       | AWS               |
-| Region      | us-west-2         |
+| Region      | eu-west-1         |
 | Status      | PROVISIONED       |
 +-------------+-------------------+

--- a/test/fixtures/output/flink/region/list-cloud.golden
+++ b/test/fixtures/output/flink/region/list-cloud.golden
@@ -1,3 +1,4 @@
   Current |        Name        | Cloud |  Region    
 ----------+--------------------+-------+------------
   *       | Europe (eu-west-1) | AWS   | eu-west-1  
+          | Europe (eu-west-2) | AWS   | eu-west-2  

--- a/test/fixtures/output/flink/region/list-json.golden
+++ b/test/fixtures/output/flink/region/list-json.golden
@@ -7,6 +7,12 @@
   },
   {
     "is_current": false,
+    "name": "Europe (eu-west-2)",
+    "cloud": "AWS",
+    "region": "eu-west-2"
+  },
+  {
+    "is_current": false,
     "name": "Frankfurt (europe-west3-a)",
     "cloud": "GCP",
     "region": "europe-west3-a"

--- a/test/fixtures/output/flink/region/list.golden
+++ b/test/fixtures/output/flink/region/list.golden
@@ -1,4 +1,5 @@
   Current |            Name            | Cloud |     Region      
 ----------+----------------------------+-------+-----------------
   *       | Europe (eu-west-1)         | AWS   | eu-west-1       
+          | Europe (eu-west-2)         | AWS   | eu-west-2       
           | Frankfurt (europe-west3-a) | GCP   | europe-west3-a  

--- a/test/fixtures/output/flink/statement/list-cp-incorrect-region.golden
+++ b/test/fixtures/output/flink/statement/list-cp-incorrect-region.golden
@@ -1,4 +1,4 @@
-Error: Flink compute pool "lfcp-123456" not found in aws eu-west-1
+Error: Flink compute pool "lfcp-123456" not found in aws eu-west-2
 
 Suggestions:
-    Select a different compute pool, or provide the correct cloud/region pair with `confluent flink statement list --cloud aws --region us-west-2 --compute-pool lfcp-123456 --environment env-596`
+    Select a different compute pool, or provide the correct cloud/region pair with `confluent flink statement list --cloud aws --region eu-west-1 --compute-pool lfcp-123456 --environment env-596`

--- a/test/flink_test.go
+++ b/test/flink_test.go
@@ -55,7 +55,7 @@ func (s *CLITestSuite) TestFlinkComputePool() {
 		{args: "flink compute-pool create my-compute-pool --cloud aws --region us-west-2", fixture: "flink/compute-pool/create.golden"},
 		{args: "flink compute-pool describe lfcp-123456", fixture: "flink/compute-pool/describe.golden"},
 		{args: "flink compute-pool list", fixture: "flink/compute-pool/list.golden"},
-		{args: "flink compute-pool list --region us-west-2", fixture: "flink/compute-pool/list-region.golden"},
+		{args: "flink compute-pool list --region eu-west-2", fixture: "flink/compute-pool/list-region.golden"},
 		{args: "flink compute-pool update lfcp-123456 --max-cfu 5", fixture: "flink/compute-pool/update.golden"},
 	}
 
@@ -151,7 +151,7 @@ func (s *CLITestSuite) TestFlinkStatement() {
 		{args: "flink statement list --cloud aws --region eu-west-1 --status completed", fixture: "flink/statement/list-completed.golden"},
 		{args: "flink statement list --cloud aws --region eu-west-1 --status pending", fixture: "flink/statement/list-pending.golden"},
 		{args: "flink statement list --cloud aws --region eu-west-1 --compute-pool lfcp-nonexistent", fixture: "flink/statement/list-cp-not-found.golden", exitCode: 1},
-		{args: "flink statement list --cloud aws --region eu-west-1 --compute-pool lfcp-123456", fixture: "flink/statement/list-cp-incorrect-region.golden", exitCode: 1},
+		{args: "flink statement list --cloud aws --region eu-west-2 --compute-pool lfcp-123456", fixture: "flink/statement/list-cp-incorrect-region.golden", exitCode: 1},
 		{args: "flink statement describe my-statement --cloud aws --region eu-west-1", fixture: "flink/statement/describe.golden"},
 		{args: "flink statement describe my-statement --cloud aws --region eu-west-1 -o yaml", fixture: "flink/statement/describe-yaml.golden"},
 		{args: "flink statement stop my-statement --region eu-west-1 --cloud aws", fixture: "flink/statement/stop.golden"},

--- a/test/test-server/fcpm_handlers.go
+++ b/test/test-server/fcpm_handlers.go
@@ -18,12 +18,12 @@ func handleFcpmComputePools(t *testing.T) http.HandlerFunc {
 
 		switch r.Method {
 		case http.MethodGet:
-			usWest1 := flinkv2.FcpmV2ComputePool{
+			euWest1 := flinkv2.FcpmV2ComputePool{
 				Id: flinkv2.PtrString("lfcp-123456"),
 				Spec: &flinkv2.FcpmV2ComputePoolSpec{
 					DisplayName: flinkv2.PtrString("my-compute-pool-1"),
 					MaxCfu:      flinkv2.PtrInt32(1),
-					Region:      flinkv2.PtrString("us-west-1"),
+					Region:      flinkv2.PtrString("eu-west-1"),
 					Cloud:       flinkv2.PtrString("AWS"),
 					Environment: &flinkv2.GlobalObjectReference{
 						Id: "env-123",
@@ -31,12 +31,12 @@ func handleFcpmComputePools(t *testing.T) http.HandlerFunc {
 				},
 				Status: &flinkv2.FcpmV2ComputePoolStatus{Phase: "PROVISIONED"},
 			}
-			usWest2 := flinkv2.FcpmV2ComputePool{
+			euWest2 := flinkv2.FcpmV2ComputePool{
 				Id: flinkv2.PtrString("lfcp-222222"),
 				Spec: &flinkv2.FcpmV2ComputePoolSpec{
 					DisplayName: flinkv2.PtrString("my-compute-pool-2"),
 					MaxCfu:      flinkv2.PtrInt32(2),
-					Region:      flinkv2.PtrString("us-west-2"),
+					Region:      flinkv2.PtrString("eu-west-2"),
 					Cloud:       flinkv2.PtrString("AWS"),
 					Environment: &flinkv2.GlobalObjectReference{
 						Id: "env-456",
@@ -45,9 +45,9 @@ func handleFcpmComputePools(t *testing.T) http.HandlerFunc {
 				Status: &flinkv2.FcpmV2ComputePoolStatus{Phase: "PROVISIONED"},
 			}
 
-			computePools := []flinkv2.FcpmV2ComputePool{usWest1, usWest2}
-			if r.URL.Query().Get("spec.region") == "us-west-2" {
-				computePools = []flinkv2.FcpmV2ComputePool{usWest2}
+			computePools := []flinkv2.FcpmV2ComputePool{euWest1, euWest2}
+			if r.URL.Query().Get("spec.region") == "eu-west-2" {
+				computePools = []flinkv2.FcpmV2ComputePool{euWest2}
 			}
 			v = flinkv2.FcpmV2ComputePoolList{Data: computePools}
 		case http.MethodPost:
@@ -85,13 +85,15 @@ func handleFcpmComputePoolsId(t *testing.T) http.HandlerFunc {
 					DisplayName: flinkv2.PtrString("my-compute-pool-1"),
 					MaxCfu:      flinkv2.PtrInt32(1),
 					Cloud:       flinkv2.PtrString("AWS"),
-					Region:      flinkv2.PtrString("us-west-2"),
+					Region:      flinkv2.PtrString("eu-west-1"),
 					Environment: &flinkv2.GlobalObjectReference{Id: "env-123"},
 				},
 				Status: &flinkv2.FcpmV2ComputePoolStatus{Phase: "PROVISIONED"},
 			}
 			if id == "lfcp-222222" {
 				computePool.Spec.DisplayName = flinkv2.PtrString("my-compute-pool-2")
+				computePool.Spec.Region = flinkv2.PtrString("eu-west-2")
+				computePool.Spec.Environment = &flinkv2.GlobalObjectReference{Id: "env-456"}
 			}
 		case http.MethodPatch:
 			update := new(flinkv2.FcpmV2ComputePool)
@@ -104,7 +106,7 @@ func handleFcpmComputePoolsId(t *testing.T) http.HandlerFunc {
 					DisplayName: flinkv2.PtrString("my-compute-pool-1"),
 					MaxCfu:      flinkv2.PtrInt32(update.Spec.GetMaxCfu()),
 					Cloud:       flinkv2.PtrString("AWS"),
-					Region:      flinkv2.PtrString("us-west-2"),
+					Region:      flinkv2.PtrString("eu-west-1"),
 					Environment: &flinkv2.GlobalObjectReference{Id: "env-123"},
 				},
 				Status: &flinkv2.FcpmV2ComputePoolStatus{Phase: "PROVISIONED"},
@@ -118,11 +120,19 @@ func handleFcpmComputePoolsId(t *testing.T) http.HandlerFunc {
 
 func handleFcpmRegions(t *testing.T) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		aws := flinkv2.FcpmV2Region{
+		awsEuWest1 := flinkv2.FcpmV2Region{
 			Id:                  flinkv2.PtrString("aws.eu-west-1"),
 			DisplayName:         flinkv2.PtrString("Europe (eu-west-1)"),
 			Cloud:               flinkv2.PtrString("AWS"),
 			RegionName:          flinkv2.PtrString("eu-west-1"),
+			HttpEndpoint:        flinkv2.PtrString(TestFlinkGatewayUrl.String()),
+			PrivateHttpEndpoint: flinkv2.PtrString(TestFlinkGatewayUrlPrivate.String()),
+		}
+		awsEuWest2 := flinkv2.FcpmV2Region{
+			Id:                  flinkv2.PtrString("aws.eu-west-2"),
+			DisplayName:         flinkv2.PtrString("Europe (eu-west-2)"),
+			Cloud:               flinkv2.PtrString("AWS"),
+			RegionName:          flinkv2.PtrString("eu-west-2"),
 			HttpEndpoint:        flinkv2.PtrString(TestFlinkGatewayUrl.String()),
 			PrivateHttpEndpoint: flinkv2.PtrString(TestFlinkGatewayUrlPrivate.String()),
 		}
@@ -134,9 +144,9 @@ func handleFcpmRegions(t *testing.T) http.HandlerFunc {
 			HttpEndpoint: flinkv2.PtrString(TestFlinkGatewayUrl.String()),
 		}
 
-		regions := []flinkv2.FcpmV2Region{aws, gcp}
+		regions := []flinkv2.FcpmV2Region{awsEuWest1, awsEuWest2, gcp}
 		if r.URL.Query().Get("cloud") == "AWS" {
-			regions = []flinkv2.FcpmV2Region{aws}
+			regions = []flinkv2.FcpmV2Region{awsEuWest1, awsEuWest2}
 		}
 
 		err := json.NewEncoder(w).Encode(flinkv2.FcpmV2RegionList{Data: regions})


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Checklist
---------
- [x] Leave this box unchecked if features are not yet available in production

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->
[Last PR](https://github.com/confluentinc/cli/pull/2846) broke tests on master. The failure came from the fact that we had an inconsistent usage of regions across tests. Gateway test handlers were assuming things to be in `eu-west-1` but then the compute pool handlers returned `us-west-1/us-west-2` regions. This PR aligns the regions between those two test backends 

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
<!--
Has it been tested? How?
Copy and paste any instructions or steps that can save the reviewer time.
-->
It looks like the integration tests do not run on PRs anymore, so this time I ran them locally to confirm they all pass

EDIT: actually, the integration tests _do_ run on PRs. The failure happened because of a semantic merge conflict with [this PR](https://github.com/confluentinc/cli/pull/2850). The new tests were merged before my PR was merged, and my branch wasn't up to date.