### PR TITLE
[CLI-2969] Prevent double decryption on Windows

### DIFF
--- a/pkg/config/api_key_pair.go
+++ b/pkg/config/api_key_pair.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"runtime"
 	"strings"
 
 	"github.com/confluentinc/cli/v4/pkg/secret"
@@ -16,7 +15,7 @@ type APIKeyPair struct {
 }
 
 func (c *APIKeyPair) DecryptSecret() error {
-	if (strings.HasPrefix(c.Secret, secret.AesGcm) && c.Salt != nil) || runtime.GOOS == "windows" {
+	if (strings.HasPrefix(c.Secret, secret.AesGcm) && c.Salt != nil) || strings.HasPrefix(c.Secret, secret.Dpapi) {
 		decryptedSecret, err := secret.Decrypt(c.Key, c.Secret, c.Salt, c.Nonce)
 		if err != nil {
 			return err


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- PLACEHOLDER

New Features
- PLACEHOLDER

Bug Fixes
- Fix an issue causing `confluent kafka topic [produce | consume]` to fail on Windows when using the `--api-key` and `--api-secret` flag

Checklist
---------
- [x] Leave this box unchecked if features are not yet available in production

What
----
When selecting an api key with the `confluent api-key use` command, API keys are only decrypted once. This is also what should happen when providing the key/secret with flags to `confluent kafka topic produce | consume`, but on Windows, the CLI would attempt to decrypt them a second time, leading to the following Windows DPAPI error
```
Error: failed to create consumer: decryptbytes: procdecryptdata: The parameter is incorrect
```
where the incorrect parameter is actually the already decrypted key (or secret).

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
Manually testing on Windows 10