### PR TITLE
`passphrase-new` shouldn't be required

### DIFF
--- a/internal/secret/command_file_rotate.go
+++ b/internal/secret/command_file_rotate.go
@@ -30,7 +30,6 @@ func (c *command) newRotateCommand() *cobra.Command {
 
 	cobra.CheckErr(cmd.MarkFlagRequired("local-secrets-file"))
 	cobra.CheckErr(cmd.MarkFlagRequired("passphrase"))
-	cobra.CheckErr(cmd.MarkFlagRequired("passphrase-new"))
 
 	return cmd
 }

--- a/test/fixtures/output/secret/file/rotate-help-onprem.golden
+++ b/test/fixtures/output/secret/file/rotate-help-onprem.golden
@@ -6,7 +6,7 @@ Usage:
 Flags:
       --local-secrets-file string   REQUIRED: Path to the encrypted configuration properties file.
       --passphrase string           REQUIRED: Master key passphrase.
-      --passphrase-new string       REQUIRED: New master key passphrase.
+      --passphrase-new string       New master key passphrase.
       --master-key                  Rotate the master key. Generates a new master key and re-encrypts with the new key.
       --data-key                    Rotate data key. Generates a new data key and re-encrypts the file with the new key.
   -o, --output string               Specify the output format as "human", "json", or "yaml". (default "human")


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- PLACEHOLDER

New Features
- PLACEHOLDER

Bug Fixes
- The `--passphrase-new` flag in `confluent secret file rotate` is no longer required

Checklist
---------
- [x] Leave this box unchecked if features are not yet available in production

What
----
This flag was marked as required in v4.0.0, which is a bug, because this flag is only required for rotating master keys, but not data keys.

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
<!--
Has it been tested? How?
Copy and paste any instructions or steps that can save the reviewer time.
-->