### PR TITLE
DOCS-29556, DOCS-29555 Add a CP on-prem example for confluent iam rbac role-binding delete to show --kafka cluster is a required flag (retry) (#41)

### DIFF
--- a/internal/iam/command_rbac_role_binding_delete.go
+++ b/internal/iam/command_rbac_role_binding_delete.go
@@ -32,6 +32,13 @@ func (c *roleBindingCommand) newDeleteCommand() *cobra.Command {
 				Code: "confluent iam rbac role-binding delete --principal User:u-123456 --role ResourceOwner --environment env-123456 --kafka-cluster lkc-123456 --resource Topic:my-topic",
 			},
 		)
+	} else {
+		cmd.Example = examples.BuildExampleString(
+			examples.Example{
+				Text: `Delete the role "ResourceOwner" for the resource "Topic:my-topic" on the specified Kafka cluster:`,
+				Code: "confluent iam rbac role-binding delete --principal User:u-123456 --role ResourceOwner --kafka-cluster 0000000000000000000000 --resource Topic:my-topic",
+			},
+		)
 	}
 
 	cmd.Flags().String("role", "", "Role name of the existing role binding.")

--- a/test/fixtures/output/iam/rbac/role-binding/delete-help-onprem.golden
+++ b/test/fixtures/output/iam/rbac/role-binding/delete-help-onprem.golden
@@ -2,7 +2,7 @@ Delete a role binding.
 
 Usage:
   confluent iam rbac role-binding delete [flags]
-  
+
 Examples:
 Delete the role "ResourceOwner" for the resource "Topic:my-topic" on the specified Kafka cluster:
 

--- a/test/fixtures/output/iam/rbac/role-binding/delete-help-onprem.golden
+++ b/test/fixtures/output/iam/rbac/role-binding/delete-help-onprem.golden
@@ -8,7 +8,6 @@ Delete the role "ResourceOwner" for the resource "Topic:my-topic" on the specifi
 
   $ confluent iam rbac role-binding delete --principal User:u-123456 --role ResourceOwner --kafka-cluster 0000000000000000000000 --resource Topic:my-topic
 
-
 Flags:
       --role string                      REQUIRED: Role name of the existing role binding.
       --principal string                 REQUIRED: Principal type and identifier using "Prefix:ID" format.

--- a/test/fixtures/output/iam/rbac/role-binding/delete-missing-role-onprem.golden
+++ b/test/fixtures/output/iam/rbac/role-binding/delete-missing-role-onprem.golden
@@ -1,13 +1,11 @@
-Delete a role binding.
-
+Error: required flag(s) "role" not set
 Usage:
   confluent iam rbac role-binding delete [flags]
-  
+
 Examples:
 Delete the role "ResourceOwner" for the resource "Topic:my-topic" on the specified Kafka cluster:
 
   $ confluent iam rbac role-binding delete --principal User:u-123456 --role ResourceOwner --kafka-cluster 0000000000000000000000 --resource Topic:my-topic
-
 
 Flags:
       --role string                      REQUIRED: Role name of the existing role binding.
@@ -27,3 +25,4 @@ Global Flags:
   -h, --help            Show help for this command.
       --unsafe-trace    Equivalent to -vvvv, but also log HTTP requests and responses which might contain plaintext secrets.
   -v, --verbose count   Increase verbosity (-v for warn, -vv for info, -vvv for debug, -vvvv for trace).
+

--- a/test/iam_test.go
+++ b/test/iam_test.go
@@ -102,6 +102,7 @@ func (s *CLITestSuite) TestIamRbacRoleBinding_OnPrem() {
 		{args: "iam rbac role-binding delete --principal User:bob --role DeveloperRead --resource Topic:connect-configs --ksql-cluster ksql-name --force", fixture: "iam/rbac/role-binding/missing-kafka-cluster-id-onprem.golden", exitCode: 1},
 		{args: "iam rbac role-binding delete --principal User:bob --role DeveloperRead --resource Topic:connect-configs --ksql-cluster ksqlName --connect-cluster connectID --kafka-cluster kafka-GUID --force", fixture: "iam/rbac/role-binding/multiple-non-kafka-id-onprem.golden", exitCode: 1},
 		{args: "iam rbac role-binding create --principal User:bob@Kafka --role DeveloperRead --resource Topic:connect-configs --kafka-cluster kafka-GUID", fixture: "iam/rbac/role-binding/create-cluster-id-at-onprem.golden"},
+		{args: "iam rbac role-binding delete --principal User:bob", fixture: "iam/rbac/role-binding/delete-missing-role-onprem.golden", exitCode: 1},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
* DOCS-29556 , DOCS-29555  Add a CP on-prem example for `confluent iam rbac role-binding delete` to show `--kafka cluster` is a required flag for this action

* Update internal/iam/command_rbac_role_binding_delete.go
* add test for new on-prem example in confluent iam rolebinding delete, per Steven's comment
* Update test/fixtures/output/iam/rbac/role-binding/delete-help-onprem.golden
* Add updates to golden file based on generated output of make integration test command

---------------
Release Notes
---------------
- No release notes needed

What
-----

- Added a CP on-prem example for `confluent iam rbac role-binding delete` to show --kafka cluster is a required flag 

References
----------
- Related Airlock PR: https://github.com/confluentinc/airlock-cli/pull/41
- Jira ticket: https://confluentinc.atlassian.net/browse/DOCS-29556
- Jira ticket: https://confluentinc.atlassian.net/browse/DOCS-29555

Test & Review
-------------
local build