### PR TITLE
SCP-3030 Add custom plugin version cmd

### DIFF
--- a/cmd/lint/main.go
+++ b/cmd/lint/main.go
@@ -38,6 +38,8 @@ var commandRules = []linter.CommandRule{
 
 	linter.RequireListRequiredFlagsFirst(),
 	linter.Filter(linter.RequireValidExamples(),
+		linter.ExcludeCommand("connect custom-plugin version create"),
+		linter.ExcludeCommand("connect custom-plugin version update"),
 		linter.ExcludeCommand("pipeline update"),
 		linter.ExcludeCommand("flink statement update")),
 

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/confluentinc/ccloud-sdk-go-v2/cli v0.3.0
 	github.com/confluentinc/ccloud-sdk-go-v2/cmk v0.10.0
 	github.com/confluentinc/ccloud-sdk-go-v2/connect v0.7.0
-	github.com/confluentinc/ccloud-sdk-go-v2/connect-custom-plugin v0.0.5
+	github.com/confluentinc/ccloud-sdk-go-v2/connect-custom-plugin v0.0.6
 	github.com/confluentinc/ccloud-sdk-go-v2/flink v0.9.0
 	github.com/confluentinc/ccloud-sdk-go-v2/flink-artifact v0.1.0
 	github.com/confluentinc/ccloud-sdk-go-v2/flink-gateway v0.12.0

--- a/go.sum
+++ b/go.sum
@@ -186,6 +186,8 @@ github.com/confluentinc/ccloud-sdk-go-v2/connect v0.7.0 h1:ISrVOX9qJ2Sxiu/fGBqqH
 github.com/confluentinc/ccloud-sdk-go-v2/connect v0.7.0/go.mod h1:zHG/3DzsnoHC81B1AY9K/8bMX3mxbIp5/nHHdypa//w=
 github.com/confluentinc/ccloud-sdk-go-v2/connect-custom-plugin v0.0.5 h1:dY7/VtRgRhB0wr/e+MxXDNchaCNvU54gm8ysKzpQFZ4=
 github.com/confluentinc/ccloud-sdk-go-v2/connect-custom-plugin v0.0.5/go.mod h1:AaF39Acy3LFnHSHExaUtqNmbs7kL5/AL54CXX61+Il8=
+github.com/confluentinc/ccloud-sdk-go-v2/connect-custom-plugin v0.0.6 h1:DYQyS4lnYVtuTMVoF+g/ogWcgCiTbsKxhQv0c5KLRJc=
+github.com/confluentinc/ccloud-sdk-go-v2/connect-custom-plugin v0.0.6/go.mod h1:odu6w/vnVrZo00N4yHq5buzWOme1vT1WqksQ3y69sQU=
 github.com/confluentinc/ccloud-sdk-go-v2/flink v0.9.0 h1:QqtIFEB5E3CIyGMJd7NQBEtc/k3K11PX7f4Fj7sPFdo=
 github.com/confluentinc/ccloud-sdk-go-v2/flink v0.9.0/go.mod h1:GPj4sfR85OyiFQUMNEq1DtPOjYVAuE222Z6Mcapwa48=
 github.com/confluentinc/ccloud-sdk-go-v2/flink-artifact v0.1.0 h1:2QuFhvrfU4AdxyfWWPFY0fqEg8p8wmKFfC6N+35pxHg=

--- a/internal/connect/command.go
+++ b/internal/connect/command.go
@@ -22,7 +22,7 @@ func New(cfg *config.Config, prerunner pcmd.PreRunner) *cobra.Command {
 	}
 
 	cmd.AddCommand(newClusterCommand(cfg, prerunner))
-	cmd.AddCommand(newCustomPluginCommand(prerunner))
+	cmd.AddCommand(newCustomPluginCommand(cfg, prerunner))
 	cmd.AddCommand(newEventCommand(prerunner))
 	cmd.AddCommand(newOffsetCommand(prerunner))
 	cmd.AddCommand(newPluginCommand(cfg, prerunner))

--- a/internal/connect/command_custom_plugin.go
+++ b/internal/connect/command_custom_plugin.go
@@ -6,6 +6,8 @@ import (
 	connectcustompluginv1 "github.com/confluentinc/ccloud-sdk-go-v2/connect-custom-plugin/v1"
 
 	pcmd "github.com/confluentinc/cli/v3/pkg/cmd"
+	"github.com/confluentinc/cli/v3/pkg/config"
+	"github.com/confluentinc/cli/v3/pkg/featureflags"
 	"github.com/confluentinc/cli/v3/pkg/output"
 )
 
@@ -23,7 +25,7 @@ type customPluginOut struct {
 	SensitiveProperties []string `human:"Sensitive Properties" serialized:"sensitive_properties"`
 }
 
-func newCustomPluginCommand(prerunner pcmd.PreRunner) *cobra.Command {
+func newCustomPluginCommand(cfg *config.Config, prerunner pcmd.PreRunner) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:         "custom-plugin",
 		Short:       "Manage custom connector plugins.",
@@ -37,6 +39,11 @@ func newCustomPluginCommand(prerunner pcmd.PreRunner) *cobra.Command {
 	cmd.AddCommand(c.newDeleteCommand())
 	cmd.AddCommand(c.newListCommand())
 	cmd.AddCommand(c.newUpdateCommand())
+
+	_ = cfg.ParseFlagsIntoConfig(cmd)
+	if cfg.IsTest || featureflags.Manager.BoolVariation("cli.custom-connect.plugin.versioning.enabled", cfg.Context(), config.CliLaunchDarklyClient, true, false) {
+		cmd.AddCommand(c.newCustomPluginVersionCommand())
+	}
 
 	return cmd
 }

--- a/internal/connect/command_custom_plugin_version.go
+++ b/internal/connect/command_custom_plugin_version.go
@@ -1,0 +1,57 @@
+package connect
+
+import (
+	"github.com/spf13/cobra"
+
+	connectcustompluginv1 "github.com/confluentinc/ccloud-sdk-go-v2/connect-custom-plugin/v1"
+	"github.com/confluentinc/cli/v3/pkg/output"
+)
+
+type customPluginVersionOut struct {
+	Plugin              string   `human:"Plugin" serialized:"plugin"`
+	Version             string   `human:"Version" serialized:"version"`
+	Name                string   `human:"Name" serialized:"name"`
+	Description         string   `human:"Description" serialized:"description"`
+	Cloud               string   `human:"Cloud" serialized:"cloud"`
+	ConnectorClass      string   `human:"Connector Class" serialized:"connector_class"`
+	ConnectorType       string   `human:"Connector Type" serialized:"connector_type"`
+	SensitiveProperties []string `human:"Sensitive Properties" serialized:"sensitive_properties"`
+	VersionNumber       string   `human:"Version Number" serialized:"version_number"`
+	IsBeta              bool     `human:"Beta" serialized:"is_beta"`
+	ReleaseNotes        string   `human:"Release Notes" serialized:"release_notes"`
+	ErrorTrace          string   `human:"Error Trace,omitempty" serialized:"error_trace,omitempty"`
+}
+
+func (c *customPluginCommand) newCustomPluginVersionCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "version",
+		Short: "Manage custom connector plugin versions.",
+	}
+
+	cmd.AddCommand(c.newVersionCreateCommand())
+	cmd.AddCommand(c.newVersionDeleteCommand())
+	cmd.AddCommand(c.newVersionDescribeCommand())
+	cmd.AddCommand(c.newVersionListCommand())
+	cmd.AddCommand(c.newVersionUpdateCommand())
+
+	return cmd
+}
+
+func printTableVersion(cmd *cobra.Command, plugin connectcustompluginv1.ConnectV1CustomConnectorPlugin, version connectcustompluginv1.ConnectV1CustomConnectorPluginVersion) error {
+	table := output.NewTable(cmd)
+	table.Add(&customPluginVersionOut{
+		Plugin:              plugin.GetId(),
+		Name:                plugin.GetDisplayName(),
+		Description:         plugin.GetDescription(),
+		Cloud:               plugin.GetCloud(),
+		ConnectorClass:      plugin.GetConnectorClass(),
+		ConnectorType:       plugin.GetConnectorType(),
+		SensitiveProperties: version.GetSensitiveConfigProperties(),
+		Version:             version.GetId(),
+		VersionNumber:       version.GetVersion(),
+		IsBeta:              version.GetIsBeta() == "true",
+		ReleaseNotes:        version.GetReleaseNotes(),
+	})
+
+	return table.Print()
+}

--- a/internal/connect/command_custom_plugin_version.go
+++ b/internal/connect/command_custom_plugin_version.go
@@ -4,6 +4,7 @@ import (
 	"github.com/spf13/cobra"
 
 	connectcustompluginv1 "github.com/confluentinc/ccloud-sdk-go-v2/connect-custom-plugin/v1"
+
 	"github.com/confluentinc/cli/v3/pkg/output"
 )
 

--- a/internal/connect/command_custom_plugin_version_create.go
+++ b/internal/connect/command_custom_plugin_version_create.go
@@ -1,0 +1,146 @@
+package connect
+
+import (
+	"fmt"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	connectcustompluginv1 "github.com/confluentinc/ccloud-sdk-go-v2/connect-custom-plugin/v1"
+
+	pcmd "github.com/confluentinc/cli/v3/pkg/cmd"
+	"github.com/confluentinc/cli/v3/pkg/examples"
+	"github.com/confluentinc/cli/v3/pkg/output"
+	"github.com/confluentinc/cli/v3/pkg/utils"
+)
+
+type pluginVersionOut struct {
+	Version             string   `human:"Version" serialized:"version"`
+	VersionNumber       string   `human:"Version Number" serialized:"version_number"`
+	IsBeta              string   `human:"Beta" serialized:"is_beta"`
+	ReleaseNotes        string   `human:"Release Notes" serialized:"release_notes"`
+	SensitiveProperties []string `human:"Sensitive Properties" serialized:"sensitive_properties"`
+}
+
+func (c *customPluginCommand) newVersionCreateCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a custom connector plugin version.",
+		Args:  cobra.NoArgs,
+		RunE:  c.createCustomPluginVersion,
+		Example: examples.BuildExampleString(
+			examples.Example{
+				Text: `Create custom connector plugin version for plugin "ccp-123456".`,
+				Code: "confluent connect custom-plugin version create --plugin ccp-123456 --plugin-file datagen.zip --version-number 0.0.1 --beta=true --sensitive-properties=passwords,keys,tokens",
+			},
+		),
+	}
+
+	cmd.Flags().String("plugin", "", "ID of custom connector plugin.")
+	cmd.Flags().String("plugin-file", "", "Custom plugin ZIP or JAR file.")
+	cmd.Flags().String("version-number", "", "Version number of custom plugin version.")
+	cmd.Flags().Bool("beta", false, `Mark the custom plugin version as beta. (default "false")`)
+	cmd.Flags().String("release-notes", "", "Release notes for custom plugin version.")
+	cmd.Flags().StringSlice("sensitive-properties", nil, "A comma-separated list of sensitive property names.")
+	pcmd.AddContextFlag(cmd, c.CLICommand)
+	pcmd.AddOutputFlag(cmd)
+
+	cobra.CheckErr(cmd.MarkFlagRequired("plugin"))
+	cobra.CheckErr(cmd.MarkFlagRequired("plugin-file"))
+	cobra.CheckErr(cmd.MarkFlagRequired("version-number"))
+	cobra.CheckErr(cmd.MarkFlagFilename("plugin-file", "zip", "jar"))
+
+	return cmd
+}
+
+func (c *customPluginCommand) createCustomPluginVersion(cmd *cobra.Command, args []string) error {
+	plugin, err := cmd.Flags().GetString("plugin")
+	if err != nil {
+		return err
+	}
+
+	pluginResp, err := c.V2Client.DescribeCustomPlugin(plugin)
+	if err != nil {
+		return err
+	}
+
+	pluginFile, err := cmd.Flags().GetString("plugin-file")
+	if err != nil {
+		return err
+	}
+
+	cloud := pluginResp.GetCloud()
+
+	versionNumber, err := cmd.Flags().GetString("version-number")
+	if err != nil {
+		return err
+	}
+
+	beta, err := cmd.Flags().GetBool("beta")
+	if err != nil {
+		return err
+	}
+	isBetaString := strconv.FormatBool(beta)
+
+	releaseNotes, err := cmd.Flags().GetString("release-notes")
+	if err != nil {
+		return err
+	}
+	sensitiveProperties, err := cmd.Flags().GetStringSlice("sensitive-properties")
+	if err != nil {
+		return err
+	}
+
+	extension := strings.ToLower(strings.TrimPrefix(filepath.Ext(pluginFile), "."))
+	if extension != "zip" && extension != "jar" {
+		return fmt.Errorf(`only file extensions ".jar" and ".zip" are allowed`)
+	}
+	cloud = strings.ToUpper(cloud)
+
+	request := connectcustompluginv1.ConnectV1PresignedUrlRequest{
+		ContentFormat: connectcustompluginv1.PtrString(extension),
+		Cloud:         connectcustompluginv1.PtrString(cloud),
+	}
+
+	resp, err := c.V2Client.GetPresignedUrl(request)
+	if err != nil {
+		return err
+	}
+
+	if cloud == "AZURE" {
+		if err := utils.UploadFileToAzureBlob(resp.GetUploadUrl(), pluginFile, strings.ToLower(resp.GetContentFormat())); err != nil {
+			return err
+		}
+	} else {
+		if err := utils.UploadFile(resp.GetUploadUrl(), pluginFile, resp.GetUploadFormData()); err != nil {
+			return err
+		}
+	}
+
+	createCustomPluginVersionRequest := connectcustompluginv1.ConnectV1CustomConnectorPluginVersion{
+		Version:                   connectcustompluginv1.PtrString(versionNumber),
+		IsBeta:                    connectcustompluginv1.PtrString(isBetaString),
+		ReleaseNotes:              connectcustompluginv1.PtrString(releaseNotes),
+		SensitiveConfigProperties: &sensitiveProperties,
+		UploadSource: &connectcustompluginv1.ConnectV1CustomConnectorPluginVersionUploadSourceOneOf{
+			ConnectV1UploadSourcePresignedUrl: connectcustompluginv1.NewConnectV1UploadSourcePresignedUrl("PRESIGNED_URL_LOCATION", resp.GetUploadId()),
+		},
+	}
+
+	pluginVersionResp, err := c.V2Client.CreateCustomPluginVersion(createCustomPluginVersionRequest, plugin)
+	if err != nil {
+		return err
+	}
+
+	table := output.NewTable(cmd)
+	table.Add(&pluginVersionOut{
+		Version:             pluginVersionResp.GetId(),
+		VersionNumber:       pluginVersionResp.GetVersion(),
+		IsBeta:              pluginVersionResp.GetIsBeta(),
+		ReleaseNotes:        pluginVersionResp.GetReleaseNotes(),
+		SensitiveProperties: pluginVersionResp.GetSensitiveConfigProperties(),
+	})
+	return table.Print()
+}

--- a/internal/connect/command_custom_plugin_version_create.go
+++ b/internal/connect/command_custom_plugin_version_create.go
@@ -33,7 +33,7 @@ func (c *customPluginCommand) newVersionCreateCommand() *cobra.Command {
 		Example: examples.BuildExampleString(
 			examples.Example{
 				Text: `Create custom connector plugin version for plugin "ccp-123456".`,
-				Code: "confluent connect custom-plugin version create --plugin ccp-123456 --plugin-file datagen.zip --version-number 0.0.1 --sensitive-properties passwords,keys,tokens",
+				Code: "confluent connect custom-plugin version create --plugin ccp-123456 --plugin-file datagen.zip --version-number 0.0.1 --beta=true --sensitive-properties passwords,keys,tokens",
 			},
 		),
 	}
@@ -41,7 +41,7 @@ func (c *customPluginCommand) newVersionCreateCommand() *cobra.Command {
 	cmd.Flags().String("plugin", "", "ID of custom connector plugin.")
 	cmd.Flags().String("plugin-file", "", "Custom plugin ZIP or JAR file.")
 	cmd.Flags().String("version-number", "", "Version number of custom plugin version.")
-	cmd.Flags().Bool("beta", false, `Mark the custom plugin version as beta. (default "false").`)
+	cmd.Flags().Bool("beta", false, "Mark the custom plugin version as beta.")
 	cmd.Flags().String("release-notes", "", "Release notes for custom plugin version.")
 	cmd.Flags().StringSlice("sensitive-properties", nil, "A comma-separated list of sensitive property names.")
 	pcmd.AddContextFlag(cmd, c.CLICommand)

--- a/internal/connect/command_custom_plugin_version_create.go
+++ b/internal/connect/command_custom_plugin_version_create.go
@@ -33,7 +33,7 @@ func (c *customPluginCommand) newVersionCreateCommand() *cobra.Command {
 		Example: examples.BuildExampleString(
 			examples.Example{
 				Text: `Create custom connector plugin version for plugin "ccp-123456".`,
-				Code: "confluent connect custom-plugin version create --plugin ccp-123456 --plugin-file datagen.zip --version-number 0.0.1 --beta=true --sensitive-properties=passwords,keys,tokens",
+				Code: "confluent connect custom-plugin version create --plugin ccp-123456 --plugin-file datagen.zip --version-number 0.0.1 --sensitive-properties passwords,keys,tokens",
 			},
 		),
 	}
@@ -41,7 +41,7 @@ func (c *customPluginCommand) newVersionCreateCommand() *cobra.Command {
 	cmd.Flags().String("plugin", "", "ID of custom connector plugin.")
 	cmd.Flags().String("plugin-file", "", "Custom plugin ZIP or JAR file.")
 	cmd.Flags().String("version-number", "", "Version number of custom plugin version.")
-	cmd.Flags().Bool("beta", false, `Mark the custom plugin version as beta. (default "false")`)
+	cmd.Flags().Bool("beta", false, `Mark the custom plugin version as beta. (default "false").`)
 	cmd.Flags().String("release-notes", "", "Release notes for custom plugin version.")
 	cmd.Flags().StringSlice("sensitive-properties", nil, "A comma-separated list of sensitive property names.")
 	pcmd.AddContextFlag(cmd, c.CLICommand)

--- a/internal/connect/command_custom_plugin_version_delete.go
+++ b/internal/connect/command_custom_plugin_version_delete.go
@@ -1,0 +1,68 @@
+package connect
+
+import (
+	"github.com/spf13/cobra"
+
+	pcmd "github.com/confluentinc/cli/v3/pkg/cmd"
+	"github.com/confluentinc/cli/v3/pkg/deletion"
+	"github.com/confluentinc/cli/v3/pkg/examples"
+	"github.com/confluentinc/cli/v3/pkg/output"
+	"github.com/confluentinc/cli/v3/pkg/resource"
+)
+
+func (c *customPluginCommand) newVersionDeleteCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "delete",
+		Short: "Delete a custom connector plugin version.",
+		Args:  cobra.NoArgs,
+		RunE:  c.deleteVersion,
+		Example: examples.BuildExampleString(
+			examples.Example{
+				Text: `Delete custom connector plugin "ccp-123456" version "ver-123456".`,
+				Code: "confluent connect custom-plugin version delete --plugin ccp-123456 --version ver-12345",
+			},
+		),
+	}
+
+	cmd.Flags().String("plugin", "", "ID of custom connector plugin.")
+	cmd.Flags().String("version", "", "ID of custom connector plugin version.")
+	pcmd.AddForceFlag(cmd)
+	pcmd.AddContextFlag(cmd, c.CLICommand)
+
+	cobra.CheckErr(cmd.MarkFlagRequired("plugin"))
+	cobra.CheckErr(cmd.MarkFlagRequired("version"))
+
+	return cmd
+}
+
+func (c *customPluginCommand) deleteVersion(cmd *cobra.Command, args []string) error {
+	plugin, err := cmd.Flags().GetString("plugin")
+	if err != nil {
+		return err
+	}
+	version, err := cmd.Flags().GetString("version")
+	if err != nil {
+		return err
+	}
+
+	if _, err := c.V2Client.DescribeCustomPluginVersion(plugin, version); err != nil {
+		return err
+	}
+
+	existenceFunc := func(id string) bool {
+		return id == version || id == plugin
+	}
+
+	args = []string{version}
+	if err := deletion.ValidateAndConfirm(cmd, args, existenceFunc, resource.CustomConnectorPluginVersion); err != nil {
+		return err
+	}
+
+	if err := c.V2Client.DeleteCustomPluginVersion(plugin, version); err != nil {
+		return err
+	}
+
+	deletedResourceMsg := "Deleted %s \"%s\" version \"%s\".\n"
+	output.Printf(false, deletedResourceMsg, resource.CustomConnectorPlugin, plugin, version)
+	return nil
+}

--- a/internal/connect/command_custom_plugin_version_describe.go
+++ b/internal/connect/command_custom_plugin_version_describe.go
@@ -1,0 +1,56 @@
+package connect
+
+import (
+	"github.com/spf13/cobra"
+
+	pcmd "github.com/confluentinc/cli/v3/pkg/cmd"
+	"github.com/confluentinc/cli/v3/pkg/examples"
+)
+
+func (c *customPluginCommand) newVersionDescribeCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "describe",
+		Short: "Describe a custom connector plugin version.",
+		Args:  cobra.NoArgs,
+		RunE:  c.describeVersion,
+		Example: examples.BuildExampleString(
+			examples.Example{
+				Text: `Describe custom connector plugin "ccp-123456" version "ver-12345".`,
+				Code: "confluent connect custom-plugin version describe --plugin ccp-123456 --version ver-12345",
+			},
+		),
+	}
+
+	cmd.Flags().String("plugin", "", "ID of custom connector plugin.")
+	cmd.Flags().String("version", "", "ID of custom connector plugin version.")
+	pcmd.AddContextFlag(cmd, c.CLICommand)
+	pcmd.AddOutputFlag(cmd)
+
+	cobra.CheckErr(cmd.MarkFlagRequired("plugin"))
+	cobra.CheckErr(cmd.MarkFlagRequired("version"))
+
+	return cmd
+}
+
+func (c *customPluginCommand) describeVersion(cmd *cobra.Command, args []string) error {
+	plugin, err := cmd.Flags().GetString("plugin")
+	if err != nil {
+		return err
+	}
+	version, err := cmd.Flags().GetString("version")
+	if err != nil {
+		return err
+	}
+
+	pluginResp, err := c.V2Client.DescribeCustomPlugin(plugin)
+	if err != nil {
+		return err
+	}
+
+	pluginVersionResp, err := c.V2Client.DescribeCustomPluginVersion(plugin, version)
+	if err != nil {
+		return err
+	}
+
+	return printTableVersion(cmd, pluginResp, pluginVersionResp)
+}

--- a/internal/connect/command_custom_plugin_version_list.go
+++ b/internal/connect/command_custom_plugin_version_list.go
@@ -1,0 +1,56 @@
+package connect
+
+import (
+	"github.com/spf13/cobra"
+
+	pcmd "github.com/confluentinc/cli/v3/pkg/cmd"
+	"github.com/confluentinc/cli/v3/pkg/examples"
+	"github.com/confluentinc/cli/v3/pkg/output"
+)
+
+func (c *customPluginCommand) newVersionListCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List custom connector plugin versions for plugin.",
+		Args:  cobra.NoArgs,
+		RunE:  c.listVersions,
+		Example: examples.BuildExampleString(
+			examples.Example{
+				Text: "List custom connector plugin versions for plugin",
+				Code: "confluent connect custom-plugin version list --plugin ccp-123456",
+			},
+		),
+	}
+
+	cmd.Flags().String("plugin", "", "ID of custom connector plugin.")
+	pcmd.AddContextFlag(cmd, c.CLICommand)
+	pcmd.AddOutputFlag(cmd)
+
+	cobra.CheckErr(cmd.MarkFlagRequired("plugin"))
+
+	return cmd
+}
+
+func (c *customPluginCommand) listVersions(cmd *cobra.Command, args []string) error {
+	plugin, err := cmd.Flags().GetString("plugin")
+	if err != nil {
+		return err
+	}
+
+	versionsResp, err := c.V2Client.ListCustomPluginVersions(plugin)
+	if err != nil {
+		return err
+	}
+
+	list := output.NewList(cmd)
+	for _, pluginVersion := range versionsResp.Data {
+		list.Add(&pluginVersionOut{
+			Version:             pluginVersion.GetId(),
+			VersionNumber:       pluginVersion.GetVersion(),
+			IsBeta:              pluginVersion.GetIsBeta(),
+			ReleaseNotes:        pluginVersion.GetReleaseNotes(),
+			SensitiveProperties: pluginVersion.GetSensitiveConfigProperties(),
+		})
+	}
+	return list.Print()
+}

--- a/internal/connect/command_custom_plugin_version_update.go
+++ b/internal/connect/command_custom_plugin_version_update.go
@@ -20,8 +20,8 @@ func (c *customPluginCommand) newVersionUpdateCommand() *cobra.Command {
 		RunE:  c.updateVersion,
 		Example: examples.BuildExampleString(
 			examples.Example{
-				Text: `Update custom connector plugin version number, beta and sensitive properties for plugin "ccp-123456" version "ver-12345."`,
-				Code: "confluent connect custom-plugin version update --plugin ccp-123456 --version ver-12345 --version-number 0.0.1 --beta=true --sensitive-properties=passwords,keys,tokens",
+				Text: `Update custom connector plugin version number and sensitive properties for plugin "ccp-123456" version "ver-12345."`,
+				Code: "confluent connect custom-plugin version update --plugin ccp-123456 --version ver-12345 --version-number 0.0.1 --sensitive-properties passwords,keys,tokens",
 			},
 			examples.Example{
 				Text: `Update release notes for custom connector plugin "ccp-123456" version "ver-12345."`,
@@ -33,7 +33,7 @@ func (c *customPluginCommand) newVersionUpdateCommand() *cobra.Command {
 	cmd.Flags().String("plugin", "", "ID of custom connector plugin.")
 	cmd.Flags().String("version", "", "ID of custom connector plugin version.")
 	cmd.Flags().String("version-number", "", "Version number of custom plugin version.")
-	cmd.Flags().Bool("beta", false, `Mark the custom plugin version as beta. (default "false")`)
+	cmd.Flags().Bool("beta", false, `Mark the custom plugin version as beta. (default "false").`)
 	cmd.Flags().String("release-notes", "", "Release notes for custom plugin version.")
 	cmd.Flags().StringSlice("sensitive-properties", nil, "A comma-separated list of sensitive property names.")
 	pcmd.AddContextFlag(cmd, c.CLICommand)

--- a/internal/connect/command_custom_plugin_version_update.go
+++ b/internal/connect/command_custom_plugin_version_update.go
@@ -1,0 +1,103 @@
+package connect
+
+import (
+	"strconv"
+
+	"github.com/spf13/cobra"
+
+	connectcustompluginv1 "github.com/confluentinc/ccloud-sdk-go-v2/connect-custom-plugin/v1"
+
+	pcmd "github.com/confluentinc/cli/v3/pkg/cmd"
+	"github.com/confluentinc/cli/v3/pkg/examples"
+	"github.com/confluentinc/cli/v3/pkg/output"
+)
+
+func (c *customPluginCommand) newVersionUpdateCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "update",
+		Short: "Update a custom connector plugin version metadata.",
+		Args:  cobra.NoArgs,
+		RunE:  c.updateVersion,
+		Example: examples.BuildExampleString(
+			examples.Example{
+				Text: `Update custom connector plugin version number, beta and sensitive properties for plugin "ccp-123456" version "ver-12345."`,
+				Code: "confluent connect custom-plugin version update --plugin ccp-123456 --version ver-12345 --version-number 0.0.1 --beta=true --sensitive-properties=passwords,keys,tokens",
+			},
+			examples.Example{
+				Text: `Update release notes for custom connector plugin "ccp-123456" version "ver-12345."`,
+				Code: `confluent connect custom-plugin version update --plugin ccp-123456 --version ver-12345 --release-notes "New release."`,
+			},
+		),
+	}
+
+	cmd.Flags().String("plugin", "", "ID of custom connector plugin.")
+	cmd.Flags().String("version", "", "ID of custom connector plugin version.")
+	cmd.Flags().String("version-number", "", "Version number of custom plugin version.")
+	cmd.Flags().Bool("beta", false, `Mark the custom plugin version as beta. (default "false")`)
+	cmd.Flags().String("release-notes", "", "Release notes for custom plugin version.")
+	cmd.Flags().StringSlice("sensitive-properties", nil, "A comma-separated list of sensitive property names.")
+	pcmd.AddContextFlag(cmd, c.CLICommand)
+
+	cobra.CheckErr(cmd.MarkFlagRequired("plugin"))
+	cobra.CheckErr(cmd.MarkFlagRequired("version"))
+	cmd.MarkFlagsOneRequired("version-number", "beta", "release-notes", "sensitive-properties")
+
+	return cmd
+}
+
+func (c *customPluginCommand) updateVersion(cmd *cobra.Command, args []string) error {
+	plugin, err := cmd.Flags().GetString("plugin")
+	if err != nil {
+		return err
+	}
+	version, err := cmd.Flags().GetString("version")
+	if err != nil {
+		return err
+	}
+
+	updateCustomPluginVersionRequest := connectcustompluginv1.ConnectV1CustomConnectorPluginVersion{}
+
+	if cmd.Flags().Changed("version-number") {
+		if versionNumber, err := cmd.Flags().GetString("version-number"); err != nil {
+			return err
+		} else {
+			updateCustomPluginVersionRequest.SetVersion(versionNumber)
+		}
+	}
+	if cmd.Flags().Changed("beta") {
+		beta, err := cmd.Flags().GetBool("beta")
+		if err != nil {
+			return err
+		}
+		isBetaString := strconv.FormatBool(beta)
+		updateCustomPluginVersionRequest.SetIsBeta(isBetaString)
+	}
+	if cmd.Flags().Changed("release-notes") {
+		if releaseNotes, err := cmd.Flags().GetString("release-notes"); err != nil {
+			return err
+		} else {
+			updateCustomPluginVersionRequest.SetReleaseNotes(releaseNotes)
+		}
+	}
+	if cmd.Flags().Changed("sensitive-properties") {
+		if sensitiveProperties, err := cmd.Flags().GetStringSlice("sensitive-properties"); err != nil {
+			return err
+		} else {
+			updateCustomPluginVersionRequest.SetSensitiveConfigProperties(sensitiveProperties)
+		}
+	}
+
+	if pluginResp, err := c.V2Client.UpdateCustomPluginVersion(plugin, version, updateCustomPluginVersionRequest); err != nil {
+		return err
+	} else {
+		table := output.NewTable(cmd)
+		table.Add(&pluginVersionOut{
+			Version:             pluginResp.GetId(),
+			VersionNumber:       pluginResp.GetVersion(),
+			IsBeta:              pluginResp.GetIsBeta(),
+			ReleaseNotes:        pluginResp.GetReleaseNotes(),
+			SensitiveProperties: pluginResp.GetSensitiveConfigProperties(),
+		})
+		return table.Print()
+	}
+}

--- a/internal/connect/command_custom_plugin_version_update.go
+++ b/internal/connect/command_custom_plugin_version_update.go
@@ -20,8 +20,8 @@ func (c *customPluginCommand) newVersionUpdateCommand() *cobra.Command {
 		RunE:  c.updateVersion,
 		Example: examples.BuildExampleString(
 			examples.Example{
-				Text: `Update custom connector plugin version number and sensitive properties for plugin "ccp-123456" version "ver-12345."`,
-				Code: "confluent connect custom-plugin version update --plugin ccp-123456 --version ver-12345 --version-number 0.0.1 --sensitive-properties passwords,keys,tokens",
+				Text: `Update custom connector plugin version number, beta and sensitive properties for plugin "ccp-123456" version "ver-12345."`,
+				Code: "confluent connect custom-plugin version update --plugin ccp-123456 --version ver-12345 --version-number 0.0.1 --beta=true --sensitive-properties passwords,keys,tokens",
 			},
 			examples.Example{
 				Text: `Update release notes for custom connector plugin "ccp-123456" version "ver-12345."`,
@@ -33,7 +33,7 @@ func (c *customPluginCommand) newVersionUpdateCommand() *cobra.Command {
 	cmd.Flags().String("plugin", "", "ID of custom connector plugin.")
 	cmd.Flags().String("version", "", "ID of custom connector plugin version.")
 	cmd.Flags().String("version-number", "", "Version number of custom plugin version.")
-	cmd.Flags().Bool("beta", false, `Mark the custom plugin version as beta. (default "false").`)
+	cmd.Flags().Bool("beta", false, "Mark the custom plugin version as beta.")
 	cmd.Flags().String("release-notes", "", "Release notes for custom plugin version.")
 	cmd.Flags().StringSlice("sensitive-properties", nil, "A comma-separated list of sensitive property names.")
 	pcmd.AddContextFlag(cmd, c.CLICommand)

--- a/pkg/ccloudv2/connect_custom_plugin.go
+++ b/pkg/ccloudv2/connect_custom_plugin.go
@@ -78,3 +78,28 @@ func (c *Client) executeListPlugins(pageToken, cloud string) (connectcustomplugi
 	}
 	return req.Execute()
 }
+
+func (c *Client) CreateCustomPluginVersion(createCustomPluginVersionRequest connectcustompluginv1.ConnectV1CustomConnectorPluginVersion, id string) (connectcustompluginv1.ConnectV1CustomConnectorPluginVersion, error) {
+	resp, httpResp, err := c.ConnectCustomPluginClient.CustomConnectorPluginVersionsConnectV1Api.CreateConnectV1CustomConnectorPluginVersion(c.connectCustomPluginApiContext(), id).ConnectV1CustomConnectorPluginVersion(createCustomPluginVersionRequest).Execute()
+	return resp, errors.CatchCCloudV2Error(err, httpResp)
+}
+
+func (c *Client) DescribeCustomPluginVersion(pluginId, versionId string) (connectcustompluginv1.ConnectV1CustomConnectorPluginVersion, error) {
+	resp, httpResp, err := c.ConnectCustomPluginClient.CustomConnectorPluginVersionsConnectV1Api.GetConnectV1CustomConnectorPluginVersion(c.connectCustomPluginApiContext(), pluginId, versionId).Execute()
+	return resp, errors.CatchCCloudV2Error(err, httpResp)
+}
+
+func (c *Client) ListCustomPluginVersions(pluginId string) (connectcustompluginv1.ConnectV1CustomConnectorPluginVersionList, error) {
+	resp, httpResp, err := c.ConnectCustomPluginClient.CustomConnectorPluginVersionsConnectV1Api.ListConnectV1CustomConnectorPluginVersions(c.connectCustomPluginApiContext(), pluginId).Execute()
+	return resp, errors.CatchCCloudV2Error(err, httpResp)
+}
+
+func (c *Client) DeleteCustomPluginVersion(pluginId, versionId string) error {
+	httpResp, err := c.ConnectCustomPluginClient.CustomConnectorPluginVersionsConnectV1Api.DeleteConnectV1CustomConnectorPluginVersion(c.connectCustomPluginApiContext(), pluginId, versionId).Execute()
+	return errors.CatchCCloudV2Error(err, httpResp)
+}
+
+func (c *Client) UpdateCustomPluginVersion(pluginId, versionId string, versionUpdate connectcustompluginv1.ConnectV1CustomConnectorPluginVersion) (connectcustompluginv1.ConnectV1CustomConnectorPluginVersion, error) {
+	resp, httpResp, err := c.ConnectCustomPluginClient.CustomConnectorPluginVersionsConnectV1Api.UpdateConnectV1CustomConnectorPluginVersion(c.connectCustomPluginApiContext(), pluginId, versionId).ConnectV1CustomConnectorPluginVersion(versionUpdate).Execute()
+	return resp, errors.CatchCCloudV2Error(err, httpResp)
+}

--- a/pkg/resource/resource.go
+++ b/pkg/resource/resource.go
@@ -25,6 +25,7 @@ const (
 	ClusterLink                     = "cluster link"
 	Connector                       = "connector"
 	CustomConnectorPlugin           = "custom connector plugin"
+	CustomConnectorPluginVersion    = "custom connector plugin version"
 	ConsumerShare                   = "consumer share"
 	Context                         = "context"
 	Dek                             = "DEK"

--- a/test/connect_test.go
+++ b/test/connect_test.go
@@ -202,6 +202,29 @@ func (s *CLITestSuite) TestConnectCustomPlugin() {
 	}
 }
 
+func (s *CLITestSuite) TestConnectCustomPluginVersioning() {
+	tests := []CLITest{
+		{args: `connect custom-plugin version create --plugin plugin123 --plugin-file "test/fixtures/input/connect/confluentinc-kafka-connect-datagen-0.6.1.zip" --version-number 0.0.1 `, fixture: "connect/custom-plugin/version/create.golden"},
+		{args: `connect custom-plugin version create --plugin plugin123 --plugin-file "test/fixtures/input/connect/confluentinc-kafka-connect-datagen-0.6.1.zip" --version-number 0.0.1 `, fixture: "connect/custom-plugin/version/create.golden"},
+		{args: `connect custom-plugin version create --plugin plugin123 --plugin-file "test/fixtures/input/connect/confluentinc-kafka-connect-datagen-0.6.1.pdf" --version-number 0.0.1 `, fixture: "connect/custom-plugin/version/create-invalid-extension.golden", exitCode: 1},
+		{args: "connect custom-plugin version list --plugin plugin23", fixture: "connect/custom-plugin/version/list.golden"},
+		{args: "connect custom-plugin version list --plugin plugin23 -o json", fixture: "connect/custom-plugin/version/list-json.golden"},
+		{args: "connect custom-plugin version list --plugin plugin23 -o yaml", fixture: "connect/custom-plugin/version/list-yaml.golden"},
+		{args: "connect custom-plugin version describe --plugin ccp-123456 --version ver-123456", fixture: "connect/custom-plugin/version/describe.golden"},
+		{args: "connect custom-plugin version describe --plugin ccp-789012 --version ver-789012", fixture: "connect/custom-plugin/version/describe-with-sensitive-properties.golden"},
+		{args: "connect custom-plugin version describe --plugin ccp-123456 --version ver-123456 -o json", fixture: "connect/custom-plugin/version/describe-json.golden"},
+		{args: "connect custom-plugin version describe --plugin ccp-123456 --version ver-123456 -o yaml", fixture: "connect/custom-plugin/version/describe-yaml.golden"},
+		{args: "connect custom-plugin version delete --plugin ccp-123456 --version ver-123456 --force", fixture: "connect/custom-plugin/version/delete.golden"},
+		{args: "connect custom-plugin version delete --plugin ccp-123456 --version ver-123456", input: "y\n", fixture: "connect/custom-plugin/version/delete-prompt.golden"},
+		{args: "connect custom-plugin version update --plugin ccp-123456 --version ver-123456 --version-number 0.0.1 ", fixture: "connect/custom-plugin/version/update.golden"},
+	}
+
+	for _, test := range tests {
+		test.login = "cloud"
+		s.runIntegrationTest(test)
+	}
+}
+
 func (s *CLITestSuite) TestConnectOffset() {
 	tests := []CLITest{
 		{args: "connect offset describe lcc-123 --cluster lkc-123 -o json", fixture: "connect/offset/describe-offset-json.golden"},

--- a/test/fixtures/output/connect/custom-plugin/help.golden
+++ b/test/fixtures/output/connect/custom-plugin/help.golden
@@ -9,6 +9,7 @@ Available Commands:
   describe    Describe a custom connector plugin.
   list        List custom connector plugins.
   update      Update a custom connector plugin configuration.
+  version     Manage custom connector plugin versions.
 
 Global Flags:
   -h, --help            Show help for this command.

--- a/test/fixtures/output/connect/custom-plugin/version/create-help.golden
+++ b/test/fixtures/output/connect/custom-plugin/version/create-help.golden
@@ -1,0 +1,24 @@
+Create a custom connector plugin version.
+
+Usage:
+  confluent connect custom-plugin version create [flags]
+
+Examples:
+Create custom connector plugin version for plugin "ccp-123456".
+
+  $ confluent connect custom-plugin version create --plugin ccp-123456 --plugin-file datagen.zip --version-number 0.0.1 --beta=true --sensitive-properties=passwords,keys,tokens
+
+Flags:
+      --plugin string                  REQUIRED: ID of custom connector plugin.
+      --plugin-file string             REQUIRED: Custom plugin ZIP or JAR file.
+      --version-number string          REQUIRED: Version number of custom plugin version.
+      --beta                           Mark the custom plugin version as beta. (default "false")
+      --release-notes string           Release notes for custom plugin version.
+      --sensitive-properties strings   A comma-separated list of sensitive property names.
+      --context string                 CLI context name.
+  -o, --output string                  Specify the output format as "human", "json", or "yaml". (default "human")
+
+Global Flags:
+  -h, --help            Show help for this command.
+      --unsafe-trace    Equivalent to -vvvv, but also log HTTP requests and responses which might contain plaintext secrets.
+  -v, --verbose count   Increase verbosity (-v for warn, -vv for info, -vvv for debug, -vvvv for trace).

--- a/test/fixtures/output/connect/custom-plugin/version/create-help.golden
+++ b/test/fixtures/output/connect/custom-plugin/version/create-help.golden
@@ -6,13 +6,13 @@ Usage:
 Examples:
 Create custom connector plugin version for plugin "ccp-123456".
 
-  $ confluent connect custom-plugin version create --plugin ccp-123456 --plugin-file datagen.zip --version-number 0.0.1 --sensitive-properties passwords,keys,tokens
+  $ confluent connect custom-plugin version create --plugin ccp-123456 --plugin-file datagen.zip --version-number 0.0.1 --beta=true --sensitive-properties passwords,keys,tokens
 
 Flags:
       --plugin string                  REQUIRED: ID of custom connector plugin.
       --plugin-file string             REQUIRED: Custom plugin ZIP or JAR file.
       --version-number string          REQUIRED: Version number of custom plugin version.
-      --beta                           Mark the custom plugin version as beta. (default "false").
+      --beta                           Mark the custom plugin version as beta.
       --release-notes string           Release notes for custom plugin version.
       --sensitive-properties strings   A comma-separated list of sensitive property names.
       --context string                 CLI context name.

--- a/test/fixtures/output/connect/custom-plugin/version/create-help.golden
+++ b/test/fixtures/output/connect/custom-plugin/version/create-help.golden
@@ -6,13 +6,13 @@ Usage:
 Examples:
 Create custom connector plugin version for plugin "ccp-123456".
 
-  $ confluent connect custom-plugin version create --plugin ccp-123456 --plugin-file datagen.zip --version-number 0.0.1 --beta=true --sensitive-properties=passwords,keys,tokens
+  $ confluent connect custom-plugin version create --plugin ccp-123456 --plugin-file datagen.zip --version-number 0.0.1 --sensitive-properties passwords,keys,tokens
 
 Flags:
       --plugin string                  REQUIRED: ID of custom connector plugin.
       --plugin-file string             REQUIRED: Custom plugin ZIP or JAR file.
       --version-number string          REQUIRED: Version number of custom plugin version.
-      --beta                           Mark the custom plugin version as beta. (default "false")
+      --beta                           Mark the custom plugin version as beta. (default "false").
       --release-notes string           Release notes for custom plugin version.
       --sensitive-properties strings   A comma-separated list of sensitive property names.
       --context string                 CLI context name.

--- a/test/fixtures/output/connect/custom-plugin/version/create-invalid-extension.golden
+++ b/test/fixtures/output/connect/custom-plugin/version/create-invalid-extension.golden
@@ -1,0 +1,1 @@
+Error: only file extensions ".jar" and ".zip" are allowed

--- a/test/fixtures/output/connect/custom-plugin/version/create-invalid-version-format.golden
+++ b/test/fixtures/output/connect/custom-plugin/version/create-invalid-version-format.golden
@@ -1,0 +1,1 @@
+Error: version number must be in the form of major.minor.patch

--- a/test/fixtures/output/connect/custom-plugin/version/create.golden
+++ b/test/fixtures/output/connect/custom-plugin/version/create.golden
@@ -1,0 +1,7 @@
++----------------------+--------------------+
+| Version              | ver-123456         |
+| Version Number       | 0.0.0              |
+| Beta                 | false              |
+| Release Notes        | test release notes |
+| Sensitive Properties |                    |
++----------------------+--------------------+

--- a/test/fixtures/output/connect/custom-plugin/version/delete-help.golden
+++ b/test/fixtures/output/connect/custom-plugin/version/delete-help.golden
@@ -1,0 +1,20 @@
+Delete a custom connector plugin version.
+
+Usage:
+  confluent connect custom-plugin version delete [flags]
+
+Examples:
+Delete custom connector plugin "ccp-123456" version "ver-123456".
+
+  $ confluent connect custom-plugin version delete --plugin ccp-123456 --version ver-12345
+
+Flags:
+      --plugin string    REQUIRED: ID of custom connector plugin.
+      --version string   REQUIRED: ID of custom connector plugin version.
+      --force            Skip the deletion confirmation prompt.
+      --context string   CLI context name.
+
+Global Flags:
+  -h, --help            Show help for this command.
+      --unsafe-trace    Equivalent to -vvvv, but also log HTTP requests and responses which might contain plaintext secrets.
+  -v, --verbose count   Increase verbosity (-v for warn, -vv for info, -vvv for debug, -vvvv for trace).

--- a/test/fixtures/output/connect/custom-plugin/version/delete-prompt.golden
+++ b/test/fixtures/output/connect/custom-plugin/version/delete-prompt.golden
@@ -1,0 +1,1 @@
+Are you sure you want to delete custom connector plugin version "ver-123456"? (y/n): Deleted custom connector plugin "ccp-123456" version "ver-123456".

--- a/test/fixtures/output/connect/custom-plugin/version/delete.golden
+++ b/test/fixtures/output/connect/custom-plugin/version/delete.golden
@@ -1,0 +1,1 @@
+Deleted custom connector plugin "ccp-123456" version "ver-123456".

--- a/test/fixtures/output/connect/custom-plugin/version/describe-help.golden
+++ b/test/fixtures/output/connect/custom-plugin/version/describe-help.golden
@@ -1,0 +1,20 @@
+Describe a custom connector plugin version.
+
+Usage:
+  confluent connect custom-plugin version describe [flags]
+
+Examples:
+Describe custom connector plugin "ccp-123456" version "ver-12345".
+
+  $ confluent connect custom-plugin version describe --plugin ccp-123456 --version ver-12345
+
+Flags:
+      --plugin string    REQUIRED: ID of custom connector plugin.
+      --version string   REQUIRED: ID of custom connector plugin version.
+      --context string   CLI context name.
+  -o, --output string    Specify the output format as "human", "json", or "yaml". (default "human")
+
+Global Flags:
+  -h, --help            Show help for this command.
+      --unsafe-trace    Equivalent to -vvvv, but also log HTTP requests and responses which might contain plaintext secrets.
+  -v, --verbose count   Increase verbosity (-v for warn, -vv for info, -vvv for debug, -vvvv for trace).

--- a/test/fixtures/output/connect/custom-plugin/version/describe-json.golden
+++ b/test/fixtures/output/connect/custom-plugin/version/describe-json.golden
@@ -1,0 +1,13 @@
+{
+  "plugin": "ccp-123456",
+  "version": "ver-123456",
+  "name": "CliPluginTest",
+  "description": "",
+  "cloud": "AWS",
+  "connector_class": "io.confluent.kafka.connect.test",
+  "connector_type": "source",
+  "sensitive_properties": null,
+  "version_number": "0.0.0",
+  "is_beta": false,
+  "release_notes": "test release notes"
+}

--- a/test/fixtures/output/connect/custom-plugin/version/describe-with-sensitive-properties.golden
+++ b/test/fixtures/output/connect/custom-plugin/version/describe-with-sensitive-properties.golden
@@ -1,0 +1,13 @@
++----------------------+---------------------------------+
+| Plugin               | ccp-789012                      |
+| Version              | ver-789012                      |
+| Name                 | CliPluginTest                   |
+| Description          | Source datagen plugin           |
+| Cloud                | AWS                             |
+| Connector Class      | io.confluent.kafka.connect.test |
+| Connector Type       | source                          |
+| Sensitive Properties | aws.key, aws.secret             |
+| Version Number       | 0.0.0                           |
+| Beta                 | false                           |
+| Release Notes        | test release notes              |
++----------------------+---------------------------------+

--- a/test/fixtures/output/connect/custom-plugin/version/describe-yaml.golden
+++ b/test/fixtures/output/connect/custom-plugin/version/describe-yaml.golden
@@ -1,0 +1,11 @@
+plugin: ccp-123456
+version: ver-123456
+name: CliPluginTest
+description: ""
+cloud: AWS
+connector_class: io.confluent.kafka.connect.test
+connector_type: source
+sensitive_properties: []
+version_number: 0.0.0
+is_beta: false
+release_notes: test release notes

--- a/test/fixtures/output/connect/custom-plugin/version/describe.golden
+++ b/test/fixtures/output/connect/custom-plugin/version/describe.golden
@@ -1,0 +1,13 @@
++----------------------+---------------------------------+
+| Plugin               | ccp-123456                      |
+| Version              | ver-123456                      |
+| Name                 | CliPluginTest                   |
+| Description          |                                 |
+| Cloud                | AWS                             |
+| Connector Class      | io.confluent.kafka.connect.test |
+| Connector Type       | source                          |
+| Sensitive Properties |                                 |
+| Version Number       | 0.0.0                           |
+| Beta                 | false                           |
+| Release Notes        | test release notes              |
++----------------------+---------------------------------+

--- a/test/fixtures/output/connect/custom-plugin/version/help.golden
+++ b/test/fixtures/output/connect/custom-plugin/version/help.golden
@@ -1,0 +1,18 @@
+Manage custom connector plugin versions.
+
+Usage:
+  confluent connect custom-plugin version [command]
+
+Available Commands:
+  create      Create a custom connector plugin version.
+  delete      Delete a custom connector plugin version.
+  describe    Describe a custom connector plugin version.
+  list        List custom connector plugin versions for plugin.
+  update      Update a custom connector plugin version metadata.
+
+Global Flags:
+  -h, --help            Show help for this command.
+      --unsafe-trace    Equivalent to -vvvv, but also log HTTP requests and responses which might contain plaintext secrets.
+  -v, --verbose count   Increase verbosity (-v for warn, -vv for info, -vvv for debug, -vvvv for trace).
+
+Use "confluent connect custom-plugin version [command] --help" for more information about a command.

--- a/test/fixtures/output/connect/custom-plugin/version/list-help.golden
+++ b/test/fixtures/output/connect/custom-plugin/version/list-help.golden
@@ -1,0 +1,19 @@
+List custom connector plugin versions for plugin.
+
+Usage:
+  confluent connect custom-plugin version list [flags]
+
+Examples:
+List custom connector plugin versions for plugin
+
+  $ confluent connect custom-plugin version list --plugin ccp-123456
+
+Flags:
+      --plugin string    REQUIRED: ID of custom connector plugin.
+      --context string   CLI context name.
+  -o, --output string    Specify the output format as "human", "json", or "yaml". (default "human")
+
+Global Flags:
+  -h, --help            Show help for this command.
+      --unsafe-trace    Equivalent to -vvvv, but also log HTTP requests and responses which might contain plaintext secrets.
+  -v, --verbose count   Increase verbosity (-v for warn, -vv for info, -vvv for debug, -vvvv for trace).

--- a/test/fixtures/output/connect/custom-plugin/version/list-json.golden
+++ b/test/fixtures/output/connect/custom-plugin/version/list-json.golden
@@ -1,0 +1,23 @@
+[
+  {
+    "version": "ver-123456",
+    "version_number": "0.0.0",
+    "is_beta": "false",
+    "release_notes": "",
+    "sensitive_properties": null
+  },
+  {
+    "version": "ver-123456",
+    "version_number": "0.0.1",
+    "is_beta": "false",
+    "release_notes": "",
+    "sensitive_properties": null
+  },
+  {
+    "version": "ver-123456",
+    "version_number": "0.0.2",
+    "is_beta": "true",
+    "release_notes": "",
+    "sensitive_properties": null
+  }
+]

--- a/test/fixtures/output/connect/custom-plugin/version/list-yaml.golden
+++ b/test/fixtures/output/connect/custom-plugin/version/list-yaml.golden
@@ -1,0 +1,15 @@
+- version: ver-123456
+  version_number: 0.0.0
+  is_beta: "false"
+  release_notes: ""
+  sensitive_properties: []
+- version: ver-123456
+  version_number: 0.0.1
+  is_beta: "false"
+  release_notes: ""
+  sensitive_properties: []
+- version: ver-123456
+  version_number: 0.0.2
+  is_beta: "true"
+  release_notes: ""
+  sensitive_properties: []

--- a/test/fixtures/output/connect/custom-plugin/version/list.golden
+++ b/test/fixtures/output/connect/custom-plugin/version/list.golden
@@ -1,0 +1,5 @@
+   Version   | Version Number | Beta  | Release Notes | Sensitive Properties  
+-------------+----------------+-------+---------------+-----------------------
+  ver-123456 | 0.0.0          | false |               |                       
+  ver-123456 | 0.0.1          | false |               |                       
+  ver-123456 | 0.0.2          | true  |               |                       

--- a/test/fixtures/output/connect/custom-plugin/version/update-help.golden
+++ b/test/fixtures/output/connect/custom-plugin/version/update-help.golden
@@ -4,9 +4,9 @@ Usage:
   confluent connect custom-plugin version update [flags]
 
 Examples:
-Update custom connector plugin version number, beta and sensitive properties for plugin "ccp-123456" version "ver-12345."
+Update custom connector plugin version number and sensitive properties for plugin "ccp-123456" version "ver-12345."
 
-  $ confluent connect custom-plugin version update --plugin ccp-123456 --version ver-12345 --version-number 0.0.1 --beta=true --sensitive-properties=passwords,keys,tokens
+  $ confluent connect custom-plugin version update --plugin ccp-123456 --version ver-12345 --version-number 0.0.1 --sensitive-properties passwords,keys,tokens
 
 Update release notes for custom connector plugin "ccp-123456" version "ver-12345."
 
@@ -16,7 +16,7 @@ Flags:
       --plugin string                  REQUIRED: ID of custom connector plugin.
       --version string                 REQUIRED: ID of custom connector plugin version.
       --version-number string          Version number of custom plugin version.
-      --beta                           Mark the custom plugin version as beta. (default "false")
+      --beta                           Mark the custom plugin version as beta. (default "false").
       --release-notes string           Release notes for custom plugin version.
       --sensitive-properties strings   A comma-separated list of sensitive property names.
       --context string                 CLI context name.

--- a/test/fixtures/output/connect/custom-plugin/version/update-help.golden
+++ b/test/fixtures/output/connect/custom-plugin/version/update-help.golden
@@ -1,0 +1,27 @@
+Update a custom connector plugin version metadata.
+
+Usage:
+  confluent connect custom-plugin version update [flags]
+
+Examples:
+Update custom connector plugin version number, beta and sensitive properties for plugin "ccp-123456" version "ver-12345."
+
+  $ confluent connect custom-plugin version update --plugin ccp-123456 --version ver-12345 --version-number 0.0.1 --beta=true --sensitive-properties=passwords,keys,tokens
+
+Update release notes for custom connector plugin "ccp-123456" version "ver-12345."
+
+  $ confluent connect custom-plugin version update --plugin ccp-123456 --version ver-12345 --release-notes "New release."
+
+Flags:
+      --plugin string                  REQUIRED: ID of custom connector plugin.
+      --version string                 REQUIRED: ID of custom connector plugin version.
+      --version-number string          Version number of custom plugin version.
+      --beta                           Mark the custom plugin version as beta. (default "false")
+      --release-notes string           Release notes for custom plugin version.
+      --sensitive-properties strings   A comma-separated list of sensitive property names.
+      --context string                 CLI context name.
+
+Global Flags:
+  -h, --help            Show help for this command.
+      --unsafe-trace    Equivalent to -vvvv, but also log HTTP requests and responses which might contain plaintext secrets.
+  -v, --verbose count   Increase verbosity (-v for warn, -vv for info, -vvv for debug, -vvvv for trace).

--- a/test/fixtures/output/connect/custom-plugin/version/update-help.golden
+++ b/test/fixtures/output/connect/custom-plugin/version/update-help.golden
@@ -4,9 +4,9 @@ Usage:
   confluent connect custom-plugin version update [flags]
 
 Examples:
-Update custom connector plugin version number and sensitive properties for plugin "ccp-123456" version "ver-12345."
+Update custom connector plugin version number, beta and sensitive properties for plugin "ccp-123456" version "ver-12345."
 
-  $ confluent connect custom-plugin version update --plugin ccp-123456 --version ver-12345 --version-number 0.0.1 --sensitive-properties passwords,keys,tokens
+  $ confluent connect custom-plugin version update --plugin ccp-123456 --version ver-12345 --version-number 0.0.1 --beta=true --sensitive-properties passwords,keys,tokens
 
 Update release notes for custom connector plugin "ccp-123456" version "ver-12345."
 
@@ -16,7 +16,7 @@ Flags:
       --plugin string                  REQUIRED: ID of custom connector plugin.
       --version string                 REQUIRED: ID of custom connector plugin version.
       --version-number string          Version number of custom plugin version.
-      --beta                           Mark the custom plugin version as beta. (default "false").
+      --beta                           Mark the custom plugin version as beta.
       --release-notes string           Release notes for custom plugin version.
       --sensitive-properties strings   A comma-separated list of sensitive property names.
       --context string                 CLI context name.

--- a/test/fixtures/output/connect/custom-plugin/version/update.golden
+++ b/test/fixtures/output/connect/custom-plugin/version/update.golden
@@ -1,0 +1,7 @@
++----------------------+--------------------+
+| Version              | ver-123456         |
+| Version Number       | 0.0.0              |
+| Beta                 | false              |
+| Release Notes        | test release notes |
+| Sensitive Properties |                    |
++----------------------+--------------------+

--- a/test/test-server/ccloudv2_router.go
+++ b/test/test-server/ccloudv2_router.go
@@ -40,6 +40,8 @@ var ccloudV2Routes = []route{
 	{"/connect/v1/environments/{environment_id}/clusters/{kafka_cluster_id}/connectors/{connector_name}/offsets/request/status", handleAlterConnectorOffsetsStatus},
 	{"/connect/v1/custom-connector-plugins", handleCustomConnectorPlugins},
 	{"/connect/v1/custom-connector-plugins/{id}", handleCustomConnectorPluginsId},
+	{"/connect/v1/custom-connector-plugins/{plugin_id}/versions", handleCustomConnectorPluginsVersions},
+	{"/connect/v1/custom-connector-plugins/{plugin_id}/versions/{version_id}", handleCustomConnectorPluginsVersionsId},
 	{"/connect/v1/presigned-upload-url", handleCustomPluginUploadUrl},
 	{"/connect/v1/dummy-presigned-url", handleCustomPluginUploadFile},
 	{"/fcpm/v2/compute-pools", handleFcpmComputePools},

--- a/test/test-server/connect_handler.go
+++ b/test/test-server/connect_handler.go
@@ -466,6 +466,110 @@ func handleCustomConnectorPluginsId(t *testing.T) http.HandlerFunc {
 	}
 }
 
+// Handler for: "/connect/v1/custom-connector-plugins/{plugin_id}/versions"
+func handleCustomConnectorPluginsVersions(t *testing.T) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodPost:
+			vars := mux.Vars(r)
+			id := vars["plugin_id"]
+			var version connectcustompluginv1.ConnectV1CustomConnectorPluginVersion
+			if id == "ccp-123456" {
+				version = connectcustompluginv1.ConnectV1CustomConnectorPluginVersion{
+					Id:           connectcustompluginv1.PtrString("ver-123456"),
+					Version:      connectcustompluginv1.PtrString("0.0.0"),
+					IsBeta:       connectcustompluginv1.PtrString("false"),
+					ReleaseNotes: connectcustompluginv1.PtrString("test release notes"),
+				}
+			} else if id == "ccp-789012" {
+				sensitiveProperties := []string{"aws.key", "aws.secret"}
+				version = connectcustompluginv1.ConnectV1CustomConnectorPluginVersion{
+					Id:                        connectcustompluginv1.PtrString("ver-123456"),
+					Version:                   connectcustompluginv1.PtrString("0.0.0"),
+					IsBeta:                    connectcustompluginv1.PtrString("false"),
+					ReleaseNotes:              connectcustompluginv1.PtrString("test release notes"),
+					SensitiveConfigProperties: &sensitiveProperties,
+				}
+			} else {
+				version = connectcustompluginv1.ConnectV1CustomConnectorPluginVersion{
+					Id:           connectcustompluginv1.PtrString("ver-123456"),
+					Version:      connectcustompluginv1.PtrString("0.0.0"),
+					IsBeta:       connectcustompluginv1.PtrString("false"),
+					ReleaseNotes: connectcustompluginv1.PtrString("test release notes"),
+				}
+			}
+			err := json.NewEncoder(w).Encode(version)
+			require.NoError(t, err)
+		case http.MethodGet:
+			version1 := connectcustompluginv1.ConnectV1CustomConnectorPluginVersion{
+				Id:      connectcustompluginv1.PtrString("ver-123456"),
+				Version: connectcustompluginv1.PtrString("0.0.0"),
+				IsBeta:  connectcustompluginv1.PtrString("false"),
+			}
+			version2 := connectcustompluginv1.ConnectV1CustomConnectorPluginVersion{
+				Id:      connectcustompluginv1.PtrString("ver-123456"),
+				Version: connectcustompluginv1.PtrString("0.0.1"),
+				IsBeta:  connectcustompluginv1.PtrString("false"),
+			}
+			version3 := connectcustompluginv1.ConnectV1CustomConnectorPluginVersion{
+				Id:      connectcustompluginv1.PtrString("ver-123456"),
+				Version: connectcustompluginv1.PtrString("0.0.2"),
+				IsBeta:  connectcustompluginv1.PtrString("true"),
+			}
+
+			err := json.NewEncoder(w).Encode(connectcustompluginv1.ConnectV1CustomConnectorPluginVersionList{Data: []connectcustompluginv1.ConnectV1CustomConnectorPluginVersion{version1, version2, version3}})
+			require.NoError(t, err)
+		}
+	}
+}
+
+// Handler for: "/connect/v1/custom-connector-plugins/{plugin_id}/versions/{version_id}"
+func handleCustomConnectorPluginsVersionsId(t *testing.T) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			vars := mux.Vars(r)
+			verId := vars["version_id"]
+			var version connectcustompluginv1.ConnectV1CustomConnectorPluginVersion
+			if verId == "ver-123456" {
+				version = connectcustompluginv1.ConnectV1CustomConnectorPluginVersion{
+					Id:           connectcustompluginv1.PtrString("ver-123456"),
+					Version:      connectcustompluginv1.PtrString("0.0.0"),
+					IsBeta:       connectcustompluginv1.PtrString("false"),
+					ReleaseNotes: connectcustompluginv1.PtrString("test release notes"),
+				}
+			} else if verId == "ver-789012" {
+				sensitiveProperties := []string{"aws.key", "aws.secret"}
+				version = connectcustompluginv1.ConnectV1CustomConnectorPluginVersion{
+					Id:                        connectcustompluginv1.PtrString("ver-789012"),
+					Version:                   connectcustompluginv1.PtrString("0.0.0"),
+					IsBeta:                    connectcustompluginv1.PtrString("false"),
+					ReleaseNotes:              connectcustompluginv1.PtrString("test release notes"),
+					SensitiveConfigProperties: &sensitiveProperties,
+				}
+			} else {
+				version = connectcustompluginv1.ConnectV1CustomConnectorPluginVersion{
+					Id:           connectcustompluginv1.PtrString("ver-123456"),
+					Version:      connectcustompluginv1.PtrString("0.0.0"),
+					IsBeta:       connectcustompluginv1.PtrString("false"),
+					ReleaseNotes: connectcustompluginv1.PtrString("test release notes"),
+				}
+			}
+			err := json.NewEncoder(w).Encode(version)
+			require.NoError(t, err)
+		case http.MethodPatch:
+			version1 := connectcustompluginv1.ConnectV1CustomConnectorPluginVersion{
+				Id:           connectcustompluginv1.PtrString("ver-123456"),
+				Version:      connectcustompluginv1.PtrString("0.0.0"),
+				IsBeta:       connectcustompluginv1.PtrString("false"),
+				ReleaseNotes: connectcustompluginv1.PtrString("test release notes"),
+			}
+			err := json.NewEncoder(w).Encode(version1)
+			require.NoError(t, err)
+		}
+	}
+}
+
 // Handler for: "/connect/v1/presigned-upload-url"
 func handleCustomPluginUploadUrl(t *testing.T) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Release Notes
-------------
New Features
- [Early Access] Add `confluent connect custom-plugin version` commands for managing custom connect plugin versions

Checklist
---------
- [ ] Leave this box unchecked if features are not yet available in production

What
----
This PR is the follow up for https://github.com/confluentinc/cli/pull/2887.
In the previous PR, there are conflicts in go.mod and pkg/deletion/deletion.go , which are preventing the merge. So create a new PR contains all the change in https://github.com/confluentinc/cli/pull/2887.

What is in this PR:

- contents in https://github.com/confluentinc/cli/pull/2887
- update deletion cmd to adopt y/n
- update plugin version feature flag to cli.custom-connect.plugin.versioning.enabled


References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
<!--
Has it been tested? How?
Copy and paste any instructions or steps that can save the reviewer time.
-->