### PR TITLE
CLI-3312: Fix major version notification when none exist

### DIFF
--- a/internal/update/command.go
+++ b/internal/update/command.go
@@ -93,7 +93,7 @@ func (c *command) update(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	minorVersions, majorVersions := pupdate.FilterUpdates(binaries, current, major)
+	minorVersions, majorVersions := pupdate.FilterUpdates(binaries, current)
 
 	if len(minorVersions) == 0 && len(majorVersions) == 0 {
 		output.Println(c.Config.EnableColor, "Already up to date.")
@@ -105,7 +105,7 @@ func (c *command) update(cmd *cobra.Command, _ []string) error {
 
 	versions := minorVersions
 	if major {
-		versions = majorVersions
+		versions = append(minorVersions, majorVersions...)
 	}
 
 	output.Printf(c.Config.EnableColor, "New version of confluent is available\n")

--- a/pkg/cmd/prerunner.go
+++ b/pkg/cmd/prerunner.go
@@ -730,7 +730,7 @@ func (r *PreRun) notifyIfUpdateAvailable(cmd *cobra.Command, _ string) {
 		return
 	}
 
-	minorVersions, majorVersions := update.FilterUpdates(binaries, current, false)
+	minorVersions, majorVersions := update.FilterUpdates(binaries, current)
 
 	if len(majorVersions) > 0 {
 		output.ErrPrintf(r.Config.EnableColor, "A major version update is available for %s from (current: %s, latest: %s).\n", pversion.CLIName, current, majorVersions[len(majorVersions)-1])

--- a/pkg/update/check.go
+++ b/pkg/update/check.go
@@ -8,7 +8,7 @@ import (
 )
 
 // FilterUpdates takes the HTML content of the binaries page and returns the versions that are valid minor and major updates.
-func FilterUpdates(binaries string, current *version.Version, major bool) (version.Collection, version.Collection) {
+func FilterUpdates(binaries string, current *version.Version) (version.Collection, version.Collection) {
 	matches := regexp.MustCompile(`<a href="/confluent-cli/binaries/([0-9]+\.[0-9]+\.[0-9]+)/">`).FindAllStringSubmatch(binaries, -1)
 
 	versions := make(version.Collection, len(matches))
@@ -24,12 +24,6 @@ func FilterUpdates(binaries string, current *version.Version, major bool) (versi
 		versions = versions[idx+1:]
 	}
 
-	if !major {
-		// Remove major versions
-		if idx := sort.Search(len(versions), func(i int) bool { return current.Segments()[0] < versions[i].Segments()[0] }); idx < len(versions) {
-			return versions[:idx], versions
-		}
-	}
-
-	return versions, versions
+	idx := sort.Search(len(versions), func(i int) bool { return versions[i].Segments()[0] > current.Segments()[0] })
+	return versions[:idx], versions[idx:]
 }

--- a/pkg/update/check_test.go
+++ b/pkg/update/check_test.go
@@ -1,0 +1,31 @@
+package update
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-version"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFilterUpdates(t *testing.T) {
+	content := `<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
+<html>
+  <head>
+    <title>Index of confluent-cli/binaries</title>
+  </head>
+  <body>
+    <h1>Index of confluent-cli/binaries</h1>
+    <hr/>
+    <pre>
+      <a href="/confluent-cli/">../</a>
+      <a href="/confluent-cli/binaries/4.6.0/">4.6.0/</a>
+      <a href="/confluent-cli/binaries/4.7.0/">4.7.0/</a>
+    </pre>
+    <hr/>
+  </body>
+</html>`
+
+	minorVersions, majorVersions := FilterUpdates(content, version.Must(version.NewVersion("4.6.0")))
+	require.Equal(t, 1, len(minorVersions))
+	require.Equal(t, 0, len(majorVersions))
+}


### PR DESCRIPTION
Release Notes
-------------
Bug Fixes
- Do not notify of major version updates when there are only minor version updates

Checklist
---------
- [x] Leave this box unchecked if features are not yet available in production

What
----
* Do not notify of major version updates when there are only minor version updates 
* Make code more readable (and slightly less efficient, but that's ok) by always choosing to split version list into minor+major

References
----------
https://confluentinc.atlassian.net/browse/CLI-3312

Test & Review
-------------
Unit test, manual verification