### PR TITLE
Revert "KGLOBAL-5675: Add support for mirror partition state summery for link describe  (#2920)"

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/confluentinc/ccloud-sdk-go-v2/iam v0.11.0
 	github.com/confluentinc/ccloud-sdk-go-v2/identity-provider v0.2.0
 	github.com/confluentinc/ccloud-sdk-go-v2/kafka-quotas v0.4.0
-	github.com/confluentinc/ccloud-sdk-go-v2/kafkarest v0.22.0
+	github.com/confluentinc/ccloud-sdk-go-v2/kafkarest v0.21.0
 	github.com/confluentinc/ccloud-sdk-go-v2/ksql v0.2.0
 	github.com/confluentinc/ccloud-sdk-go-v2/mds v0.4.0
 	github.com/confluentinc/ccloud-sdk-go-v2/metrics v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -233,8 +233,8 @@ github.com/confluentinc/ccloud-sdk-go-v2/identity-provider v0.2.0 h1:9TT8UCFRc5z
 github.com/confluentinc/ccloud-sdk-go-v2/identity-provider v0.2.0/go.mod h1:JLmrXfnT2PzcuXHD8a6c2cW1c9LKK7aMsdZjjqxYPEk=
 github.com/confluentinc/ccloud-sdk-go-v2/kafka-quotas v0.4.0 h1:T9e7lNj/VjxE89+tcpX2RS2NE4rWNWbJjxcO2yehEqM=
 github.com/confluentinc/ccloud-sdk-go-v2/kafka-quotas v0.4.0/go.mod h1:7gqwWFIyj2MAGpL/kf6SGXm/pi2Z6qpMJIjKlgEEhhg=
-github.com/confluentinc/ccloud-sdk-go-v2/kafkarest v0.22.0 h1:nnp7SQnGxhAIcSGSjZd0bjRWWN5qV4TPgsxBRSKKD6M=
-github.com/confluentinc/ccloud-sdk-go-v2/kafkarest v0.22.0/go.mod h1:FOaBPIbG2+RApcd9uriBno/yBRzjDOrGYIeJW2ZmIcY=
+github.com/confluentinc/ccloud-sdk-go-v2/kafkarest v0.21.0 h1:QXdyHcmx5xuX2D0THt2nJdhQ3YHOuPqoR8JfqalODCs=
+github.com/confluentinc/ccloud-sdk-go-v2/kafkarest v0.21.0/go.mod h1:1hTwJlTy/3WPjA6I4tFf3X8RjXRHe0RQhRYfR+gHaqc=
 github.com/confluentinc/ccloud-sdk-go-v2/ksql v0.2.0 h1:g6OHa1iW3HO3N/YiTAL9Q6Y7rdjMBAjOPYK37akTt0M=
 github.com/confluentinc/ccloud-sdk-go-v2/ksql v0.2.0/go.mod h1:0LAvd4VqlaRwKU4yvDEkVCtV43yNezt56+hBe9Lmg7Q=
 github.com/confluentinc/ccloud-sdk-go-v2/mds v0.4.0 h1:jIXXhGi+Xn+XYFCErnMvd035QijbYXla1Bo8W7V7lFM=

--- a/internal/kafka/command_link_describe.go
+++ b/internal/kafka/command_link_describe.go
@@ -1,9 +1,6 @@
 package kafka
 
 import (
-	"fmt"
-	"strings"
-
 	"github.com/spf13/cobra"
 
 	kafkarestv3 "github.com/confluentinc/ccloud-sdk-go-v2/kafkarest/v3"
@@ -21,7 +18,6 @@ type linkOut struct {
 	State              string `human:"State" serialized:"state"`
 	Error              string `human:"Error,omitempty" serialized:"error,omitempty"`
 	ErrorMessage       string `human:"Error Message,omitempty" serialized:"error_message,omitempty"`
-	CategoryCounts     string `human:"Mirror Partition States Count,omitempty" serialized:"category_counts,omitempty"`
 }
 
 func (c *linkCommand) newDescribeCommand() *cobra.Command {
@@ -56,7 +52,7 @@ func (c *linkCommand) describe(cmd *cobra.Command, args []string) error {
 
 	table := output.NewTable(cmd)
 	table.Add(newDescribeLink(link, ""))
-	table.Filter(getDescribeFields(false))
+	table.Filter(getListFields(false))
 	return table.Print()
 }
 
@@ -64,11 +60,6 @@ func newDescribeLink(link kafkarestv3.ListLinksResponseData, topic string) *link
 	var linkError string
 	if link.GetLinkError() != "NO_ERROR" {
 		linkError = link.GetLinkError()
-	}
-	linkCategories := link.GetCategoryCounts()
-	categories := make([]string, len(linkCategories))
-	for i, category := range linkCategories {
-		categories[i] = fmt.Sprintf(`%s: %d`, category.StateCategory, category.Count)
 	}
 	return &linkOut{
 		Name:               link.GetLinkName(),
@@ -79,16 +70,5 @@ func newDescribeLink(link kafkarestv3.ListLinksResponseData, topic string) *link
 		State:              link.GetLinkState(),
 		Error:              linkError,
 		ErrorMessage:       link.GetLinkErrorMessage(),
-		CategoryCounts:     strings.Join(categories, ", "),
 	}
-}
-
-func getDescribeFields(includeTopics bool) []string {
-	x := []string{"Name"}
-
-	if includeTopics {
-		x = append(x, "TopicName")
-	}
-
-	return append(x, "SourceCluster", "DestinationCluster", "RemoteCluster", "State", "Error", "ErrorMessage", "CategoryCounts")
 }

--- a/test/fixtures/output/kafka/link/describe-bidirectional-link.golden
+++ b/test/fixtures/output/kafka/link/describe-bidirectional-link.golden
@@ -1,8 +1,7 @@
-+-------------------------------+-------------------------+
-| Name                          | link-4                  |
-| Source Cluster                |                         |
-| Destination Cluster           |                         |
-| Remote Cluster                | cluster-2               |
-| State                         | AVAILABLE               |
-| Mirror Partition States Count | ACTIVE: 10, IN_ERROR: 2 |
-+-------------------------------+-------------------------+
++---------------------+-----------+
+| Name                | link-4    |
+| Source Cluster      |           |
+| Destination Cluster |           |
+| Remote Cluster      | cluster-2 |
+| State               | AVAILABLE |
++---------------------+-----------+

--- a/test/test-server/kafka_rest_router.go
+++ b/test/test-server/kafka_rest_router.go
@@ -718,10 +718,6 @@ func handleKafkaRestLink(t *testing.T) http.HandlerFunc {
 					ClusterLinkId:   "LINKID4",
 					TopicNames:      []string{"link-1-topic-1", "link-1-topic-2"},
 					LinkState:       cckafkarestv3.PtrString("AVAILABLE"),
-					CategoryCounts: []cckafkarestv3.LinkCategory{
-						{StateCategory: "ACTIVE", Count: 10},
-						{StateCategory: "IN_ERROR", Count: 2},
-					},
 				})
 				require.NoError(t, err)
 			} else if link == "link-5" {


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- PLACEHOLDER

New Features
- PLACEHOLDER

Bug Fixes
- PLACEHOLDER

Checklist
---------
- [ ] Leave this box unchecked if features are not yet available in production

What
----
Temporarily reverting to unblock release while we resolve the naming mismatch for
```
CategoryCounts string `human:"Mirror Partition States Count,omitempty" serialized:"category_counts,omitempty"`
```

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
<!--
Has it been tested? How?
Copy and paste any instructions or steps that can save the reviewer time.
-->