### PR TITLE
[CLI-3342] Fix issue of describe command return none found in staging

### DIFF
--- a/internal/api-key/command_describe.go
+++ b/internal/api-key/command_describe.go
@@ -71,9 +71,11 @@ func (c *command) describe(cmd *cobra.Command, args []string) error {
 
 	resources := []apikeysv2.ObjectReference{apiKey.Spec.GetResource()}
 
+	multiClusterResources := apiKey.Spec.GetResources()
+
 	// Check if multicluster keys are enabled, and if so check the resources field
-	if featureflags.Manager.BoolVariation("cli.multicluster-api-keys.enable", c.Context, config.CliLaunchDarklyClient, true, false) {
-		resources = apiKey.Spec.GetResources()
+	if featureflags.Manager.BoolVariation("cli.multicluster-api-keys.enable", c.Context, config.CliLaunchDarklyClient, true, false) && len(multiClusterResources) > 0 {
+		resources = multiClusterResources
 	}
 
 	list := output.NewList(cmd)

--- a/internal/api-key/command_list.go
+++ b/internal/api-key/command_list.go
@@ -117,9 +117,11 @@ func (c *command) list(cmd *cobra.Command, _ []string) error {
 		email := c.getEmail(ownerId, auditLogServiceAccountId, resourceIdToUserIdMap, usersMap, serviceAccountsMap)
 		resources := []apikeysv2.ObjectReference{apiKey.Spec.GetResource()}
 
+		multiClusterResources := apiKey.Spec.GetResources()
+
 		// Check if multicluster keys are enabled, and if so check the resources field
-		if featureflags.Manager.BoolVariation("cli.multicluster-api-keys.enable", c.Context, config.CliLaunchDarklyClient, true, false) && len(apiKey.Spec.GetResources()) > 0 {
-			resources = apiKey.Spec.GetResources()
+		if featureflags.Manager.BoolVariation("cli.multicluster-api-keys.enable", c.Context, config.CliLaunchDarklyClient, true, false) && len(multiClusterResources) > 0 {
+			resources = multiClusterResources
 		}
 
 		// Note that if more resource types are added with no logical clusters, then additional logic


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- PLACEHOLDER

New Features
- PLACEHOLDER

Bug Fixes
- Fix a bug in non-prod environment for `confluent api-key describe [API_KEY]` where api key is not correctly displayed

Checklist
---------
- [x] Leave this box unchecked if features are not yet available in production

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->
The `confluent api-key describe` command always returns “None found.” in stag environment. The root cause is that in stag the feature flag is enabled, while in prod it's disabled, and in stag the resource gets override during describe, which is unexpected. This fix is to workaround the "None found." issue by following the same coding pattern in command_list.go.


References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
<!--
Has it been tested? How?
Copy and paste any instructions or steps that can save the reviewer time.
-->
Tested using a stag org and a prod org.

