### PR TITLE
DGS-19209 AsyncApi export - failing to read from topic and output correct data

### DIFF
--- a/internal/asyncapi/command_export.go
+++ b/internal/asyncapi/command_export.go
@@ -111,7 +111,9 @@ func (c *command) export(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return err
 	}
-	defer accountDetails.consumer.Close()
+	if flags.consumeExamples {
+		defer accountDetails.consumer.Close()
+	}
 	// Servers & Info Section
 	reflector := addServer(accountDetails.kafkaUrl, accountDetails.schemaRegistryUrl, flags.specVersion)
 	log.CliLogger.Debug("Generating AsyncAPI specification")


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Bug Fixes
- Prevent `confluent asyncapi export` from always failing when `--consume-examples` is passed

Checklist
---------
- [x] Leave this box unchecked if features are not yet available in production

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->

Consume examples flag for asyncapi export had some issues, fixed
- Closing Kafka consumer too early
- Passing incorrect type to schema deserializer

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
<!--
Has it been tested? How?
Copy and paste any instructions or steps that can save the reviewer time.
-->

Manually tested to confirm `--consume-examples` works