### PR TITLE
[CLI-3272] Add panic stack trace to `-vvvv` output for non-Cloud users

### DIFF
--- a/internal/command.go
+++ b/internal/command.go
@@ -3,6 +3,7 @@ package internal
 import (
 	"fmt"
 	"os"
+	"runtime/debug"
 	"strings"
 
 	shell "github.com/brianstrauch/cobra-shell"
@@ -54,6 +55,7 @@ import (
 	"github.com/confluentinc/cli/v4/pkg/form"
 	"github.com/confluentinc/cli/v4/pkg/help"
 	"github.com/confluentinc/cli/v4/pkg/jwt"
+	"github.com/confluentinc/cli/v4/pkg/log"
 	"github.com/confluentinc/cli/v4/pkg/output"
 	ppanic "github.com/confluentinc/cli/v4/pkg/panic-recovery"
 	pplugin "github.com/confluentinc/cli/v4/pkg/plugin"
@@ -151,8 +153,8 @@ func NewConfluentCommand(cfg *config.Config) *cobra.Command {
 func Execute(cmd *cobra.Command, args []string, cfg *config.Config) error {
 	defer func() {
 		if r := recover(); r != nil {
-			if !cfg.Version.IsReleased() {
-				panic(r)
+			if !cfg.IsCloudLogin() || cfg.HasGovHostname() || !cfg.Version.IsReleased() {
+				log.CliLogger.Trace(string(debug.Stack()))
 			}
 			u := ppanic.CollectPanic(cmd, args, cfg)
 			if err := reportUsage(cmd, cfg, u); err != nil {


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- PLACEHOLDER

New Features
- PLACEHOLDER

Bug Fixes
- Stack traces for some errors are now included in the output of the `-vvvv` debug flag

Checklist
---------
- [x] Leave this box unchecked if features are not yet available in production

What
----
For Cloud users, the CLI collects and reports panic stack traces and hides them from the user. However, no stack traces are collected for users logged out or logged into on-prem. Those users have no way to access the panic trace, which makes it harder for support to help debug the issue.

This PR adds panic traces to the `-vvvv` trace flag when users aren't logged into Cloud.

We also don't send reports when `cfg.HasGovHostname()` is true, so this PR also adds local `-vvvv` output for this case.

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
Manually tested by adding a temporary panic to the `confluent version` command and temporarily removing the `!cfg.Version.IsReleased()` condition (which is always true for test builds). Verified that the trace is included when logged out, and not included when logged in.