### PR TITLE
[CLI-3288] Build all OS/Arch combinations in pipeline

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -17,7 +17,7 @@ blocks:
     dependencies: []
     task:
       jobs:
-        - name: linux/amd64
+        - name: "Test linux/amd64"
           commands:
             - checkout
             - sem-version go $(cat .go-version)
@@ -27,24 +27,60 @@ blocks:
             - make lint
             - make test
             - make test-installer
+        - name: "Build linux/amd64 (GLIBC)"
+          commands:
+            - checkout
+            - docker build . --file docker/Dockerfile_build_linux_amd64 --tag test-build
+        - name: "Build linux/amd64 (Alpine)"
+          commands:
+            - checkout
+            - sem-version go $(cat .go-version)
+            - export PATH=$(go env GOPATH)/bin:$PATH
+            - sudo apt install musl-tools --yes
+            - CC=musl-gcc CGO_LDFLAGS="-static" CGO_ENABLED=1 go build -tags musl -ldflags="-s -w -X main.commit="00000000" -X main.date="1970-01-01T00:00:00Z" -X main.isTest=true" ./cmd/confluent
       epilogue:
         always:
           commands:
             - test-results publish . -N "linux/amd64"
 
-  - name: darwin/arm64
+  - name: linux/arm64
+    dependencies: []
+    task:
+      agent:
+        machine:
+          type: s1-prod-ubuntu20-04-arm64-1
+      jobs:
+        - name: "Build linux/arm64 (GLIBC)"
+          commands:
+            - checkout
+            - docker build . --file docker/Dockerfile_build_linux_arm64 --tag test-build
+        - name: "Build linux/arm64 (Alpine)"
+          commands:
+            - checkout
+            - sem-version go $(cat .go-version)
+            - export PATH=$(go env GOPATH)/bin:$PATH
+            - sudo apt install musl-tools --yes
+            - CC=musl-gcc CGO_LDFLAGS="-static" CGO_ENABLED=1 go build -tags musl -ldflags="-s -w -X main.commit="00000000" -X main.date="1970-01-01T00:00:00Z" -X main.isTest=true" ./cmd/confluent
+
+  - name: darwin
     dependencies: []
     task:
       agent:
         machine:
           type: s1-prod-macos-13-5-arm64
       jobs:
-        - name: darwin/arm64
+        - name: "Build & Test darwin/arm64"
           commands:
             - checkout
             - sem-version go $(cat .go-version)
             - export PATH=$(go env GOPATH)/bin:$PATH
             - make test
+        - name: "Build darwin/amd64"
+          commands:
+            - checkout
+            - sem-version go $(cat .go-version)
+            - export PATH=$(go env GOPATH)/bin:$PATH
+            - GOARCH=amd64 CGO_ENABLED=1 go build -ldflags="-s -w -X main.commit="00000000" -X main.date="1970-01-01T00:00:00Z" -X main.isTest=true" ./cmd/confluent
       epilogue:
         always:
           commands:
@@ -57,7 +93,7 @@ blocks:
         machine:
           type: s1-prod-windows
       jobs:
-        - name: windows/amd64
+        - name: "Build & Test windows/amd64"
           commands:
             - checkout
             # https://confluentinc.atlassian.net/browse/DP-9532

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -37,7 +37,7 @@ blocks:
             - sem-version go $(cat .go-version)
             - export PATH=$(go env GOPATH)/bin:$PATH
             - sudo apt install musl-tools --yes
-            - CC=musl-gcc CGO_LDFLAGS="-static" CGO_ENABLED=1 go build -tags musl -ldflags="-s -w -X main.commit="00000000" -X main.date="1970-01-01T00:00:00Z" -X main.isTest=true" ./cmd/confluent
+            - CC=musl-gcc CGO_LDFLAGS="-static" CGO_ENABLED=1 GOEXPERIMENT=boringcrypto go build -tags musl -ldflags="-s -w -X main.commit="00000000" -X main.date="1970-01-01T00:00:00Z" -X main.isTest=true" ./cmd/confluent
       epilogue:
         always:
           commands:
@@ -60,7 +60,7 @@ blocks:
             - sem-version go $(cat .go-version)
             - export PATH=$(go env GOPATH)/bin:$PATH
             - sudo apt install musl-tools --yes
-            - CC=musl-gcc CGO_LDFLAGS="-static" CGO_ENABLED=1 go build -tags musl -ldflags="-s -w -X main.commit="00000000" -X main.date="1970-01-01T00:00:00Z" -X main.isTest=true" ./cmd/confluent
+            - CC=musl-gcc CGO_LDFLAGS="-static" CGO_ENABLED=1 GOEXPERIMENT=boringcrypto go build -tags musl -ldflags="-s -w -X main.commit="00000000" -X main.date="1970-01-01T00:00:00Z" -X main.isTest=true" ./cmd/confluent
 
   - name: darwin
     dependencies: []

--- a/docker/Dockerfile_build_linux_amd64
+++ b/docker/Dockerfile_build_linux_amd64
@@ -19,4 +19,4 @@ RUN export GO_VERSION=$(cat /cli/.go-version) && \
 ENV PATH=${PATH}:/usr/local/go/bin:/root/go/bin
 
 RUN cd /cli/ && \
-    CGO_ENABLED=1 go build -ldflags="-s -w -X main.commit="00000000" -X main.date="1970-01-01T00:00:00Z" -X main.isTest=true" ./cmd/confluent
+    CGO_ENABLED=1 GOEXPERIMENT=boringcrypto go build -ldflags="-s -w -X main.commit="00000000" -X main.date="1970-01-01T00:00:00Z" -X main.isTest=true" ./cmd/confluent

--- a/docker/Dockerfile_build_linux_amd64
+++ b/docker/Dockerfile_build_linux_amd64
@@ -1,0 +1,22 @@
+FROM --platform=linux/amd64 almalinux:8.10
+
+SHELL ["/bin/bash", "-c"]
+
+RUN yum -y update
+
+RUN yum -y install make sudo
+
+RUN sudo yum -y install git wget gcc-toolset-9
+
+RUN scl enable gcc-toolset-9 bash
+
+COPY . /cli/
+
+RUN export GO_VERSION=$(cat /cli/.go-version) && \
+    wget "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz" && \
+    sudo tar -C /usr/local -xzf "go${GO_VERSION}.linux-amd64.tar.gz"
+
+ENV PATH=${PATH}:/usr/local/go/bin:/root/go/bin
+
+RUN cd /cli/ && \
+    CGO_ENABLED=1 go build -ldflags="-s -w -X main.commit="00000000" -X main.date="1970-01-01T00:00:00Z" -X main.isTest=true" ./cmd/confluent

--- a/docker/Dockerfile_build_linux_arm64
+++ b/docker/Dockerfile_build_linux_arm64
@@ -19,4 +19,4 @@ RUN export GO_VERSION=$(cat /cli/.go-version) && \
 ENV PATH=${PATH}:/usr/local/go/bin:/root/go/bin
 
 RUN cd /cli/ && \
-    CGO_ENABLED=1 go build -ldflags="-s -w -X main.commit="00000000" -X main.date="1970-01-01T00:00:00Z" -X main.isTest=true" ./cmd/confluent
+    CGO_ENABLED=1 GOEXPERIMENT=boringcrypto go build -ldflags="-s -w -X main.commit="00000000" -X main.date="1970-01-01T00:00:00Z" -X main.isTest=true" ./cmd/confluent

--- a/docker/Dockerfile_build_linux_arm64
+++ b/docker/Dockerfile_build_linux_arm64
@@ -1,0 +1,22 @@
+FROM --platform=linux/arm64/v8 almalinux:8.10
+
+SHELL ["/bin/bash", "-c"]
+
+RUN yum -y update
+
+RUN yum -y install make sudo
+
+RUN sudo yum -y install git wget gcc-toolset-9
+
+RUN scl enable gcc-toolset-9 bash
+
+COPY . /cli/
+
+RUN export GO_VERSION=$(cat /cli/.go-version) && \
+    wget "https://go.dev/dl/go${GO_VERSION}.linux-arm64.tar.gz" && \
+    sudo tar -C /usr/local -xzf "go${GO_VERSION}.linux-arm64.tar.gz"
+
+ENV PATH=${PATH}:/usr/local/go/bin:/root/go/bin
+
+RUN cd /cli/ && \
+    CGO_ENABLED=1 go build -ldflags="-s -w -X main.commit="00000000" -X main.date="1970-01-01T00:00:00Z" -X main.isTest=true" ./cmd/confluent


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- PLACEHOLDER

New Features
- PLACEHOLDER

Bug Fixes
- PLACEHOLDER

Checklist
---------
- [ ] Leave this box unchecked if features are not yet available in production

What
----
Since the Darwin and Windows tests already build for amd64, this PR adds builds for the other five:
- Darwin arm64
- Linux GLIBC amd64 & arm64
- Linux Alpine amd64 & arm64

Even though the current Linux test builds a GLIBC version, this PR re-builds it in a docker image to enforce the required GLIBC version

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
New pipeline passed. Overall runtime looks like the same as before, because the new tasks run in parallel to the old ones.