### PR TITLE
Fix URL generation with trailing backspaces

### DIFF
--- a/pkg/flink/cmf_rest_client.go
+++ b/pkg/flink/cmf_rest_client.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"strings"
 
@@ -63,7 +64,10 @@ func NewCmfRestClient(cfg *cmfsdk.Configuration, restFlags *OnPremCMFRestFlagVal
 		if restFlags.url == "" {
 			return nil, perrors.NewErrorWithSuggestions("url is required", "Specify a URL with `--url` or set the variable \"CONFLUENT_CMF_URL\" in place of this flag.")
 		}
-		cfg.BasePath = restFlags.url + "/cmf/api/v1"
+		cfg.BasePath, err = url.JoinPath(restFlags.url, "/cmf/api/v1")
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	cfg.HTTPClient, err = NewCmfRestHttpClient(restFlags)


### PR DESCRIPTION
Release Notes
-------------
```
$ ./confluent_4.7.0_darwin_arm64 flink environment list --url http://localhost:8080/
Error: failed to list environments: {"errors":[{"message":"No static resource cmf/api/v1/environments."}]}
```
doesn't work but

```
$ ./confluent_4.7.0_darwin_arm64 flink environment list --url http://localhost:8080
None found.
```

works

This PR ensures that both the ways of specifying the URL work

Breaking Changes
- PLACEHOLDER

New Features
- PLACEHOLDER

Bug Fixes
- PLACEHOLDER

Checklist
---------
- [ ] Leave this box unchecked if features are not yet available in production

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
`make test` passes