### PR TITLE
[CLI-3337] Map single-zone and multi-zone to high and low for freight clusters

### DIFF
--- a/internal/kafka/command_cluster.go
+++ b/internal/kafka/command_cluster.go
@@ -14,16 +14,25 @@ const (
 	multiZone        = "multi-zone"
 	lowAvailability  = "SINGLE_ZONE"
 	highAvailability = "MULTI_ZONE"
+	low              = "LOW"
+	high             = "HIGH"
 )
 
 var availabilitiesToHuman = map[string]string{
 	lowAvailability:  singleZone,
 	highAvailability: multiZone,
+	low:              singleZone,
+	high:             multiZone,
 }
 
 var availabilitiesToModel = map[string]string{
 	singleZone: lowAvailability,
 	multiZone:  highAvailability,
+}
+
+var availabilitiesToFreightModel = map[string]string{
+	singleZone: low,
+	multiZone:  high,
 }
 
 type clusterCommand struct {

--- a/internal/kafka/command_cluster_create.go
+++ b/internal/kafka/command_cluster_create.go
@@ -77,22 +77,22 @@ func (c *clusterCommand) create(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	availabilityString, err := cmd.Flags().GetString("availability")
-	if err != nil {
-		return err
-	}
-
-	availability, err := stringToAvailability(availabilityString)
-	if err != nil {
-		return err
-	}
-
 	clusterType, err := cmd.Flags().GetString("type")
 	if err != nil {
 		return err
 	}
 
 	sku, err := stringToSku(clusterType)
+	if err != nil {
+		return err
+	}
+
+	availabilityString, err := cmd.Flags().GetString("availability")
+	if err != nil {
+		return err
+	}
+
+	availability, err := stringToAvailability(availabilityString, sku)
 	if err != nil {
 		return err
 	}
@@ -163,7 +163,12 @@ func (c *clusterCommand) create(cmd *cobra.Command, args []string) error {
 	return c.outputKafkaClusterDescription(cmd, &kafkaCluster, false)
 }
 
-func stringToAvailability(s string) (string, error) {
+func stringToAvailability(s string, sku ccstructs.Sku) (string, error) {
+	if sku == ccstructs.Sku_FREIGHT {
+		if modelAvailability, ok := availabilitiesToFreightModel[s]; ok {
+			return modelAvailability, nil
+		}
+	}
 	if modelAvailability, ok := availabilitiesToModel[s]; ok {
 		return modelAvailability, nil
 	}

--- a/internal/kafka/command_cluster_create.go
+++ b/internal/kafka/command_cluster_create.go
@@ -168,9 +168,10 @@ func stringToAvailability(s string, sku ccstructs.Sku) (string, error) {
 		if modelAvailability, ok := availabilitiesToFreightModel[s]; ok {
 			return modelAvailability, nil
 		}
-	}
-	if modelAvailability, ok := availabilitiesToModel[s]; ok {
-		return modelAvailability, nil
+	} else {
+		if modelAvailability, ok := availabilitiesToModel[s]; ok {
+			return modelAvailability, nil
+		}
 	}
 	return "", errors.NewErrorWithSuggestions(
 		fmt.Sprintf("invalid value \"%s\" for `--availability` flag", s),

--- a/test/fixtures/output/kafka/cluster/create-freight-low.golden
+++ b/test/fixtures/output/kafka/cluster/create-freight-low.golden
@@ -1,0 +1,16 @@
+It may take up to 5 minutes for the Kafka cluster to be ready.
++----------------------+---------------------------+
+| Current              | false                     |
+| ID                   | lkc-def963                |
+| Name                 | my-new-cluster            |
+| Type                 | FREIGHT                   |
+| Ingress Limit (MB/s) | 250                       |
+| Egress Limit (MB/s)  | 750                       |
+| Storage              | Infinite                  |
+| Cloud                | aws                       |
+| Region               | us-east-1                 |
+| Availability         | single-zone               |
+| Status               | PROVISIONING              |
+| Endpoint             | SASL_SSL://kafka-endpoint |
+| REST Endpoint        | https://pkc-endpoint      |
++----------------------+---------------------------+

--- a/test/kafka_test.go
+++ b/test/kafka_test.go
@@ -37,7 +37,7 @@ func (s *CLITestSuite) TestKafka() {
 		{args: "kafka cluster create my-new-cluster --cloud aws --region us-east-1 --type enterprise --availability multi-zone", fixture: "kafka/cluster/create-enterprise.golden"},
 		{args: "kafka cluster create my-new-cluster --cloud aws --region us-east-1 --type enterprise", fixture: "kafka/cluster/create-enterprise-availability-zone-error.golden", exitCode: 1},
 		{args: "kafka cluster create my-new-cluster --cloud aws --region us-east-1 --type freight --availability multi-zone", fixture: "kafka/cluster/create-freight.golden"},
-		{args: "kafka cluster create my-new-cluster --cloud aws --region us-east-1 --type freight", fixture: "kafka/cluster/create-freight-availability-zone-error.golden", exitCode: 1},
+		{args: "kafka cluster create my-new-cluster --cloud aws --region us-east-1 --type freight", fixture: "kafka/cluster/create-freight-low.golden"},
 
 		{args: "kafka cluster update lkc-update", fixture: "kafka/cluster/create-flag-error.golden", exitCode: 1},
 		{args: "kafka cluster update lkc-update --name lkc-update-name", fixture: "kafka/26.golden"},


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- PLACEHOLDER

New Features
- PLACEHOLDER

Bug Fixes
- PLACEHOLDER

Checklist
---------
- [ ] Leave this box unchecked if features are not yet available in production

What
----
For freight clusters, `LOW` and `SINGLE_ZONE` are not the same. `LOW` is acceptable but `SINGLE_ZONE` is not. For freight clusters only, we want to map single-zone and multi-zone to low and high.

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
<!--
Has it been tested? How?
Copy and paste any instructions or steps that can save the reviewer time.
-->