### PR TITLE
Update packaging script

### DIFF
--- a/debian/Makefile
+++ b/debian/Makefile
@@ -27,6 +27,10 @@ PREFIX=/usr
 SYSCONFDIR=/etc/$(PACKAGE_TITLE)
 endif
 
+_empty :=
+_space := $(_empty) $(empty)
+split_version := $(subst .,$(_space),$(CLI_VERSION))
+
 all: install
 
 archive: install
@@ -43,6 +47,9 @@ BINPATH=$(PREFIX)/bin
 LIBPATH=$(PREFIX)/libexec/$(PACKAGE_TITLE)
 DOCPATH=$(PREFIX)/share/doc/$(PACKAGE_TITLE)
 
+# Notes on the archive download links:
+# For CLI v2, the version number has the 'v' prefix
+# For CLI v3.43.0 and above, we download the '_disableupdates' variant
 install: apply-patches
 	rm -rf $(DESTDIR)$(PREFIX)
 	mkdir -p $(DESTDIR)$(PREFIX)
@@ -56,13 +63,21 @@ install: apply-patches
 	chmod 755 $(DESTDIR)$(BINPATH)/confluent
 
 	cd $(DESTDIR)$(LIBPATH); \
-	for dir in darwin_amd64 darwin_arm64 linux_amd64 linux_arm64 windows_amd64; do \
-		mkdir -p $${dir}; \
-		ext=""; if [[ $${dir} =~ windows_.+ ]]; then ext=".exe"; fi; \
-		filepath=$${dir}/confluent$${ext}; \
-		curl -f -s https://s3-us-west-2.amazonaws.com/confluent.cloud/confluent-cli/binaries/$(CLI_VERSION)/confluent-disableupdates_$(CLI_VERSION)_$${dir}$${ext} -o $${filepath}; \
-		chmod 755 $${filepath}; \
-	done
+	v=""; if [[ $(word 1,$(split_version)) -eq 2 ]]; then v="v"; fi; \
+	disableupdates=""; if [[ $(word 1,$(split_version)) -ge 3 && $(word 2,$(split_version)) -ge 43 ]]; then disableupdates="_disableupdates"; fi; \
+	for dir in darwin_amd64 darwin_arm64 linux_amd64 linux_arm64; do \
+		archive=confluent_$${v}$(CLI_VERSION)_$${dir}$${disableupdates}.tar.gz; \
+		curl -f -s https://s3-us-west-2.amazonaws.com/confluent.cloud/confluent-cli/archives/$(CLI_VERSION)/$${archive} -o $${archive}; \
+		mkdir -p $${dir} $${dir}-temp; \
+		tar -xzf $${archive} -C $${dir}-temp confluent/confluent; \
+		mv $${dir}-temp/confluent/confluent $${dir}/confluent; \
+		rm -rf $${archive} $${dir}-temp; \
+		chmod 755 $${dir}/confluent; \
+	done; \
+	mkdir -p windows_amd64; \
+	filepath=windows_amd64/confluent.exe; \
+	curl -f -s https://s3-us-west-2.amazonaws.com/confluent.cloud/confluent-cli/binaries/$(CLI_VERSION)/confluent_$(CLI_VERSION)_windows_amd64.exe -o $${filepath}; \
+	chmod 755 $${filepath}
 
 	cp LICENSE $(DESTDIR)$(DOCPATH)/COPYRIGHT
 	$(DESTDIR)$(BINPATH)/confluent --version | awk -F' ' '{ print $3 }' > $(DESTDIR)$(DOCPATH)/version.txt

--- a/debian/patches/standard_build_layout.patch
+++ b/debian/patches/standard_build_layout.patch
@@ -1,6 +1,6 @@
---- cli/Makefile	2024-07-02 20:56:36.753423056 -0700
-+++ debian/Makefile	2024-07-02 18:21:01.618798613 -0700
-@@ -1,146 +1,144 @@
+--- cli/Makefile	2024-08-07 12:56:17.727187329 -0700
++++ debian/Makefile	2024-08-13 15:17:56.588603066 -0700
+@@ -1,146 +1,159 @@
 -SHELL := /bin/bash
 -GORELEASER_VERSION := v1.21.2
 +SHELL=/bin/bash
@@ -78,25 +78,25 @@
 -S3_BUCKET_PATH=s3://confluent.cloud
 -S3_STAG_FOLDER_NAME=cli-release-stag
 -S3_STAG_PATH=s3://confluent.cloud/$(S3_STAG_FOLDER_NAME)
--
++# Defaults that are likely to vary by platform. These are cleanly separated so
++# it should be easy to maintain altered values on platform-specific branches
++# when the values aren't overridden by the script invoking the Makefile
+ 
 -S3_DEB_RPM_BUCKET_NAME=confluent-cli-release
 -S3_DEB_RPM_PROD_PREFIX=confluent-cli
 -S3_DEB_RPM_PROD_PATH=s3://$(S3_DEB_RPM_BUCKET_NAME)/$(S3_DEB_RPM_PROD_PREFIX)
 -S3_DEB_RPM_STAG_PATH=s3://$(S3_DEB_RPM_BUCKET_NAME)/confluent-cli-staging
--
++APPLY_PATCHES?=yes
+ 
 -.PHONY: clean
 -clean:
 -	for dir in bin dist docs legal prebuilt release-notes; do \
 -		[ -d $$dir ] && rm -r $$dir || true; \
 -	done
-+# Defaults that are likely to vary by platform. These are cleanly separated so
-+# it should be easy to maintain altered values on platform-specific branches
-+# when the values aren't overridden by the script invoking the Makefile
- 
+-
 -.PHONY: lint
 -lint: lint-go lint-cli
-+APPLY_PATCHES?=yes
- 
+-
 -.PHONY: lint-go
 -lint-go:
 -	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.59.0 && \
@@ -146,7 +146,9 @@
 -else
 -	go build -ldflags="-s -w -X main.commit="0000000" -X main.date="2023-12-07T19:01:49Z" -X main.version=$(VERSION) -X main.isTest=true" -o test/bin/confluent.exe ./cmd/confluent
 -endif
-+all: install
++_empty :=
++_space := $(_empty) $(empty)
++split_version := $(subst .,$(_space),$(CLI_VERSION))
  
 -.PHONY: integration-test
 -integration-test:
@@ -158,6 +160,8 @@
 -	go tool covdata textfmt -i $${GOCOVERDIR} -o test/coverage.out
 -else
 -	go test -timeout 0 -v $$(go list ./... | grep github.com/confluentinc/cli/v3/test) $(INTEGRATION_TEST_ARGS)
++all: install
++
 +archive: install
 +	rm -f $(CURDIR)/$(PACKAGE_NAME).tar.gz && cd $(DESTDIR) && tar -czf $(CURDIR)/$(PACKAGE_NAME).tar.gz $(PREFIX)
 +	rm -f $(CURDIR)/$(PACKAGE_NAME).zip && cd $(DESTDIR) && zip -r $(CURDIR)/$(PACKAGE_NAME).zip $(PREFIX)
@@ -174,6 +178,9 @@
 +LIBPATH=$(PREFIX)/libexec/$(PACKAGE_TITLE)
 +DOCPATH=$(PREFIX)/share/doc/$(PACKAGE_TITLE)
 +
++# Notes on the archive download links:
++# For CLI v2, the version number has the 'v' prefix
++# For CLI v3.43.0 and above, we download the '_disableupdates' variant
 +install: apply-patches
 +	rm -rf $(DESTDIR)$(PREFIX)
 +	mkdir -p $(DESTDIR)$(PREFIX)
@@ -187,13 +194,21 @@
 +	chmod 755 $(DESTDIR)$(BINPATH)/confluent
 +
 +	cd $(DESTDIR)$(LIBPATH); \
-+	for dir in darwin_amd64 darwin_arm64 linux_amd64 linux_arm64 windows_amd64; do \
-+		mkdir -p $${dir}; \
-+		ext=""; if [[ $${dir} =~ windows_.+ ]]; then ext=".exe"; fi; \
-+		filepath=$${dir}/confluent$${ext}; \
-+		curl -f -s https://s3-us-west-2.amazonaws.com/confluent.cloud/confluent-cli/binaries/$(CLI_VERSION)/confluent-disableupdates_$(CLI_VERSION)_$${dir}$${ext} -o $${filepath}; \
-+		chmod 755 $${filepath}; \
-+	done
++	v=""; if [[ $(word 1,$(split_version)) -eq 2 ]]; then v="v"; fi; \
++	disableupdates=""; if [[ $(word 1,$(split_version)) -ge 3 && $(word 2,$(split_version)) -ge 43 ]]; then disableupdates="_disableupdates"; fi; \
++	for dir in darwin_amd64 darwin_arm64 linux_amd64 linux_arm64; do \
++		archive=confluent_$${v}$(CLI_VERSION)_$${dir}$${disableupdates}.tar.gz; \
++		curl -f -s https://s3-us-west-2.amazonaws.com/confluent.cloud/confluent-cli/archives/$(CLI_VERSION)/$${archive} -o $${archive}; \
++		mkdir -p $${dir} $${dir}-temp; \
++		tar -xzf $${archive} -C $${dir}-temp confluent/confluent; \
++		mv $${dir}-temp/confluent/confluent $${dir}/confluent; \
++		rm -rf $${archive} $${dir}-temp; \
++		chmod 755 $${dir}/confluent; \
++	done; \
++	mkdir -p windows_amd64; \
++	filepath=windows_amd64/confluent.exe; \
++	curl -f -s https://s3-us-west-2.amazonaws.com/confluent.cloud/confluent-cli/binaries/$(CLI_VERSION)/confluent_$(CLI_VERSION)_windows_amd64.exe -o $${filepath}; \
++	chmod 755 $${filepath}
 +
 +	cp LICENSE $(DESTDIR)$(DOCPATH)/COPYRIGHT
 +	$(DESTDIR)$(BINPATH)/confluent --version | awk -F' ' '{ print $3 }' > $(DESTDIR)$(DOCPATH)/version.txt


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- PLACEHOLDER

New Features
- PLACEHOLDER

Bug Fixes
- PLACEHOLDER

Checklist
---------
- [x] Leave this box unchecked if features are not yet available in production

What
----
The binary packaged with Platform should have the update command disabled, because each release of Confluent Platform has a fixed CLI version. Even if customers do want to upgrade it, they should do so through package managers.

We upload archives, but not binaries, with updates disabled. This PR corrects a bug that tries to pull the binary by instead pulling the archive and extracting the binary from it.

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
I tested the updated for loop locally on my machine.