### PR TITLE
Switch back to 1.22.7 in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/confluentinc/cli/v4
 
-go 1.22.8
-
-toolchain go1.22.9
+go 1.22.7
 
 require (
 	github.com/antihax/optional v1.0.0
@@ -29,9 +27,10 @@ require (
 	github.com/confluentinc/ccloud-sdk-go-v2/connect v0.7.0
 	github.com/confluentinc/ccloud-sdk-go-v2/connect-custom-plugin v0.0.6
 	github.com/confluentinc/ccloud-sdk-go-v2/flink v0.9.0
-	github.com/confluentinc/ccloud-sdk-go-v2/flink-artifact v0.2.0
+	github.com/confluentinc/ccloud-sdk-go-v2/flink-artifact v0.3.0
 	github.com/confluentinc/ccloud-sdk-go-v2/flink-gateway v0.17.0
 	github.com/confluentinc/ccloud-sdk-go-v2/iam v0.11.0
+	github.com/confluentinc/ccloud-sdk-go-v2/iam-ip-filtering v0.3.0
 	github.com/confluentinc/ccloud-sdk-go-v2/identity-provider v0.2.0
 	github.com/confluentinc/ccloud-sdk-go-v2/kafka-quotas v0.4.0
 	github.com/confluentinc/ccloud-sdk-go-v2/kafkarest v0.21.0
@@ -140,7 +139,6 @@ require (
 	github.com/charmbracelet/x/term v0.1.1 // indirect
 	github.com/charmbracelet/x/windows v0.1.0 // indirect
 	github.com/cloudflare/circl v1.3.7 // indirect
-	github.com/confluentinc/ccloud-sdk-go-v2/iam-ip-filtering v0.3.0 // indirect
 	github.com/confluentinc/proto-go-setter v0.3.0 // indirect
 	github.com/cyphar/filepath-securejoin v0.2.4 // indirect
 	github.com/distribution/reference v0.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -219,14 +219,12 @@ github.com/confluentinc/ccloud-sdk-go-v2/connect-custom-plugin v0.0.6 h1:DYQyS4l
 github.com/confluentinc/ccloud-sdk-go-v2/connect-custom-plugin v0.0.6/go.mod h1:odu6w/vnVrZo00N4yHq5buzWOme1vT1WqksQ3y69sQU=
 github.com/confluentinc/ccloud-sdk-go-v2/flink v0.9.0 h1:QqtIFEB5E3CIyGMJd7NQBEtc/k3K11PX7f4Fj7sPFdo=
 github.com/confluentinc/ccloud-sdk-go-v2/flink v0.9.0/go.mod h1:GPj4sfR85OyiFQUMNEq1DtPOjYVAuE222Z6Mcapwa48=
-github.com/confluentinc/ccloud-sdk-go-v2/flink-artifact v0.2.0 h1:pK6FXbkUpi/bsXITNqn8QlP5FBo3AWkOGAAy1PFxbhQ=
-github.com/confluentinc/ccloud-sdk-go-v2/flink-artifact v0.2.0/go.mod h1:wNjniScBvFY3xsT+PWGqU8kLJ+QXLn0fpvdK9R4B68A=
+github.com/confluentinc/ccloud-sdk-go-v2/flink-artifact v0.3.0 h1:DVWL3Y4b5azgCADubtyp3EhGZuyJkleINaTy2V3iius=
+github.com/confluentinc/ccloud-sdk-go-v2/flink-artifact v0.3.0/go.mod h1:P4fdIkI1ynjSvhDEGX283KhtzG51eGHQc5Cqtp7bu1Q=
 github.com/confluentinc/ccloud-sdk-go-v2/flink-gateway v0.17.0 h1:8Y1uXjolI2d5mawcfLn4OfJ81WRMQpjMFWdBm3dLdrk=
 github.com/confluentinc/ccloud-sdk-go-v2/flink-gateway v0.17.0/go.mod h1:cJ6erfVlWSyz6L+2dR46cF2+s5I2r+pTNrPm2fNbcqU=
 github.com/confluentinc/ccloud-sdk-go-v2/iam v0.11.0 h1:ZUAow4L6De1FwYoiwvEodm4lvxc+46wNW+IEAb7K9VU=
 github.com/confluentinc/ccloud-sdk-go-v2/iam v0.11.0/go.mod h1:2Lm82ly9Yh5LLhp8OTnUGqjz4JdIXAZ5a0/u9T+rGGU=
-github.com/confluentinc/ccloud-sdk-go-v2/iam-ip-filtering v0.1.0 h1:SowmwmquKo6hIjK+VmadgCtRQa8rxt78uFzXkMCrKqQ=
-github.com/confluentinc/ccloud-sdk-go-v2/iam-ip-filtering v0.1.0/go.mod h1:S/XMI3WghekXGkLkHvt0l6RfK/2v67Dk+ZCaDjmGz8g=
 github.com/confluentinc/ccloud-sdk-go-v2/iam-ip-filtering v0.3.0 h1:fOUGLnsL+oASdPwYcWX7wB4Wck1OYZEOLAkSB6nd3pE=
 github.com/confluentinc/ccloud-sdk-go-v2/iam-ip-filtering v0.3.0/go.mod h1:S/XMI3WghekXGkLkHvt0l6RfK/2v67Dk+ZCaDjmGz8g=
 github.com/confluentinc/ccloud-sdk-go-v2/identity-provider v0.2.0 h1:9TT8UCFRc5zUdsE7UgMz7hqN+2KYnIkBcAKCaiZJrXw=


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- PLACEHOLDER

New Features
- PLACEHOLDER

Bug Fixes
- PLACEHOLDER

Checklist
---------
- [ ] Leave this box unchecked if features are not yet available in production

What
----
The previous PR changed the version in .go-version, but did not change the version in go.mod.

This PR updates the flink-artifact SDK to a new version that doesn't require 1.22.8, and removes the 1.22.9 toolchain requirement.

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
<!--
Has it been tested? How?
Copy and paste any instructions or steps that can save the reviewer time.
-->