### PR TITLE
KGLOBAL-5237: Implement Confluent CLI for TRUNCATE_AND_RESTORE

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/confluentinc/ccloud-sdk-go-v2/iam v0.11.0
 	github.com/confluentinc/ccloud-sdk-go-v2/identity-provider v0.2.0
 	github.com/confluentinc/ccloud-sdk-go-v2/kafka-quotas v0.4.0
-	github.com/confluentinc/ccloud-sdk-go-v2/kafkarest v0.18.0
+	github.com/confluentinc/ccloud-sdk-go-v2/kafkarest v0.21.0
 	github.com/confluentinc/ccloud-sdk-go-v2/ksql v0.2.0
 	github.com/confluentinc/ccloud-sdk-go-v2/mds v0.4.0
 	github.com/confluentinc/ccloud-sdk-go-v2/metrics v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -194,8 +194,8 @@ github.com/confluentinc/ccloud-sdk-go-v2/identity-provider v0.2.0 h1:9TT8UCFRc5z
 github.com/confluentinc/ccloud-sdk-go-v2/identity-provider v0.2.0/go.mod h1:JLmrXfnT2PzcuXHD8a6c2cW1c9LKK7aMsdZjjqxYPEk=
 github.com/confluentinc/ccloud-sdk-go-v2/kafka-quotas v0.4.0 h1:T9e7lNj/VjxE89+tcpX2RS2NE4rWNWbJjxcO2yehEqM=
 github.com/confluentinc/ccloud-sdk-go-v2/kafka-quotas v0.4.0/go.mod h1:7gqwWFIyj2MAGpL/kf6SGXm/pi2Z6qpMJIjKlgEEhhg=
-github.com/confluentinc/ccloud-sdk-go-v2/kafkarest v0.18.0 h1:RxHzj41V0T9bHtnGNanflGwWP4lA8A1IjVr/09bkuVM=
-github.com/confluentinc/ccloud-sdk-go-v2/kafkarest v0.18.0/go.mod h1:1hTwJlTy/3WPjA6I4tFf3X8RjXRHe0RQhRYfR+gHaqc=
+github.com/confluentinc/ccloud-sdk-go-v2/kafkarest v0.21.0 h1:QXdyHcmx5xuX2D0THt2nJdhQ3YHOuPqoR8JfqalODCs=
+github.com/confluentinc/ccloud-sdk-go-v2/kafkarest v0.21.0/go.mod h1:1hTwJlTy/3WPjA6I4tFf3X8RjXRHe0RQhRYfR+gHaqc=
 github.com/confluentinc/ccloud-sdk-go-v2/ksql v0.2.0 h1:g6OHa1iW3HO3N/YiTAL9Q6Y7rdjMBAjOPYK37akTt0M=
 github.com/confluentinc/ccloud-sdk-go-v2/ksql v0.2.0/go.mod h1:0LAvd4VqlaRwKU4yvDEkVCtV43yNezt56+hBe9Lmg7Q=
 github.com/confluentinc/ccloud-sdk-go-v2/mds v0.4.0 h1:jIXXhGi+Xn+XYFCErnMvd035QijbYXla1Bo8W7V7lFM=

--- a/internal/kafka/command_link.go
+++ b/internal/kafka/command_link.go
@@ -8,8 +8,9 @@ import (
 )
 
 const (
-	configFileFlagName = "config-file"
-	dryrunFlagName     = "dry-run"
+	configFileFlagName           = "config-file"
+	dryrunFlagName               = "dry-run"
+	includePartitionDataFlagName = "include-partitions"
 )
 
 const createdLinkResourceMsg = `Created %s "%s" with configs:`

--- a/internal/kafka/command_mirror.go
+++ b/internal/kafka/command_mirror.go
@@ -19,6 +19,8 @@ type mirrorOut struct {
 	LastSourceFetchOffset    int64  `human:"Last Source Fetch Offset" serialized:"last_source_fetch_offset"`
 	ErrorMessage             string `human:"Error Message" serialized:"error_message"`
 	ErrorCode                string `human:"Error Code" serialized:"error_code"`
+	MessagesTruncated        int64  `human:"Messages Truncated" serialized:"messages_truncated"`
+	OffsetTruncatedTo        string `human:"Offset Truncated To" serialized:"offset_truncated_to"`
 }
 
 type mirrorCommand struct {
@@ -44,6 +46,7 @@ func newMirrorCommand(prerunner pcmd.PreRunner) *cobra.Command {
 	cmd.AddCommand(c.newReverseAndPauseMirrorCommand())
 	cmd.AddCommand(c.newReverseAndStartMirrorCommand())
 	cmd.AddCommand(c.newStateTransitionErrorCommand())
+	cmd.AddCommand(c.newTruncateAndRestoreCommand())
 
 	return cmd
 }

--- a/internal/kafka/command_mirror_truncate_and_restore.go
+++ b/internal/kafka/command_mirror_truncate_and_restore.go
@@ -1,0 +1,69 @@
+package kafka
+
+import (
+	"github.com/spf13/cobra"
+
+	kafkarestv3 "github.com/confluentinc/ccloud-sdk-go-v2/kafkarest/v3"
+
+	pcmd "github.com/confluentinc/cli/v4/pkg/cmd"
+	"github.com/confluentinc/cli/v4/pkg/examples"
+)
+
+func (c *mirrorCommand) newTruncateAndRestoreCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:               "truncate-and-restore <local-topic-1> [local-topic-2] ... [local-topic-N]",
+		Short:             "Truncate topics and restore mirroring.",
+		RunE:              c.truncateAndRestore,
+		Args:              cobra.MinimumNArgs(1),
+		ValidArgsFunction: pcmd.NewValidArgsFunction(c.validArgsMultiple),
+		Example: examples.BuildExampleString(
+			examples.Example{
+				Text: `Truncates and restores local topics for "my-topic-1" and "my-topic-2":`,
+				Code: "confluent kafka mirror truncate-and-restore my-topic-1 my-topic-2 --link my-link",
+			},
+		),
+	}
+
+	pcmd.AddLinkFlag(cmd, c.AuthenticatedCLICommand)
+	cmd.Flags().Bool(dryrunFlagName, false, "If set, does not actually truncate the local topic, but simply validates it.")
+	cmd.Flags().Bool(includePartitionDataFlagName, false, "If set, returns the number of messages truncated per partition.")
+	pcmd.AddClusterFlag(cmd, c.AuthenticatedCLICommand)
+	pcmd.AddContextFlag(cmd, c.CLICommand)
+	pcmd.AddEnvironmentFlag(cmd, c.AuthenticatedCLICommand)
+	pcmd.AddOutputFlag(cmd)
+
+	cobra.CheckErr(cmd.MarkFlagRequired("link"))
+
+	return cmd
+}
+
+func (c *mirrorCommand) truncateAndRestore(cmd *cobra.Command, args []string) error {
+	link, err := cmd.Flags().GetString("link")
+	if err != nil {
+		return err
+	}
+
+	dryRun, err := cmd.Flags().GetBool(dryrunFlagName)
+	if err != nil {
+		return err
+	}
+
+	includePartitionData, err := cmd.Flags().GetBool(includePartitionDataFlagName)
+	if err != nil {
+		return err
+	}
+
+	kafkaREST, err := c.GetKafkaREST()
+	if err != nil {
+		return err
+	}
+
+	data := kafkarestv3.AlterMirrorsRequestData{MirrorTopicNames: &args}
+
+	results, err := kafkaREST.CloudClient.UpdateKafkaTruncateAndRestore(link, dryRun, includePartitionData, data)
+	if err != nil {
+		return err
+	}
+
+	return printAlterMirrorResult(cmd, results)
+}

--- a/pkg/ccloudv2/kafkarest.go
+++ b/pkg/ccloudv2/kafkarest.go
@@ -212,6 +212,14 @@ func (c *KafkaRestClient) UpdateKafkaMirrorTopicsReverseAndPauseMirror(linkName 
 	return res.GetData(), nil
 }
 
+func (c *KafkaRestClient) UpdateKafkaTruncateAndRestore(linkName string, validateOnly bool, includePartitionData bool, data kafkarestv3.AlterMirrorsRequestData) ([]kafkarestv3.AlterMirrorStatusResponseData, error) {
+	res, httpResp, err := c.ClusterLinkingV3Api.UpdateKafkaMirrorTopicsTruncateAndRestoreMirror(c.kafkaRestApiContext(), c.ClusterId, linkName).ValidateOnly(validateOnly).IncludePartitionLevelTruncationData(includePartitionData).AlterMirrorsRequestData(data).Execute()
+	if err != nil {
+		return nil, kafkarest.NewError(c.GetUrl(), err, httpResp)
+	}
+	return res.GetData(), nil
+}
+
 func (c *KafkaRestClient) DeleteKafkaLink(linkName string) error {
 	httpResp, err := c.ClusterLinkingV3Api.DeleteKafkaLink(c.kafkaRestApiContext(), c.ClusterId, linkName).Execute()
 	return kafkarest.NewError(c.GetUrl(), err, httpResp)

--- a/test/fixtures/output/kafka/mirror/help.golden
+++ b/test/fixtures/output/kafka/mirror/help.golden
@@ -14,6 +14,7 @@ Available Commands:
   reverse-and-pause      Reverse local mirror topics and pause remote mirror topics.
   reverse-and-start      Reverse local mirror topics and start remote mirror topics.
   state-transition-error Manages state transition errors.
+  truncate-and-restore   Truncate topics and restore mirroring.
 
 Global Flags:
   -h, --help            Show help for this command.

--- a/test/fixtures/output/kafka/mirror/truncate-and-restore-help.golden
+++ b/test/fixtures/output/kafka/mirror/truncate-and-restore-help.golden
@@ -1,0 +1,23 @@
+Truncate topics and restore mirroring.
+
+Usage:
+  confluent kafka mirror truncate-and-restore <local-topic-1> [local-topic-2] ... [local-topic-N] [flags]
+
+Examples:
+Truncates and restores local topics for "my-topic-1" and "my-topic-2":
+
+  $ confluent kafka mirror truncate-and-restore my-topic-1 my-topic-2 --link my-link
+
+Flags:
+      --link string          REQUIRED: Name of cluster link.
+      --dry-run              If set, does not actually truncate the local topic, but simply validates it.
+      --include-partitions   If set, returns the number of messages truncated per partition.
+      --cluster string       Kafka cluster ID.
+      --context string       CLI context name.
+      --environment string   Environment ID.
+  -o, --output string        Specify the output format as "human", "json", or "yaml". (default "human")
+
+Global Flags:
+  -h, --help            Show help for this command.
+      --unsafe-trace    Equivalent to -vvvv, but also log HTTP requests and responses which might contain plaintext secrets.
+  -v, --verbose count   Increase verbosity (-v for warn, -vv for info, -vvv for debug, -vvvv for trace).

--- a/test/fixtures/output/kafka/mirror/truncate-and-restore-mirror-json.golden
+++ b/test/fixtures/output/kafka/mirror/truncate-and-restore-mirror-json.golden
@@ -1,0 +1,14 @@
+[
+  {
+    "mirror_topic_name": "topic 2",
+    "error_message": "Not authorized",
+    "error_code": "401",
+    "messages_truncated": 0
+  },
+  {
+    "mirror_topic_name": "topic-1",
+    "error_message": "",
+    "error_code": "",
+    "messages_truncated": 50
+  }
+]

--- a/test/fixtures/output/kafka/mirror/truncate-and-restore-mirror-with-partition-data-json.golden
+++ b/test/fixtures/output/kafka/mirror/truncate-and-restore-mirror-with-partition-data-json.golden
@@ -1,0 +1,34 @@
+[
+  {
+    "mirror_topic_name": "topic 2",
+    "partition": -1,
+    "error_message": "Not authorized",
+    "error_code": "401",
+    "messages_truncated": 0,
+    "offset_truncated_to": ""
+  },
+  {
+    "mirror_topic_name": "topic-1",
+    "partition": 0,
+    "error_message": "",
+    "error_code": "",
+    "messages_truncated": 25,
+    "offset_truncated_to": "10"
+  },
+  {
+    "mirror_topic_name": "topic-1",
+    "partition": 1,
+    "error_message": "",
+    "error_code": "",
+    "messages_truncated": 0,
+    "offset_truncated_to": ""
+  },
+  {
+    "mirror_topic_name": "topic-1",
+    "partition": 2,
+    "error_message": "",
+    "error_code": "",
+    "messages_truncated": 25,
+    "offset_truncated_to": "15"
+  }
+]

--- a/test/fixtures/output/kafka/mirror/truncate-and-restore-mirror-with-partition-data-yaml.golden
+++ b/test/fixtures/output/kafka/mirror/truncate-and-restore-mirror-with-partition-data-yaml.golden
@@ -1,0 +1,24 @@
+- mirror_topic_name: topic 2
+  partition: -1
+  error_message: Not authorized
+  error_code: "401"
+  messages_truncated: 0
+  offset_truncated_to: ""
+- mirror_topic_name: topic-1
+  partition: 0
+  error_message: ""
+  error_code: ""
+  messages_truncated: 25
+  offset_truncated_to: "10"
+- mirror_topic_name: topic-1
+  partition: 1
+  error_message: ""
+  error_code: ""
+  messages_truncated: 0
+  offset_truncated_to: ""
+- mirror_topic_name: topic-1
+  partition: 2
+  error_message: ""
+  error_code: ""
+  messages_truncated: 25
+  offset_truncated_to: "15"

--- a/test/fixtures/output/kafka/mirror/truncate-and-restore-mirror-with-partition-data.golden
+++ b/test/fixtures/output/kafka/mirror/truncate-and-restore-mirror-with-partition-data.golden
@@ -1,0 +1,6 @@
+  Mirror Topic Name | Partition | Error Message  | Error Code | Messages Truncated | Offset Truncated To  
+--------------------+-----------+----------------+------------+--------------------+----------------------
+  topic 2           |        -1 | Not authorized | 401        |                  0 |                      
+  topic-1           |         0 |                |            |                 25 | 10                   
+  topic-1           |         1 |                |            |                  0 |                      
+  topic-1           |         2 |                |            |                 25 | 15                   

--- a/test/fixtures/output/kafka/mirror/truncate-and-restore-mirror-yaml.golden
+++ b/test/fixtures/output/kafka/mirror/truncate-and-restore-mirror-yaml.golden
@@ -1,0 +1,8 @@
+- mirror_topic_name: topic 2
+  error_message: Not authorized
+  error_code: "401"
+  messages_truncated: 0
+- mirror_topic_name: topic-1
+  error_message: ""
+  error_code: ""
+  messages_truncated: 50

--- a/test/fixtures/output/kafka/mirror/truncate-and-restore-mirror.golden
+++ b/test/fixtures/output/kafka/mirror/truncate-and-restore-mirror.golden
@@ -1,0 +1,4 @@
+  Mirror Topic Name | Error Message  | Error Code | Messages Truncated  
+--------------------+----------------+------------+---------------------
+  topic 2           | Not authorized | 401        |                  0  
+  topic-1           |                |            |                 50  

--- a/test/kafka_test.go
+++ b/test/kafka_test.go
@@ -362,6 +362,12 @@ func (s *CLITestSuite) TestKafkaMirror() {
 		{args: "kafka mirror resume topic1 topic2 --cluster lkc-describe-topic --link link-1", fixture: "kafka/mirror/resume-mirror.golden", useKafka: "lkc-describe-topic"},
 		{args: "kafka mirror reverse-and-start topic1 topic2 --cluster lkc-describe-topic --link link-1", fixture: "kafka/mirror/reverse-and-start-mirror.golden", useKafka: "lkc-describe-topic"},
 		{args: "kafka mirror reverse-and-pause topic1 topic2 --cluster lkc-describe-topic --link link-1", fixture: "kafka/mirror/reverse-and-pause-mirror.golden", useKafka: "lkc-describe-topic"},
+		{args: "kafka mirror truncate-and-restore topic1 topic2 --cluster lkc-describe-topic --link link-1", fixture: "kafka/mirror/truncate-and-restore-mirror.golden", useKafka: "lkc-describe-topic"},
+		{args: "kafka mirror truncate-and-restore topic1 topic2 --cluster lkc-describe-topic --link link-1 -o json", fixture: "kafka/mirror/truncate-and-restore-mirror-json.golden", useKafka: "lkc-describe-topic"},
+		{args: "kafka mirror truncate-and-restore topic1 topic2 --cluster lkc-describe-topic --link link-1 -o yaml", fixture: "kafka/mirror/truncate-and-restore-mirror-yaml.golden", useKafka: "lkc-describe-topic"},
+		{args: "kafka mirror truncate-and-restore topic1 topic2 --cluster lkc-describe-topic --link link-1 --include-partitions", fixture: "kafka/mirror/truncate-and-restore-mirror-with-partition-data.golden", useKafka: "lkc-describe-topic"},
+		{args: "kafka mirror truncate-and-restore topic1 topic2 --cluster lkc-describe-topic --link link-1 --include-partitions -o json", fixture: "kafka/mirror/truncate-and-restore-mirror-with-partition-data-json.golden", useKafka: "lkc-describe-topic"},
+		{args: "kafka mirror truncate-and-restore topic1 topic2 --cluster lkc-describe-topic --link link-1 --include-partitions -o yaml", fixture: "kafka/mirror/truncate-and-restore-mirror-with-partition-data-yaml.golden", useKafka: "lkc-describe-topic"},
 	}
 
 	for _, test := range tests {

--- a/test/test-server/kafka_rest_router.go
+++ b/test/test-server/kafka_rest_router.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -59,6 +60,7 @@ var kafkaRestRoutes = []route{
 	{"/kafka/v3/clusters/{cluster}/links/{link}/mirrors:resume", handleKafkaRestMirrorsResume},
 	{"/kafka/v3/clusters/{cluster}/links/{link}/mirrors:reverse-and-start-mirror", handleKafkaRestMirrorsReverseAndStart},
 	{"/kafka/v3/clusters/{cluster}/links/{link}/mirrors:reverse-and-pause-mirror", handleKafkaRestMirrorsReverseAndPause},
+	{"/kafka/v3/clusters/{cluster}/links/{link}/mirrors:truncate-and-restore", handleKafkaRestTruncateAndRestore},
 	{"/kafka/v3/clusters/{cluster}/topic/{topic}/partitions/-/replica-status", handleClustersClusterIdTopicsTopicsNamePartitionsReplicaStatus},
 	{"/kafka/v3/clusters/{cluster}/topics", handleKafkaRestTopics},
 	{"/kafka/v3/clusters/{cluster}/topics/{topic}", handleKafkaRestTopic},
@@ -1040,6 +1042,7 @@ func handleKafkaRestLagSummary(t *testing.T) http.HandlerFunc {
 // Handler for: "/kafka/v3/clusters/{cluster_id}/links/{link_name}/mirrors:reverse-and-start-mirror"
 func handleKafkaRestMirrorsReverseAndStart(t *testing.T) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		i := int64(-1)
 		switch r.Method {
 		case http.MethodPost:
 			err := json.NewEncoder(w).Encode(cckafkarestv3.AlterMirrorStatusResponseDataList{Data: []cckafkarestv3.AlterMirrorStatusResponseData{
@@ -1064,6 +1067,10 @@ func handleKafkaRestMirrorsReverseAndStart(t *testing.T) http.HandlerFunc {
 							},
 						},
 					},
+					MessagesTruncated: *cckafkarestv3.NewNullableInt64(&i),
+					PartitionLevelTruncationData: cckafkarestv3.PartitionLevelTruncationDataList{
+						Items: []cckafkarestv3.PartitionLevelTruncationData{},
+					},
 				},
 				{
 					MirrorTopicName: "topic 2",
@@ -1087,6 +1094,10 @@ func handleKafkaRestMirrorsReverseAndStart(t *testing.T) http.HandlerFunc {
 								LastSourceFetchOffset: 5739304,
 							},
 						},
+					},
+					MessagesTruncated: *cckafkarestv3.NewNullableInt64(&i),
+					PartitionLevelTruncationData: cckafkarestv3.PartitionLevelTruncationDataList{
+						Items: []cckafkarestv3.PartitionLevelTruncationData{},
 					},
 				},
 			}})
@@ -1098,6 +1109,7 @@ func handleKafkaRestMirrorsReverseAndStart(t *testing.T) http.HandlerFunc {
 // Handler for: "/kafka/v3/clusters/{cluster_id}/links/{link_name}/mirrors:reverse-and-pause-mirror"
 func handleKafkaRestMirrorsReverseAndPause(t *testing.T) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		i := int64(-1)
 		switch r.Method {
 		case http.MethodPost:
 			err := json.NewEncoder(w).Encode(cckafkarestv3.AlterMirrorStatusResponseDataList{Data: []cckafkarestv3.AlterMirrorStatusResponseData{
@@ -1122,6 +1134,10 @@ func handleKafkaRestMirrorsReverseAndPause(t *testing.T) http.HandlerFunc {
 							},
 						},
 					},
+					MessagesTruncated: *cckafkarestv3.NewNullableInt64(&i),
+					PartitionLevelTruncationData: cckafkarestv3.PartitionLevelTruncationDataList{
+						Items: []cckafkarestv3.PartitionLevelTruncationData{},
+					},
 				},
 				{
 					MirrorTopicName: "topic 2",
@@ -1145,6 +1161,97 @@ func handleKafkaRestMirrorsReverseAndPause(t *testing.T) http.HandlerFunc {
 								LastSourceFetchOffset: 5739304,
 							},
 						},
+					},
+					MessagesTruncated: *cckafkarestv3.NewNullableInt64(&i),
+					PartitionLevelTruncationData: cckafkarestv3.PartitionLevelTruncationDataList{
+						Items: []cckafkarestv3.PartitionLevelTruncationData{},
+					},
+				},
+			}})
+			require.NoError(t, err)
+		}
+	}
+}
+
+// Handler for: "/kafka/v3/clusters/{cluster_id}/links/{link_name}/mirrors:truncate-and-restore"
+func handleKafkaRestTruncateAndRestore(t *testing.T) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		i := int64(-1)
+		i2 := int64(50)
+		switch r.Method {
+		case http.MethodPost:
+			var partitionLevelTruncationData cckafkarestv3.PartitionLevelTruncationDataList
+			if strings.Contains(r.RequestURI, "include_partition_level_truncation_data=true") {
+				partitionLevelTruncationData = cckafkarestv3.PartitionLevelTruncationDataList{
+					Items: []cckafkarestv3.PartitionLevelTruncationData{
+						{
+							PartitionId:       0,
+							MessagesTruncated: int64(25),
+							OffsetTruncatedTo: int64(10),
+						},
+						{
+							PartitionId:       2,
+							MessagesTruncated: int64(25),
+							OffsetTruncatedTo: int64(15),
+						},
+					},
+				}
+			} else {
+				partitionLevelTruncationData = cckafkarestv3.PartitionLevelTruncationDataList{
+					Items: []cckafkarestv3.PartitionLevelTruncationData{},
+				}
+			}
+			err := json.NewEncoder(w).Encode(cckafkarestv3.AlterMirrorStatusResponseDataList{Data: []cckafkarestv3.AlterMirrorStatusResponseData{
+				{
+					MirrorTopicName: "topic-1",
+					MirrorLags: cckafkarestv3.MirrorLags{
+						Items: []cckafkarestv3.MirrorLag{
+							{
+								Partition:             0,
+								Lag:                   142857,
+								LastSourceFetchOffset: 1000,
+							},
+							{
+								Partition:             1,
+								Lag:                   285714,
+								LastSourceFetchOffset: 10000,
+							},
+							{
+								Partition:             2,
+								Lag:                   571428,
+								LastSourceFetchOffset: 100000,
+							},
+						},
+					},
+					MessagesTruncated:            *cckafkarestv3.NewNullableInt64(&i2),
+					PartitionLevelTruncationData: partitionLevelTruncationData,
+				},
+				{
+					MirrorTopicName: "topic 2",
+					ErrorMessage:    *cckafkarestv3.NewNullableString(cckafkarestv3.PtrString("Not authorized")),
+					ErrorCode:       *cckafkarestv3.NewNullableInt32(cckafkarestv3.PtrInt32(401)),
+					MirrorLags: cckafkarestv3.MirrorLags{
+						Items: []cckafkarestv3.MirrorLag{
+							{
+								Partition:             0,
+								Lag:                   142857,
+								LastSourceFetchOffset: 1293009,
+							},
+							{
+								Partition:             1,
+								Lag:                   285714,
+								LastSourceFetchOffset: 28340404,
+							},
+							{
+								Partition:             2,
+								Lag:                   571428,
+								LastSourceFetchOffset: 5739304,
+							},
+						},
+					},
+					MessagesTruncated: *cckafkarestv3.NewNullableInt64(&i),
+					PartitionLevelTruncationData: cckafkarestv3.PartitionLevelTruncationDataList{
+						Items: []cckafkarestv3.PartitionLevelTruncationData{},
 					},
 				},
 			}})
@@ -1156,6 +1263,7 @@ func handleKafkaRestMirrorsReverseAndPause(t *testing.T) http.HandlerFunc {
 // Handler for: "/kafka/v3/clusters/{cluster_id}/links/{link_name}/mirrors:failover"
 func handleKafkaRestMirrorsFailover(t *testing.T) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		i := int64(-1)
 		switch r.Method {
 		case http.MethodPost:
 			err := json.NewEncoder(w).Encode(cckafkarestv3.AlterMirrorStatusResponseDataList{Data: []cckafkarestv3.AlterMirrorStatusResponseData{
@@ -1180,6 +1288,10 @@ func handleKafkaRestMirrorsFailover(t *testing.T) http.HandlerFunc {
 							},
 						},
 					},
+					MessagesTruncated: *cckafkarestv3.NewNullableInt64(&i),
+					PartitionLevelTruncationData: cckafkarestv3.PartitionLevelTruncationDataList{
+						Items: []cckafkarestv3.PartitionLevelTruncationData{},
+					},
 				},
 				{
 					MirrorTopicName: "topic 2",
@@ -1204,6 +1316,10 @@ func handleKafkaRestMirrorsFailover(t *testing.T) http.HandlerFunc {
 							},
 						},
 					},
+					MessagesTruncated: *cckafkarestv3.NewNullableInt64(&i),
+					PartitionLevelTruncationData: cckafkarestv3.PartitionLevelTruncationDataList{
+						Items: []cckafkarestv3.PartitionLevelTruncationData{},
+					},
 				},
 			}})
 			require.NoError(t, err)
@@ -1214,6 +1330,7 @@ func handleKafkaRestMirrorsFailover(t *testing.T) http.HandlerFunc {
 // Handler for: "/kafka/v3/clusters/{cluster_id}/links/{link_name}/mirrors:pause"
 func handleKafkaRestMirrorsPause(t *testing.T) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		i := int64(-1)
 		switch r.Method {
 		case http.MethodPost:
 			err := json.NewEncoder(w).Encode(cckafkarestv3.AlterMirrorStatusResponseDataList{Data: []cckafkarestv3.AlterMirrorStatusResponseData{
@@ -1233,6 +1350,10 @@ func handleKafkaRestMirrorsPause(t *testing.T) http.HandlerFunc {
 							},
 						},
 					},
+					MessagesTruncated: *cckafkarestv3.NewNullableInt64(&i),
+					PartitionLevelTruncationData: cckafkarestv3.PartitionLevelTruncationDataList{
+						Items: []cckafkarestv3.PartitionLevelTruncationData{},
+					},
 				},
 				{
 					MirrorTopicName: "topic 2",
@@ -1257,6 +1378,10 @@ func handleKafkaRestMirrorsPause(t *testing.T) http.HandlerFunc {
 							},
 						},
 					},
+					MessagesTruncated: *cckafkarestv3.NewNullableInt64(&i),
+					PartitionLevelTruncationData: cckafkarestv3.PartitionLevelTruncationDataList{
+						Items: []cckafkarestv3.PartitionLevelTruncationData{},
+					},
 				},
 			}})
 			require.NoError(t, err)
@@ -1267,6 +1392,7 @@ func handleKafkaRestMirrorsPause(t *testing.T) http.HandlerFunc {
 // Handler for: "/kafka/v3/clusters/{cluster_id}/links/{link_name}/mirrors:promote"
 func handleKafkaRestMirrorsPromote(t *testing.T) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		i := int64(-1)
 		switch r.Method {
 		case http.MethodPost:
 			err := json.NewEncoder(w).Encode(cckafkarestv3.AlterMirrorStatusResponseDataList{Data: []cckafkarestv3.AlterMirrorStatusResponseData{
@@ -1290,6 +1416,10 @@ func handleKafkaRestMirrorsPromote(t *testing.T) http.HandlerFunc {
 								LastSourceFetchOffset: 5739304,
 							},
 						},
+					},
+					MessagesTruncated: *cckafkarestv3.NewNullableInt64(&i),
+					PartitionLevelTruncationData: cckafkarestv3.PartitionLevelTruncationDataList{
+						Items: []cckafkarestv3.PartitionLevelTruncationData{},
 					},
 				},
 				{
@@ -1315,6 +1445,10 @@ func handleKafkaRestMirrorsPromote(t *testing.T) http.HandlerFunc {
 							},
 						},
 					},
+					MessagesTruncated: *cckafkarestv3.NewNullableInt64(&i),
+					PartitionLevelTruncationData: cckafkarestv3.PartitionLevelTruncationDataList{
+						Items: []cckafkarestv3.PartitionLevelTruncationData{},
+					},
 				},
 			}})
 			require.NoError(t, err)
@@ -1325,6 +1459,7 @@ func handleKafkaRestMirrorsPromote(t *testing.T) http.HandlerFunc {
 // Handler for: "/kafka/v3/clusters/{cluster_id}/links/{link_name}/mirrors:resume"
 func handleKafkaRestMirrorsResume(t *testing.T) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		i := int64(-1)
 		switch r.Method {
 		case http.MethodPost:
 			err := json.NewEncoder(w).Encode(cckafkarestv3.AlterMirrorStatusResponseDataList{Data: []cckafkarestv3.AlterMirrorStatusResponseData{
@@ -1344,6 +1479,10 @@ func handleKafkaRestMirrorsResume(t *testing.T) http.HandlerFunc {
 							},
 						},
 					},
+					MessagesTruncated: *cckafkarestv3.NewNullableInt64(&i),
+					PartitionLevelTruncationData: cckafkarestv3.PartitionLevelTruncationDataList{
+						Items: []cckafkarestv3.PartitionLevelTruncationData{},
+					},
 				},
 				{
 					MirrorTopicName: "topic 2",
@@ -1367,6 +1506,10 @@ func handleKafkaRestMirrorsResume(t *testing.T) http.HandlerFunc {
 								LastSourceFetchOffset: 5739304,
 							},
 						},
+					},
+					MessagesTruncated: *cckafkarestv3.NewNullableInt64(&i),
+					PartitionLevelTruncationData: cckafkarestv3.PartitionLevelTruncationDataList{
+						Items: []cckafkarestv3.PartitionLevelTruncationData{},
 					},
 				},
 			}})


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

New Features
- Add `confluent kafka mirror truncate-and-restore`

Checklist
---------
- [x] Leave this box unchecked if features are not yet available in production

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->
Added new functionality for Confluent CLI via `truncate-and-restore` command. 

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->
https://confluentinc.atlassian.net/browse/KGLOBAL-5237 and https://confluentinc.atlassian.net/browse/KGLOBAL-5410
Also supersedes https://github.com/confluentinc/cli/pull/2859.

Test & Review
-------------
<!--
Has it been tested? How?
Copy and paste any instructions or steps that can save the reviewer time.
-->
Has been tested via new test cases and with manual e2e testing.