### PR TITLE
Fixes issue when application attributes are null

### DIFF
--- a/internal/flink/command_application_list.go
+++ b/internal/flink/command_application_list.go
@@ -5,6 +5,7 @@ import (
 
 	pcmd "github.com/confluentinc/cli/v4/pkg/cmd"
 	"github.com/confluentinc/cli/v4/pkg/output"
+	cmfsdk "github.com/confluentinc/cmf-sdk-go/v1"
 )
 
 func (c *command) newApplicationListCommand() *cobra.Command {
@@ -43,23 +44,42 @@ func (c *command) applicationList(cmd *cobra.Command, _ []string) error {
 	if output.GetFormat(cmd) == output.Human {
 		list := output.NewList(cmd)
 		for _, app := range applications {
-			jobStatus, ok := app.Status["jobStatus"].(map[string]any)
-			if !ok {
-				jobStatus = map[string]any{}
-			}
-			envInApp, ok := app.Spec["environment"].(string)
-			if !ok {
-				envInApp = environment
-			}
-			list.Add(&flinkApplicationSummaryOut{
-				Name:        app.Metadata["name"].(string),
-				Environment: envInApp,
-				JobName:     jobStatus["jobName"].(string),
-				JobStatus:   jobStatus["state"].(string),
-			})
+			appSummary := populateFlinkApplicationSummaryOut(app, environment)
+			list.Add(appSummary)
 		}
 		return list.Print()
 	}
 	// if the output format is not human, we serialize the output as it is (JSON or YAML)
 	return output.SerializedOutput(cmd, applications)
+}
+
+func populateFlinkApplicationSummaryOut(application cmfsdk.Application, envFromFlag string) *flinkApplicationSummaryOut {
+	var appSummary *flinkApplicationSummaryOut
+
+	var jobStatus map[string]any = getOrDefault(application.Status, "jobStatus", map[string]any{})
+	jobNameString := getOrDefault(jobStatus, "jobName", "")
+	jobStatusString := getOrDefault(jobStatus, "state", "")
+	name := getOrDefault(application.Metadata, "name", "")
+	environment := getOrDefault(application.Spec, "environment", envFromFlag)
+
+	appSummary = &flinkApplicationSummaryOut{
+		Name:        name,
+		Environment: environment,
+		JobName:     jobNameString,
+		JobStatus:   jobStatusString,
+	}
+
+	return appSummary
+}
+
+func getOrDefault[T any](m map[string]any, key string, d T) T {
+	value, ok := m[key]
+	if !ok {
+		return d
+	}
+	valueCast, ok := value.(T)
+	if !ok {
+		return d
+	}
+	return valueCast
 }


### PR DESCRIPTION
Release Notes
-------------
In the `flink application list --output human` command, we did not have null check on the properties we want to show in the application summary command. But this is a valid situation, when application is created, it can have `jobName` as null till it starts and same for status. 

This PR adds check on those attributes.

Note: `json` and `yaml` output works fine 

Breaking Changes
- PLACEHOLDER

New Features
- PLACEHOLDER

Bug Fixes
- PLACEHOLDER

Checklist
---------
- [ ] Leave this box unchecked if features are not yet available in production

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
<!--
Has it been tested? How?
Copy and paste any instructions or steps that can save the reviewer time.
-->