### PR TITLE
[CLI-3355] Fix some `confluent kafka topic consume` errors

### DIFF
--- a/internal/kafka/command_topic_consume.go
+++ b/internal/kafka/command_topic_consume.go
@@ -173,9 +173,13 @@ func (c *command) consumeCloud(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	token, err := auth.GetDataplaneToken(c.Context)
-	if err != nil {
-		return err
+
+	var token string
+	if c.Config.IsCloudLogin() { // Do no get token if users are consuming from Cloud while logged out
+		token, err = auth.GetDataplaneToken(c.Context)
+		if err != nil {
+			return err
+		}
 	}
 
 	consumer, err := newConsumer(group, cluster, c.clientID, configFile, config)

--- a/internal/kafka/command_topic_consume.go
+++ b/internal/kafka/command_topic_consume.go
@@ -229,6 +229,7 @@ func (c *command) consumeCloud(cmd *cobra.Command, args []string) error {
 	}
 
 	var srClient *schemaregistry.Client
+	var srClusterId, srEndpoint string
 	if slices.Contains(serdes.SchemaBasedFormats, valueFormat) || slices.Contains(serdes.SchemaBasedFormats, keyFormat) {
 		// Only initialize client and context when schema is specified.
 		srClient, err = c.GetSchemaRegistryClient(cmd)
@@ -238,6 +239,11 @@ func (c *command) consumeCloud(cmd *cobra.Command, args []string) error {
 			} else {
 				return err
 			}
+		}
+		// Fetch the current SR cluster id and endpoint
+		srClusterId, srEndpoint, err = c.GetCurrentSchemaRegistryClusterIdAndEndpoint()
+		if err != nil {
+			return err
 		}
 	}
 
@@ -256,12 +262,6 @@ func (c *command) consumeCloud(cmd *cobra.Command, args []string) error {
 	}
 	if schemaRegistryContext != "" {
 		subject = schemaRegistryContext
-	}
-
-	// Fetch the current SR cluster id and endpoint
-	srClusterId, srEndpoint, err := c.GetCurrentSchemaRegistryClusterIdAndEndpoint()
-	if err != nil {
-		return err
 	}
 
 	groupHandler := &GroupHandler{


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- PLACEHOLDER

New Features
- PLACEHOLDER

Bug Fixes
- Fix a bug preventing users from consuming audit logs with `confluent kafka topic consume`
- Fix a bug preventing users from consuming from a Cloud cluster while logged out using `confluent kafka topic consume --bootstrap`

Checklist
---------
- [x] Leave this box unchecked if features are not yet available in production

What
----
- The assumption that a SR cluster always exists is false in the audit log environment, so this PR changes the call to get SR ID and endpoint to only happen if the key or value type is avro, protobuf, or jsonschema
- The `GetDataplaneToken` call will fail for users consuming from a cloud cluster using `--bootstrap` while logged out, so this PR adds a check that the user is logged in before attempting to get the token

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
Tested with the following.
- while logged in: `confluent kafka topic consume -b confluent-audit-log-events`
- while logged out: `confluent kafka topic consume -b confluent-audit-log-events --bootstrap <ENDPOINT> --api-key <API_KEY> --api-secret <API_SECRET>`