### PR TITLE
CLI-3149 confluent local kafka start requires Docker to be running as a prerequisite (#27)

### DIFF
--- a/pkg/docs/doc_page.go
+++ b/pkg/docs/doc_page.go
@@ -43,8 +43,14 @@ func printDocPage(tabs []Tab, depth int) []string {
 func printWarnings(cmd *cobra.Command, depth int) []string {
 	var rows []string
 
-	if strings.HasPrefix(cmd.CommandPath(), "confluent local") {
-		include := strings.Repeat("../", depth) + "includes/cli.rst"
+	include := strings.Repeat("../", depth) + "includes/cli.rst"
+	if cmd.CommandPath() == "confluent local kafka start" {
+		args := map[string]string{
+			"start-after": "cli_limitations_confluent_kafka_local_start",
+			"end-before":  "cli_limitations_confluent_kafka_local_end",
+		}
+		rows = append(rows, printSphinxBlock("include", include, args)...)
+	} else if strings.HasPrefix(cmd.CommandPath(), "confluent local") {
 		args := map[string]string{
 			"start-after": "cli_limitations_start",
 			"end-before":  "cli_limitations_end",


### PR DESCRIPTION
This requirement only applies to confluent local kafka commands, and particularly to `confluent local kafka start`, so adding a note specific to that command.

What
----
`confluent local kafka start` requires Docker to be running as a prerequisite, added a new note that describes this and the test pre-production caveat that's in all the other `confluent local` command descriptions

References
----------
- JIra: https://confluentinc.atlassian.net/browse/CLI-3149
- PR for the `docs-common` update: https://github.com/confluentinc/docs-common/pull/1383
- Airlock PR: https://github.com/confluentinc/airlock-cli/pull/27 ([These commits](https://github.com/confluentinc/airlock-cli/pull/27/commits) were made on that airlock branch.)


Test & Review
-------------

Run `make docs` locally.