### PR TITLE
[APIT-2278] Provider Integration Feature for CLI (public)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -39,6 +39,7 @@ require (
 	github.com/confluentinc/ccloud-sdk-go-v2/networking-ip v0.2.0
 	github.com/confluentinc/ccloud-sdk-go-v2/networking-privatelink v0.2.0
 	github.com/confluentinc/ccloud-sdk-go-v2/org v0.9.0
+	github.com/confluentinc/ccloud-sdk-go-v2/provider-integration v0.1.0
 	github.com/confluentinc/ccloud-sdk-go-v2/service-quota v0.2.0
 	github.com/confluentinc/ccloud-sdk-go-v2/srcm v0.6.0
 	github.com/confluentinc/ccloud-sdk-go-v2/sso v0.0.1

--- a/go.sum
+++ b/go.sum
@@ -180,6 +180,8 @@ github.com/confluentinc/ccloud-sdk-go-v2/networking-privatelink v0.2.0 h1:3nm/8K
 github.com/confluentinc/ccloud-sdk-go-v2/networking-privatelink v0.2.0/go.mod h1:uj/ybBJPQbmuuBdSoznMiMGEwW3z/g0Uko8uKWg36I8=
 github.com/confluentinc/ccloud-sdk-go-v2/org v0.9.0 h1:FtaqHX0kBTK7fCQK+9SJcOso+XpWCWzY2roT3gBQGfw=
 github.com/confluentinc/ccloud-sdk-go-v2/org v0.9.0/go.mod h1:X0uaTYPp+mr19W1R/Z1LuB1ePZJZrH7kxnQckDx6zoc=
+github.com/confluentinc/ccloud-sdk-go-v2/provider-integration v0.1.0 h1:a6GlDTUoeX5zRlIPVToH3Aa779QA2Ajj/LYyJC5UQN8=
+github.com/confluentinc/ccloud-sdk-go-v2/provider-integration v0.1.0/go.mod h1:aNAIuiIUbfvqtQrl4yp1f7dMdUInXs+PDrHLvKCr0PE=
 github.com/confluentinc/ccloud-sdk-go-v2/service-quota v0.2.0 h1:xVSmwdycExze1E2Jta99CaFuMOlL6k6KExOOSY1hSFg=
 github.com/confluentinc/ccloud-sdk-go-v2/service-quota v0.2.0/go.mod h1:zZWZoGWJuO0Qm4lO6H2KlXMx4OoB/yhD8y6J1ZB/97Q=
 github.com/confluentinc/ccloud-sdk-go-v2/srcm v0.6.0 h1:BfhTmbkEWaRbvWZ4mxzkAE9/0DVBClClO34GibG8OkM=

--- a/internal/command.go
+++ b/internal/command.go
@@ -37,6 +37,7 @@ import (
 	"github.com/confluentinc/cli/v3/internal/pipeline"
 	"github.com/confluentinc/cli/v3/internal/plugin"
 	"github.com/confluentinc/cli/v3/internal/prompt"
+	providerintegration "github.com/confluentinc/cli/v3/internal/provider-integration"
 	schemaregistry "github.com/confluentinc/cli/v3/internal/schema-registry"
 	"github.com/confluentinc/cli/v3/internal/secret"
 	servicequota "github.com/confluentinc/cli/v3/internal/service-quota"
@@ -123,6 +124,7 @@ func NewConfluentCommand(cfg *config.Config) *cobra.Command {
 	cmd.AddCommand(pipeline.New(prerunner))
 	cmd.AddCommand(plugin.New(cfg, prerunner))
 	cmd.AddCommand(prompt.New(cfg))
+	cmd.AddCommand(providerintegration.New(prerunner))
 	cmd.AddCommand(servicequota.New(prerunner))
 	cmd.AddCommand(schemaregistry.New(cfg, prerunner))
 	cmd.AddCommand(secret.New(prerunner, secrets.NewPasswordProtectionPlugin()))

--- a/internal/network/command.go
+++ b/internal/network/command.go
@@ -50,12 +50,6 @@ type command struct {
 	*pcmd.AuthenticatedCLICommand
 }
 
-const (
-	CloudAws   = "AWS"
-	CloudAzure = "AZURE"
-	CloudGcp   = "GCP"
-)
-
 var (
 	ConnectionTypes = []string{"privatelink", "peering", "transitgateway"}
 	DnsResolutions  = []string{"private", "chased-private"}
@@ -126,13 +120,13 @@ func printTable(cmd *cobra.Command, network networkingv1.NetworkingV1Network) er
 		}
 
 		switch cloud {
-		case CloudAws:
+		case resource.CloudAws:
 			human.AwsPrivateLinkEndpointService = network.Status.Cloud.NetworkingV1AwsNetwork.GetPrivateLinkEndpointService()
 			describeFields = append(describeFields, "AwsPrivateLinkEndpointService")
-		case CloudGcp:
+		case resource.CloudGcp:
 			human.GcpPrivateServiceConnectServiceAttachments = network.Status.Cloud.NetworkingV1GcpNetwork.GetPrivateServiceConnectServiceAttachments()
 			describeFields = append(describeFields, "GcpPrivateServiceConnectServiceAttachments")
-		case CloudAzure:
+		case resource.CloudAzure:
 			human.AzurePrivateLinkServiceAliases = network.Status.Cloud.NetworkingV1AzureNetwork.GetPrivateLinkServiceAliases()
 			human.AzurePrivateLinkServiceResourceIds = network.Status.Cloud.NetworkingV1AzureNetwork.GetPrivateLinkServiceResourceIds()
 			describeFields = append(describeFields, "AzurePrivateLinkServiceAliases", "AzurePrivateLinkServiceResourceIds")
@@ -148,15 +142,15 @@ func printTable(cmd *cobra.Command, network networkingv1.NetworkingV1Network) er
 		}
 
 		switch cloud {
-		case CloudAws:
+		case resource.CloudAws:
 			human.AwsVpc = network.Status.Cloud.NetworkingV1AwsNetwork.GetVpc()
 			human.AwsAccount = network.Status.Cloud.NetworkingV1AwsNetwork.GetAccount()
 			describeFields = append(describeFields, "AwsVpc", "AwsAccount")
-		case CloudGcp:
+		case resource.CloudGcp:
 			human.GcpVpcNetwork = network.Status.Cloud.NetworkingV1GcpNetwork.GetVpcNetwork()
 			human.GcpProject = network.Status.Cloud.NetworkingV1GcpNetwork.GetProject()
 			describeFields = append(describeFields, "GcpVpcNetwork", "GcpProject")
-		case CloudAzure:
+		case resource.CloudAzure:
 			human.AzureVNet = network.Status.Cloud.NetworkingV1AzureNetwork.GetVnet()
 			human.AzureSubscription = network.Status.Cloud.NetworkingV1AzureNetwork.GetSubscription()
 			describeFields = append(describeFields, "AzureVNet", "AzureSubscription")

--- a/internal/network/command_access_point_private_link_egress_endpoint_create.go
+++ b/internal/network/command_access_point_private_link_egress_endpoint_create.go
@@ -10,6 +10,7 @@ import (
 
 	pcmd "github.com/confluentinc/cli/v3/pkg/cmd"
 	"github.com/confluentinc/cli/v3/pkg/examples"
+	"github.com/confluentinc/cli/v3/pkg/resource"
 	"github.com/confluentinc/cli/v3/pkg/utils"
 )
 
@@ -96,7 +97,7 @@ func (c *accessPointCommand) create(cmd *cobra.Command, args []string) error {
 	}
 
 	switch cloud {
-	case CloudAws:
+	case resource.CloudAws:
 		createEgressEndpoint.Spec.Config = &networkingaccesspointv1.NetworkingV1AccessPointSpecConfigOneOf{
 			NetworkingV1AwsEgressPrivateLinkEndpoint: &networkingaccesspointv1.NetworkingV1AwsEgressPrivateLinkEndpoint{
 				Kind:                   "AwsEgressPrivateLinkEndpoint",
@@ -104,7 +105,7 @@ func (c *accessPointCommand) create(cmd *cobra.Command, args []string) error {
 				EnableHighAvailability: networkingaccesspointv1.PtrBool(highAvailability),
 			},
 		}
-	case CloudAzure:
+	case resource.CloudAzure:
 		createEgressEndpoint.Spec.Config = &networkingaccesspointv1.NetworkingV1AccessPointSpecConfigOneOf{
 			NetworkingV1AzureEgressPrivateLinkEndpoint: &networkingaccesspointv1.NetworkingV1AzureEgressPrivateLinkEndpoint{
 				Kind:                         "AzureEgressPrivateLinkEndpoint",

--- a/internal/network/command_gateway.go
+++ b/internal/network/command_gateway.go
@@ -8,6 +8,7 @@ import (
 	networkingv1 "github.com/confluentinc/ccloud-sdk-go-v2/networking/v1"
 
 	"github.com/confluentinc/cli/v3/pkg/ccloudv2"
+	"github.com/confluentinc/cli/v3/pkg/resource"
 )
 
 type gatewayOut struct {
@@ -67,11 +68,11 @@ func getGatewayCloud(gateway networkingv1.NetworkingV1Gateway) string {
 	cloud := gateway.Status.GetCloudGateway()
 
 	if cloud.NetworkingV1AwsEgressPrivateLinkGatewayStatus != nil {
-		return CloudAws
+		return resource.CloudAws
 	}
 
 	if cloud.NetworkingV1AzureEgressPrivateLinkGatewayStatus != nil {
-		return CloudAzure
+		return resource.CloudAzure
 	}
 
 	return ""

--- a/internal/network/command_gateway_describe.go
+++ b/internal/network/command_gateway_describe.go
@@ -9,6 +9,7 @@ import (
 	"github.com/confluentinc/cli/v3/pkg/errors"
 	"github.com/confluentinc/cli/v3/pkg/examples"
 	"github.com/confluentinc/cli/v3/pkg/output"
+	"github.com/confluentinc/cli/v3/pkg/resource"
 )
 
 func (c *command) newGatewayDescribeCommand() *cobra.Command {
@@ -74,9 +75,9 @@ func (c *command) gatewayDescribe(cmd *cobra.Command, args []string) error {
 	cloud := getGatewayCloud(gateway)
 
 	switch cloud {
-	case CloudAws:
+	case resource.CloudAws:
 		out.AwsPrincipalArn = gateway.Status.CloudGateway.NetworkingV1AwsEgressPrivateLinkGatewayStatus.GetPrincipalArn()
-	case CloudAzure:
+	case resource.CloudAzure:
 		out.AzureSubscription = gateway.Status.CloudGateway.NetworkingV1AzureEgressPrivateLinkGatewayStatus.GetSubscription()
 	}
 

--- a/internal/network/command_gateway_list.go
+++ b/internal/network/command_gateway_list.go
@@ -8,6 +8,7 @@ import (
 	pcmd "github.com/confluentinc/cli/v3/pkg/cmd"
 	"github.com/confluentinc/cli/v3/pkg/errors"
 	"github.com/confluentinc/cli/v3/pkg/output"
+	"github.com/confluentinc/cli/v3/pkg/resource"
 )
 
 func (c *command) newGatewayListCommand() *cobra.Command {
@@ -68,9 +69,9 @@ func (c *command) gatewayList(cmd *cobra.Command, _ []string) error {
 		cloud := getGatewayCloud(gateway)
 
 		switch cloud {
-		case CloudAws:
+		case resource.CloudAws:
 			out.AwsPrincipalArn = gateway.Status.CloudGateway.NetworkingV1AwsEgressPrivateLinkGatewayStatus.GetPrincipalArn()
-		case CloudAzure:
+		case resource.CloudAzure:
 			out.AzureSubscription = gateway.Status.CloudGateway.NetworkingV1AzureEgressPrivateLinkGatewayStatus.GetSubscription()
 		}
 

--- a/internal/network/command_peering.go
+++ b/internal/network/command_peering.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/confluentinc/cli/v3/pkg/errors"
 	"github.com/confluentinc/cli/v3/pkg/output"
+	"github.com/confluentinc/cli/v3/pkg/resource"
 )
 
 type peeringOut struct {
@@ -84,11 +85,11 @@ func getPeeringCloud(peering networkingv1.NetworkingV1Peering) (string, error) {
 	cloud := peering.Spec.GetCloud()
 
 	if cloud.NetworkingV1AwsPeering != nil {
-		return CloudAws, nil
+		return resource.CloudAws, nil
 	} else if cloud.NetworkingV1GcpPeering != nil {
-		return CloudGcp, nil
+		return resource.CloudGcp, nil
 	} else if cloud.NetworkingV1AzurePeering != nil {
-		return CloudAzure, nil
+		return resource.CloudAzure, nil
 	}
 
 	return "", fmt.Errorf(errors.CorruptedNetworkResponseErrorMsg, "cloud")
@@ -118,17 +119,17 @@ func printPeeringTable(cmd *cobra.Command, peering networkingv1.NetworkingV1Peer
 	describeFields := []string{"Id", "Name", "Network", "Cloud", "Phase"}
 
 	switch cloud {
-	case CloudAws:
+	case resource.CloudAws:
 		out.AwsVpc = peering.Spec.Cloud.NetworkingV1AwsPeering.GetVpc()
 		out.AwsAccount = peering.Spec.Cloud.NetworkingV1AwsPeering.GetAccount()
 		out.AwsRoutes = peering.Spec.Cloud.NetworkingV1AwsPeering.GetRoutes()
 		out.CustomRegion = peering.Spec.Cloud.NetworkingV1AwsPeering.GetCustomerRegion()
 		describeFields = append(describeFields, "AwsVpc", "AwsAccount", "AwsRoutes", "CustomRegion")
-	case CloudGcp:
+	case resource.CloudGcp:
 		out.GcpVpcNetwork = peering.Spec.Cloud.NetworkingV1GcpPeering.GetVpcNetwork()
 		out.GcpProject = peering.Spec.Cloud.NetworkingV1GcpPeering.GetProject()
 		describeFields = append(describeFields, "GcpVpcNetwork", "GcpProject")
-	case CloudAzure:
+	case resource.CloudAzure:
 		out.AzureVNet = peering.Spec.Cloud.NetworkingV1AzurePeering.GetVnet()
 		out.AzureTenant = peering.Spec.Cloud.NetworkingV1AzurePeering.GetTenant()
 		out.CustomRegion = peering.Spec.Cloud.NetworkingV1AzurePeering.GetCustomerRegion()

--- a/internal/network/command_peering_create.go
+++ b/internal/network/command_peering_create.go
@@ -9,6 +9,7 @@ import (
 
 	pcmd "github.com/confluentinc/cli/v3/pkg/cmd"
 	"github.com/confluentinc/cli/v3/pkg/examples"
+	"github.com/confluentinc/cli/v3/pkg/resource"
 )
 
 func (c *command) newPeeringCreateCommand() *cobra.Command {
@@ -96,7 +97,7 @@ func (c *command) peeringCreate(cmd *cobra.Command, args []string) error {
 	}
 
 	switch cloud {
-	case CloudAws:
+	case resource.CloudAws:
 		awsPeering, err := createAwsPeeringRequest(cmd, region)
 		if err != nil {
 			return err
@@ -104,7 +105,7 @@ func (c *command) peeringCreate(cmd *cobra.Command, args []string) error {
 		createPeering.Spec.Cloud = &networkingv1.NetworkingV1PeeringSpecCloudOneOf{
 			NetworkingV1AwsPeering: awsPeering,
 		}
-	case CloudGcp:
+	case resource.CloudGcp:
 		gcpPeering, err := createGcpPeeringRequest(cmd)
 		if err != nil {
 			return err
@@ -112,7 +113,7 @@ func (c *command) peeringCreate(cmd *cobra.Command, args []string) error {
 		createPeering.Spec.Cloud = &networkingv1.NetworkingV1PeeringSpecCloudOneOf{
 			NetworkingV1GcpPeering: gcpPeering,
 		}
-	case CloudAzure:
+	case resource.CloudAzure:
 		azurePeering, err := createAzurePeeringRequest(cmd, region)
 		if err != nil {
 			return err

--- a/internal/network/command_peering_list.go
+++ b/internal/network/command_peering_list.go
@@ -85,14 +85,14 @@ func (c *command) peeringList(cmd *cobra.Command, _ []string) error {
 			Phase:   peering.Status.GetPhase(),
 		}
 		switch cloud {
-		case CloudAws:
+		case resource.CloudAws:
 			out.CustomRegion = peering.Spec.Cloud.NetworkingV1AwsPeering.GetCustomerRegion()
 			out.VirtualNetwork = peering.Spec.Cloud.NetworkingV1AwsPeering.GetVpc()
 			out.CloudAccount = peering.Spec.Cloud.NetworkingV1AwsPeering.GetAccount()
-		case CloudGcp:
+		case resource.CloudGcp:
 			out.VirtualNetwork = peering.Spec.Cloud.NetworkingV1GcpPeering.GetVpcNetwork()
 			out.CloudAccount = peering.Spec.Cloud.NetworkingV1GcpPeering.GetProject()
-		case CloudAzure:
+		case resource.CloudAzure:
 			out.CustomRegion = peering.Spec.Cloud.NetworkingV1AzurePeering.GetCustomerRegion()
 			out.VirtualNetwork = peering.Spec.Cloud.NetworkingV1AzurePeering.GetVnet()
 			out.CloudAccount = peering.Spec.Cloud.NetworkingV1AzurePeering.GetTenant()

--- a/internal/network/command_private_link_access.go
+++ b/internal/network/command_private_link_access.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/confluentinc/cli/v3/pkg/errors"
 	"github.com/confluentinc/cli/v3/pkg/output"
+	"github.com/confluentinc/cli/v3/pkg/resource"
 )
 
 type privateLinkAccessOut struct {
@@ -79,11 +80,11 @@ func getPrivateLinkAccessCloud(access networkingv1.NetworkingV1PrivateLinkAccess
 	cloud := access.Spec.GetCloud()
 
 	if cloud.NetworkingV1AwsPrivateLinkAccess != nil {
-		return CloudAws, nil
+		return resource.CloudAws, nil
 	} else if cloud.NetworkingV1GcpPrivateServiceConnectAccess != nil {
-		return CloudGcp, nil
+		return resource.CloudGcp, nil
 	} else if cloud.NetworkingV1AzurePrivateLinkAccess != nil {
-		return CloudAzure, nil
+		return resource.CloudAzure, nil
 	}
 
 	return "", fmt.Errorf(errors.CorruptedNetworkResponseErrorMsg, "cloud")
@@ -111,11 +112,11 @@ func printPrivateLinkAccessTable(cmd *cobra.Command, access networkingv1.Network
 	}
 
 	switch cloud {
-	case CloudAws:
+	case resource.CloudAws:
 		out.AwsAccount = access.Spec.Cloud.NetworkingV1AwsPrivateLinkAccess.GetAccount()
-	case CloudGcp:
+	case resource.CloudGcp:
 		out.GcpProject = access.Spec.Cloud.NetworkingV1GcpPrivateServiceConnectAccess.GetProject()
-	case CloudAzure:
+	case resource.CloudAzure:
 		out.AzureSubscription = access.Spec.Cloud.NetworkingV1AzurePrivateLinkAccess.GetSubscription()
 	}
 

--- a/internal/network/command_private_link_access_create.go
+++ b/internal/network/command_private_link_access_create.go
@@ -9,6 +9,7 @@ import (
 
 	pcmd "github.com/confluentinc/cli/v3/pkg/cmd"
 	"github.com/confluentinc/cli/v3/pkg/examples"
+	"github.com/confluentinc/cli/v3/pkg/resource"
 )
 
 func (c *command) newPrivateLinkAccessCreateCommand() *cobra.Command {
@@ -90,21 +91,21 @@ func (c *command) privateLinkAccessCreate(cmd *cobra.Command, args []string) err
 	}
 
 	switch cloud {
-	case CloudAws:
+	case resource.CloudAws:
 		createPrivateLinkAccess.Spec.Cloud = &networkingv1.NetworkingV1PrivateLinkAccessSpecCloudOneOf{
 			NetworkingV1AwsPrivateLinkAccess: &networkingv1.NetworkingV1AwsPrivateLinkAccess{
 				Kind:    "AwsPrivateLinkAccess",
 				Account: cloudAccount,
 			},
 		}
-	case CloudAzure:
+	case resource.CloudAzure:
 		createPrivateLinkAccess.Spec.Cloud = &networkingv1.NetworkingV1PrivateLinkAccessSpecCloudOneOf{
 			NetworkingV1AzurePrivateLinkAccess: &networkingv1.NetworkingV1AzurePrivateLinkAccess{
 				Kind:         "AzurePrivateLinkAccess",
 				Subscription: cloudAccount,
 			},
 		}
-	case CloudGcp:
+	case resource.CloudGcp:
 		createPrivateLinkAccess.Spec.Cloud = &networkingv1.NetworkingV1PrivateLinkAccessSpecCloudOneOf{
 			NetworkingV1GcpPrivateServiceConnectAccess: &networkingv1.NetworkingV1GcpPrivateServiceConnectAccess{
 				Kind:    "GcpPrivateServiceConnectAccess",

--- a/internal/network/command_private_link_access_list.go
+++ b/internal/network/command_private_link_access_list.go
@@ -84,11 +84,11 @@ func (c *command) privateLinkAccessList(cmd *cobra.Command, _ []string) error {
 		}
 
 		switch cloud {
-		case CloudAws:
+		case resource.CloudAws:
 			out.CloudAccount = access.Spec.Cloud.NetworkingV1AwsPrivateLinkAccess.GetAccount()
-		case CloudGcp:
+		case resource.CloudGcp:
 			out.CloudAccount = access.Spec.Cloud.NetworkingV1GcpPrivateServiceConnectAccess.GetProject()
-		case CloudAzure:
+		case resource.CloudAzure:
 			out.CloudAccount = access.Spec.Cloud.NetworkingV1AzurePrivateLinkAccess.GetSubscription()
 		}
 

--- a/internal/network/command_private_link_access_test.go
+++ b/internal/network/command_private_link_access_test.go
@@ -6,6 +6,8 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	networkingv1 "github.com/confluentinc/ccloud-sdk-go-v2/networking/v1"
+
+	"github.com/confluentinc/cli/v3/pkg/resource"
 )
 
 func TestGetPrivateLinkAccessCloudWithAws(t *testing.T) {
@@ -27,7 +29,7 @@ func TestGetPrivateLinkAccessCloudWithAws(t *testing.T) {
 		},
 	})
 	assert.NoError(t, err)
-	assert.Equal(t, CloudAws, cloud)
+	assert.Equal(t, resource.CloudAws, cloud)
 }
 
 func TestGetPrivateLinkAccessCloudWithAzure(t *testing.T) {
@@ -49,7 +51,7 @@ func TestGetPrivateLinkAccessCloudWithAzure(t *testing.T) {
 		},
 	})
 	assert.NoError(t, err)
-	assert.Equal(t, CloudAzure, cloud)
+	assert.Equal(t, resource.CloudAzure, cloud)
 }
 
 func TestGetPrivateLinkAccessCloudWithGcp(t *testing.T) {
@@ -71,7 +73,7 @@ func TestGetPrivateLinkAccessCloudWithGcp(t *testing.T) {
 		},
 	})
 	assert.NoError(t, err)
-	assert.Equal(t, CloudGcp, cloud)
+	assert.Equal(t, resource.CloudGcp, cloud)
 }
 
 func TestGetPrivateLinkAccessCloudWithEmptyValue(t *testing.T) {

--- a/internal/network/command_private_link_attachment_connection.go
+++ b/internal/network/command_private_link_attachment_connection.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/confluentinc/cli/v3/pkg/errors"
 	"github.com/confluentinc/cli/v3/pkg/output"
+	"github.com/confluentinc/cli/v3/pkg/resource"
 )
 
 type privateLinkAttachmentConnectionOut struct {
@@ -57,10 +58,10 @@ func printPrivateLinkAttachmentConnectionTable(cmd *cobra.Command, connection ne
 	if connection.Spec.HasCloud() {
 		switch {
 		case connection.Spec.Cloud.NetworkingV1AwsPrivateLinkAttachmentConnection != nil:
-			out.Cloud = CloudAws
+			out.Cloud = resource.CloudAws
 			out.AwsVpcEndpointId = connection.Spec.Cloud.NetworkingV1AwsPrivateLinkAttachmentConnection.GetVpcEndpointId()
 		case connection.Spec.Cloud.NetworkingV1AzurePrivateLinkAttachmentConnection != nil:
-			out.Cloud = CloudAzure
+			out.Cloud = resource.CloudAzure
 			out.AzurePrivateEndpointResourceId = connection.Spec.Cloud.NetworkingV1AzurePrivateLinkAttachmentConnection.GetPrivateEndpointResourceId()
 		}
 	}

--- a/internal/network/command_private_link_attachment_connection_create.go
+++ b/internal/network/command_private_link_attachment_connection_create.go
@@ -9,6 +9,7 @@ import (
 
 	pcmd "github.com/confluentinc/cli/v3/pkg/cmd"
 	"github.com/confluentinc/cli/v3/pkg/examples"
+	"github.com/confluentinc/cli/v3/pkg/resource"
 )
 
 func (c *command) newPrivateLinkAttachmentConnectionCreateCommand() *cobra.Command {
@@ -78,21 +79,21 @@ func (c *command) privateLinkAttachmentConnectionCreate(cmd *cobra.Command, args
 	}
 
 	switch cloud {
-	case CloudAws:
+	case resource.CloudAws:
 		createPrivateLinkAttachmentConnection.Spec.Cloud = &networkingprivatelinkv1.NetworkingV1PrivateLinkAttachmentConnectionSpecCloudOneOf{
 			NetworkingV1AwsPrivateLinkAttachmentConnection: &networkingprivatelinkv1.NetworkingV1AwsPrivateLinkAttachmentConnection{
 				Kind:          "AwsPrivateLinkAttachmentConnection",
 				VpcEndpointId: endpoint,
 			},
 		}
-	case CloudGcp:
+	case resource.CloudGcp:
 		createPrivateLinkAttachmentConnection.Spec.Cloud = &networkingprivatelinkv1.NetworkingV1PrivateLinkAttachmentConnectionSpecCloudOneOf{
 			NetworkingV1GcpPrivateLinkAttachmentConnection: &networkingprivatelinkv1.NetworkingV1GcpPrivateLinkAttachmentConnection{
 				Kind:                              "GcpPrivateLinkAttachmentConnection",
 				PrivateServiceConnectConnectionId: endpoint,
 			},
 		}
-	case CloudAzure:
+	case resource.CloudAzure:
 		createPrivateLinkAttachmentConnection.Spec.Cloud = &networkingprivatelinkv1.NetworkingV1PrivateLinkAttachmentConnectionSpecCloudOneOf{
 			NetworkingV1AzurePrivateLinkAttachmentConnection: &networkingprivatelinkv1.NetworkingV1AzurePrivateLinkAttachmentConnection{
 				Kind:                      "AzurePrivateLinkAttachmentConnection",

--- a/internal/network/command_private_link_attachment_connection_list.go
+++ b/internal/network/command_private_link_attachment_connection_list.go
@@ -9,6 +9,7 @@ import (
 	"github.com/confluentinc/cli/v3/pkg/errors"
 	"github.com/confluentinc/cli/v3/pkg/examples"
 	"github.com/confluentinc/cli/v3/pkg/output"
+	"github.com/confluentinc/cli/v3/pkg/resource"
 )
 
 func (c *command) newPrivateLinkAttachmentConnectionListCommand() *cobra.Command {
@@ -70,10 +71,10 @@ func (c *command) privateLinkAttachmentConnectionList(cmd *cobra.Command, _ []st
 		if connection.Spec.HasCloud() {
 			switch {
 			case connection.Spec.Cloud.NetworkingV1AwsPrivateLinkAttachmentConnection != nil:
-				out.Cloud = CloudAws
+				out.Cloud = resource.CloudAws
 				out.AwsVpcEndpointId = connection.Spec.Cloud.NetworkingV1AwsPrivateLinkAttachmentConnection.GetVpcEndpointId()
 			case connection.Spec.Cloud.NetworkingV1AzurePrivateLinkAttachmentConnection != nil:
-				out.Cloud = CloudAzure
+				out.Cloud = resource.CloudAzure
 				out.AzurePrivateEndpointResourceId = connection.Spec.Cloud.NetworkingV1AzurePrivateLinkAttachmentConnection.GetPrivateEndpointResourceId()
 			}
 		}

--- a/internal/provider-integration/command.go
+++ b/internal/provider-integration/command.go
@@ -1,0 +1,40 @@
+package provider_integration
+
+import (
+	"github.com/spf13/cobra"
+
+	pcmd "github.com/confluentinc/cli/v3/pkg/cmd"
+)
+
+type command struct {
+	*pcmd.AuthenticatedCLICommand
+}
+
+type providerIntegrationOut struct {
+	Id                 string   `human:"ID" serialized:"id"`
+	Name               string   `human:"Name" serialized:"name"`
+	Provider           string   `human:"Provider" serialized:"provider"`
+	Environment        string   `human:"Environment" serialized:"environment"`
+	IamRoleArn         string   `human:"IAM Role Arn" serialized:"iam_role_arn"`
+	ExternalId         string   `human:"External ID" serialized:"external_id"`
+	CustomerIamRoleArn string   `human:"Customer IAM Role Arn" serialized:"customer_iam_role_arn"`
+	Usages             []string `human:"Usages" serialized:"usages"`
+}
+
+func New(prerunner pcmd.PreRunner) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:         "provider-integration",
+		Aliases:     []string{"pi"},
+		Short:       "Manage CLI provider integrations.",
+		Annotations: map[string]string{pcmd.RunRequirement: pcmd.RequireNonAPIKeyCloudLogin},
+	}
+
+	c := &command{pcmd.NewAuthenticatedCLICommand(cmd, prerunner)}
+
+	cmd.AddCommand(c.newCreateCommand())
+	cmd.AddCommand(c.newDeleteCommand())
+	cmd.AddCommand(c.newDescribeCommand())
+	cmd.AddCommand(c.newListCommand())
+
+	return cmd
+}

--- a/internal/provider-integration/command_create.go
+++ b/internal/provider-integration/command_create.go
@@ -1,0 +1,116 @@
+package provider_integration
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	providerintegrationv1 "github.com/confluentinc/ccloud-sdk-go-v2/provider-integration/v1"
+
+	pcmd "github.com/confluentinc/cli/v3/pkg/cmd"
+	"github.com/confluentinc/cli/v3/pkg/examples"
+	"github.com/confluentinc/cli/v3/pkg/output"
+	"github.com/confluentinc/cli/v3/pkg/resource"
+)
+
+func (c *command) newCreateCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "create <name>",
+		Short: "Create a provider integration.",
+		Long:  "Create a Provider Integration that allow users to manage access to public cloud service provider resources through Confluent resources.",
+		Args:  cobra.ExactArgs(1),
+		RunE:  c.create,
+		Example: examples.BuildExampleString(
+			examples.Example{
+				Text: `Create a provider integration "s3-provider-integration" associated with AWS IAM role arn "arn:aws:iam::000000000000:role/my-test-aws-role in current environment".`,
+				Code: `confluent provider-integration create s3-provider-integration --cloud aws --customer-iam-role-arn arn:aws:iam::000000000000:role/my-test-aws-role`,
+			},
+			examples.Example{
+				Text: `Create a provider integration "s3-provider-integration" associated with AWS IAM role arn "arn:aws:iam::000000000000:role/my-test-aws-role in environment env-abcdef".`,
+				Code: `confluent provider-integration create s3-provider-integration --cloud aws --customer-iam-role-arn arn:aws:iam::000000000000:role/my-test-aws-role --environment env-abcdef`,
+			},
+		),
+	}
+
+	// Handle the flags, for cloud flag only AWS is supported now
+	cmd.Flags().String("customer-iam-role-arn", "", "Amazon Resource Name (ARN) that identifies the AWS Identity and Access Management (IAM) role that Confluent Cloud assumes when it accesses resources in your AWS account, having to be unique in the same environment.")
+	pcmd.AddCloudFlag(cmd)
+	pcmd.AddEnvironmentFlag(cmd, c.AuthenticatedCLICommand)
+	pcmd.AddContextFlag(cmd, c.CLICommand)
+	pcmd.AddOutputFlag(cmd)
+
+	// Check the argument from flags
+	cobra.CheckErr(cmd.MarkFlagRequired("cloud"))
+	cobra.CheckErr(cmd.MarkFlagRequired("customer-iam-role-arn"))
+
+	return cmd
+}
+
+func (c *command) create(cmd *cobra.Command, args []string) error {
+	displayName := args[0]
+
+	cloud, err := cmd.Flags().GetString("cloud")
+	if err != nil {
+		return err
+	}
+
+	customerIamRoleArn, err := cmd.Flags().GetString("customer-iam-role-arn")
+	if err != nil {
+		return err
+	}
+
+	environmentId, err := c.Context.EnvironmentId()
+	if err != nil {
+		return err
+	}
+
+	kind, err := getProviderConfigKind(cloud)
+	if err != nil {
+		return err
+	}
+
+	// Populate the PimV1Integration request object
+	request := &providerintegrationv1.PimV1Integration{
+		DisplayName: providerintegrationv1.PtrString(displayName),
+		Provider:    providerintegrationv1.PtrString(cloud),
+		Environment: &providerintegrationv1.GlobalObjectReference{Id: environmentId},
+		Config: &providerintegrationv1.PimV1IntegrationConfigOneOf{
+			PimV1AwsIntegrationConfig: &providerintegrationv1.PimV1AwsIntegrationConfig{
+				CustomerIamRoleArn: providerintegrationv1.PtrString(customerIamRoleArn),
+				Kind:               kind,
+			},
+		},
+	}
+
+	providerIntegration, err := c.V2Client.CreateProviderIntegration(*request)
+	if err != nil {
+		return err
+	}
+
+	table := output.NewTable(cmd)
+
+	resp := providerIntegrationOut{
+		Id:                 providerIntegration.GetId(),
+		Name:               providerIntegration.GetDisplayName(),
+		Provider:           providerIntegration.GetProvider(),
+		Environment:        providerIntegration.Environment.GetId(),
+		IamRoleArn:         providerIntegration.GetConfig().PimV1AwsIntegrationConfig.GetIamRoleArn(),
+		ExternalId:         providerIntegration.GetConfig().PimV1AwsIntegrationConfig.GetExternalId(),
+		CustomerIamRoleArn: providerIntegration.GetConfig().PimV1AwsIntegrationConfig.GetCustomerIamRoleArn(),
+	}
+
+	// `PimV1Integration.Usages` field is empty after create() and this field should be hidden
+	table.Add(&resp)
+	table.Filter([]string{"Id", "Name", "Provider", "Environment", "IamRoleArn", "ExternalId", "CustomerIamRoleArn"})
+	return table.Print()
+}
+
+func getProviderConfigKind(provider string) (string, error) {
+	switch strings.ToUpper(provider) {
+	case resource.CloudAws:
+		return "AwsIntegrationConfig", nil
+	default:
+		return "", errors.New("can't find a supported cloud provider config kind")
+	}
+}

--- a/internal/provider-integration/command_delete.go
+++ b/internal/provider-integration/command_delete.go
@@ -1,0 +1,61 @@
+package provider_integration
+
+import (
+	"github.com/spf13/cobra"
+
+	pcmd "github.com/confluentinc/cli/v3/pkg/cmd"
+	"github.com/confluentinc/cli/v3/pkg/deletion"
+	"github.com/confluentinc/cli/v3/pkg/examples"
+	"github.com/confluentinc/cli/v3/pkg/resource"
+)
+
+func (c *command) newDeleteCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "delete <id-1> [id-2] ... [id-n]",
+		Short: "Delete one or more provider integrations.",
+		Long:  "Delete one or more Provider Integrations, specified by the given provider integration ID.",
+		Args:  cobra.MinimumNArgs(1),
+		RunE:  c.delete,
+		Example: examples.BuildExampleString(
+			examples.Example{
+				Text: `Delete the Provider Integration "cspi-12345".`,
+				Code: `confluent provider-integration delete cspi-12345`,
+			},
+			examples.Example{
+				Text: `Delete the Provider Integrations "cspi-12345" and "cspi-67890" in environment "env-abcdef".`,
+				Code: `confluent provider-integration delete cspi-12345 cspi-67890 --environment env-abcdef`,
+			},
+		),
+	}
+
+	// Auto-complete flags
+	pcmd.AddEnvironmentFlag(cmd, c.AuthenticatedCLICommand)
+	pcmd.AddContextFlag(cmd, c.CLICommand)
+	pcmd.AddOutputFlag(cmd)
+	pcmd.AddForceFlag(cmd)
+
+	return cmd
+}
+
+func (c *command) delete(cmd *cobra.Command, args []string) error {
+	environmentId, err := c.Context.EnvironmentId()
+	if err != nil {
+		return err
+	}
+
+	existenceFunc := func(id string) bool {
+		_, err := c.V2Client.DescribeProviderIntegration(id, environmentId)
+		return err == nil
+	}
+
+	if err := deletion.ValidateAndConfirm(cmd, args, existenceFunc, resource.ProviderIntegration); err != nil {
+		return err
+	}
+
+	deleteFunc := func(id string) error {
+		return c.V2Client.DeleteProviderIntegration(id, environmentId)
+	}
+
+	_, err = deletion.Delete(args, deleteFunc, resource.ProviderIntegration)
+	return err
+}

--- a/internal/provider-integration/command_describe.go
+++ b/internal/provider-integration/command_describe.go
@@ -1,0 +1,63 @@
+package provider_integration
+
+import (
+	"github.com/spf13/cobra"
+
+	pcmd "github.com/confluentinc/cli/v3/pkg/cmd"
+	"github.com/confluentinc/cli/v3/pkg/examples"
+	"github.com/confluentinc/cli/v3/pkg/output"
+)
+
+func (c *command) newDescribeCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "describe <id>",
+		Short: "Describe a provider integration.",
+		Long:  "Describe a Provider Integration, specified by the given provider integration ID.",
+		Args:  cobra.ExactArgs(1),
+		RunE:  c.describe,
+		Example: examples.BuildExampleString(
+			examples.Example{
+				Text: "Describe a Provider Integration with id=cspi-12345 in current environment",
+				Code: `confluent provider-integration describe cspi-12345`,
+			},
+			examples.Example{
+				Text: "Describe a Provider Integration with id=cspi-12345 in environment env-abcdef",
+				Code: `confluent provider-integration describe cspi-12345 --environment env-abcdef`,
+			},
+		),
+	}
+
+	pcmd.AddEnvironmentFlag(cmd, c.AuthenticatedCLICommand)
+	pcmd.AddContextFlag(cmd, c.CLICommand)
+	pcmd.AddOutputFlag(cmd)
+
+	return cmd
+}
+
+func (c *command) describe(cmd *cobra.Command, args []string) error {
+	id := args[0]
+	environmentId, err := c.Context.EnvironmentId()
+	if err != nil {
+		return err
+	}
+
+	providerIntegration, err := c.V2Client.DescribeProviderIntegration(id, environmentId)
+	if err != nil {
+		return err
+	}
+
+	table := output.NewTable(cmd)
+	resp := providerIntegrationOut{
+		Id:                 providerIntegration.GetId(),
+		Name:               providerIntegration.GetDisplayName(),
+		Provider:           providerIntegration.GetProvider(),
+		Environment:        providerIntegration.Environment.GetId(),
+		IamRoleArn:         providerIntegration.Config.PimV1AwsIntegrationConfig.GetIamRoleArn(),
+		ExternalId:         providerIntegration.Config.PimV1AwsIntegrationConfig.GetExternalId(),
+		CustomerIamRoleArn: providerIntegration.Config.PimV1AwsIntegrationConfig.GetCustomerIamRoleArn(),
+		Usages:             providerIntegration.GetUsages(),
+	}
+
+	table.Add(&resp)
+	return table.Print()
+}

--- a/internal/provider-integration/command_list.go
+++ b/internal/provider-integration/command_list.go
@@ -1,0 +1,72 @@
+package provider_integration
+
+import (
+	"github.com/spf13/cobra"
+
+	pcmd "github.com/confluentinc/cli/v3/pkg/cmd"
+	"github.com/confluentinc/cli/v3/pkg/examples"
+	"github.com/confluentinc/cli/v3/pkg/output"
+)
+
+func (c *command) newListCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List provider integrations.",
+		Long:  "List Provider Integrations, optionally filtered by cloud provider.",
+		Args:  cobra.NoArgs,
+		RunE:  c.list,
+		Example: examples.BuildExampleString(
+			examples.Example{
+				Text: "List Provider Integrations in current environment.",
+				Code: `confluent provider-integration list`,
+			},
+			examples.Example{
+				Text: "List Provider Integrations in environment env-abcdef.",
+				Code: `confluent provider-integration list --environment env-abcdef`,
+			},
+			examples.Example{
+				Text: "List Provider Integrations in current environment with AWS as cloud provider.",
+				Code: `confluent provider-integration list --cloud aws`,
+			},
+		),
+	}
+
+	pcmd.AddCloudFlag(cmd)
+	pcmd.AddEnvironmentFlag(cmd, c.AuthenticatedCLICommand)
+	pcmd.AddContextFlag(cmd, c.CLICommand)
+	pcmd.AddOutputFlag(cmd)
+
+	return cmd
+}
+
+func (c *command) list(cmd *cobra.Command, _ []string) error {
+	environmentId, err := c.Context.EnvironmentId()
+	if err != nil {
+		return err
+	}
+
+	// Provider information is optional
+	provider, _ := cmd.Flags().GetString("cloud")
+
+	providerIntegrations, err := c.V2Client.ListProviderIntegrations(provider, environmentId)
+	if err != nil {
+		return err
+	}
+
+	list := output.NewList(cmd)
+
+	for _, providerIntegration := range providerIntegrations {
+		list.Add(&providerIntegrationOut{
+			Id:                 providerIntegration.GetId(),
+			Name:               providerIntegration.GetDisplayName(),
+			Provider:           providerIntegration.GetProvider(),
+			Environment:        providerIntegration.Environment.GetId(),
+			IamRoleArn:         providerIntegration.Config.PimV1AwsIntegrationConfig.GetIamRoleArn(),
+			ExternalId:         providerIntegration.Config.PimV1AwsIntegrationConfig.GetExternalId(),
+			CustomerIamRoleArn: providerIntegration.Config.PimV1AwsIntegrationConfig.GetCustomerIamRoleArn(),
+			Usages:             providerIntegration.GetUsages(),
+		})
+	}
+
+	return list.Print()
+}

--- a/pkg/ccloudv2/client.go
+++ b/pkg/ccloudv2/client.go
@@ -23,6 +23,7 @@ import (
 	networkingprivatelinkv1 "github.com/confluentinc/ccloud-sdk-go-v2/networking-privatelink/v1"
 	networkingv1 "github.com/confluentinc/ccloud-sdk-go-v2/networking/v1"
 	orgv2 "github.com/confluentinc/ccloud-sdk-go-v2/org/v2"
+	pi "github.com/confluentinc/ccloud-sdk-go-v2/provider-integration/v1"
 	servicequotav1 "github.com/confluentinc/ccloud-sdk-go-v2/service-quota/v1"
 	srcmv3 "github.com/confluentinc/ccloud-sdk-go-v2/srcm/v3"
 	ssov2 "github.com/confluentinc/ccloud-sdk-go-v2/sso/v2"
@@ -58,6 +59,7 @@ type Client struct {
 	NetworkingAccessPointClient  *networkingaccesspointv1.APIClient
 	NetworkingPrivateLinkClient  *networkingprivatelinkv1.APIClient
 	OrgClient                    *orgv2.APIClient
+	ProviderIntegrationClient    *pi.APIClient
 	ServiceQuotaClient           *servicequotav1.APIClient
 	SrcmClient                   *srcmv3.APIClient
 	SsoClient                    *ssov2.APIClient
@@ -99,6 +101,7 @@ func NewClient(cfg *config.Config, unsafeTrace bool) *Client {
 		NetworkingAccessPointClient:  newNetworkingAccessPointClient(httpClient, url, userAgent, unsafeTrace),
 		NetworkingPrivateLinkClient:  newNetworkingPrivateLinkClient(httpClient, url, userAgent, unsafeTrace),
 		OrgClient:                    newOrgClient(httpClient, url, userAgent, unsafeTrace),
+		ProviderIntegrationClient:    newProviderIntegrationClient(httpClient, url, userAgent, unsafeTrace),
 		ServiceQuotaClient:           newServiceQuotaClient(httpClient, url, userAgent, unsafeTrace),
 		SrcmClient:                   newSrcmClient(httpClient, url, userAgent, unsafeTrace),
 		SsoClient:                    newSsoClient(httpClient, url, userAgent, unsafeTrace),

--- a/pkg/ccloudv2/provider_integration.go
+++ b/pkg/ccloudv2/provider_integration.go
@@ -1,0 +1,71 @@
+package ccloudv2
+
+import (
+	"context"
+	"net/http"
+
+	pi "github.com/confluentinc/ccloud-sdk-go-v2/provider-integration/v1"
+
+	"github.com/confluentinc/cli/v3/pkg/errors"
+)
+
+func newProviderIntegrationClient(httpClient *http.Client, url, userAgent string, unsafeTrace bool) *pi.APIClient {
+	cfg := pi.NewConfiguration()
+	cfg.Debug = unsafeTrace
+	cfg.HTTPClient = httpClient
+	cfg.Servers = pi.ServerConfigurations{{URL: url}}
+	cfg.UserAgent = userAgent
+
+	return pi.NewAPIClient(cfg)
+}
+
+func (c *Client) providerIntegrationApiContext() context.Context {
+	return context.WithValue(context.Background(), pi.ContextAccessToken, c.cfg.Context().GetAuthToken())
+}
+
+func (c *Client) CreateProviderIntegration(providerIntegration pi.PimV1Integration) (pi.PimV1Integration, error) {
+	res, httpResp, err := c.ProviderIntegrationClient.IntegrationsPimV1Api.CreatePimV1Integration(c.providerIntegrationApiContext()).PimV1Integration(providerIntegration).Execute()
+	return res, errors.CatchCCloudV2Error(err, httpResp)
+}
+
+func (c *Client) DescribeProviderIntegration(id, environment string) (pi.PimV1Integration, error) {
+	res, httpResp, err := c.ProviderIntegrationClient.IntegrationsPimV1Api.GetPimV1Integration(c.providerIntegrationApiContext(), id).Environment(environment).Execute()
+	return res, errors.CatchCCloudV2Error(err, httpResp)
+}
+
+func (c *Client) ListProviderIntegrations(provider, environment string) ([]pi.PimV1Integration, error) {
+	var list []pi.PimV1Integration
+	done := false
+	pageToken := ""
+
+	for !done {
+		page, httpResp, err := c.executeListProviderIntegration(provider, pageToken, environment)
+		if err != nil {
+			return nil, errors.CatchCCloudV2Error(err, httpResp)
+		}
+		list = append(list, page.GetData()...)
+
+		pageToken, done, err = extractNextPageToken(page.GetMetadata().Next)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return list, nil
+}
+
+func (c *Client) DeleteProviderIntegration(id, environment string) error {
+	httpResp, err := c.ProviderIntegrationClient.IntegrationsPimV1Api.DeletePimV1Integration(c.providerIntegrationApiContext(), id).Environment(environment).Execute()
+	return errors.CatchCCloudV2Error(err, httpResp)
+}
+
+func (c *Client) executeListProviderIntegration(provider, pageToken, environment string) (pi.PimV1IntegrationList, *http.Response, error) {
+	req := c.ProviderIntegrationClient.IntegrationsPimV1Api.ListPimV1Integrations(c.providerIntegrationApiContext()).Environment(environment).PageSize(ccloudV2ListPageSize)
+	if provider != "" {
+		req = req.Provider(provider)
+	}
+	if pageToken != "" {
+		req = req.PageToken(pageToken)
+	}
+	return req.Execute()
+}

--- a/pkg/resource/resource.go
+++ b/pkg/resource/resource.go
@@ -54,6 +54,7 @@ const (
 	PrivateLinkAccess               = "private link access"
 	PrivateLinkAttachment           = "private link attachment"
 	PrivateLinkAttachmentConnection = "private link attachment connection"
+	ProviderIntegration             = "provider integration"
 	ProviderShare                   = "provider share"
 	Pipeline                        = "pipeline"
 	SchemaExporter                  = "schema exporter"
@@ -80,6 +81,12 @@ const (
 	ServiceAccountPrefix        = "sa"
 	SsoGroupMappingPrefix       = "group"
 	UserPrefix                  = "u"
+)
+
+const (
+	CloudAws   = "AWS"
+	CloudAzure = "AZURE"
+	CloudGcp   = "GCP"
 )
 
 var prefixToResource = map[string]string{

--- a/test/fixtures/output/help-onprem.golden
+++ b/test/fixtures/output/help-onprem.golden
@@ -4,27 +4,27 @@ Usage:
   confluent [command]
 
 Available Commands:
-  audit-log       Manage audit log configuration.
-  cloud-signup    Sign up for Confluent Cloud.
-  cluster         Retrieve metadata about Confluent Platform clusters.
-  completion      Print shell completion code.
-  configuration   Configure the Confluent CLI.
-  connect         Manage Kafka Connect.
-  context         Manage CLI configuration contexts.
-  help            Help about any command
-  iam             Manage RBAC, ACL and IAM permissions.
-  kafka           Manage Apache Kafka.
-  ksql            Manage ksqlDB.
-  local           Manage a local Confluent Platform development environment.
-  login           Log in to Confluent Cloud or Confluent Platform.
-  logout          Log out of Confluent Platform.
-  plugin          Manage Confluent plugins.
-  prompt          Add Confluent CLI context to your terminal prompt.
-  schema-registry Manage Schema Registry.
-  secret          Manage secrets for Confluent Platform.
-  shell           Start an interactive shell.
-  update          Update the Confluent CLI.
-  version         Show version of the Confluent CLI.
+  audit-log            Manage audit log configuration.
+  cloud-signup         Sign up for Confluent Cloud.
+  cluster              Retrieve metadata about Confluent Platform clusters.
+  completion           Print shell completion code.
+  configuration        Configure the Confluent CLI.
+  connect              Manage Kafka Connect.
+  context              Manage CLI configuration contexts.
+  help                 Help about any command
+  iam                  Manage RBAC, ACL and IAM permissions.
+  kafka                Manage Apache Kafka.
+  ksql                 Manage ksqlDB.
+  local                Manage a local Confluent Platform development environment.
+  login                Log in to Confluent Cloud or Confluent Platform.
+  logout               Log out of Confluent Platform.
+  plugin               Manage Confluent plugins.
+  prompt               Add Confluent CLI context to your terminal prompt.
+  schema-registry      Manage Schema Registry.
+  secret               Manage secrets for Confluent Platform.
+  shell                Start an interactive shell.
+  update               Update the Confluent CLI.
+  version              Show version of the Confluent CLI.
 
 Flags:
       --version         Show version of the Confluent CLI.

--- a/test/fixtures/output/help.golden
+++ b/test/fixtures/output/help.golden
@@ -4,38 +4,39 @@ Usage:
   confluent [command]
 
 Available Commands:
-  ai              Start an interactive AI shell.
-  api-key         Manage API keys.
-  asyncapi        Manage AsyncAPI document tooling.
-  audit-log       Manage audit log configuration.
-  billing         Manage Confluent Cloud billing.
-  byok            Manage your keys in Confluent Cloud.
-  cloud-signup    Sign up for Confluent Cloud.
-  completion      Print shell completion code.
-  configuration   Configure the Confluent CLI.
-  connect         Manage Kafka Connect.
-  context         Manage CLI configuration contexts.
-  environment     Manage and select Confluent Cloud environments.
-  feedback        Submit feedback for the Confluent CLI.
-  flink           Manage Apache Flink.
-  help            Help about any command
-  iam             Manage RBAC and IAM permissions.
-  kafka           Manage Apache Kafka.
-  ksql            Manage ksqlDB.
-  local           Manage a local Confluent Platform development environment.
-  login           Log in to Confluent Cloud or Confluent Platform.
-  logout          Log out of Confluent Cloud.
-  network         Manage Confluent Cloud networks.
-  organization    Manage your Confluent Cloud organizations.
-  pipeline        Manage Stream Designer pipelines.
-  plugin          Manage Confluent plugins.
-  prompt          Add Confluent CLI context to your terminal prompt.
-  schema-registry Manage Schema Registry.
-  service-quota   Look up Confluent Cloud service quota limits.
-  shell           Start an interactive shell.
-  stream-share    Manage stream shares.
-  update          Update the Confluent CLI.
-  version         Show version of the Confluent CLI.
+  ai                   Start an interactive AI shell.
+  api-key              Manage API keys.
+  asyncapi             Manage AsyncAPI document tooling.
+  audit-log            Manage audit log configuration.
+  billing              Manage Confluent Cloud billing.
+  byok                 Manage your keys in Confluent Cloud.
+  cloud-signup         Sign up for Confluent Cloud.
+  completion           Print shell completion code.
+  configuration        Configure the Confluent CLI.
+  connect              Manage Kafka Connect.
+  context              Manage CLI configuration contexts.
+  environment          Manage and select Confluent Cloud environments.
+  feedback             Submit feedback for the Confluent CLI.
+  flink                Manage Apache Flink.
+  help                 Help about any command
+  iam                  Manage RBAC and IAM permissions.
+  kafka                Manage Apache Kafka.
+  ksql                 Manage ksqlDB.
+  local                Manage a local Confluent Platform development environment.
+  login                Log in to Confluent Cloud or Confluent Platform.
+  logout               Log out of Confluent Cloud.
+  network              Manage Confluent Cloud networks.
+  organization         Manage your Confluent Cloud organizations.
+  pipeline             Manage Stream Designer pipelines.
+  plugin               Manage Confluent plugins.
+  prompt               Add Confluent CLI context to your terminal prompt.
+  provider-integration Manage CLI provider integrations.
+  schema-registry      Manage Schema Registry.
+  service-quota        Look up Confluent Cloud service quota limits.
+  shell                Start an interactive shell.
+  stream-share         Manage stream shares.
+  update               Update the Confluent CLI.
+  version              Show version of the Confluent CLI.
 
 Flags:
       --version         Show version of the Confluent CLI.

--- a/test/fixtures/output/provider-integration/create-help.golden
+++ b/test/fixtures/output/provider-integration/create-help.golden
@@ -1,0 +1,25 @@
+Create a Provider Integration that allow users to manage access to public cloud service provider resources through Confluent resources.
+
+Usage:
+  confluent provider-integration create <name> [flags]
+
+Examples:
+Create a provider integration "s3-provider-integration" associated with AWS IAM role arn "arn:aws:iam::000000000000:role/my-test-aws-role in current environment".
+
+  $ confluent provider-integration create s3-provider-integration --cloud aws --customer-iam-role-arn arn:aws:iam::000000000000:role/my-test-aws-role
+
+Create a provider integration "s3-provider-integration" associated with AWS IAM role arn "arn:aws:iam::000000000000:role/my-test-aws-role in environment env-abcdef".
+
+  $ confluent provider-integration create s3-provider-integration --cloud aws --customer-iam-role-arn arn:aws:iam::000000000000:role/my-test-aws-role --environment env-abcdef
+
+Flags:
+      --customer-iam-role-arn string   REQUIRED: Amazon Resource Name (ARN) that identifies the AWS Identity and Access Management (IAM) role that Confluent Cloud assumes when it accesses resources in your AWS account, having to be unique in the same environment.
+      --cloud string                   REQUIRED: Specify the cloud provider as "aws", "azure", or "gcp".
+      --environment string             Environment ID.
+      --context string                 CLI context name.
+  -o, --output string                  Specify the output format as "human", "json", or "yaml". (default "human")
+
+Global Flags:
+  -h, --help            Show help for this command.
+      --unsafe-trace    Equivalent to -vvvv, but also log HTTP requests and responses which might contain plaintext secrets.
+  -v, --verbose count   Increase verbosity (-v for warn, -vv for info, -vvv for debug, -vvvv for trace).

--- a/test/fixtures/output/provider-integration/create.golden
+++ b/test/fixtures/output/provider-integration/create.golden
@@ -1,0 +1,9 @@
++-----------------------+----------------------------------------------------+
+| ID                    | cspi-42o61                                         |
+| Name                  | cdong-test2                                        |
+| Provider              | aws                                                |
+| Environment           | env-9zgy77                                         |
+| IAM Role Arn          | arn:aws:iam::851725421142:role/cspi-42o61          |
+| External ID           | 999219d4-37f4-49ac-abfe-d2b6528fb21b               |
+| Customer IAM Role Arn | arn:aws:iam::037803949979:role/tarun-iam-test-role |
++-----------------------+----------------------------------------------------+

--- a/test/fixtures/output/provider-integration/delete-help.golden
+++ b/test/fixtures/output/provider-integration/delete-help.golden
@@ -1,0 +1,24 @@
+Delete one or more Provider Integrations, specified by the given provider integration ID.
+
+Usage:
+  confluent provider-integration delete <id-1> [id-2] ... [id-n] [flags]
+
+Examples:
+Delete the Provider Integration "cspi-12345".
+
+  $ confluent provider-integration delete cspi-12345
+
+Delete the Provider Integrations "cspi-12345" and "cspi-67890" in environment "env-abcdef".
+
+  $ confluent provider-integration delete cspi-12345 cspi-67890 --environment env-abcdef
+
+Flags:
+      --environment string   Environment ID.
+      --context string       CLI context name.
+  -o, --output string        Specify the output format as "human", "json", or "yaml". (default "human")
+      --force                Skip the deletion confirmation prompt.
+
+Global Flags:
+  -h, --help            Show help for this command.
+      --unsafe-trace    Equivalent to -vvvv, but also log HTTP requests and responses which might contain plaintext secrets.
+  -v, --verbose count   Increase verbosity (-v for warn, -vv for info, -vvv for debug, -vvvv for trace).

--- a/test/fixtures/output/provider-integration/delete-multiple-success-prompt.golden
+++ b/test/fixtures/output/provider-integration/delete-multiple-success-prompt.golden
@@ -1,0 +1,1 @@
+Are you sure you want to delete provider integrations "cspi-42o61" and "cspi-43q6j"? (y/n): Deleted provider integrations "cspi-42o61" and "cspi-43q6j".

--- a/test/fixtures/output/provider-integration/delete-multiple-success.golden
+++ b/test/fixtures/output/provider-integration/delete-multiple-success.golden
@@ -1,0 +1,1 @@
+Deleted provider integrations "cspi-42o61" and "cspi-43q6j".

--- a/test/fixtures/output/provider-integration/delete-not-exist.golden
+++ b/test/fixtures/output/provider-integration/delete-not-exist.golden
@@ -1,0 +1,4 @@
+Error: provider integration "cspi-invalid" not found
+
+Suggestions:
+    List available provider integrations with `confluent provider-integration list`.

--- a/test/fixtures/output/provider-integration/delete-success-prompt.golden
+++ b/test/fixtures/output/provider-integration/delete-success-prompt.golden
@@ -1,0 +1,1 @@
+Are you sure you want to delete provider integration "cspi-42o61"? (y/n): Deleted provider integration "cspi-42o61".

--- a/test/fixtures/output/provider-integration/delete-success.golden
+++ b/test/fixtures/output/provider-integration/delete-success.golden
@@ -1,0 +1,1 @@
+Deleted provider integration "cspi-42o61".

--- a/test/fixtures/output/provider-integration/describe-help.golden
+++ b/test/fixtures/output/provider-integration/describe-help.golden
@@ -1,0 +1,23 @@
+Describe a Provider Integration, specified by the given provider integration ID.
+
+Usage:
+  confluent provider-integration describe <id> [flags]
+
+Examples:
+Describe a Provider Integration with id=cspi-12345 in current environment
+
+  $ confluent provider-integration describe cspi-12345
+
+Describe a Provider Integration with id=cspi-12345 in environment env-abcdef
+
+  $ confluent provider-integration describe cspi-12345 --environment env-abcdef
+
+Flags:
+      --environment string   Environment ID.
+      --context string       CLI context name.
+  -o, --output string        Specify the output format as "human", "json", or "yaml". (default "human")
+
+Global Flags:
+  -h, --help            Show help for this command.
+      --unsafe-trace    Equivalent to -vvvv, but also log HTTP requests and responses which might contain plaintext secrets.
+  -v, --verbose count   Increase verbosity (-v for warn, -vv for info, -vvv for debug, -vvvv for trace).

--- a/test/fixtures/output/provider-integration/describe.golden
+++ b/test/fixtures/output/provider-integration/describe.golden
@@ -1,0 +1,10 @@
++-----------------------+----------------------------------------------------+
+| ID                    | cspi-42o61                                         |
+| Name                  | cdong-test2                                        |
+| Provider              | aws                                                |
+| Environment           | env-9zgy77                                         |
+| IAM Role Arn          | arn:aws:iam::851725421142:role/cspi-42o61          |
+| External ID           | 999219d4-37f4-49ac-abfe-d2b6528fb21b               |
+| Customer IAM Role Arn | arn:aws:iam::037803949979:role/tarun-iam-test-role |
+| Usages                |                                                    |
++-----------------------+----------------------------------------------------+

--- a/test/fixtures/output/provider-integration/help.golden
+++ b/test/fixtures/output/provider-integration/help.golden
@@ -1,0 +1,20 @@
+Manage CLI provider integrations.
+
+Usage:
+  confluent provider-integration [command]
+
+Aliases:
+  provider-integration, pi
+
+Available Commands:
+  create      Create a provider integration.
+  delete      Delete one or more provider integrations.
+  describe    Describe a provider integration.
+  list        List provider integrations.
+
+Global Flags:
+  -h, --help            Show help for this command.
+      --unsafe-trace    Equivalent to -vvvv, but also log HTTP requests and responses which might contain plaintext secrets.
+  -v, --verbose count   Increase verbosity (-v for warn, -vv for info, -vvv for debug, -vvvv for trace).
+
+Use "confluent provider-integration [command] --help" for more information about a command.

--- a/test/fixtures/output/provider-integration/list-help.golden
+++ b/test/fixtures/output/provider-integration/list-help.golden
@@ -1,0 +1,28 @@
+List Provider Integrations, optionally filtered by cloud provider.
+
+Usage:
+  confluent provider-integration list [flags]
+
+Examples:
+List Provider Integrations in current environment.
+
+  $ confluent provider-integration list
+
+List Provider Integrations in environment env-abcdef.
+
+  $ confluent provider-integration list --environment env-abcdef
+
+List Provider Integrations in current environment with AWS as cloud provider.
+
+  $ confluent provider-integration list --cloud aws
+
+Flags:
+      --cloud string         Specify the cloud provider as "aws", "azure", or "gcp".
+      --environment string   Environment ID.
+      --context string       CLI context name.
+  -o, --output string        Specify the output format as "human", "json", or "yaml". (default "human")
+
+Global Flags:
+  -h, --help            Show help for this command.
+      --unsafe-trace    Equivalent to -vvvv, but also log HTTP requests and responses which might contain plaintext secrets.
+  -v, --verbose count   Increase verbosity (-v for warn, -vv for info, -vvv for debug, -vvvv for trace).

--- a/test/fixtures/output/provider-integration/list.golden
+++ b/test/fixtures/output/provider-integration/list.golden
@@ -1,0 +1,4 @@
+      ID     |    Name     | Provider | Environment |               IAM Role Arn                |             External ID              |               Customer IAM Role Arn                | Usages  
+-------------+-------------+----------+-------------+-------------------------------------------+--------------------------------------+----------------------------------------------------+---------
+  cspi-42o61 | cdong-test2 | aws      | env-9zgy77  | arn:aws:iam::851725421142:role/cspi-42o61 | 999219d4-37f4-49ac-abfe-d2b6528fb21b | arn:aws:iam::037803949979:role/tarun-iam-test-role |         
+  cspi-4xgwq | cdong-test  | aws      | env-9zgy77  | arn:aws:iam::851725421142:role/cspi-4xgwq | b5f0a7e6-15e3-4879-aa01-881910554cd4 | arn:aws:iam::000000000000:role/my-test-aws-role    |         

--- a/test/provider_integration_test.go
+++ b/test/provider_integration_test.go
@@ -1,0 +1,21 @@
+package test
+
+func (s *CLITestSuite) TestProviderIntegration() {
+	tests := []CLITest{
+		{args: "provider-integration create cdong-test2 --cloud aws --customer-iam-role-arn arn:aws:iam::037803949979:role/tarun-iam-test-role", fixture: "provider-integration/create.golden"},
+		{args: "provider-integration describe cspi-42o61", fixture: "provider-integration/describe.golden"},
+		{args: "provider-integration list", fixture: "provider-integration/list.golden"},
+		{args: "provider-integration list --cloud aws", fixture: "provider-integration/list.golden"},
+		{args: "provider-integration delete cspi-42o61 --force", fixture: "provider-integration/delete-success.golden"},
+		{args: "provider-integration delete cspi-42o61", input: "y\n", fixture: "provider-integration/delete-success-prompt.golden"},
+		{args: "provider-integration delete cspi-invalid", fixture: "provider-integration/delete-not-exist.golden", exitCode: 1},
+		{args: "provider-integration delete cspi-42o61 cspi-43q6j --force", fixture: "provider-integration/delete-multiple-success.golden"},
+		{args: "provider-integration delete cspi-42o61 cspi-43q6j", input: "y\n", fixture: "provider-integration/delete-multiple-success-prompt.golden"},
+		{args: "provider-integration delete cspi-42o61 cspi-43q6j cspi-invalid", input: "y\n", fixture: "provider-integration/delete-not-exist.golden", exitCode: 1},
+	}
+
+	for _, test := range tests {
+		test.login = "cloud"
+		s.runIntegrationTest(test)
+	}
+}

--- a/test/test-server/ccloudv2_router.go
+++ b/test/test-server/ccloudv2_router.go
@@ -100,6 +100,8 @@ var ccloudV2Routes = []route{
 	{"/org/v2/environments/{id}", handleOrgEnvironment},
 	{"/org/v2/organizations", handleOrgOrganizations},
 	{"/org/v2/organizations/{id}", handleOrgOrganization},
+	{"/pim/v1/integrations", handleProviderIntegrations},
+	{"/pim/v1/integrations/{id}", handleProviderIntegration},
 	{"/sd/v1/pipelines", handlePipelines},
 	{"/sd/v1/pipelines/{id}", handlePipeline},
 	{"/service-quota/v1/applied-quotas", handleAppliedQuotas},

--- a/test/test-server/provider_integration_handler.go
+++ b/test/test-server/provider_integration_handler.go
@@ -1,0 +1,171 @@
+package testserver
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/require"
+
+	pi "github.com/confluentinc/ccloud-sdk-go-v2/provider-integration/v1"
+)
+
+const (
+	AwsIntegrationConfig = "AwsIntegrationConfig"
+)
+
+// Handler for "/pim/v1/integrations/{id}"
+func handleProviderIntegration(t *testing.T) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		id := mux.Vars(r)["id"]
+		switch r.Method {
+		case http.MethodGet:
+			handleProviderIntegrationGet(t, id)(w, r)
+		case http.MethodDelete:
+			handleProviderIntegrationDelete(t)(w, r)
+		}
+	}
+}
+
+// Handler for "/pim/v1/integrations"
+func handleProviderIntegrations(t *testing.T) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodPost:
+			handleProviderIntegrationCreate(t)(w, r)
+		case http.MethodGet:
+			handleProviderIntegrationList(t)(w, r)
+		}
+	}
+}
+
+func handleProviderIntegrationGet(t *testing.T, id string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		switch id {
+		case "cspi-42o61":
+			mockResponse := pi.PimV1Integration{
+				Id:          pi.PtrString(id),
+				DisplayName: pi.PtrString("cdong-test2"),
+				Provider:    pi.PtrString("aws"),
+				Environment: &pi.GlobalObjectReference{Id: "env-9zgy77"},
+				Config:      getPimV1IntegrationConfig("aws"),
+			}
+			err := json.NewEncoder(w).Encode(mockResponse)
+			require.NoError(t, err)
+		case "cspi-4xgwq":
+			mockResponse := pi.PimV1Integration{
+				Id:          pi.PtrString(id),
+				DisplayName: pi.PtrString("cdong-test2"),
+				Provider:    pi.PtrString("aws"),
+				Environment: &pi.GlobalObjectReference{Id: "env-9zgy77"},
+				Config:      getPimV1IntegrationConfig("aws"),
+			}
+			err := json.NewEncoder(w).Encode(mockResponse)
+			require.NoError(t, err)
+		case "cspi-invalid":
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}
+}
+
+func handleProviderIntegrationDelete(t *testing.T) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		err := json.NewEncoder(w).Encode(pi.PimV1Integration{})
+		require.NoError(t, err)
+	}
+}
+
+func handleProviderIntegrationList(t *testing.T) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		configs := getPimV1IntegrationConfigList("aws")
+		require.Len(t, configs, 2, "expected 2 configs, but got a different length")
+		mockResponse := []pi.PimV1Integration{
+			{
+				Id:          pi.PtrString("cspi-42o61"),
+				DisplayName: pi.PtrString("cdong-test2"),
+				Provider:    pi.PtrString("aws"),
+				Environment: &pi.GlobalObjectReference{Id: "env-9zgy77"},
+				Config:      configs[0],
+				Usages:      &[]string{},
+			},
+			{
+				Id:          pi.PtrString("cspi-4xgwq"),
+				DisplayName: pi.PtrString("cdong-test"),
+				Provider:    pi.PtrString("aws"),
+				Environment: &pi.GlobalObjectReference{Id: "env-9zgy77"},
+				Config:      configs[1],
+				Usages:      &[]string{},
+			},
+		}
+		result := pi.PimV1IntegrationList{Data: mockResponse}
+		err := json.NewEncoder(w).Encode(result)
+		require.NoError(t, err)
+	}
+}
+
+func handleProviderIntegrationCreate(t *testing.T) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var mockRequest pi.PimV1Integration
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&mockRequest))
+
+		provider := mockRequest.GetProvider()
+		mockResponse := &pi.PimV1Integration{
+			Id:          pi.PtrString("cspi-42o61"),
+			DisplayName: pi.PtrString("cdong-test2"),
+			Provider:    pi.PtrString(provider),
+			Environment: &pi.GlobalObjectReference{Id: "env-9zgy77"},
+			Config:      getPimV1IntegrationConfig(provider),
+		}
+
+		err := json.NewEncoder(w).Encode(mockResponse)
+		require.NoError(t, err)
+	}
+}
+
+// Return provider specific config, Azure and Gcp are to be implemented from SDK
+func getPimV1IntegrationConfig(provider string) *pi.PimV1IntegrationConfigOneOf {
+	provider = strings.ToLower(provider)
+	switch provider {
+	case "aws":
+		return &pi.PimV1IntegrationConfigOneOf{
+			PimV1AwsIntegrationConfig: &pi.PimV1AwsIntegrationConfig{
+				IamRoleArn:         pi.PtrString("arn:aws:iam::851725421142:role/cspi-42o61"),
+				ExternalId:         pi.PtrString("999219d4-37f4-49ac-abfe-d2b6528fb21b"),
+				CustomerIamRoleArn: pi.PtrString("arn:aws:iam::037803949979:role/tarun-iam-test-role"),
+				Kind:               AwsIntegrationConfig,
+			},
+		}
+	default:
+		return &pi.PimV1IntegrationConfigOneOf{}
+	}
+}
+
+// Return provider specific config list, Azure and Gcp are to be implemented from SDK
+func getPimV1IntegrationConfigList(provider string) []*pi.PimV1IntegrationConfigOneOf {
+	provider = strings.ToLower(provider)
+	switch provider {
+	case "aws":
+		return []*pi.PimV1IntegrationConfigOneOf{
+			{
+				PimV1AwsIntegrationConfig: &pi.PimV1AwsIntegrationConfig{
+					IamRoleArn:         pi.PtrString("arn:aws:iam::851725421142:role/cspi-42o61"),
+					ExternalId:         pi.PtrString("999219d4-37f4-49ac-abfe-d2b6528fb21b"),
+					CustomerIamRoleArn: pi.PtrString("arn:aws:iam::037803949979:role/tarun-iam-test-role"),
+					Kind:               AwsIntegrationConfig,
+				},
+			},
+			{
+				PimV1AwsIntegrationConfig: &pi.PimV1AwsIntegrationConfig{
+					IamRoleArn:         pi.PtrString("arn:aws:iam::851725421142:role/cspi-4xgwq"),
+					ExternalId:         pi.PtrString("b5f0a7e6-15e3-4879-aa01-881910554cd4"),
+					CustomerIamRoleArn: pi.PtrString("arn:aws:iam::000000000000:role/my-test-aws-role"),
+					Kind:               AwsIntegrationConfig,
+				},
+			},
+		}
+	default:
+		return []*pi.PimV1IntegrationConfigOneOf{}
+	}
+}


### PR DESCRIPTION
### Summary:

The provider integration feature from [APIT-2278](https://confluentinc.atlassian.net/browse/APIT-2278).

Adding the fundamental CRUD operation and associated integration tests.

### Supported operations:

- Create a provider integration
- Describe a provider integration
- List provider integrations, optionally filtered by cloud provider, supporting pagination.
- Delete a provider integration, supporting multiple delete.

### References

https://confluentinc.atlassian.net/wiki/spaces/OAAC/pages/3291517621/Provider+Integration+Resource+APIs+and+RBAC

[APIT-2278]: https://confluentinc.atlassian.net/browse/APIT-2278?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ