### PR TITLE
[CLI-3262] - CLI: Flink carry over offset onboarding in Flink Statement API

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/confluentinc/ccloud-sdk-go-v2/connect-custom-plugin v0.0.6
 	github.com/confluentinc/ccloud-sdk-go-v2/flink v0.9.0
 	github.com/confluentinc/ccloud-sdk-go-v2/flink-artifact v0.1.0
-	github.com/confluentinc/ccloud-sdk-go-v2/flink-gateway v0.12.0
+	github.com/confluentinc/ccloud-sdk-go-v2/flink-gateway v0.17.0
 	github.com/confluentinc/ccloud-sdk-go-v2/iam v0.11.0
 	github.com/confluentinc/ccloud-sdk-go-v2/identity-provider v0.2.0
 	github.com/confluentinc/ccloud-sdk-go-v2/kafka-quotas v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -188,6 +188,8 @@ github.com/confluentinc/ccloud-sdk-go-v2/flink-artifact v0.1.0 h1:2QuFhvrfU4Adxy
 github.com/confluentinc/ccloud-sdk-go-v2/flink-artifact v0.1.0/go.mod h1:cl7LEL6bFgiXQ+8sEZvo3BrYZxDOvGkx4jV7eX1ssN4=
 github.com/confluentinc/ccloud-sdk-go-v2/flink-gateway v0.12.0 h1:fra7uBCCtYkUFtHb6ununxMWqYuVonG52t1mV9o7qRE=
 github.com/confluentinc/ccloud-sdk-go-v2/flink-gateway v0.12.0/go.mod h1:cJ6erfVlWSyz6L+2dR46cF2+s5I2r+pTNrPm2fNbcqU=
+github.com/confluentinc/ccloud-sdk-go-v2/flink-gateway v0.17.0 h1:8Y1uXjolI2d5mawcfLn4OfJ81WRMQpjMFWdBm3dLdrk=
+github.com/confluentinc/ccloud-sdk-go-v2/flink-gateway v0.17.0/go.mod h1:cJ6erfVlWSyz6L+2dR46cF2+s5I2r+pTNrPm2fNbcqU=
 github.com/confluentinc/ccloud-sdk-go-v2/iam v0.11.0 h1:ZUAow4L6De1FwYoiwvEodm4lvxc+46wNW+IEAb7K9VU=
 github.com/confluentinc/ccloud-sdk-go-v2/iam v0.11.0/go.mod h1:2Lm82ly9Yh5LLhp8OTnUGqjz4JdIXAZ5a0/u9T+rGGU=
 github.com/confluentinc/ccloud-sdk-go-v2/identity-provider v0.2.0 h1:9TT8UCFRc5zUdsE7UgMz7hqN+2KYnIkBcAKCaiZJrXw=

--- a/internal/flink/command_statement.go
+++ b/internal/flink/command_statement.go
@@ -9,12 +9,14 @@ import (
 )
 
 type statementOut struct {
-	CreationDate time.Time `human:"Creation Date" serialized:"creation_date"`
-	Name         string    `human:"Name" serialized:"name"`
-	Statement    string    `human:"Statement" serialized:"statement"`
-	ComputePool  string    `human:"Compute Pool" serialized:"compute_pool"`
-	Status       string    `human:"Status" serialized:"status"`
-	StatusDetail string    `human:"Status Detail,omitempty" serialized:"status_detail,omitempty"`
+	CreationDate           time.Time         `human:"Creation Date" serialized:"creation_date"`
+	Name                   string            `human:"Name" serialized:"name"`
+	Statement              string            `human:"Statement" serialized:"statement"`
+	ComputePool            string            `human:"Compute Pool" serialized:"compute_pool"`
+	Status                 string            `human:"Status" serialized:"status"`
+	StatusDetail           string            `human:"Status Detail,omitempty" serialized:"status_detail,omitempty"`
+	LatestOffsets          map[string]string `human:"Latest Offsets" serialized:"latest_offsets"`
+	LatestOffsetsTimestamp *time.Time        `human:"Latest Offsets Timestamp" serialized:"latest_offsets_timestamp"`
 }
 
 func (c *command) newStatementCommand() *cobra.Command {

--- a/internal/flink/command_statement_create.go
+++ b/internal/flink/command_statement_create.go
@@ -148,5 +148,6 @@ func (c *command) statementCreate(cmd *cobra.Command, args []string) error {
 		Status:       statement.Status.GetPhase(),
 		StatusDetail: statement.Status.GetDetail(),
 	})
+	table.Filter([]string{"CreationDate", "Name", "Statement", "ComputePool", "Status", "StatusDetail"})
 	return table.Print()
 }

--- a/internal/flink/command_statement_describe.go
+++ b/internal/flink/command_statement_describe.go
@@ -1,10 +1,11 @@
 package flink
 
 import (
-	flinkgatewayv1 "github.com/confluentinc/ccloud-sdk-go-v2/flink-gateway/v1"
 	"time"
 
 	"github.com/spf13/cobra"
+
+	flinkgatewayv1 "github.com/confluentinc/ccloud-sdk-go-v2/flink-gateway/v1"
 
 	pcmd "github.com/confluentinc/cli/v4/pkg/cmd"
 	"github.com/confluentinc/cli/v4/pkg/output"

--- a/internal/flink/command_statement_describe.go
+++ b/internal/flink/command_statement_describe.go
@@ -1,6 +1,7 @@
 package flink
 
 import (
+	flinkgatewayv1 "github.com/confluentinc/ccloud-sdk-go-v2/flink-gateway/v1"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -10,14 +11,16 @@ import (
 )
 
 type describeStatementOut struct {
-	CreationDate time.Time         `human:"Creation Date" serialized:"creation_date"`
-	Name         string            `human:"Name" serialized:"name"`
-	Statement    string            `human:"Statement" serialized:"statement"`
-	ComputePool  string            `human:"Compute Pool" serialized:"compute_pool"`
-	Status       string            `human:"Status" serialized:"status"`
-	StatusDetail string            `human:"Status Detail,omitempty" serialized:"status_detail,omitempty"`
-	Properties   map[string]string `human:"Properties" serialized:"properties"`
-	Principal    string            `human:"Principal" serialized:"principal"`
+	CreationDate           time.Time         `human:"Creation Date" serialized:"creation_date"`
+	Name                   string            `human:"Name" serialized:"name"`
+	Statement              string            `human:"Statement" serialized:"statement"`
+	ComputePool            string            `human:"Compute Pool" serialized:"compute_pool"`
+	Status                 string            `human:"Status" serialized:"status"`
+	StatusDetail           string            `human:"Status Detail,omitempty" serialized:"status_detail,omitempty"`
+	LatestOffsets          map[string]string `human:"Latest Offsets" serialized:"latest_offsets"`
+	LatestOffsetsTimestamp *time.Time        `human:"Latest Offsets Timestamp" serialized:"latest_offsets_timestamp"`
+	Properties             map[string]string `human:"Properties" serialized:"properties"`
+	Principal              string            `human:"Principal" serialized:"principal"`
 }
 
 func (c *command) newStatementDescribeCommand() *cobra.Command {
@@ -56,14 +59,16 @@ func (c *command) statementDescribe(cmd *cobra.Command, args []string) error {
 
 	table := output.NewTable(cmd)
 	table.Add(&describeStatementOut{
-		CreationDate: statement.Metadata.GetCreatedAt(),
-		Name:         statement.GetName(),
-		Statement:    statement.Spec.GetStatement(),
-		ComputePool:  statement.Spec.GetComputePoolId(),
-		Status:       statement.Status.GetPhase(),
-		StatusDetail: statement.Status.GetDetail(),
-		Properties:   statement.Spec.GetProperties(),
-		Principal:    statement.Spec.GetPrincipal(),
+		CreationDate:           statement.Metadata.GetCreatedAt(),
+		Name:                   statement.GetName(),
+		Statement:              statement.Spec.GetStatement(),
+		ComputePool:            statement.Spec.GetComputePoolId(),
+		Status:                 statement.Status.GetPhase(),
+		StatusDetail:           statement.Status.GetDetail(),
+		LatestOffsets:          statement.Status.GetLatestOffsets(),
+		LatestOffsetsTimestamp: flinkgatewayv1.PtrTime(statement.Status.GetLatestOffsetsTimestamp()),
+		Properties:             statement.Spec.GetProperties(),
+		Principal:              statement.Spec.GetPrincipal(),
 	})
 	return table.Print()
 }

--- a/internal/flink/command_statement_list.go
+++ b/internal/flink/command_statement_list.go
@@ -94,12 +94,14 @@ func (c *command) statementList(cmd *cobra.Command, _ []string) error {
 	list := output.NewList(cmd)
 	for _, statement := range statements {
 		list.Add(&statementOut{
-			CreationDate: statement.Metadata.GetCreatedAt(),
-			Name:         statement.GetName(),
-			Statement:    statement.Spec.GetStatement(),
-			ComputePool:  statement.Spec.GetComputePoolId(),
-			Status:       statement.Status.GetPhase(),
-			StatusDetail: statement.Status.GetDetail(),
+			CreationDate:           statement.Metadata.GetCreatedAt(),
+			Name:                   statement.GetName(),
+			Statement:              statement.Spec.GetStatement(),
+			ComputePool:            statement.Spec.GetComputePoolId(),
+			Status:                 statement.Status.GetPhase(),
+			StatusDetail:           statement.Status.GetDetail(),
+			LatestOffsets:          statement.Status.GetLatestOffsets(),
+			LatestOffsetsTimestamp: flinkgatewayv1.PtrTime(statement.Status.GetLatestOffsetsTimestamp()),
 		})
 	}
 	return list.Print()

--- a/test/fixtures/output/flink/connectivity-type/list-public.golden
+++ b/test/fixtures/output/flink/connectivity-type/list-public.golden
@@ -1,4 +1,4 @@
-          Creation Date         |         Name         |     Statement      | Compute Pool |  Status   |       Status Detail         
---------------------------------+----------------------+--------------------+--------------+-----------+-----------------------------
-  2022-01-01 00:00:00 +0000 UTC | 22222222-2222-2222-2 | CREATE TABLE test; | lfcp-123456  | COMPLETED | SQL statement is completed  
-  2023-01-01 00:00:00 +0000 UTC | 11111111-1111-1111-1 | CREATE TABLE test; | lfcp-123456  | COMPLETED | SQL statement is completed  
+          Creation Date         |         Name         |     Statement      | Compute Pool |  Status   |       Status Detail        |                     Latest Offsets                      |   Latest Offsets Timestamp     
+--------------------------------+----------------------+--------------------+--------------+-----------+----------------------------+---------------------------------------------------------+--------------------------------
+  2022-01-01 00:00:00 +0000 UTC | 22222222-2222-2222-2 | CREATE TABLE test; | lfcp-123456  | COMPLETED | SQL statement is completed | customers_source=partition:0,offset:9223372036854775808 | 2022-01-01 00:00:00 +0000 UTC  
+  2023-01-01 00:00:00 +0000 UTC | 11111111-1111-1111-1 | CREATE TABLE test; | lfcp-123456  | COMPLETED | SQL statement is completed | customers_source=partition:0,offset:9223372036854775808 | 2022-01-01 00:00:00 +0000 UTC  

--- a/test/fixtures/output/flink/statement/describe-yaml.golden
+++ b/test/fixtures/output/flink/statement/describe-yaml.golden
@@ -4,6 +4,9 @@ statement: CREATE TABLE test;
 compute_pool: lfcp-123456
 status: COMPLETED
 status_detail: SQL statement is completed
+latest_offsets:
+    customers_source: partition:0,offset:9223372036854775808
+latest_offsets_timestamp: 2022-01-01T00:00:00Z
 properties:
     sql.current-catalog: default
     sql.current-database: my-cluster

--- a/test/fixtures/output/flink/statement/describe.golden
+++ b/test/fixtures/output/flink/statement/describe.golden
@@ -1,11 +1,13 @@
-+---------------+---------------------------------+
-| Creation Date | 2022-01-01 00:00:00 +0000 UTC   |
-| Name          | my-statement                    |
-| Statement     | CREATE TABLE test;              |
-| Compute Pool  | lfcp-123456                     |
-| Status        | COMPLETED                       |
-| Status Detail | SQL statement is completed      |
-| Properties    | sql.current-catalog=default     |
-|               | sql.current-database=my-cluster |
-| Principal     | u-123456                        |
-+---------------+---------------------------------+
++--------------------------+---------------------------------------------------------+
+| Creation Date            | 2022-01-01 00:00:00 +0000 UTC                           |
+| Name                     | my-statement                                            |
+| Statement                | CREATE TABLE test;                                      |
+| Compute Pool             | lfcp-123456                                             |
+| Status                   | COMPLETED                                               |
+| Status Detail            | SQL statement is completed                              |
+| Latest Offsets           | customers_source=partition:0,offset:9223372036854775808 |
+| Latest Offsets Timestamp | 2022-01-01 00:00:00 +0000 UTC                           |
+| Properties               | sql.current-catalog=default                             |
+|                          | sql.current-database=my-cluster                         |
+| Principal                | u-123456                                                |
++--------------------------+---------------------------------------------------------+

--- a/test/fixtures/output/flink/statement/list-completed.golden
+++ b/test/fixtures/output/flink/statement/list-completed.golden
@@ -1,4 +1,4 @@
-          Creation Date         |         Name         |     Statement      | Compute Pool |  Status   |       Status Detail         
---------------------------------+----------------------+--------------------+--------------+-----------+-----------------------------
-  2022-01-01 00:00:00 +0000 UTC | 22222222-2222-2222-2 | CREATE TABLE test; | lfcp-123456  | COMPLETED | SQL statement is completed  
-  2023-01-01 00:00:00 +0000 UTC | 11111111-1111-1111-1 | CREATE TABLE test; | lfcp-123456  | COMPLETED | SQL statement is completed  
+          Creation Date         |         Name         |     Statement      | Compute Pool |  Status   |       Status Detail        |                     Latest Offsets                      |   Latest Offsets Timestamp     
+--------------------------------+----------------------+--------------------+--------------+-----------+----------------------------+---------------------------------------------------------+--------------------------------
+  2022-01-01 00:00:00 +0000 UTC | 22222222-2222-2222-2 | CREATE TABLE test; | lfcp-123456  | COMPLETED | SQL statement is completed | customers_source=partition:0,offset:9223372036854775808 | 2022-01-01 00:00:00 +0000 UTC  
+  2023-01-01 00:00:00 +0000 UTC | 11111111-1111-1111-1 | CREATE TABLE test; | lfcp-123456  | COMPLETED | SQL statement is completed | customers_source=partition:0,offset:9223372036854775808 | 2022-01-01 00:00:00 +0000 UTC  

--- a/test/fixtures/output/flink/statement/list-yaml.golden
+++ b/test/fixtures/output/flink/statement/list-yaml.golden
@@ -4,9 +4,15 @@
   compute_pool: lfcp-123456
   status: COMPLETED
   status_detail: SQL statement is completed
+  latest_offsets:
+    customers_source: partition:0,offset:9223372036854775808
+  latest_offsets_timestamp: 2022-01-01T00:00:00Z
 - creation_date: 2023-01-01T00:00:00Z
   name: 11111111-1111-1111-1
   statement: CREATE TABLE test;
   compute_pool: lfcp-123456
   status: COMPLETED
   status_detail: SQL statement is completed
+  latest_offsets:
+    customers_source: partition:0,offset:9223372036854775808
+  latest_offsets_timestamp: 2022-01-01T00:00:00Z

--- a/test/fixtures/output/flink/statement/list.golden
+++ b/test/fixtures/output/flink/statement/list.golden
@@ -1,4 +1,4 @@
-          Creation Date         |         Name         |     Statement      | Compute Pool |  Status   |       Status Detail         
---------------------------------+----------------------+--------------------+--------------+-----------+-----------------------------
-  2022-01-01 00:00:00 +0000 UTC | 22222222-2222-2222-2 | CREATE TABLE test; | lfcp-123456  | COMPLETED | SQL statement is completed  
-  2023-01-01 00:00:00 +0000 UTC | 11111111-1111-1111-1 | CREATE TABLE test; | lfcp-123456  | COMPLETED | SQL statement is completed  
+          Creation Date         |         Name         |     Statement      | Compute Pool |  Status   |       Status Detail        |                     Latest Offsets                      |   Latest Offsets Timestamp     
+--------------------------------+----------------------+--------------------+--------------+-----------+----------------------------+---------------------------------------------------------+--------------------------------
+  2022-01-01 00:00:00 +0000 UTC | 22222222-2222-2222-2 | CREATE TABLE test; | lfcp-123456  | COMPLETED | SQL statement is completed | customers_source=partition:0,offset:9223372036854775808 | 2022-01-01 00:00:00 +0000 UTC  
+  2023-01-01 00:00:00 +0000 UTC | 11111111-1111-1111-1 | CREATE TABLE test; | lfcp-123456  | COMPLETED | SQL statement is completed | customers_source=partition:0,offset:9223372036854775808 | 2022-01-01 00:00:00 +0000 UTC  

--- a/test/test-server/flink_gateway_router.go
+++ b/test/test-server/flink_gateway_router.go
@@ -136,8 +136,12 @@ func handleSqlEnvironmentsEnvironmentStatements(t *testing.T) http.HandlerFunc {
 				Status: &flinkgatewayv1.SqlV1StatementStatus{
 					Phase:  "COMPLETED",
 					Detail: flinkgatewayv1.PtrString("SQL statement is completed"),
+					LatestOffsets: &map[string]string{
+						"customers_source": "partition:0,offset:9223372036854775808",
+					},
+					LatestOffsetsTimestamp: flinkgatewayv1.PtrTime(time.Date(2022, 1, 1, 0, 0, 0, 0, time.UTC)),
 				},
-				Metadata: &flinkgatewayv1.ObjectMeta{CreatedAt: flinkgatewayv1.PtrTime(time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC))},
+				Metadata: &flinkgatewayv1.StatementObjectMeta{CreatedAt: flinkgatewayv1.PtrTime(time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC))},
 			}, {
 				Name: flinkgatewayv1.PtrString("22222222-2222-2222-2"),
 				Spec: &flinkgatewayv1.SqlV1StatementSpec{
@@ -147,8 +151,12 @@ func handleSqlEnvironmentsEnvironmentStatements(t *testing.T) http.HandlerFunc {
 				Status: &flinkgatewayv1.SqlV1StatementStatus{
 					Phase:  "COMPLETED",
 					Detail: flinkgatewayv1.PtrString("SQL statement is completed"),
+					LatestOffsets: &map[string]string{
+						"customers_source": "partition:0,offset:9223372036854775808",
+					},
+					LatestOffsetsTimestamp: flinkgatewayv1.PtrTime(time.Date(2022, 1, 1, 0, 0, 0, 0, time.UTC)),
 				},
-				Metadata: &flinkgatewayv1.ObjectMeta{CreatedAt: flinkgatewayv1.PtrTime(time.Date(2022, 1, 1, 0, 0, 0, 0, time.UTC))},
+				Metadata: &flinkgatewayv1.StatementObjectMeta{CreatedAt: flinkgatewayv1.PtrTime(time.Date(2022, 1, 1, 0, 0, 0, 0, time.UTC))},
 			}}}
 
 			err := json.NewEncoder(w).Encode(statements)
@@ -158,7 +166,7 @@ func handleSqlEnvironmentsEnvironmentStatements(t *testing.T) http.HandlerFunc {
 			err := json.NewDecoder(r.Body).Decode(statement)
 			require.NoError(t, err)
 
-			statement.Metadata = &flinkgatewayv1.ObjectMeta{CreatedAt: flinkgatewayv1.PtrTime(time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC))}
+			statement.Metadata = &flinkgatewayv1.StatementObjectMeta{CreatedAt: flinkgatewayv1.PtrTime(time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC))}
 			statement.Spec.ComputePoolId = flinkgatewayv1.PtrString("lfcp-123456")
 			statement.Status = &flinkgatewayv1.SqlV1StatementStatus{Phase: "PENDING"}
 
@@ -203,8 +211,12 @@ func handleSqlEnvironmentsEnvironmentStatementsStatement(t *testing.T) http.Hand
 			Status: &flinkgatewayv1.SqlV1StatementStatus{
 				Phase:  "COMPLETED",
 				Detail: flinkgatewayv1.PtrString("SQL statement is completed"),
+				LatestOffsets: &map[string]string{
+					"customers_source": "partition:0,offset:9223372036854775808",
+				},
+				LatestOffsetsTimestamp: flinkgatewayv1.PtrTime(time.Date(2022, 1, 1, 0, 0, 0, 0, time.UTC)),
 			},
-			Metadata: &flinkgatewayv1.ObjectMeta{CreatedAt: flinkgatewayv1.PtrTime(time.Date(2022, 1, 1, 0, 0, 0, 0, time.UTC))},
+			Metadata: &flinkgatewayv1.StatementObjectMeta{CreatedAt: flinkgatewayv1.PtrTime(time.Date(2022, 1, 1, 0, 0, 0, 0, time.UTC))},
 		}
 
 		err := json.NewEncoder(w).Encode(statement)


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

New Features
- Added `LatestOffsets` and `LatestOffsetsTimestamp` fields to the `flink statement describe` and `flink statement list` commands

Checklist
---------
- [x] Leave this box unchecked if features are not yet available in production

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->

Flink carry over offset onboarding in Flink Statement API

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->
https://confluentinc.atlassian.net/browse/CLI-3262

Test & Review
-------------
<!--
Has it been tested? How?
Copy and paste any instructions or steps that can save the reviewer time.
-->
Wrote integration tests and tested it manually