### PR TITLE
Fix bug preventing `confluent kafka cluster configuration` from being used while logged out

### DIFF
--- a/internal/kafka/command_cluster.go
+++ b/internal/kafka/command_cluster.go
@@ -32,9 +32,8 @@ type clusterCommand struct {
 
 func newClusterCommand(cfg *config.Config, prerunner pcmd.PreRunner) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:         "cluster",
-		Short:       "Manage Kafka clusters.",
-		Annotations: map[string]string{pcmd.RunRequirement: pcmd.RequireNonAPIKeyCloudLoginOrOnPremLogin},
+		Use:   "cluster",
+		Short: "Manage Kafka clusters.",
 	}
 
 	c := &clusterCommand{}

--- a/internal/kafka/command_cluster_configuration.go
+++ b/internal/kafka/command_cluster_configuration.go
@@ -15,9 +15,8 @@ type configurationOut struct {
 
 func (c *clusterCommand) newConfigurationCommand(cfg *config.Config, prerunner pcmd.PreRunner) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:         "configuration",
-		Short:       "Manage Kafka cluster configurations.",
-		Annotations: map[string]string{pcmd.RunRequirement: pcmd.RequireNonAPIKeyCloudLoginOrOnPremLogin},
+		Use:   "configuration",
+		Short: "Manage Kafka cluster configurations.",
 	}
 
 	if cfg.IsCloudLogin() {

--- a/internal/kafka/command_cluster_list_onprem.go
+++ b/internal/kafka/command_cluster_list_onprem.go
@@ -16,11 +16,12 @@ const kafkaClusterTypeName = "kafka-cluster"
 
 func (c *clusterCommand) newListCommandOnPrem() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "list",
-		Args:  cobra.NoArgs,
-		Short: "List registered Kafka clusters.",
-		Long:  "List Kafka clusters that are registered with the MDS cluster registry.",
-		RunE:  c.listOnPrem,
+		Use:         "list",
+		Args:        cobra.NoArgs,
+		Short:       "List registered Kafka clusters.",
+		Long:        "List Kafka clusters that are registered with the MDS cluster registry.",
+		RunE:        c.listOnPrem,
+		Annotations: map[string]string{pcmd.RunRequirement: pcmd.RequireOnPremLogin},
 	}
 
 	pcmd.AddContextFlag(cmd, c.CLICommand)

--- a/test/kafka_test.go
+++ b/test/kafka_test.go
@@ -200,6 +200,18 @@ func (s *CLITestSuite) TestKafkaClusterConfiguration() {
 		test.env = []string{"CONFLUENT_REST_URL=" + kafkaRestURL}
 		s.runIntegrationTest(test)
 	}
+
+	// test logged out version
+	tests = []CLITest{
+		{args: "kafka cluster configuration update --config compression.type=zip,sasl_mechanism=SASL/PLAIN --no-authentication", fixture: "kafka/cluster/configuration/update-onprem.golden"},
+		{args: "kafka cluster configuration list --no-authentication", fixture: "kafka/cluster/configuration/list-onprem.golden"},
+		{args: "kafka cluster configuration list --config compression.type --no-authentication", fixture: "kafka/cluster/configuration/list-specific-config-onprem.golden"},
+	}
+
+	for _, test := range tests {
+		test.env = []string{"CONFLUENT_REST_URL=" + kafkaRestURL}
+		s.runIntegrationTest(test)
+	}
 }
 
 func (s *CLITestSuite) TestKafkaClientConfig() {


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- PLACEHOLDER

New Features
- PLACEHOLDER

Bug Fixes
- Allow `confluent kafka cluster configuration` commands to be used while logged out

Checklist
---------
- [x] Leave this box unchecked if features are not yet available in production

What
----
Fix incorrect annotations after splitting this functionality off of `kafka broker`.

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
<!--
Has it been tested? How?
Copy and paste any instructions or steps that can save the reviewer time.
-->