### PR TITLE
Handles not found errors with more suggestions

### DIFF
--- a/internal/flink/command_application_delete.go
+++ b/internal/flink/command_application_delete.go
@@ -5,6 +5,7 @@ import (
 
 	pcmd "github.com/confluentinc/cli/v4/pkg/cmd"
 	"github.com/confluentinc/cli/v4/pkg/deletion"
+	"github.com/confluentinc/cli/v4/pkg/errors"
 	"github.com/confluentinc/cli/v4/pkg/resource"
 )
 
@@ -41,7 +42,11 @@ func (c *command) applicationDelete(cmd *cobra.Command, args []string) error {
 	}
 
 	if err := deletion.ValidateAndConfirm(cmd, args, existenceFunc, resource.FlinkApplication); err != nil {
-		return err
+		// We are validating only the existence of the resources (there is no prefix validation).
+		// Thus we can add some extra context for the error.
+		suggestions := "List available Flink applications with `confluent flink application list`."
+		suggestions += "\nCheck that CMF is running and accessible."
+		return errors.NewErrorWithSuggestions(err.Error(), suggestions)
 	}
 
 	deleteFunc := func(name string) error {

--- a/internal/flink/command_application_webui.go
+++ b/internal/flink/command_application_webui.go
@@ -56,7 +56,7 @@ func (c *command) applicationWebUiForward(cmd *cobra.Command, args []string) err
 	applicationName := args[0]
 	_, err = cmfClient.DescribeApplication(cmd.Context(), environment, applicationName)
 	if err != nil {
-		return fmt.Errorf(`application "%s" does not exist in the environment "%s" or environment "%s" does not exist`, applicationName, environment, environment)
+		return fmt.Errorf(`failed to forward web UI: %s`, err)
 	}
 
 	restFlags, err := flink.ResolveOnPremCmfRestFlags(cmd)

--- a/internal/flink/command_environment_delete.go
+++ b/internal/flink/command_environment_delete.go
@@ -5,6 +5,7 @@ import (
 
 	pcmd "github.com/confluentinc/cli/v4/pkg/cmd"
 	"github.com/confluentinc/cli/v4/pkg/deletion"
+	"github.com/confluentinc/cli/v4/pkg/errors"
 	"github.com/confluentinc/cli/v4/pkg/resource"
 )
 
@@ -35,7 +36,11 @@ func (c *command) environmentDelete(cmd *cobra.Command, args []string) error {
 	}
 
 	if err := deletion.ValidateAndConfirm(cmd, args, existenceFunc, resource.FlinkEnvironment); err != nil {
-		return err
+		// We are validating only the existence of the resources (there is no prefix validation). Thus we can
+		// add some extra context for the error.
+		suggestions := "List available Flink environments with `confluent flink environment list`."
+		suggestions += "\nCheck that CMF is running and accessible."
+		return errors.NewErrorWithSuggestions(err.Error(), suggestions)
 	}
 
 	deleteFunc := func(name string) error {

--- a/test/fixtures/input/flink/application/update-with-get-failure.json
+++ b/test/fixtures/input/flink/application/update-with-get-failure.json
@@ -1,0 +1,10 @@
+{
+    "apiVersion": "cmf.confluent.io/v1alpha1",
+    "kind": "FlinkApplication",
+    "metadata": {
+        "name": "get-failure"
+    },
+    "spec": {
+        "serviceAccount": "flink-new-service-account"
+    }
+}

--- a/test/fixtures/output/flink/application/delete-mixed.golden
+++ b/test/fixtures/output/flink/application/delete-mixed.golden
@@ -2,3 +2,4 @@ Error: Flink applications "default-application-1" and "non-existent" not found
 
 Suggestions:
     List available Flink applications with `confluent flink application list`.
+    Check that CMF is running and accessible.

--- a/test/fixtures/output/flink/application/delete-non-existent-app.golden
+++ b/test/fixtures/output/flink/application/delete-non-existent-app.golden
@@ -2,3 +2,4 @@ Error: Flink application "non-existent" not found
 
 Suggestions:
     List available Flink applications with `confluent flink application list`.
+    Check that CMF is running and accessible.

--- a/test/fixtures/output/flink/application/delete-non-existent-env.golden
+++ b/test/fixtures/output/flink/application/delete-non-existent-env.golden
@@ -2,3 +2,4 @@ Error: Flink application "default-application-1" not found
 
 Suggestions:
     List available Flink applications with `confluent flink application list`.
+    Check that CMF is running and accessible.

--- a/test/fixtures/output/flink/application/forward-get-failure.golden
+++ b/test/fixtures/output/flink/application/forward-get-failure.golden
@@ -1,0 +1,1 @@
+Error: failed to forward web UI: failed to describe application "get-failure" in the environment "default": 422 Unprocessable Entity

--- a/test/fixtures/output/flink/application/forward-nonexistent-application.golden
+++ b/test/fixtures/output/flink/application/forward-nonexistent-application.golden
@@ -1,1 +1,1 @@
-Error: application "non-existent" does not exist in the environment "default" or environment "default" does not exist
+Error: failed to forward web UI: failed to describe application "non-existent" in the environment "default": Application not found

--- a/test/fixtures/output/flink/application/forward-nonexistent-environment.golden
+++ b/test/fixtures/output/flink/application/forward-nonexistent-environment.golden
@@ -1,0 +1,1 @@
+Error: failed to forward web UI: failed to describe application "default-application-1" in the environment "non-existent": Environment not found

--- a/test/fixtures/output/flink/application/update-with-get-failure.golden
+++ b/test/fixtures/output/flink/application/update-with-get-failure.golden
@@ -1,0 +1,1 @@
+Error: failed to update application "get-failure" in the environment "default": 422 Unprocessable Entity

--- a/test/fixtures/output/flink/environment/delete-mixed.golden
+++ b/test/fixtures/output/flink/environment/delete-mixed.golden
@@ -2,3 +2,4 @@ Error: Flink environment "non-existent" not found
 
 Suggestions:
     List available Flink environments with `confluent flink environment list`.
+    Check that CMF is running and accessible.

--- a/test/fixtures/output/flink/environment/delete-non-existent-env.golden
+++ b/test/fixtures/output/flink/environment/delete-non-existent-env.golden
@@ -2,3 +2,4 @@ Error: Flink environment "non-existent" not found
 
 Suggestions:
     List available Flink environments with `confluent flink environment list`.
+    Check that CMF is running and accessible.

--- a/test/fixtures/output/flink/environment/update-get-failure.golden
+++ b/test/fixtures/output/flink/environment/update-get-failure.golden
@@ -1,0 +1,1 @@
+Error: failed to update environment "get-failure": 422 Unprocessable Entity

--- a/test/flink_onprem_test.go
+++ b/test/flink_onprem_test.go
@@ -83,6 +83,7 @@ func (s *CLITestSuite) TestFlinkApplicationUpdate() {
 		{args: "flink application update --environment default test/fixtures/input/flink/application/update-non-existent.json", fixture: "flink/application/update-non-existent.golden", exitCode: 1},
 		{args: "flink application update --environment update-failure test/fixtures/input/flink/application/update-failure.json", fixture: "flink/application/update-failure.golden", exitCode: 1},
 		{args: "flink application update --environment non-existent test/fixtures/input/flink/application/update-with-non-existent-environment.json", fixture: "flink/application/update-with-non-existent-environment.golden", exitCode: 1},
+		{args: "flink application update --environment default test/fixtures/input/flink/application/update-with-get-failure.json", fixture: "flink/application/update-with-get-failure.golden", exitCode: 1},
 		// success
 		{args: "flink application update --environment default test/fixtures/input/flink/application/update-successful.json", fixture: "flink/application/update-successful.golden"},
 	}
@@ -115,6 +116,7 @@ func (s *CLITestSuite) TestFlinkEnvironmentUpdate() {
 		// failure
 		{args: "flink environment update update-failure", fixture: "flink/environment/update-failure.golden", exitCode: 1},
 		{args: "flink environment update non-existent", fixture: "flink/environment/update-non-existent.golden", exitCode: 1},
+		{args: "flink environment update get-failure", fixture: "flink/environment/update-get-failure.golden", exitCode: 1},
 	}
 
 	for _, test := range tests {
@@ -160,6 +162,8 @@ func (s *CLITestSuite) TestFlinkApplicationWebUiForward() {
 		// failure
 		{args: "flink --url dummy-url application web-ui-forward forward-negative-port --environment forward-test --port -30", fixture: "flink/application/forward-negative-port.golden", exitCode: 1},
 		{args: "flink --url dummy-url application web-ui-forward non-existent --environment default", fixture: "flink/application/forward-nonexistent-application.golden", exitCode: 1},
+		{args: "flink --url dummy-url application web-ui-forward default-application-1 --environment non-existent", fixture: "flink/application/forward-nonexistent-environment.golden", exitCode: 1},
+		{args: "flink --url dummy-url application web-ui-forward get-failure --environment default", fixture: "flink/application/forward-get-failure.golden", exitCode: 1},
 	}
 
 	for _, test := range tests {

--- a/test/test-server/flink_onprem_handler.go
+++ b/test/test-server/flink_onprem_handler.go
@@ -195,6 +195,11 @@ func handleCmfEnvironment(t *testing.T) http.HandlerFunc {
 				return
 			}
 
+			if strings.Contains(environment, "failure") {
+				http.Error(w, "", http.StatusUnprocessableEntity)
+				return
+			}
+
 			http.Error(w, "Environment not found", http.StatusNotFound)
 			return
 		case http.MethodDelete:
@@ -323,6 +328,11 @@ func handleCmfApplication(t *testing.T) http.HandlerFunc {
 				outputApplication := createApplication(application, environment)
 				err := json.NewEncoder(w).Encode(outputApplication)
 				require.NoError(t, err)
+				return
+			}
+
+			if strings.Contains(application, "failure") {
+				http.Error(w, "", http.StatusUnprocessableEntity)
 				return
 			}
 


### PR DESCRIPTION
Release Notes
-------------
Till now, for the following API calls:
- Delete environment/Delete Application 
- Update environment/Update application
- Forward web-ui
We used to give `not found` even if it has any other issue. 
This PR handles those case and gives more info about the error


Since the delete API depends on the existence check same as other commands, we haven't changed the behaviour there, just that we have added another line of suggestion to the error:

```
Error: Flink application "default-application-1" not found

Suggestions:
    List available Flink applications with `confluent flink application list`.
    Check that CMF is running and accessible.
```

In case of connectivity issues with CMF: 
```
> go run cmd/confluent/main.go flink environment update ralo
Error: failed to update environment "ralo": Get "http://localhost:8080/cmf/api/v1/environments/ralo": dial tcp [::1]:8080: connect: connection refused
```


Breaking Changes
- PLACEHOLDER

New Features
- Gives better error message than `not found` in case of other API errors

Bug Fixes
- PLACEHOLDER

Checklist
---------
- [ ] Leave this box unchecked if features are not yet available in production

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
<!--
Has it been tested? How?
Copy and paste any instructions or steps that can save the reviewer time.
-->