### PR TITLE
Passes CLI version info to flink APIs

### DIFF
--- a/internal/flink/command_application_webui.go
+++ b/internal/flink/command_application_webui.go
@@ -70,7 +70,7 @@ func (c *command) applicationWebUiForward(cmd *cobra.Command, args []string) err
 	}
 
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		handleRequest(w, r, url, environment, applicationName, client)
+		handleRequest(w, r, url, environment, applicationName, cmfClient.APIClient.GetConfig().UserAgent, client)
 	})
 
 	listener, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
@@ -85,7 +85,7 @@ func (c *command) applicationWebUiForward(cmd *cobra.Command, args []string) err
 	return nil
 }
 
-func handleRequest(userResponseWriter http.ResponseWriter, userRequest *http.Request, url, environmentName, applicationName string, client *http.Client) {
+func handleRequest(userResponseWriter http.ResponseWriter, userRequest *http.Request, url, environmentName, applicationName, userAgent string, client *http.Client) {
 	body, err := io.ReadAll(userRequest.Body)
 	if err != nil {
 		http.Error(userResponseWriter, fmt.Sprintf("Failed to read request body: %s", err), http.StatusInternalServerError)
@@ -99,6 +99,7 @@ func handleRequest(userResponseWriter http.ResponseWriter, userRequest *http.Req
 		return
 	}
 	reqToCmf.Header = userRequest.Header
+	reqToCmf.Header.Set("x-confluent-cli-version", userAgent)
 
 	resFromCmf, err := client.Do(reqToCmf)
 	if err != nil {

--- a/pkg/cmd/cli_command.go
+++ b/pkg/cmd/cli_command.go
@@ -41,6 +41,7 @@ func (c *CLICommand) GetCmfClient(cmd *cobra.Command) (*flink.CmfRestClient, err
 			return nil, err
 		}
 		cfg.Debug = unsafeTrace
+		cfg.UserAgent = c.Version.UserAgent
 
 		restFlags, err := flink.ResolveOnPremCmfRestFlags(cmd)
 		if err != nil {


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

We want to be able to pass the CLI version information to the backend server for CMF to perform compatibility checks.
All the commands except `web-ui-forward` use a SDK which sets up the `UserAgent` header. We simply pass the value of the version to the same header.
In case of `web-ui-forward`, since the origin of the calls will be from user's browser, we did not want to override the user agent header as it might be used by browsers for checks of their own, we have introduced a new header for just that API. 

Validation

- I have verified that the version is being propagated into the request by using `ldflags` and validating that it has the same behaviour for the flink commands as the base `version` command 
```
> go run -ldflags "-X main.version=1.2.0" cmd/confluent/main.go  flink environment list --unsafe-trace
2024/10/15 22:21:27
GET /cmf/api/v1/environments?page=0&size=100 HTTP/1.1
Host: localhost:8080
User-Agent: Confluent-CLI/v1.2.0 (https://confluent.io; support@confluent.io)
Accept: application/json
Accept-Encoding: gzip

> go run  -ldflags "-X main.version=1.2.0" cmd/confluent/main.go --version
confluent version v1.2.0
```


Breaking Changes
- PLACEHOLDER

New Features
- PLACEHOLDER

Bug Fixes
- PLACEHOLDER

Checklist
---------
- [ ] Leave this box unchecked if features are not yet available in production

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
<!--
Has it been tested? How?
Copy and paste any instructions or steps that can save the reviewer time.
-->