### PR TITLE
Make tests not depend on whether or not Confluent Platform is installed

### DIFF
--- a/cmd/docs/main.go
+++ b/cmd/docs/main.go
@@ -29,6 +29,14 @@ func main() {
 		panic(err)
 	}
 
+	tempCH, err := createTemporaryConfluentHome()
+	if err != nil {
+		panic(err)
+	}
+	defer func() {
+		_ = os.RemoveAll(tempCH)
+	}()
+
 	// Generate documentation for both subsets of commands: cloud and on-prem
 	configs := []*config.Config{
 		{CurrentContext: "Cloud", Contexts: map[string]*config.Context{"Cloud": {PlatformName: "https://confluent.cloud"}}},
@@ -103,4 +111,23 @@ func removeLineFromFile(line, file string) error {
 	out = re.ReplaceAll(out, []byte(""))
 
 	return os.WriteFile(file, out, 0644)
+}
+
+func createTemporaryConfluentHome() (string, error) {
+	dir := filepath.Join(os.TempDir(), "ch")
+	if err := os.Setenv("CONFLUENT_HOME", dir); err != nil {
+		return "", err
+	}
+
+	path := filepath.Join(dir, "share/java/confluent-control-center/control-center-0.0.0.jar")
+
+	if err := os.MkdirAll(filepath.Dir(path), 0777); err != nil {
+		return "", err
+	}
+
+	if err := os.WriteFile(path, []byte{}, 0644); err != nil {
+		return "", err
+	}
+
+	return dir, nil
 }

--- a/test/fixtures/output/local/services/help-onprem.golden
+++ b/test/fixtures/output/local/services/help-onprem.golden
@@ -5,6 +5,7 @@ Usage:
 
 Available Commands:
   connect         Manage Connect.
+  control-center  Manage Control Center.
   kafka           Manage Apache Kafka®.
   kafka-rest      Manage Kafka REST.
   ksql-server     Manage ksqlDB Server.

--- a/test/fixtures/output/local/services/help.golden
+++ b/test/fixtures/output/local/services/help.golden
@@ -5,6 +5,7 @@ Usage:
 
 Available Commands:
   connect         Manage Connect.
+  control-center  Manage Control Center.
   kafka           Manage Apache Kafka®.
   kafka-rest      Manage Kafka REST.
   ksql-server     Manage ksqlDB Server.

--- a/test/help_test.go
+++ b/test/help_test.go
@@ -14,6 +14,11 @@ import (
 )
 
 func (s *CLITestSuite) TestHelp() {
+	s.createCH([]string{ // Include Control Center in help tests even if Confluent Platform is not installed locally
+		"share/java/confluent-control-center/control-center-0.0.0.jar",
+	})
+	defer s.destroy()
+
 	configurations := []*config.Config{
 		{
 			CurrentContext: "cloud",


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- PLACEHOLDER

New Features
- PLACEHOLDER

Bug Fixes
- PLACEHOLDER

Checklist
---------
- [x] Leave this box unchecked if features are not yet available in production

What
----
The confluent local services command only shows control-center commands if it detects a Platform installation on the machine.

The TestHelp golden files for local services do not include control-center, which causes TestCLI/TestHelp/local_services_--help and TestCLI/TestHelp/local_services_--help#01 to fail when running the tests locally if you have Platform installed.
This PR uses a temporary file and a temporary change to $CONFLUENT_HOME to force docs and tests to include control center, even if you don't have it installed locally.

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
I removed all installations of Confluent Platform from my local machine and then ran `make docs` and the `TestHelp` integration tests, and checked that the `local services control-center` output was there