### PR TITLE
This PR reapplies the reverted PR(#2922)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,7 +55,7 @@ go.work.sum
 .LSOverride
 
 # Icon must end with two \r
-Icon
+Icon
 
 # Thumbnails
 ._*

--- a/internal/flink/command_statement.go
+++ b/internal/flink/command_statement.go
@@ -31,6 +31,7 @@ func (c *command) newStatementCommand() *cobra.Command {
 	cmd.AddCommand(c.newStatementDescribeCommand())
 	cmd.AddCommand(c.newStatementExceptionCommand())
 	cmd.AddCommand(c.newStatementListCommand())
+	cmd.AddCommand(c.newStatementResumeCommand())
 	cmd.AddCommand(c.newStatementStopCommand())
 	cmd.AddCommand(c.newStatementUpdateCommand())
 

--- a/internal/flink/command_statement_resume.go
+++ b/internal/flink/command_statement_resume.go
@@ -1,0 +1,100 @@
+package flink
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	flinkgatewayv1 "github.com/confluentinc/ccloud-sdk-go-v2/flink-gateway/v1"
+
+	pcmd "github.com/confluentinc/cli/v4/pkg/cmd"
+	"github.com/confluentinc/cli/v4/pkg/examples"
+	"github.com/confluentinc/cli/v4/pkg/output"
+	"github.com/confluentinc/cli/v4/pkg/resource"
+)
+
+func (c *command) newStatementResumeCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:               "resume <name>",
+		Short:             "Resume a Flink SQL statement.",
+		Args:              cobra.ExactArgs(1),
+		ValidArgsFunction: pcmd.NewValidArgsFunction(c.validStatementArgs),
+		RunE:              c.statementResume,
+		Example: examples.BuildExampleString(
+			examples.Example{
+				Text: `Request to resume statement "my-statement" with original principal id and compute pool.`,
+				Code: "confluent flink statement resume my-statement",
+			},
+			examples.Example{
+				Text: `Request to resume statement "my-statement" with service account "sa-123456".`,
+				Code: "confluent flink statement resume my-statement --principal sa-123456",
+			},
+			examples.Example{
+				Text: `Request to resume statement "my-statement" with user account "u-987654".`,
+				Code: "confluent flink statement resume my-statement --principal u-987654",
+			},
+			examples.Example{
+				Text: `Request to resume statement "my-statement" and move to compute pool "lfcp-123456".`,
+				Code: "confluent flink statement resume my-statement --compute-pool lfcp-123456",
+			},
+			examples.Example{
+				Text: `Request to resume statement "my-statement" with service account "sa-123456" and move to compute pool "lfcp-123456".`,
+				Code: "confluent flink statement resume my-statement --principal sa-123456 --compute-pool lfcp-123456",
+			},
+		),
+	}
+
+	c.addPrincipalFlag(cmd)
+	c.addComputePoolFlag(cmd)
+	pcmd.AddCloudFlag(cmd)
+	pcmd.AddRegionFlagFlink(cmd, c.AuthenticatedCLICommand)
+	pcmd.AddEnvironmentFlag(cmd, c.AuthenticatedCLICommand)
+	pcmd.AddContextFlag(cmd, c.CLICommand)
+
+	return cmd
+}
+
+func (c *command) statementResume(cmd *cobra.Command, args []string) error {
+	environmentId, err := c.Context.EnvironmentId()
+	if err != nil {
+		return err
+	}
+
+	client, err := c.GetFlinkGatewayClient(false)
+	if err != nil {
+		return err
+	}
+
+	statement, err := client.GetStatement(environmentId, args[0], c.Context.GetCurrentOrganization())
+	if err != nil {
+		return err
+	}
+
+	// Support resume a Flink statement with a different principal and/or compute-pool
+	principal, err := cmd.Flags().GetString("principal")
+	if err != nil {
+		return err
+	}
+	if principal != "" {
+		statement.Spec.SetPrincipal(principal)
+	}
+
+	computePool, err := cmd.Flags().GetString("compute-pool")
+	if err != nil {
+		return err
+	}
+	if computePool != "" {
+		statement.Spec.SetComputePoolId(computePool)
+	}
+
+	statement.Spec.Stopped = flinkgatewayv1.PtrBool(false)
+
+	// the UPDATE statement is an async API
+	// An accepted response 202 doesn't necessarily mean the UPDATE will be successful/complete
+	if err := client.UpdateStatement(environmentId, args[0], c.Context.GetCurrentOrganization(), statement); err != nil {
+		return fmt.Errorf("failed to resume %s \"%s\": %w", resource.FlinkStatement, args[0], err)
+	}
+
+	output.Printf(c.Config.EnableColor, "Requested to resume %s \"%s\".\n", resource.FlinkStatement, args[0])
+	return nil
+}

--- a/test/fixtures/output/flink/statement/help.golden
+++ b/test/fixtures/output/flink/statement/help.golden
@@ -9,6 +9,7 @@ Available Commands:
   describe    Describe a Flink SQL statement.
   exception   Manage Flink SQL statement exceptions.
   list        List Flink SQL statements.
+  resume      Resume a Flink SQL statement.
   stop        Stop a Flink SQL statement.
   update      Update a Flink SQL statement.
 

--- a/test/fixtures/output/flink/statement/resume-help.golden
+++ b/test/fixtures/output/flink/statement/resume-help.golden
@@ -1,45 +1,32 @@
-Update a Flink SQL statement.
+Resume a Flink SQL statement.
 
 Usage:
-  confluent flink statement update <name> [flags]
+  confluent flink statement resume <name> [flags]
 
 Examples:
-Request to update the principal of statement "my-statement" to service account "sa-123456".
-
-  $ confluent flink statement update my-statement --principal sa-123456
-
-Request to move "my-statement" to compute pool "lfcp-123456".
-
-  $ confluent flink statement update my-statement --compute-pool lfcp-123456
-
 Request to resume statement "my-statement" with original principal id and compute pool.
 
-  $ confluent flink statement update my-statement --stopped=false
+  $ confluent flink statement resume my-statement
 
 Request to resume statement "my-statement" with service account "sa-123456".
 
-  $ confluent flink statement update my-statement --stopped=false --principal sa-123456
+  $ confluent flink statement resume my-statement --principal sa-123456
 
 Request to resume statement "my-statement" with user account "u-987654".
 
-  $ confluent flink statement update my-statement --stopped=false --principal u-987654
+  $ confluent flink statement resume my-statement --principal u-987654
 
 Request to resume statement "my-statement" and move to compute pool "lfcp-123456".
 
-  $ confluent flink statement update my-statement --stopped=false --compute-pool lfcp-123456
+  $ confluent flink statement resume my-statement --compute-pool lfcp-123456
 
 Request to resume statement "my-statement" with service account "sa-123456" and move to compute pool "lfcp-123456".
 
-  $ confluent flink statement update my-statement --stopped=false --principal sa-123456 --compute-pool lfcp-123456
-
-Request to stop statement "my-statement".
-
-  $ confluent flink statement update my-statement --stopped=true
+  $ confluent flink statement resume my-statement --principal sa-123456 --compute-pool lfcp-123456
 
 Flags:
       --principal string      A user or service account the statement runs as.
       --compute-pool string   Flink compute pool ID.
-      --stopped               Request to stop or resume the statement.
       --cloud string          Specify the cloud provider as "aws", "azure", or "gcp".
       --region string         Cloud region for Flink (use "confluent flink region list" to see all).
       --environment string    Environment ID.

--- a/test/fixtures/output/flink/statement/resume-invalid-compute-pool.golden
+++ b/test/fixtures/output/flink/statement/resume-invalid-compute-pool.golden
@@ -1,0 +1,1 @@
+Error: failed to resume Flink SQL statement "my-statement": logical compute pool=lfcp-654321 not found

--- a/test/fixtures/output/flink/statement/resume-invalid-principal.golden
+++ b/test/fixtures/output/flink/statement/resume-invalid-principal.golden
@@ -1,0 +1,1 @@
+Error: failed to resume Flink SQL statement "my-statement": Bad Request

--- a/test/fixtures/output/flink/statement/resume-valid.golden
+++ b/test/fixtures/output/flink/statement/resume-valid.golden
@@ -1,0 +1,1 @@
+Requested to resume Flink SQL statement "my-statement".

--- a/test/fixtures/output/flink/statement/update-invalid-compute-pool.golden
+++ b/test/fixtures/output/flink/statement/update-invalid-compute-pool.golden
@@ -1,0 +1,1 @@
+Error: failed to update Flink SQL statement "my-statement": logical compute pool=lfcp-654321 not found

--- a/test/fixtures/output/flink/statement/update-invalid-principal.golden
+++ b/test/fixtures/output/flink/statement/update-invalid-principal.golden
@@ -1,0 +1,1 @@
+Error: failed to update Flink SQL statement "my-statement": Bad Request

--- a/test/flink_test.go
+++ b/test/flink_test.go
@@ -224,9 +224,20 @@ func (s *CLITestSuite) TestFlinkStatement() {
 		{args: "flink statement list --cloud aws --region eu-west-1 --compute-pool lfcp-nonexistent", fixture: "flink/statement/list-cp-not-found.golden", exitCode: 1},
 		{args: "flink statement list --cloud aws --region eu-west-2 --compute-pool lfcp-123456", fixture: "flink/statement/list-cp-incorrect-region.golden", exitCode: 1},
 		{args: "flink statement stop my-statement --cloud aws --region eu-west-1", fixture: "flink/statement/stop.golden"},
+		{args: "flink statement resume my-statement --cloud aws --region eu-west-1", fixture: "flink/statement/resume-valid.golden"},
+		{args: "flink statement resume my-statement --cloud aws --region eu-west-1 --principal u-123456", fixture: "flink/statement/resume-valid.golden"},
+		{args: "flink statement resume my-statement --cloud aws --region eu-west-1 --compute-pool lfcp-123456", fixture: "flink/statement/resume-valid.golden"},
+		{args: "flink statement resume my-statement --cloud aws --region eu-west-1 --principal u-123456 --compute-pool lfcp-123456", fixture: "flink/statement/resume-valid.golden"},
+		{args: "flink statement resume my-statement --cloud aws --region eu-west-1 --principal sa-654321", fixture: "flink/statement/resume-invalid-principal.golden", exitCode: 1},
+		{args: "flink statement resume my-statement --cloud aws --region eu-west-1 --compute-pool lfcp-654321", fixture: "flink/statement/resume-invalid-compute-pool.golden", exitCode: 1},
 		{args: "flink statement update my-statement --cloud aws --region eu-west-1 --compute-pool lfcp-123456", fixture: "flink/statement/update-compute-pool.golden"},
-		{args: "flink statement update my-statement --cloud aws --region eu-west-1 --principal sa-123456", fixture: "flink/statement/update-principal.golden"},
+		{args: "flink statement update my-statement --cloud aws --region eu-west-1 --principal u-123456", fixture: "flink/statement/update-principal.golden"},
 		{args: "flink statement update my-statement --cloud aws --region eu-west-1 --stopped=false", fixture: "flink/statement/update-stopped.golden"},
+		{args: "flink statement update my-statement --cloud aws --region eu-west-1 --stopped=false --principal u-123456", fixture: "flink/statement/update-stopped.golden"},
+		{args: "flink statement update my-statement --cloud aws --region eu-west-1 --stopped=false --compute-pool lfcp-123456", fixture: "flink/statement/update-stopped.golden"},
+		{args: "flink statement update my-statement --cloud aws --region eu-west-1 --stopped=false --compute-pool lfcp-123456 --principal u-123456", fixture: "flink/statement/update-stopped.golden"},
+		{args: "flink statement update my-statement --cloud aws --region eu-west-1 --stopped=false --compute-pool lfcp-654321", fixture: "flink/statement/update-invalid-compute-pool.golden", exitCode: 1},
+		{args: "flink statement update my-statement --cloud aws --region eu-west-1 --stopped=false --principal u-654321", fixture: "flink/statement/update-invalid-principal.golden", exitCode: 1},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

This PR supports resume the Flink statement with below different valid scenarios:

- Resume under the original `computePool` and `principalId`.
- Resume under a different `computePool` but original `principalId`.
- Resume under a different `principalId` but original `computePool`.
- Resume under a different `computePool` and different `principalId`.

And invalid scenarios:

- Resume under an invalid computePool, the UPDATE request will fail immediately.
- Resume under an invalid user account principalId, the UPDATE request will fail immediately.
- Resume under an invalid service account principalId, the UPDATE request will pass but the statement itself will fail subsequently, and the failed statement can be resumed later.

New Features
-------------
- The Flink statement resume support can use both the `resume` and `update` interfaces, which are functionally equivalent, for example:

```
`Request to resume statement "my-statement" with service account "sa-123456" and move to compute pool "lfcp-123456".`
confluent flink statement update my-statement --stopped=false --principal sa-123456 --compute-pool lfcp-123456
confluent flink statement resume my-statement --principal sa-123456 --compute-pool lfcp-123456
```
Checklist
---------
- [x] Leave this box unchecked if features are not yet available in production

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
<!--
Has it been tested? How?
Copy and paste any instructions or steps that can save the reviewer time.
-->
Manual verification:
https://docs.google.com/document/d/1q93WL5HXyh9i4143tQwbTyBs5LwIUbieiRL4IQT-PWc/edit?tab=t.0#heading=h.q4ezisb3sd4t