### PR TITLE
Update glibc requirements in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Then, follow the instructions below in the section titled "Build an OpenSSL FIPS
 
 #### APT (Ubuntu and Debian)
 
-Install the latest version of `confluent` to `/usr/bin` (requires `glibc 2.17` or above for `amd64` and `glibc 2.27` or above for `arm64`):
+Install the latest version of `confluent` to `/usr/bin` (requires `glibc 2.28` or above):
 
     wget -qO - https://packages.confluent.io/confluent-cli/deb/archive.key | sudo apt-key add -
     sudo apt install software-properties-common
@@ -44,7 +44,7 @@ Install the latest version of `confluent` to `/usr/bin` (requires `glibc 2.17` o
 
 #### YUM (RHEL and CentOS)
 
-Install the latest version of `confluent` to `/usr/bin` (requires `glibc 2.17` or above for `amd64` and `glibc 2.27` or above for `arm64`):
+Install the latest version of `confluent` to `/usr/bin` (requires `glibc 2.28` or above):
 
     sudo rpm --import https://packages.confluent.io/confluent-cli/rpm/archive.key
     sudo yum install yum-utils


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- PLACEHOLDER

New Features
- PLACEHOLDER

Bug Fixes
- PLACEHOLDER

Checklist
---------
<!-- 
Check each item below to ensure high-quality CLI development practices are followed. PR approval will not be granted until the checklist is fully reviewed.
For detailed instructions, please refer to this Confluence page: https://confluentinc.atlassian.net/wiki/spaces/AEGI/pages/3949592874/
-->
- [ ] I have successfully built and used a custom CLI binary, with no linting issues identified from this PR.
- [ ] I have clearly specified in the `Release Notes` section above whether this PR applies to Confluent Cloud, Confluent Platform, or both. 
- [ ] I have verified this PR with Confluent Cloud resources in a production environment, if applicable.
- [ ] I have verified this PR with Confluent Platform resources in an on-premises environment, if applicable.
- [ ] I have attached manual CLI verification results or screenshots in the `Test & Review` section below.
- [ ] I have added appropriate CLI integration tests for any new or updated commands and functionality.
- [ ] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [ ] Leave this box unchecked if features introduced in this PR are not yet available in production.

N/A, this is only a change to the README file and not a code change.

What
----
Update stale GLIBC requirements in the README.

The correct version is now 2.28. The 2.31 requirement mentioned in the comments was a bug that has been fixed.

References
----------
https://docs.confluent.io/confluent-cli/current/overview.html#gnu-c-library-glibc

Test & Review
-------------
N/A