### PR TITLE
[hotfix] validate env before getting gateway client

### DIFF
--- a/internal/flink/command_connection_list.go
+++ b/internal/flink/command_connection_list.go
@@ -34,11 +34,6 @@ func (c *command) newConnectionListCommand() *cobra.Command {
 }
 
 func (c *command) connectionList(cmd *cobra.Command, _ []string) error {
-	client, err := c.GetFlinkGatewayClient(false)
-	if err != nil {
-		return err
-	}
-
 	environmentId, err := c.Context.EnvironmentId()
 	if err != nil {
 		return err
@@ -57,6 +52,11 @@ func (c *command) connectionList(cmd *cobra.Command, _ []string) error {
 		if err = validateConnectionType(connectionType); err != nil {
 			return err
 		}
+	}
+
+	client, err := c.GetFlinkGatewayClient(false)
+	if err != nil {
+		return err
 	}
 
 	connections, err := client.ListConnections(environmentId, c.Context.GetCurrentOrganization(), strings.ToUpper(connectionType))


### PR DESCRIPTION
Release Notes
-------------

Bug Fixes
- Check env before getting gateway client so env not found error can pop first

Checklist
---------
- [ ] Leave this box unchecked if features are not yet available in production

What
----
Check env before getting gateway client so env not found error can pop first

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------
Manual test
```
haoli@FX2J5RXQ21 ~/projects/flink/cli$ dist/confluent_darwin_arm64/confluent flink connection list  --cloud GCP --region us-central1 --environment abcd
Error: Resource Not Found

Suggestions:
    Failed to get environment 'abcd'. List available environments with confluent environment list.
```

Otherwise, it outputs like this:
```
haoli@FX2J5RXQ21 ~/projects/flink/cli$ dist/confluent_darwin_arm64/confluent flink connection list  --cloud GCP --region us-central1 --environment abcd
Error: Forbidden Access
```