### PR TITLE
[APIT-2655] Unable to start Kafka local with CLI

### DIFF
--- a/internal/local/command_kafka_start.go
+++ b/internal/local/command_kafka_start.go
@@ -372,6 +372,10 @@ func checkMachineArch() error {
 		systemArch = "amd64"
 	}
 
+	if systemArch == "aarch64" {
+		systemArch = "arm64"
+	}
+
 	if systemArch != runtime.GOARCH {
 		return errors.NewErrorWithSuggestions(
 			fmt.Sprintf(`binary architecture "%s" does not match system architecture "%s"`, runtime.GOARCH, systemArch),


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- PLACEHOLDER

New Features
- PLACEHOLDER

Bug Fixes
- Fix an architecture CLI error for `confluent local kafka start` command  

Checklist
---------
- [x] Leave this box unchecked if features are not yet available in production

What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->
The CLI outputs an `Error: binary architecture "arm64" does not match system architecture "aarch64"` error when user has a system architecture of aarch64. This change adds a mapping from aarch64 to arm64. 

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
<!--
Has it been tested? How?
Copy and paste any instructions or steps that can save the reviewer time.
--> 