### PR TITLE
Remove dependence on remote docker image

### DIFF
--- a/docker/Dockerfile_linux_repos
+++ b/docker/Dockerfile_linux_repos
@@ -1,6 +1,9 @@
-FROM --platform=linux/amd64 050879227952.dkr.ecr.us-west-1.amazonaws.com/confluentinc/cli-linux-repo-base-amd64:latest
+FROM --platform=linux/amd64 ubuntu:jammy-20231211.1
 
 SHELL ["/bin/bash", "-c"]
+
+RUN apt-get update && \
+    apt-get install -y aptly createrepo-c libxml2-utils
 
 COPY . /cli/
 


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- PLACEHOLDER

New Features
- General updates and improvements

Bug Fixes
- PLACEHOLDER

Checklist
---------
- [x] Leave this box unchecked if features are not yet available in production

What
----
The base image for the Dockerfile_linux_repos dockerfile is currently unavailable, so this PR modifies Dockerfile_linux_repos to account for it.

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
Ran `VERSION=v4.10.0 scripts/build_linux.sh` to verify that it builds correctly.