### PR TITLE
[CLI-3095] On kafka topic update --config num.partitions=XXX, poll for updates or print warning

### DIFF
--- a/internal/kafka/command_topic_update.go
+++ b/internal/kafka/command_topic_update.go
@@ -122,6 +122,7 @@ func (c *command) update(cmd *cobra.Command, args []string) error {
 		}
 		topic, httpRespPartition, err := kafkaREST.CloudClient.GetKafkaTopic(topicName)
 		errPartition := retry.Retry(time.Second/10, time.Second, func() error {
+			topic, httpRespPartition, err = kafkaREST.CloudClient.GetKafkaTopic(topicName)
 			if err != nil {
 				if restErr, parseErr := kafkarest.ParseOpenAPIErrorCloud(err); parseErr == nil && restErr.Code == ccloudv2.UnknownTopicOrPartitionErrorCode {
 					return fmt.Errorf(errors.UnknownTopicErrorMsg, topicName)
@@ -137,14 +138,6 @@ func (c *command) update(cmd *cobra.Command, args []string) error {
 
 		if errPartition != nil {
 			return errPartition
-		}
-
-		topic, httpRespPartition, err = kafkaREST.CloudClient.GetKafkaTopic(topicName)
-		if err != nil {
-			if restErr, parseErr := kafkarest.ParseOpenAPIErrorCloud(err); parseErr == nil && restErr.Code == ccloudv2.UnknownTopicOrPartitionErrorCode {
-				return fmt.Errorf(errors.UnknownTopicErrorMsg, topicName)
-			}
-			return kafkarest.NewError(kafkaREST.CloudClient.GetUrl(), err, httpRespPartition)
 		}
 
 		configsValues[numPartitionsKey] = fmt.Sprint(topic.PartitionsCount)

--- a/internal/kafka/command_topic_update.go
+++ b/internal/kafka/command_topic_update.go
@@ -2,6 +2,7 @@ package kafka
 
 import (
 	"fmt"
+	"net/http"
 	"strconv"
 	"time"
 
@@ -120,7 +121,8 @@ func (c *command) update(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return err
 		}
-		topic, httpRespPartition, err := kafkaREST.CloudClient.GetKafkaTopic(topicName)
+		var topic kafkarestv3.TopicData
+		var httpRespPartition *http.Response
 		errPartition := retry.Retry(time.Second/10, time.Second, func() error {
 			topic, httpRespPartition, err = kafkaREST.CloudClient.GetKafkaTopic(topicName)
 			if err != nil {

--- a/internal/kafka/command_topic_update.go
+++ b/internal/kafka/command_topic_update.go
@@ -120,9 +120,8 @@ func (c *command) update(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return err
 		}
-
+		topic, httpRespPartition, err := kafkaREST.CloudClient.GetKafkaTopic(topicName)
 		errPartition := retry.Retry(time.Second/10, time.Second, func() error {
-			topic, httpRespPartition, err := kafkaREST.CloudClient.GetKafkaTopic(topicName)
 			if err != nil {
 				if restErr, parseErr := kafkarest.ParseOpenAPIErrorCloud(err); parseErr == nil && restErr.Code == ccloudv2.UnknownTopicOrPartitionErrorCode {
 					return fmt.Errorf(errors.UnknownTopicErrorMsg, topicName)
@@ -140,12 +139,12 @@ func (c *command) update(cmd *cobra.Command, args []string) error {
 			return errPartition
 		}
 
-		topic, httpRespPartition, errUpdated := kafkaREST.CloudClient.GetKafkaTopic(topicName)
-		if errUpdated != nil {
-			if restErr, parseErr := kafkarest.ParseOpenAPIErrorCloud(errUpdated); parseErr == nil && restErr.Code == ccloudv2.UnknownTopicOrPartitionErrorCode {
+		topic, httpRespPartition, err = kafkaREST.CloudClient.GetKafkaTopic(topicName)
+		if err != nil {
+			if restErr, parseErr := kafkarest.ParseOpenAPIErrorCloud(err); parseErr == nil && restErr.Code == ccloudv2.UnknownTopicOrPartitionErrorCode {
 				return fmt.Errorf(errors.UnknownTopicErrorMsg, topicName)
 			}
-			return kafkarest.NewError(kafkaREST.CloudClient.GetUrl(), errUpdated, httpRespPartition)
+			return kafkarest.NewError(kafkaREST.CloudClient.GetUrl(), err, httpRespPartition)
 		}
 
 		configsValues[numPartitionsKey] = fmt.Sprint(topic.PartitionsCount)

--- a/test/test-server/kafka_rest_router.go
+++ b/test/test-server/kafka_rest_router.go
@@ -543,6 +543,13 @@ func handleKafkaRestTopic(t *testing.T) http.HandlerFunc {
 				TopicName:       topic,
 				PartitionsCount: 3,
 			}
+			if topic == "topic-exist-rest" {
+				data = cckafkarestv3.TopicData{
+					TopicName:       topic,
+					PartitionsCount: 6,
+				}
+			}
+
 			err := json.NewEncoder(w).Encode(data)
 			require.NoError(t, err)
 		case http.MethodPatch:


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- PLACEHOLDER

New Features
- PLACEHOLDER

Bug Fixes
- CLI shows the correct partition count on confluent `kafka topic update my-topic --config num.partitions=X` command

Checklist
---------
- [x] Leave this box unchecked if features are not yet available in production

What
----
Poll for updates or print warning on `kafka topic update --config num.partitions=XXX`
<!--
Briefly describe **what** you have changed and **why**.
Optionally include your implementation strategy.
-->

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->
https://confluentinc.atlassian.net/browse/CLI-3095

Test & Review
-------------
<!--
Has it been tested? How?
Copy and paste any instructions or steps that can save the reviewer time.
-->
Updated the integration tests.