### PR TITLE
Adds support for output command in env

### DIFF
--- a/internal/flink/command_application_create.go
+++ b/internal/flink/command_application_create.go
@@ -26,7 +26,7 @@ func (c *command) newApplicationCreateCommand() *cobra.Command {
 
 	cmd.Flags().String("environment", "", "Name of the environment to delete the Flink application from.")
 	addCmfFlagSet(cmd)
-	pcmd.AddOutputFlagWithDefaultValue(cmd, output.JSON.String())
+	pcmd.AddOutputFlagWithHumanRestricted(cmd)
 
 	cobra.CheckErr(cmd.MarkFlagRequired("environment"))
 
@@ -37,10 +37,6 @@ func (c *command) applicationCreate(cmd *cobra.Command, args []string) error {
 	environment, err := cmd.Flags().GetString("environment")
 	if err != nil {
 		return err
-	}
-	// Disallow human output for this command
-	if output.GetFormat(cmd) == output.Human {
-		return errors.NewErrorWithSuggestions("human output is not supported for this command", "Try using --output flag with json or yaml.\n")
 	}
 
 	client, err := c.GetCmfClient(cmd)

--- a/internal/flink/command_application_describe.go
+++ b/internal/flink/command_application_describe.go
@@ -4,7 +4,6 @@ import (
 	"github.com/spf13/cobra"
 
 	pcmd "github.com/confluentinc/cli/v4/pkg/cmd"
-	"github.com/confluentinc/cli/v4/pkg/errors"
 	"github.com/confluentinc/cli/v4/pkg/output"
 )
 
@@ -18,7 +17,7 @@ func (c *command) newApplicationDescribeCommand() *cobra.Command {
 
 	cmd.Flags().String("environment", "", "Name of the environment to delete the Flink application from.")
 	addCmfFlagSet(cmd)
-	pcmd.AddOutputFlagWithDefaultValue(cmd, output.JSON.String())
+	pcmd.AddOutputFlagWithHumanRestricted(cmd)
 
 	cobra.CheckErr(cmd.MarkFlagRequired("environment"))
 
@@ -29,10 +28,6 @@ func (c *command) applicationDescribe(cmd *cobra.Command, args []string) error {
 	environment, err := cmd.Flags().GetString("environment")
 	if err != nil {
 		return err
-	}
-	// Disallow human output for this command
-	if output.GetFormat(cmd) == output.Human {
-		return errors.NewErrorWithSuggestions("human output is not supported for this command", "Try using --output flag with json or yaml.\n")
 	}
 
 	client, err := c.GetCmfClient(cmd)

--- a/internal/flink/command_application_update.go
+++ b/internal/flink/command_application_update.go
@@ -26,7 +26,7 @@ func (c *command) newApplicationUpdateCommand() *cobra.Command {
 
 	cmd.Flags().String("environment", "", "Name of the environment to delete the Flink application from.")
 	addCmfFlagSet(cmd)
-	pcmd.AddOutputFlagWithDefaultValue(cmd, output.JSON.String())
+	pcmd.AddOutputFlagWithHumanRestricted(cmd)
 
 	cobra.CheckErr(cmd.MarkFlagRequired("environment"))
 
@@ -37,10 +37,6 @@ func (c *command) applicationUpdate(cmd *cobra.Command, args []string) error {
 	environment, err := cmd.Flags().GetString("environment")
 	if err != nil {
 		return err
-	}
-	// Disallow human output for this command
-	if output.GetFormat(cmd) == output.Human {
-		return errors.NewErrorWithSuggestions("human output is not supported for this command", "Try using --output flag with json or yaml.\n")
 	}
 
 	client, err := c.GetCmfClient(cmd)

--- a/internal/flink/command_environment_create.go
+++ b/internal/flink/command_environment_create.go
@@ -11,6 +11,7 @@ import (
 
 	cmfsdk "github.com/confluentinc/cmf-sdk-go/v1"
 
+	pcmd "github.com/confluentinc/cli/v4/pkg/cmd"
 	"github.com/confluentinc/cli/v4/pkg/output"
 )
 
@@ -26,6 +27,7 @@ func (c *command) newEnvironmentCreateCommand() *cobra.Command {
 	cmd.Flags().String("defaults", "", "JSON string defining the environment's Flink application defaults, or path to a file to read defaults from (with .yml, .yaml or .json extension).")
 
 	addCmfFlagSet(cmd)
+	pcmd.AddOutputFlag(cmd)
 
 	cobra.CheckErr(cmd.MarkFlagRequired("kubernetes-namespace"))
 

--- a/internal/flink/command_environment_create.go
+++ b/internal/flink/command_environment_create.go
@@ -91,19 +91,23 @@ func (c *command) environmentCreate(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	table := output.NewTable(cmd)
-	var defaultsBytes []byte
-	defaultsBytes, err = json.Marshal(outputEnvironment.FlinkApplicationDefaults)
-	if err != nil {
-		return fmt.Errorf("failed to marshal defaults: %s", err)
+	if output.GetFormat(cmd) == output.Human {
+		table := output.NewTable(cmd)
+		var defaultsBytes []byte
+		defaultsBytes, err = json.Marshal(outputEnvironment.FlinkApplicationDefaults)
+		if err != nil {
+			return fmt.Errorf("failed to marshal defaults: %s", err)
+		}
+
+		table.Add(&flinkEnvironmentOutput{
+			Name:                     outputEnvironment.Name,
+			KubernetesNamespace:      outputEnvironment.KubernetesNamespace,
+			FlinkApplicationDefaults: string(defaultsBytes),
+			CreatedTime:              outputEnvironment.CreatedTime.String(),
+			UpdatedTime:              outputEnvironment.UpdatedTime.String(),
+		})
+		return table.Print()
 	}
 
-	table.Add(&flinkEnvironmentOutput{
-		Name:                     outputEnvironment.Name,
-		KubernetesNamespace:      outputEnvironment.KubernetesNamespace,
-		FlinkApplicationDefaults: string(defaultsBytes),
-		CreatedTime:              outputEnvironment.CreatedTime.String(),
-		UpdatedTime:              outputEnvironment.UpdatedTime.String(),
-	})
-	return table.Print()
+	return output.SerializedOutput(cmd, outputEnvironment)
 }

--- a/internal/flink/command_environment_describe.go
+++ b/internal/flink/command_environment_describe.go
@@ -38,19 +38,22 @@ func (c *command) environmentDescribe(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	table := output.NewTable(cmd)
-	var defaultsBytes []byte
-	defaultsBytes, err = json.Marshal(environment.FlinkApplicationDefaults)
-	if err != nil {
-		return fmt.Errorf(`failed to marshal defaults for environment "%s": %s`, environmentName, err)
-	}
+	if output.GetFormat(cmd) == output.Human {
+		table := output.NewTable(cmd)
+		var defaultsBytes []byte
+		defaultsBytes, err = json.Marshal(environment.FlinkApplicationDefaults)
+		if err != nil {
+			return fmt.Errorf(`failed to marshal defaults for environment "%s": %s`, environmentName, err)
+		}
 
-	table.Add(&flinkEnvironmentOutput{
-		Name:                     environment.Name,
-		KubernetesNamespace:      environment.KubernetesNamespace,
-		FlinkApplicationDefaults: string(defaultsBytes),
-		CreatedTime:              environment.CreatedTime.String(),
-		UpdatedTime:              environment.UpdatedTime.String(),
-	})
-	return table.Print()
+		table.Add(&flinkEnvironmentOutput{
+			Name:                     environment.Name,
+			KubernetesNamespace:      environment.KubernetesNamespace,
+			FlinkApplicationDefaults: string(defaultsBytes),
+			CreatedTime:              environment.CreatedTime.String(),
+			UpdatedTime:              environment.UpdatedTime.String(),
+		})
+		return table.Print()
+	}
+	return output.SerializedOutput(cmd, environment)
 }

--- a/internal/flink/command_environment_update.go
+++ b/internal/flink/command_environment_update.go
@@ -11,6 +11,7 @@ import (
 
 	cmfsdk "github.com/confluentinc/cmf-sdk-go/v1"
 
+	pcmd "github.com/confluentinc/cli/v4/pkg/cmd"
 	"github.com/confluentinc/cli/v4/pkg/output"
 )
 
@@ -24,6 +25,7 @@ func (c *command) newEnvironmentUpdateCommand() *cobra.Command {
 
 	addCmfFlagSet(cmd)
 	cmd.Flags().String("defaults", "", "JSON string defining the environment's Flink application defaults, or path to a file to read defaults from (with .yml, .yaml or .json extension).")
+	pcmd.AddOutputFlag(cmd)
 
 	return cmd
 }

--- a/internal/flink/command_environment_update.go
+++ b/internal/flink/command_environment_update.go
@@ -80,19 +80,22 @@ func (c *command) environmentUpdate(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	table := output.NewTable(cmd)
-	var defaultsBytes []byte
-	defaultsBytes, err = json.Marshal(outputEnvironment.FlinkApplicationDefaults)
-	if err != nil {
-		return fmt.Errorf("failed to marshal defaults: %s", err)
-	}
+	if output.GetFormat(cmd) == output.Human {
+		table := output.NewTable(cmd)
+		var defaultsBytes []byte
+		defaultsBytes, err = json.Marshal(outputEnvironment.FlinkApplicationDefaults)
+		if err != nil {
+			return fmt.Errorf("failed to marshal defaults: %s", err)
+		}
 
-	table.Add(&flinkEnvironmentOutput{
-		Name:                     outputEnvironment.Name,
-		KubernetesNamespace:      outputEnvironment.KubernetesNamespace,
-		FlinkApplicationDefaults: string(defaultsBytes),
-		CreatedTime:              outputEnvironment.CreatedTime.String(),
-		UpdatedTime:              outputEnvironment.UpdatedTime.String(),
-	})
-	return table.Print()
+		table.Add(&flinkEnvironmentOutput{
+			Name:                     outputEnvironment.Name,
+			KubernetesNamespace:      outputEnvironment.KubernetesNamespace,
+			FlinkApplicationDefaults: string(defaultsBytes),
+			CreatedTime:              outputEnvironment.CreatedTime.String(),
+			UpdatedTime:              outputEnvironment.UpdatedTime.String(),
+		})
+		return table.Print()
+	}
+	return output.SerializedOutput(cmd, outputEnvironment)
 }

--- a/pkg/cmd/flags.go
+++ b/pkg/cmd/flags.go
@@ -290,6 +290,11 @@ func AddOutputFlag(cmd *cobra.Command) {
 	AddOutputFlagWithDefaultValue(cmd, output.Human.String())
 }
 
+func AddOutputFlagWithHumanRestricted(cmd *cobra.Command) {
+	cmd.Flags().StringP(output.FlagName, "o", output.JSON.String(), fmt.Sprintf("Specify the output format as %s.", utils.ArrayToCommaDelimitedString(output.ValidFlagValuesHumanRestricted, "or")))
+	RegisterFlagCompletionFunc(cmd, output.FlagName, func(_ *cobra.Command, _ []string) []string { return output.ValidFlagValuesHumanRestricted })
+}
+
 func AddOutputFlagWithDefaultValue(cmd *cobra.Command, defaultValue string) {
 	cmd.Flags().StringP(output.FlagName, "o", defaultValue, fmt.Sprintf("Specify the output format as %s.", utils.ArrayToCommaDelimitedString(output.ValidFlagValues, "or")))
 	RegisterFlagCompletionFunc(cmd, output.FlagName, func(_ *cobra.Command, _ []string) []string { return output.ValidFlagValues })

--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -16,6 +16,8 @@ const FlagName = "output"
 
 var ValidFlagValues = []string{"human", "json", "yaml"}
 
+var ValidFlagValuesHumanRestricted = []string{"json", "yaml"}
+
 func GetFormat(cmd *cobra.Command) Format {
 	format, _ := cmd.Flags().GetString(FlagName)
 

--- a/test/fixtures/output/flink/application/create-help-onprem.golden
+++ b/test/fixtures/output/flink/application/create-help-onprem.golden
@@ -9,7 +9,7 @@ Flags:
       --client-key-path string              Path to client private key for mTLS authentication. Environment variable "CONFLUENT_CMF_CLIENT_KEY_PATH" may be set in place of this flag.
       --client-cert-path string             Path to client cert to be verified by Confluent Manager for Apache Flink. Include for mTLS authentication. Environment variable "CONFLUENT_CMF_CLIENT_CERT_PATH" may be set in place of this flag.
       --certificate-authority-path string   Path to a PEM-encoded Certificate Authority to verify the Confluent Manager for Apache Flink connection. Environment variable "CONFLUENT_CMF_CERTIFICATE_AUTHORITY_PATH" may be set in place of this flag.
-  -o, --output string                       Specify the output format as "human", "json", or "yaml". (default "json")
+  -o, --output string                       Specify the output format as "json" or "yaml". (default "json")
 
 Global Flags:
   -h, --help            Show help for this command.

--- a/test/fixtures/output/flink/application/create-help.golden
+++ b/test/fixtures/output/flink/application/create-help.golden
@@ -9,7 +9,7 @@ Flags:
       --client-key-path string              Path to client private key for mTLS authentication. Environment variable "CONFLUENT_CMF_CLIENT_KEY_PATH" may be set in place of this flag.
       --client-cert-path string             Path to client cert to be verified by Confluent Manager for Apache Flink. Include for mTLS authentication. Environment variable "CONFLUENT_CMF_CLIENT_CERT_PATH" may be set in place of this flag.
       --certificate-authority-path string   Path to a PEM-encoded Certificate Authority to verify the Confluent Manager for Apache Flink connection. Environment variable "CONFLUENT_CMF_CERTIFICATE_AUTHORITY_PATH" may be set in place of this flag.
-  -o, --output string                       Specify the output format as "human", "json", or "yaml". (default "json")
+  -o, --output string                       Specify the output format as "json" or "yaml". (default "json")
 
 Global Flags:
   -h, --help            Show help for this command.

--- a/test/fixtures/output/flink/application/create-success-yaml.golden
+++ b/test/fixtures/output/flink/application/create-success-yaml.golden
@@ -1,0 +1,27 @@
+apiversion: cmf.confluent.io/v1alpha1
+kind: FlinkApplication
+metadata:
+    name: default-application-3
+spec:
+    flinkConfiguration:
+        metrics.reporter.prom.factory.class: org.apache.flink.metrics.prometheus.PrometheusReporterFactory
+        metrics.reporter.prom.port: 9249-9250
+        taskmanager.numberOfTaskSlots: "2"
+    flinkEnvironment: default
+    flinkVersion: v1_19
+    image: confluentinc/cp-flink:1.19.1-cp1
+    job:
+        jarURI: local:///opt/flink/examples/streaming/StateMachineExample.jar
+        parallelism: 3
+        state: running
+        upgradeMode: stateless
+    jobManager:
+        resource:
+            cpu: 1
+            memory: 1048m
+    serviceAccount: flink
+    taskManager:
+        resource:
+            cpu: 1
+            memory: 1048m
+status: {}

--- a/test/fixtures/output/flink/application/create-with-human.golden
+++ b/test/fixtures/output/flink/application/create-with-human.golden
@@ -1,0 +1,5 @@
+Error: human output is not supported for this command
+
+Suggestions:
+    Try using --output flag with json or yaml.
+    

--- a/test/fixtures/output/flink/application/create-with-human.golden
+++ b/test/fixtures/output/flink/application/create-with-human.golden
@@ -1,5 +1,82 @@
-Error: human output is not supported for this command
-
-Suggestions:
-    Try using --output flag with json or yaml.
-    
+{
+  "apiVersion": "cmf.confluent.io/v1alpha1",
+  "kind": "FlinkApplication",
+  "metadata": {
+    "name": "default-application-1"
+  },
+  "spec": {
+    "flinkConfiguration": {
+      "metrics.reporter.prom.factory.class": "org.apache.flink.metrics.prometheus.PrometheusReporterFactory",
+      "metrics.reporter.prom.port": "9249-9250",
+      "taskmanager.numberOfTaskSlots": "8"
+    },
+    "flinkEnvironmentName": "default",
+    "flinkVersion": "v1_19",
+    "image": "confluentinc/cp-flink:1.19.1-cp1",
+    "job": {
+      "jarURI": "local:///opt/flink/examples/streaming/StateMachineExample.jar",
+      "parallelism": 3,
+      "state": "running",
+      "upgradeMode": "stateless"
+    },
+    "jobManager": {
+      "resource": {
+        "cpu": 1,
+        "memory": "1048m"
+      }
+    },
+    "serviceAccount": "flink",
+    "taskManager": {
+      "resource": {
+        "cpu": 1,
+        "memory": "1048m"
+      }
+    }
+  },
+  "status": {
+    "clusterInfo": {
+      "flink-revision": "89d0b8f @ 2024-06-22T13:19:31+02:00",
+      "flink-version": "1.19.1-cp1",
+      "total-cpu": "3.0",
+      "total-memory": "3296722944"
+    },
+    "error": null,
+    "jobManagerDeploymentStatus": "DEPLOYING",
+    "jobStatus": {
+      "checkpointInfo": {
+        "formatType": null,
+        "lastCheckpoint": null,
+        "lastPeriodicCheckpointTimestamp": 0,
+        "triggerId": null,
+        "triggerTimestamp": null,
+        "triggerType": null
+      },
+      "jobId": "dcabb1ad6c40495bc2d7fa7a0097c5aa",
+      "jobName": "State machine job",
+      "savepointInfo": {
+        "formatType": null,
+        "lastPeriodicSavepointTimestamp": 0,
+        "lastSavepoint": null,
+        "savepointHistory": [],
+        "triggerId": null,
+        "triggerTimestamp": null,
+        "triggerType": null
+      },
+      "startTime": "1726640263746",
+      "state": "RECONCILING",
+      "updateTime": "1726640280561"
+    },
+    "lifecycleState": "DEPLOYED",
+    "observedGeneration": 4,
+    "reconciliationStatus": {
+      "lastReconciledSpec": "",
+      "lastStableSpec": "",
+      "reconciliationTimestamp": 1726640346899,
+      "state": "DEPLOYED"
+    },
+    "taskManager": {
+      "labelSelector": "component=taskmanager,app=basic-example",
+      "replicas": 1
+    }
+  }
+}

--- a/test/fixtures/output/flink/application/create-with-human.golden
+++ b/test/fixtures/output/flink/application/create-with-human.golden
@@ -2,15 +2,15 @@
   "apiVersion": "cmf.confluent.io/v1alpha1",
   "kind": "FlinkApplication",
   "metadata": {
-    "name": "default-application-1"
+    "name": "default-application-3"
   },
   "spec": {
     "flinkConfiguration": {
       "metrics.reporter.prom.factory.class": "org.apache.flink.metrics.prometheus.PrometheusReporterFactory",
       "metrics.reporter.prom.port": "9249-9250",
-      "taskmanager.numberOfTaskSlots": "8"
+      "taskmanager.numberOfTaskSlots": "2"
     },
-    "flinkEnvironmentName": "default",
+    "flinkEnvironment": "default",
     "flinkVersion": "v1_19",
     "image": "confluentinc/cp-flink:1.19.1-cp1",
     "job": {
@@ -31,52 +31,6 @@
         "cpu": 1,
         "memory": "1048m"
       }
-    }
-  },
-  "status": {
-    "clusterInfo": {
-      "flink-revision": "89d0b8f @ 2024-06-22T13:19:31+02:00",
-      "flink-version": "1.19.1-cp1",
-      "total-cpu": "3.0",
-      "total-memory": "3296722944"
-    },
-    "error": null,
-    "jobManagerDeploymentStatus": "DEPLOYING",
-    "jobStatus": {
-      "checkpointInfo": {
-        "formatType": null,
-        "lastCheckpoint": null,
-        "lastPeriodicCheckpointTimestamp": 0,
-        "triggerId": null,
-        "triggerTimestamp": null,
-        "triggerType": null
-      },
-      "jobId": "dcabb1ad6c40495bc2d7fa7a0097c5aa",
-      "jobName": "State machine job",
-      "savepointInfo": {
-        "formatType": null,
-        "lastPeriodicSavepointTimestamp": 0,
-        "lastSavepoint": null,
-        "savepointHistory": [],
-        "triggerId": null,
-        "triggerTimestamp": null,
-        "triggerType": null
-      },
-      "startTime": "1726640263746",
-      "state": "RECONCILING",
-      "updateTime": "1726640280561"
-    },
-    "lifecycleState": "DEPLOYED",
-    "observedGeneration": 4,
-    "reconciliationStatus": {
-      "lastReconciledSpec": "",
-      "lastStableSpec": "",
-      "reconciliationTimestamp": 1726640346899,
-      "state": "DEPLOYED"
-    },
-    "taskManager": {
-      "labelSelector": "component=taskmanager,app=basic-example",
-      "replicas": 1
     }
   }
 }

--- a/test/fixtures/output/flink/application/describe-help-onprem.golden
+++ b/test/fixtures/output/flink/application/describe-help-onprem.golden
@@ -9,7 +9,7 @@ Flags:
       --client-key-path string              Path to client private key for mTLS authentication. Environment variable "CONFLUENT_CMF_CLIENT_KEY_PATH" may be set in place of this flag.
       --client-cert-path string             Path to client cert to be verified by Confluent Manager for Apache Flink. Include for mTLS authentication. Environment variable "CONFLUENT_CMF_CLIENT_CERT_PATH" may be set in place of this flag.
       --certificate-authority-path string   Path to a PEM-encoded Certificate Authority to verify the Confluent Manager for Apache Flink connection. Environment variable "CONFLUENT_CMF_CERTIFICATE_AUTHORITY_PATH" may be set in place of this flag.
-  -o, --output string                       Specify the output format as "human", "json", or "yaml". (default "json")
+  -o, --output string                       Specify the output format as "json" or "yaml". (default "json")
 
 Global Flags:
   -h, --help            Show help for this command.

--- a/test/fixtures/output/flink/application/describe-help.golden
+++ b/test/fixtures/output/flink/application/describe-help.golden
@@ -9,7 +9,7 @@ Flags:
       --client-key-path string              Path to client private key for mTLS authentication. Environment variable "CONFLUENT_CMF_CLIENT_KEY_PATH" may be set in place of this flag.
       --client-cert-path string             Path to client cert to be verified by Confluent Manager for Apache Flink. Include for mTLS authentication. Environment variable "CONFLUENT_CMF_CLIENT_CERT_PATH" may be set in place of this flag.
       --certificate-authority-path string   Path to a PEM-encoded Certificate Authority to verify the Confluent Manager for Apache Flink connection. Environment variable "CONFLUENT_CMF_CERTIFICATE_AUTHORITY_PATH" may be set in place of this flag.
-  -o, --output string                       Specify the output format as "human", "json", or "yaml". (default "json")
+  -o, --output string                       Specify the output format as "json" or "yaml". (default "json")
 
 Global Flags:
   -h, --help            Show help for this command.

--- a/test/fixtures/output/flink/application/describe-no-environment.golden
+++ b/test/fixtures/output/flink/application/describe-no-environment.golden
@@ -8,7 +8,7 @@ Flags:
       --client-key-path string              Path to client private key for mTLS authentication. Environment variable "CONFLUENT_CMF_CLIENT_KEY_PATH" may be set in place of this flag.
       --client-cert-path string             Path to client cert to be verified by Confluent Manager for Apache Flink. Include for mTLS authentication. Environment variable "CONFLUENT_CMF_CLIENT_CERT_PATH" may be set in place of this flag.
       --certificate-authority-path string   Path to a PEM-encoded Certificate Authority to verify the Confluent Manager for Apache Flink connection. Environment variable "CONFLUENT_CMF_CERTIFICATE_AUTHORITY_PATH" may be set in place of this flag.
-  -o, --output string                       Specify the output format as "human", "json", or "yaml". (default "json")
+  -o, --output string                       Specify the output format as "json" or "yaml". (default "json")
 
 Global Flags:
   -h, --help            Show help for this command.

--- a/test/fixtures/output/flink/application/describe-success-yaml.golden
+++ b/test/fixtures/output/flink/application/describe-success-yaml.golden
@@ -7,7 +7,7 @@ spec:
         metrics.reporter.prom.factory.class: org.apache.flink.metrics.prometheus.PrometheusReporterFactory
         metrics.reporter.prom.port: 9249-9250
         taskmanager.numberOfTaskSlots: "8"
-    flinkEnvironmentName: default
+    flinkEnvironment: default
     flinkVersion: v1_19
     image: confluentinc/cp-flink:1.19.1-cp1
     job:

--- a/test/fixtures/output/flink/application/describe-success.golden
+++ b/test/fixtures/output/flink/application/describe-success.golden
@@ -10,7 +10,7 @@
       "metrics.reporter.prom.port": "9249-9250",
       "taskmanager.numberOfTaskSlots": "8"
     },
-    "flinkEnvironmentName": "default",
+    "flinkEnvironment": "default",
     "flinkVersion": "v1_19",
     "image": "confluentinc/cp-flink:1.19.1-cp1",
     "job": {

--- a/test/fixtures/output/flink/application/describe-with-human.golden
+++ b/test/fixtures/output/flink/application/describe-with-human.golden
@@ -1,0 +1,82 @@
+{
+  "apiVersion": "cmf.confluent.io/v1alpha1",
+  "kind": "FlinkApplication",
+  "metadata": {
+    "name": "default-application-1"
+  },
+  "spec": {
+    "flinkConfiguration": {
+      "metrics.reporter.prom.factory.class": "org.apache.flink.metrics.prometheus.PrometheusReporterFactory",
+      "metrics.reporter.prom.port": "9249-9250",
+      "taskmanager.numberOfTaskSlots": "8"
+    },
+    "flinkEnvironment": "default",
+    "flinkVersion": "v1_19",
+    "image": "confluentinc/cp-flink:1.19.1-cp1",
+    "job": {
+      "jarURI": "local:///opt/flink/examples/streaming/StateMachineExample.jar",
+      "parallelism": 3,
+      "state": "running",
+      "upgradeMode": "stateless"
+    },
+    "jobManager": {
+      "resource": {
+        "cpu": 1,
+        "memory": "1048m"
+      }
+    },
+    "serviceAccount": "flink",
+    "taskManager": {
+      "resource": {
+        "cpu": 1,
+        "memory": "1048m"
+      }
+    }
+  },
+  "status": {
+    "clusterInfo": {
+      "flink-revision": "89d0b8f @ 2024-06-22T13:19:31+02:00",
+      "flink-version": "1.19.1-cp1",
+      "total-cpu": "3.0",
+      "total-memory": "3296722944"
+    },
+    "error": null,
+    "jobManagerDeploymentStatus": "DEPLOYING",
+    "jobStatus": {
+      "checkpointInfo": {
+        "formatType": null,
+        "lastCheckpoint": null,
+        "lastPeriodicCheckpointTimestamp": 0,
+        "triggerId": null,
+        "triggerTimestamp": null,
+        "triggerType": null
+      },
+      "jobId": "dcabb1ad6c40495bc2d7fa7a0097c5aa",
+      "jobName": "State machine job",
+      "savepointInfo": {
+        "formatType": null,
+        "lastPeriodicSavepointTimestamp": 0,
+        "lastSavepoint": null,
+        "savepointHistory": [],
+        "triggerId": null,
+        "triggerTimestamp": null,
+        "triggerType": null
+      },
+      "startTime": "1726640263746",
+      "state": "RECONCILING",
+      "updateTime": "1726640280561"
+    },
+    "lifecycleState": "DEPLOYED",
+    "observedGeneration": 4,
+    "reconciliationStatus": {
+      "lastReconciledSpec": "",
+      "lastStableSpec": "",
+      "reconciliationTimestamp": 1726640346899,
+      "state": "DEPLOYED"
+    },
+    "taskManager": {
+      "labelSelector": "component=taskmanager,app=basic-example",
+      "replicas": 1
+    }
+  }
+}

--- a/test/fixtures/output/flink/application/list-json.golden
+++ b/test/fixtures/output/flink/application/list-json.golden
@@ -11,7 +11,7 @@
         "metrics.reporter.prom.port": "9249-9250",
         "taskmanager.numberOfTaskSlots": "8"
       },
-      "flinkEnvironmentName": "default",
+      "flinkEnvironment": "default",
       "flinkVersion": "v1_19",
       "image": "confluentinc/cp-flink:1.19.1-cp1",
       "job": {
@@ -93,7 +93,7 @@
         "metrics.reporter.prom.port": "9249-9250",
         "taskmanager.numberOfTaskSlots": "8"
       },
-      "flinkEnvironmentName": "default",
+      "flinkEnvironment": "default",
       "flinkVersion": "v1_19",
       "image": "confluentinc/cp-flink:1.19.1-cp1",
       "job": {

--- a/test/fixtures/output/flink/application/update-help-onprem.golden
+++ b/test/fixtures/output/flink/application/update-help-onprem.golden
@@ -9,7 +9,7 @@ Flags:
       --client-key-path string              Path to client private key for mTLS authentication. Environment variable "CONFLUENT_CMF_CLIENT_KEY_PATH" may be set in place of this flag.
       --client-cert-path string             Path to client cert to be verified by Confluent Manager for Apache Flink. Include for mTLS authentication. Environment variable "CONFLUENT_CMF_CLIENT_CERT_PATH" may be set in place of this flag.
       --certificate-authority-path string   Path to a PEM-encoded Certificate Authority to verify the Confluent Manager for Apache Flink connection. Environment variable "CONFLUENT_CMF_CERTIFICATE_AUTHORITY_PATH" may be set in place of this flag.
-  -o, --output string                       Specify the output format as "human", "json", or "yaml". (default "json")
+  -o, --output string                       Specify the output format as "json" or "yaml". (default "json")
 
 Global Flags:
   -h, --help            Show help for this command.

--- a/test/fixtures/output/flink/application/update-help.golden
+++ b/test/fixtures/output/flink/application/update-help.golden
@@ -9,7 +9,7 @@ Flags:
       --client-key-path string              Path to client private key for mTLS authentication. Environment variable "CONFLUENT_CMF_CLIENT_KEY_PATH" may be set in place of this flag.
       --client-cert-path string             Path to client cert to be verified by Confluent Manager for Apache Flink. Include for mTLS authentication. Environment variable "CONFLUENT_CMF_CLIENT_CERT_PATH" may be set in place of this flag.
       --certificate-authority-path string   Path to a PEM-encoded Certificate Authority to verify the Confluent Manager for Apache Flink connection. Environment variable "CONFLUENT_CMF_CERTIFICATE_AUTHORITY_PATH" may be set in place of this flag.
-  -o, --output string                       Specify the output format as "human", "json", or "yaml". (default "json")
+  -o, --output string                       Specify the output format as "json" or "yaml". (default "json")
 
 Global Flags:
   -h, --help            Show help for this command.

--- a/test/fixtures/output/flink/application/update-successful-yaml.golden
+++ b/test/fixtures/output/flink/application/update-successful-yaml.golden
@@ -7,7 +7,7 @@ spec:
         metrics.reporter.prom.factory.class: org.apache.flink.metrics.prometheus.PrometheusReporterFactory
         metrics.reporter.prom.port: 9249-9250
         taskmanager.numberOfTaskSlots: "8"
-    flinkEnvironmentName: default
+    flinkEnvironment: default
     flinkVersion: v1_19
     image: confluentinc/cp-flink:1.19.1-cp1
     job:

--- a/test/fixtures/output/flink/application/update-successful-yaml.golden
+++ b/test/fixtures/output/flink/application/update-successful-yaml.golden
@@ -1,0 +1,65 @@
+apiversion: cmf.confluent.io/v1alpha1
+kind: FlinkApplication
+metadata:
+    name: default-application-2
+spec:
+    flinkConfiguration:
+        metrics.reporter.prom.factory.class: org.apache.flink.metrics.prometheus.PrometheusReporterFactory
+        metrics.reporter.prom.port: 9249-9250
+        taskmanager.numberOfTaskSlots: "8"
+    flinkEnvironmentName: default
+    flinkVersion: v1_19
+    image: confluentinc/cp-flink:1.19.1-cp1
+    job:
+        jarURI: local:///opt/flink/examples/streaming/StateMachineExample.jar
+        parallelism: 3
+        state: running
+        upgradeMode: stateless
+    jobManager:
+        resource:
+            cpu: 1
+            memory: 1048m
+    serviceAccount: flink-new-service-account
+    taskManager:
+        resource:
+            cpu: 1
+            memory: 1048m
+status:
+    clusterInfo:
+        flink-revision: 89d0b8f @ 2024-06-22T13:19:31+02:00
+        flink-version: 1.19.1-cp1
+        total-cpu: "3.0"
+        total-memory: "3296722944"
+    error: null
+    jobManagerDeploymentStatus: DEPLOYING
+    jobStatus:
+        checkpointInfo:
+            formatType: null
+            lastCheckpoint: null
+            lastPeriodicCheckpointTimestamp: 0
+            triggerId: null
+            triggerTimestamp: null
+            triggerType: null
+        jobId: dcabb1ad6c40495bc2d7fa7a0097c5aa
+        jobName: State machine job
+        savepointInfo:
+            formatType: null
+            lastPeriodicSavepointTimestamp: 0
+            lastSavepoint: null
+            savepointHistory: []
+            triggerId: null
+            triggerTimestamp: null
+            triggerType: null
+        startTime: "1726640263746"
+        state: RECONCILING
+        updateTime: "1726640280561"
+    lifecycleState: DEPLOYED
+    observedGeneration: 4
+    reconciliationStatus:
+        lastReconciledSpec: ""
+        lastStableSpec: ""
+        reconciliationTimestamp: 1.726640346899e+12
+        state: DEPLOYED
+    taskManager:
+        labelSelector: component=taskmanager,app=basic-example
+        replicas: 1

--- a/test/fixtures/output/flink/application/update-successful.golden
+++ b/test/fixtures/output/flink/application/update-successful.golden
@@ -10,7 +10,7 @@
       "metrics.reporter.prom.port": "9249-9250",
       "taskmanager.numberOfTaskSlots": "8"
     },
-    "flinkEnvironmentName": "default",
+    "flinkEnvironment": "default",
     "flinkVersion": "v1_19",
     "image": "confluentinc/cp-flink:1.19.1-cp1",
     "job": {

--- a/test/fixtures/output/flink/application/update-with-human.golden
+++ b/test/fixtures/output/flink/application/update-with-human.golden
@@ -1,5 +1,82 @@
-Error: human output is not supported for this command
-
-Suggestions:
-    Try using --output flag with json or yaml.
-    
+{
+  "apiVersion": "cmf.confluent.io/v1alpha1",
+  "kind": "FlinkApplication",
+  "metadata": {
+    "name": "default-application-2"
+  },
+  "spec": {
+    "flinkConfiguration": {
+      "metrics.reporter.prom.factory.class": "org.apache.flink.metrics.prometheus.PrometheusReporterFactory",
+      "metrics.reporter.prom.port": "9249-9250",
+      "taskmanager.numberOfTaskSlots": "8"
+    },
+    "flinkEnvironmentName": "default",
+    "flinkVersion": "v1_19",
+    "image": "confluentinc/cp-flink:1.19.1-cp1",
+    "job": {
+      "jarURI": "local:///opt/flink/examples/streaming/StateMachineExample.jar",
+      "parallelism": 3,
+      "state": "running",
+      "upgradeMode": "stateless"
+    },
+    "jobManager": {
+      "resource": {
+        "cpu": 1,
+        "memory": "1048m"
+      }
+    },
+    "serviceAccount": "flink-new-service-account",
+    "taskManager": {
+      "resource": {
+        "cpu": 1,
+        "memory": "1048m"
+      }
+    }
+  },
+  "status": {
+    "clusterInfo": {
+      "flink-revision": "89d0b8f @ 2024-06-22T13:19:31+02:00",
+      "flink-version": "1.19.1-cp1",
+      "total-cpu": "3.0",
+      "total-memory": "3296722944"
+    },
+    "error": null,
+    "jobManagerDeploymentStatus": "DEPLOYING",
+    "jobStatus": {
+      "checkpointInfo": {
+        "formatType": null,
+        "lastCheckpoint": null,
+        "lastPeriodicCheckpointTimestamp": 0,
+        "triggerId": null,
+        "triggerTimestamp": null,
+        "triggerType": null
+      },
+      "jobId": "dcabb1ad6c40495bc2d7fa7a0097c5aa",
+      "jobName": "State machine job",
+      "savepointInfo": {
+        "formatType": null,
+        "lastPeriodicSavepointTimestamp": 0,
+        "lastSavepoint": null,
+        "savepointHistory": [],
+        "triggerId": null,
+        "triggerTimestamp": null,
+        "triggerType": null
+      },
+      "startTime": "1726640263746",
+      "state": "RECONCILING",
+      "updateTime": "1726640280561"
+    },
+    "lifecycleState": "DEPLOYED",
+    "observedGeneration": 4,
+    "reconciliationStatus": {
+      "lastReconciledSpec": "",
+      "lastStableSpec": "",
+      "reconciliationTimestamp": 1726640346899,
+      "state": "DEPLOYED"
+    },
+    "taskManager": {
+      "labelSelector": "component=taskmanager,app=basic-example",
+      "replicas": 1
+    }
+  }
+}

--- a/test/fixtures/output/flink/application/update-with-human.golden
+++ b/test/fixtures/output/flink/application/update-with-human.golden
@@ -1,0 +1,5 @@
+Error: human output is not supported for this command
+
+Suggestions:
+    Try using --output flag with json or yaml.
+    

--- a/test/fixtures/output/flink/application/update-with-human.golden
+++ b/test/fixtures/output/flink/application/update-with-human.golden
@@ -10,7 +10,7 @@
       "metrics.reporter.prom.port": "9249-9250",
       "taskmanager.numberOfTaskSlots": "8"
     },
-    "flinkEnvironmentName": "default",
+    "flinkEnvironment": "default",
     "flinkVersion": "v1_19",
     "image": "confluentinc/cp-flink:1.19.1-cp1",
     "job": {

--- a/test/fixtures/output/flink/environment/create-help-onprem.golden
+++ b/test/fixtures/output/flink/environment/create-help-onprem.golden
@@ -10,6 +10,7 @@ Flags:
       --client-key-path string              Path to client private key for mTLS authentication. Environment variable "CONFLUENT_CMF_CLIENT_KEY_PATH" may be set in place of this flag.
       --client-cert-path string             Path to client cert to be verified by Confluent Manager for Apache Flink. Include for mTLS authentication. Environment variable "CONFLUENT_CMF_CLIENT_CERT_PATH" may be set in place of this flag.
       --certificate-authority-path string   Path to a PEM-encoded Certificate Authority to verify the Confluent Manager for Apache Flink connection. Environment variable "CONFLUENT_CMF_CERTIFICATE_AUTHORITY_PATH" may be set in place of this flag.
+  -o, --output string                       Specify the output format as "human", "json", or "yaml". (default "human")
 
 Global Flags:
   -h, --help            Show help for this command.

--- a/test/fixtures/output/flink/environment/create-help.golden
+++ b/test/fixtures/output/flink/environment/create-help.golden
@@ -10,6 +10,7 @@ Flags:
       --client-key-path string              Path to client private key for mTLS authentication. Environment variable "CONFLUENT_CMF_CLIENT_KEY_PATH" may be set in place of this flag.
       --client-cert-path string             Path to client cert to be verified by Confluent Manager for Apache Flink. Include for mTLS authentication. Environment variable "CONFLUENT_CMF_CLIENT_CERT_PATH" may be set in place of this flag.
       --certificate-authority-path string   Path to a PEM-encoded Certificate Authority to verify the Confluent Manager for Apache Flink connection. Environment variable "CONFLUENT_CMF_CERTIFICATE_AUTHORITY_PATH" may be set in place of this flag.
+  -o, --output string                       Specify the output format as "human", "json", or "yaml". (default "human")
 
 Global Flags:
   -h, --help            Show help for this command.

--- a/test/fixtures/output/flink/environment/create-no-namespace.golden
+++ b/test/fixtures/output/flink/environment/create-no-namespace.golden
@@ -9,6 +9,7 @@ Flags:
       --client-key-path string              Path to client private key for mTLS authentication. Environment variable "CONFLUENT_CMF_CLIENT_KEY_PATH" may be set in place of this flag.
       --client-cert-path string             Path to client cert to be verified by Confluent Manager for Apache Flink. Include for mTLS authentication. Environment variable "CONFLUENT_CMF_CLIENT_CERT_PATH" may be set in place of this flag.
       --certificate-authority-path string   Path to a PEM-encoded Certificate Authority to verify the Confluent Manager for Apache Flink connection. Environment variable "CONFLUENT_CMF_CERTIFICATE_AUTHORITY_PATH" may be set in place of this flag.
+  -o, --output string                       Specify the output format as "human", "json", or "yaml". (default "human")
 
 Global Flags:
   -h, --help            Show help for this command.

--- a/test/fixtures/output/flink/environment/create-success-with-defaults-json.golden
+++ b/test/fixtures/output/flink/environment/create-success-with-defaults-json.golden
@@ -1,0 +1,7 @@
+{
+  "name": "default-2",
+  "kubernetes_namespace": "default-staging",
+  "created_time": "2024-09-10 23:00:00 +0000 UTC",
+  "updated_time": "2024-09-10 23:00:00 +0000 UTC",
+  "flink_application_defaults": "{\"metadata\":{\"annotations\":{\"fmc.platform.confluent.io/intra-cluster-ssl\":\"false\"}},\"spec\":{\"flinkConfiguration\":{\"taskmanager.numberOfTaskSlots\":\"8\"}}}"
+}

--- a/test/fixtures/output/flink/environment/create-success-with-defaults-json.golden
+++ b/test/fixtures/output/flink/environment/create-success-with-defaults-json.golden
@@ -1,7 +1,18 @@
 {
   "name": "default-2",
-  "kubernetes_namespace": "default-staging",
-  "created_time": "2024-09-10 23:00:00 +0000 UTC",
-  "updated_time": "2024-09-10 23:00:00 +0000 UTC",
-  "flink_application_defaults": "{\"metadata\":{\"annotations\":{\"fmc.platform.confluent.io/intra-cluster-ssl\":\"false\"}},\"spec\":{\"flinkConfiguration\":{\"taskmanager.numberOfTaskSlots\":\"8\"}}}"
+  "created_time": "2024-09-10T23:00:00Z",
+  "updated_time": "2024-09-10T23:00:00Z",
+  "flinkApplicationDefaults": {
+    "metadata": {
+      "annotations": {
+        "fmc.platform.confluent.io/intra-cluster-ssl": "false"
+      }
+    },
+    "spec": {
+      "flinkConfiguration": {
+        "taskmanager.numberOfTaskSlots": "8"
+      }
+    }
+  },
+  "kubernetesNamespace": "default-staging"
 }

--- a/test/fixtures/output/flink/environment/create-success-yaml.golden
+++ b/test/fixtures/output/flink/environment/create-success-yaml.golden
@@ -1,0 +1,5 @@
+name: default-2
+kubernetes_namespace: default-staging
+created_time: 2024-09-10 23:00:00 +0000 UTC
+updated_time: 2024-09-10 23:00:00 +0000 UTC
+flink_application_defaults: "null"

--- a/test/fixtures/output/flink/environment/create-success-yaml.golden
+++ b/test/fixtures/output/flink/environment/create-success-yaml.golden
@@ -1,5 +1,5 @@
 name: default-2
-kubernetes_namespace: default-staging
-created_time: 2024-09-10 23:00:00 +0000 UTC
-updated_time: 2024-09-10 23:00:00 +0000 UTC
-flink_application_defaults: "null"
+createdtime: 2024-09-10T23:00:00Z
+updatedtime: 2024-09-10T23:00:00Z
+flinkapplicationdefaults: {}
+kubernetesnamespace: default-staging

--- a/test/fixtures/output/flink/environment/describe-success-json.golden
+++ b/test/fixtures/output/flink/environment/describe-success-json.golden
@@ -1,7 +1,6 @@
 {
   "name": "default",
-  "kubernetes_namespace": "default-namespace",
-  "created_time": "2024-09-10 23:00:00 +0000 UTC",
-  "updated_time": "2024-09-10 23:00:00 +0000 UTC",
-  "flink_application_defaults": "null"
+  "created_time": "2024-09-10T23:00:00Z",
+  "updated_time": "2024-09-10T23:00:00Z",
+  "kubernetesNamespace": "default-namespace"
 }

--- a/test/fixtures/output/flink/environment/describe-success-yaml.golden
+++ b/test/fixtures/output/flink/environment/describe-success-yaml.golden
@@ -1,5 +1,5 @@
 name: default
-kubernetes_namespace: default-namespace
-created_time: 2024-09-10 23:00:00 +0000 UTC
-updated_time: 2024-09-10 23:00:00 +0000 UTC
-flink_application_defaults: "null"
+createdtime: 2024-09-10T23:00:00Z
+updatedtime: 2024-09-10T23:00:00Z
+flinkapplicationdefaults: {}
+kubernetesnamespace: default-namespace

--- a/test/fixtures/output/flink/environment/update-help-onprem.golden
+++ b/test/fixtures/output/flink/environment/update-help-onprem.golden
@@ -9,6 +9,7 @@ Flags:
       --client-cert-path string             Path to client cert to be verified by Confluent Manager for Apache Flink. Include for mTLS authentication. Environment variable "CONFLUENT_CMF_CLIENT_CERT_PATH" may be set in place of this flag.
       --certificate-authority-path string   Path to a PEM-encoded Certificate Authority to verify the Confluent Manager for Apache Flink connection. Environment variable "CONFLUENT_CMF_CERTIFICATE_AUTHORITY_PATH" may be set in place of this flag.
       --defaults string                     JSON string defining the environment's Flink application defaults, or path to a file to read defaults from (with .yml, .yaml or .json extension).
+  -o, --output string                       Specify the output format as "human", "json", or "yaml". (default "human")
 
 Global Flags:
   -h, --help            Show help for this command.

--- a/test/fixtures/output/flink/environment/update-help.golden
+++ b/test/fixtures/output/flink/environment/update-help.golden
@@ -9,6 +9,7 @@ Flags:
       --client-cert-path string             Path to client cert to be verified by Confluent Manager for Apache Flink. Include for mTLS authentication. Environment variable "CONFLUENT_CMF_CLIENT_CERT_PATH" may be set in place of this flag.
       --certificate-authority-path string   Path to a PEM-encoded Certificate Authority to verify the Confluent Manager for Apache Flink connection. Environment variable "CONFLUENT_CMF_CERTIFICATE_AUTHORITY_PATH" may be set in place of this flag.
       --defaults string                     JSON string defining the environment's Flink application defaults, or path to a file to read defaults from (with .yml, .yaml or .json extension).
+  -o, --output string                       Specify the output format as "human", "json", or "yaml". (default "human")
 
 Global Flags:
   -h, --help            Show help for this command.

--- a/test/fixtures/output/flink/environment/update-success-json.golden
+++ b/test/fixtures/output/flink/environment/update-success-json.golden
@@ -1,7 +1,9 @@
 {
   "name": "default",
-  "kubernetes_namespace": "default-namespace",
-  "created_time": "2024-09-10 23:00:00 +0000 UTC",
-  "updated_time": "2024-09-10 23:00:00 +0000 UTC",
-  "flink_application_defaults": "{\"property\":\"value\"}"
+  "created_time": "2024-09-10T23:00:00Z",
+  "updated_time": "2024-09-10T23:00:00Z",
+  "flinkApplicationDefaults": {
+    "property": "value"
+  },
+  "kubernetesNamespace": "default-namespace"
 }

--- a/test/fixtures/output/flink/environment/update-success-json.golden
+++ b/test/fixtures/output/flink/environment/update-success-json.golden
@@ -1,0 +1,7 @@
+{
+  "name": "default",
+  "kubernetes_namespace": "default-namespace",
+  "created_time": "2024-09-10 23:00:00 +0000 UTC",
+  "updated_time": "2024-09-10 23:00:00 +0000 UTC",
+  "flink_application_defaults": "{\"property\":\"value\"}"
+}

--- a/test/fixtures/output/flink/environment/update-success-yaml.golden
+++ b/test/fixtures/output/flink/environment/update-success-yaml.golden
@@ -1,5 +1,6 @@
 name: default
-kubernetes_namespace: default-namespace
-created_time: 2024-09-10 23:00:00 +0000 UTC
-updated_time: 2024-09-10 23:00:00 +0000 UTC
-flink_application_defaults: '{"property":"value"}'
+createdtime: 2024-09-10T23:00:00Z
+updatedtime: 2024-09-10T23:00:00Z
+flinkapplicationdefaults:
+    property: value
+kubernetesnamespace: default-namespace

--- a/test/fixtures/output/flink/environment/update-success-yaml.golden
+++ b/test/fixtures/output/flink/environment/update-success-yaml.golden
@@ -1,0 +1,5 @@
+name: default
+kubernetes_namespace: default-namespace
+created_time: 2024-09-10 23:00:00 +0000 UTC
+updated_time: 2024-09-10 23:00:00 +0000 UTC
+flink_application_defaults: '{"property":"value"}'

--- a/test/flink_onprem_test.go
+++ b/test/flink_onprem_test.go
@@ -74,10 +74,11 @@ func (s *CLITestSuite) TestFlinkApplicationCreate() {
 		{args: "flink application create --environment default test/fixtures/input/flink/application/create-unsuccessful-application.json", fixture: "flink/application/create-unsuccessful-application.golden", exitCode: 1},
 		{args: "flink application create --environment default test/fixtures/input/flink/application/create-duplicate-application.json", fixture: "flink/application/create-duplicate-application.golden", exitCode: 1},
 		{args: "flink application create --environment non-existent test/fixtures/input/flink/application/create-with-non-existent-environment.json", fixture: "flink/application/create-with-non-existent-environment.golden", exitCode: 1},
-		{args: "flink application create --environment default test/fixtures/input/flink/application/create-new.json --output human", fixture: "flink/application/create-with-human.golden", exitCode: 1},
 		// success
 		{args: "flink application create --environment default test/fixtures/input/flink/application/create-new.json", fixture: "flink/application/create-success.golden"},
 		{args: "flink application create --environment default test/fixtures/input/flink/application/create-new.json --output yaml", fixture: "flink/application/create-success-yaml.golden"},
+		// explicit test to see that even if the output is set to human, the output is still in json
+		{args: "flink application create --environment default test/fixtures/input/flink/application/create-new.json --output human", fixture: "flink/application/create-with-human.golden"},
 	}
 
 	for _, test := range tests {
@@ -91,10 +92,11 @@ func (s *CLITestSuite) TestFlinkApplicationUpdate() {
 		{args: "flink application update --environment default test/fixtures/input/flink/application/update-non-existent.json", fixture: "flink/application/update-non-existent.golden", exitCode: 1},
 		{args: "flink application update --environment update-failure test/fixtures/input/flink/application/update-failure.json", fixture: "flink/application/update-failure.golden", exitCode: 1},
 		{args: "flink application update --environment non-existent test/fixtures/input/flink/application/update-with-non-existent-environment.json", fixture: "flink/application/update-with-non-existent-environment.golden", exitCode: 1},
-		{args: "flink application update --environment default test/fixtures/input/flink/application/update-successful.json --output human", fixture: "flink/application/update-with-human.golden", exitCode: 1},
 		// success
 		{args: "flink application update --environment default test/fixtures/input/flink/application/update-successful.json", fixture: "flink/application/update-successful.golden"},
 		{args: "flink application update --environment default test/fixtures/input/flink/application/update-successful.json --output yaml", fixture: "flink/application/update-successful-yaml.golden"},
+		// explicit test to see that even if the output is set to human, the output is still in json
+		{args: "flink application update --environment default test/fixtures/input/flink/application/update-successful.json --output human", fixture: "flink/application/update-with-human.golden"},
 	}
 
 	for _, test := range tests {
@@ -157,6 +159,8 @@ func (s *CLITestSuite) TestFlinkApplicationDescribe() {
 		// success
 		{args: "flink application describe --environment default default-application-1", fixture: "flink/application/describe-success.golden"},
 		{args: "flink application describe --environment default default-application-1 --output yaml", fixture: "flink/application/describe-success-yaml.golden"},
+		// explicit test to see that even if the output is set to human, the output is still in json
+		{args: "flink application describe --environment default default-application-1 --output human", fixture: "flink/application/create-with-human.golden"},
 		// failure
 		{args: "flink application describe --environment default non-existent", fixture: "flink/application/describe-non-existent.golden", exitCode: 1},
 		{args: "flink application describe --environment non-existent default-application", fixture: "flink/application/describe-non-existent-environment.golden", exitCode: 1},

--- a/test/flink_onprem_test.go
+++ b/test/flink_onprem_test.go
@@ -160,7 +160,7 @@ func (s *CLITestSuite) TestFlinkApplicationDescribe() {
 		{args: "flink application describe --environment default default-application-1", fixture: "flink/application/describe-success.golden"},
 		{args: "flink application describe --environment default default-application-1 --output yaml", fixture: "flink/application/describe-success-yaml.golden"},
 		// explicit test to see that even if the output is set to human, the output is still in json
-		{args: "flink application describe --environment default default-application-1 --output human", fixture: "flink/application/create-with-human.golden"},
+		{args: "flink application describe --environment default default-application-1 --output human", fixture: "flink/application/describe-with-human.golden"},
 		// failure
 		{args: "flink application describe --environment default non-existent", fixture: "flink/application/describe-non-existent.golden", exitCode: 1},
 		{args: "flink application describe --environment non-existent default-application", fixture: "flink/application/describe-non-existent-environment.golden", exitCode: 1},

--- a/test/flink_onprem_test.go
+++ b/test/flink_onprem_test.go
@@ -74,8 +74,10 @@ func (s *CLITestSuite) TestFlinkApplicationCreate() {
 		{args: "flink application create --environment default test/fixtures/input/flink/application/create-unsuccessful-application.json", fixture: "flink/application/create-unsuccessful-application.golden", exitCode: 1},
 		{args: "flink application create --environment default test/fixtures/input/flink/application/create-duplicate-application.json", fixture: "flink/application/create-duplicate-application.golden", exitCode: 1},
 		{args: "flink application create --environment non-existent test/fixtures/input/flink/application/create-with-non-existent-environment.json", fixture: "flink/application/create-with-non-existent-environment.golden", exitCode: 1},
+		{args: "flink application create --environment default test/fixtures/input/flink/application/create-new.json --output human", fixture: "flink/application/create-with-human.golden", exitCode: 1},
 		// success
 		{args: "flink application create --environment default test/fixtures/input/flink/application/create-new.json", fixture: "flink/application/create-success.golden"},
+		{args: "flink application create --environment default test/fixtures/input/flink/application/create-new.json --output yaml", fixture: "flink/application/create-success-yaml.golden"},
 	}
 
 	for _, test := range tests {
@@ -89,8 +91,10 @@ func (s *CLITestSuite) TestFlinkApplicationUpdate() {
 		{args: "flink application update --environment default test/fixtures/input/flink/application/update-non-existent.json", fixture: "flink/application/update-non-existent.golden", exitCode: 1},
 		{args: "flink application update --environment update-failure test/fixtures/input/flink/application/update-failure.json", fixture: "flink/application/update-failure.golden", exitCode: 1},
 		{args: "flink application update --environment non-existent test/fixtures/input/flink/application/update-with-non-existent-environment.json", fixture: "flink/application/update-with-non-existent-environment.golden", exitCode: 1},
+		{args: "flink application update --environment default test/fixtures/input/flink/application/update-successful.json --output human", fixture: "flink/application/update-with-human.golden", exitCode: 1},
 		// success
 		{args: "flink application update --environment default test/fixtures/input/flink/application/update-successful.json", fixture: "flink/application/update-successful.golden"},
+		{args: "flink application update --environment default test/fixtures/input/flink/application/update-successful.json --output yaml", fixture: "flink/application/update-successful-yaml.golden"},
 	}
 
 	for _, test := range tests {
@@ -102,7 +106,9 @@ func (s *CLITestSuite) TestFlinkEnvironmentCreate() {
 	tests := []CLITest{
 		// success
 		{args: "flink environment create default-2 --kubernetes-namespace default-staging", fixture: "flink/environment/create-success.golden"},
+		{args: "flink environment create default-2 --kubernetes-namespace default-staging --output yaml", fixture: "flink/environment/create-success-yaml.golden"},
 		{args: "flink environment create default-2 --defaults test/fixtures/input/flink/environment/create-success-with-defaults.json --kubernetes-namespace default-staging", fixture: "flink/environment/create-success-with-defaults.golden"},
+		{args: "flink environment create default-2 --defaults test/fixtures/input/flink/environment/create-success-with-defaults.json --kubernetes-namespace default-staging --output json", fixture: "flink/environment/create-success-with-defaults-json.golden"},
 		// failure
 		{args: "flink environment create default-failure --kubernetes-namespace default-staging", fixture: "flink/environment/create-failure.golden", exitCode: 1},
 		{args: "flink environment create default --kubernetes-namespace default-staging", fixture: "flink/environment/create-existing.golden", exitCode: 1},
@@ -118,6 +124,8 @@ func (s *CLITestSuite) TestFlinkEnvironmentUpdate() {
 	tests := []CLITest{
 		// success
 		{args: "flink environment update default --defaults '{\"property\": \"value\"}'", fixture: "flink/environment/update-success.golden"},
+		{args: "flink environment update default --defaults '{\"property\": \"value\"}' --output yaml", fixture: "flink/environment/update-success-yaml.golden"},
+		{args: "flink environment update default --defaults '{\"property\": \"value\"}' --output json", fixture: "flink/environment/update-success-json.golden"},
 		// failure
 		{args: "flink environment update update-failure", fixture: "flink/environment/update-failure.golden", exitCode: 1},
 		{args: "flink environment update non-existent", fixture: "flink/environment/update-non-existent.golden", exitCode: 1},

--- a/test/test-server/flink_onprem_handler.go
+++ b/test/test-server/flink_onprem_handler.go
@@ -25,8 +25,8 @@ func createApplication(name string, environment string) cmfsdk.Application {
 		},
 		Spec: map[string]interface{}{
 			"flinkEnvironment": environment,
-			"image":                "confluentinc/cp-flink:1.19.1-cp1",
-			"flinkVersion":         "v1_19",
+			"image":            "confluentinc/cp-flink:1.19.1-cp1",
+			"flinkVersion":     "v1_19",
 			"flinkConfiguration": map[string]interface{}{
 				"taskmanager.numberOfTaskSlots":       "8",
 				"metrics.reporter.prom.factory.class": "org.apache.flink.metrics.prometheus.PrometheusReporterFactory",

--- a/test/test-server/flink_onprem_handler.go
+++ b/test/test-server/flink_onprem_handler.go
@@ -24,7 +24,7 @@ func createApplication(name string, environment string) cmfsdk.Application {
 			"name": name,
 		},
 		Spec: map[string]interface{}{
-			"flinkEnvironmentName": environment,
+			"flinkEnvironment": environment,
 			"image":                "confluentinc/cp-flink:1.19.1-cp1",
 			"flinkVersion":         "v1_19",
 			"flinkConfiguration": map[string]interface{}{


### PR DESCRIPTION
Release Notes
-------------
This change fixes two major issues:
- `flink environment create`, `flink environment update` and `flink environment describe` did not have an `--output` flag and always printed human output. With this change, we are introducing JSON and YAML output as well.
- So far, even though the `flink application create`, `flink application update` and `flink application describe` command did not have support for `human` output, the help section used to show it like `Specify the output format as "human", "json", or "yaml". (default "json")` which gives false hopes. With this PR, we are  fixing that by changing the registration method. 

Breaking Changes
- PLACEHOLDER

New Features
- PLACEHOLDER

Bug Fixes
- Adds `output` flag support to `flink environment create`, `flink environment describe` and `flink environment update` commands
- Remove misleading help from application commands for human output

Checklist
---------
- [ ] Leave this box unchecked if features are not yet available in production

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
<!--
Has it been tested? How?
Copy and paste any instructions or steps that can save the reviewer time.
-->