### PR TITLE
Add notes to CLI reference source re: renamed commands (#44)

### DIFF
--- a/pkg/docs/doc_page.go
+++ b/pkg/docs/doc_page.go
@@ -50,6 +50,12 @@ func printWarnings(cmd *cobra.Command, depth int) []string {
 			"end-before":  "cli_limitations_confluent_kafka_local_end",
 		}
 		rows = append(rows, printSphinxBlock("include", include, args)...)
+	} else if strings.HasPrefix(cmd.CommandPath(), "confluent local kafka broker describe") {
+		args := map[string]string{
+			"start-after": "cli_new_local_kafka_broker_describe_start",
+			"end-before":  "cli_new_kafka_broker_describe_end",
+		}
+		rows = append(rows, printSphinxBlock("include", include, args)...)		
 	} else if strings.HasPrefix(cmd.CommandPath(), "confluent local") {
 		args := map[string]string{
 			"start-after": "cli_limitations_start",
@@ -63,6 +69,44 @@ func printWarnings(cmd *cobra.Command, depth int) []string {
 		args := map[string]string{
 			"start-after": "cli_cloud_logout_note_start",
 			"end-before":  "cli_cloud_logout_note_end",
+		}
+		rows = append(rows, printSphinxBlock("include", include, args)...)
+	}
+
+	if strings.HasPrefix(cmd.CommandPath(), "confluent kafka broker describe") {
+		include := strings.Repeat("../", depth) + "includes/cli-share.rst"
+		args := map[string]string{
+			"start-after": "cli_new_kafka_broker_describe_start",
+			"end-before":  "cli_new_kafka_broker_describe_end",
+		}
+		rows = append(rows, printSphinxBlock("include", include, args)...)
+	}
+
+	if strings.HasPrefix(cmd.CommandPath(), "confluent kafka broker task list") {
+		include := strings.Repeat("../", depth) + "includes/cli-share.rst"
+		args := map[string]string{
+			"start-after": "cli_new_kafka_broker_task_list_start",
+			"end-before":  "cli_new_kafka_broker_task_list_end",
+		}
+		rows = append(rows, printSphinxBlock("include", include, args)...)
+	}
+
+
+	if strings.HasPrefix(cmd.CommandPath(), "confluent kafka replica list") {
+		include := strings.Repeat("../", depth) + "includes/cli-share.rst"
+		args := map[string]string{
+			"start-after": "cli_new_kafka_replica_list_start",
+			"end-before":  "cli_new_kafka_replica_list_end",
+		}
+		rows = append(rows, printSphinxBlock("include", include, args)...)
+	}
+
+
+	if strings.HasPrefix(cmd.CommandPath(), "confluent kafka topic describe") {
+		include := strings.Repeat("../", depth) + "includes/cli-share.rst"
+		args := map[string]string{
+			"start-after": "cli_new_kafka_topic_describe_start",
+			"end-before":  "cli_new_kafka_topic_describe_end",
 		}
 		rows = append(rows, printSphinxBlock("include", include, args)...)
 	}


### PR DESCRIPTION
Release Notes
-------------
Docs improvement

- Adds explanatory notes at the top of commands affected by the CLI v4 update command renaming, whose names stayed the same, but have new functionality


What
----
Added notes to some commands (these notes were previously added to the generated output files during the v4 CLI release. We needed to get them into the CLI source code.

References
----------
https://confluentinc.atlassian.net/browse/DOCS-30090

Test & Review
-------------
Built docs locally