### PR TITLE
[hotfix] Fix 'delete' environment typo for CP Flink commands

### DIFF
--- a/internal/flink/command_application_create.go
+++ b/internal/flink/command_application_create.go
@@ -24,7 +24,7 @@ func (c *command) newApplicationCreateCommand() *cobra.Command {
 		RunE:  c.applicationCreate,
 	}
 
-	cmd.Flags().String("environment", "", "Name of the environment to delete the Flink application from.")
+	cmd.Flags().String("environment", "", "Name of the environment to create the Flink application from.")
 	addCmfFlagSet(cmd)
 	pcmd.AddOutputFlagWithHumanRestricted(cmd)
 

--- a/internal/flink/command_application_describe.go
+++ b/internal/flink/command_application_describe.go
@@ -15,7 +15,7 @@ func (c *command) newApplicationDescribeCommand() *cobra.Command {
 		RunE:  c.applicationDescribe,
 	}
 
-	cmd.Flags().String("environment", "", "Name of the environment to delete the Flink application from.")
+	cmd.Flags().String("environment", "", "Name of the environment to describe the Flink application from.")
 	addCmfFlagSet(cmd)
 	pcmd.AddOutputFlagWithHumanRestricted(cmd)
 

--- a/internal/flink/command_application_list.go
+++ b/internal/flink/command_application_list.go
@@ -15,7 +15,7 @@ func (c *command) newApplicationListCommand() *cobra.Command {
 		RunE:  c.applicationList,
 	}
 
-	cmd.Flags().String("environment", "", "Name of the environment to delete the Flink application from.")
+	cmd.Flags().String("environment", "", "Name of the environment to list the Flink application from.")
 	addCmfFlagSet(cmd)
 	pcmd.AddOutputFlag(cmd)
 

--- a/internal/flink/command_application_update.go
+++ b/internal/flink/command_application_update.go
@@ -24,7 +24,7 @@ func (c *command) newApplicationUpdateCommand() *cobra.Command {
 		RunE:  c.applicationUpdate,
 	}
 
-	cmd.Flags().String("environment", "", "Name of the environment to delete the Flink application from.")
+	cmd.Flags().String("environment", "", "Name of the environment to update the Flink application from.")
 	addCmfFlagSet(cmd)
 	pcmd.AddOutputFlagWithHumanRestricted(cmd)
 

--- a/internal/flink/command_application_webui.go
+++ b/internal/flink/command_application_webui.go
@@ -24,7 +24,7 @@ func (c *command) newApplicationWebUiForwardCommand() *cobra.Command {
 		RunE:  c.applicationWebUiForward,
 	}
 
-	cmd.Flags().String("environment", "", "Name of the environment to delete the Flink application from.")
+	cmd.Flags().String("environment", "", "Name of the environment to forward the Flink application from.")
 	addCmfFlagSet(cmd)
 	cmd.Flags().Uint16("port", 0, "Port to forward the web UI to. If not provided, a random, OS-assigned port will be used.")
 

--- a/test/fixtures/output/flink/application/create-help-onprem.golden
+++ b/test/fixtures/output/flink/application/create-help-onprem.golden
@@ -4,7 +4,7 @@ Usage:
   confluent flink application create <resourceFilePath> [flags]
 
 Flags:
-      --environment string                  REQUIRED: Name of the environment to delete the Flink application from.
+      --environment string                  REQUIRED: Name of the environment to create the Flink application from.
       --url string                          Base URL of the Confluent Manager for Apache Flink (CMF). Environment variable "CONFLUENT_CMF_URL" may be set in place of this flag.
       --client-key-path string              Path to client private key for mTLS authentication. Environment variable "CONFLUENT_CMF_CLIENT_KEY_PATH" may be set in place of this flag.
       --client-cert-path string             Path to client cert to be verified by Confluent Manager for Apache Flink. Include for mTLS authentication. Environment variable "CONFLUENT_CMF_CLIENT_CERT_PATH" may be set in place of this flag.

--- a/test/fixtures/output/flink/application/create-help.golden
+++ b/test/fixtures/output/flink/application/create-help.golden
@@ -4,7 +4,7 @@ Usage:
   confluent flink application create <resourceFilePath> [flags]
 
 Flags:
-      --environment string                  REQUIRED: Name of the environment to delete the Flink application from.
+      --environment string                  REQUIRED: Name of the environment to create the Flink application from.
       --url string                          Base URL of the Confluent Manager for Apache Flink (CMF). Environment variable "CONFLUENT_CMF_URL" may be set in place of this flag.
       --client-key-path string              Path to client private key for mTLS authentication. Environment variable "CONFLUENT_CMF_CLIENT_KEY_PATH" may be set in place of this flag.
       --client-cert-path string             Path to client cert to be verified by Confluent Manager for Apache Flink. Include for mTLS authentication. Environment variable "CONFLUENT_CMF_CLIENT_CERT_PATH" may be set in place of this flag.

--- a/test/fixtures/output/flink/application/describe-help-onprem.golden
+++ b/test/fixtures/output/flink/application/describe-help-onprem.golden
@@ -4,7 +4,7 @@ Usage:
   confluent flink application describe <name> [flags]
 
 Flags:
-      --environment string                  REQUIRED: Name of the environment to delete the Flink application from.
+      --environment string                  REQUIRED: Name of the environment to describe the Flink application from.
       --url string                          Base URL of the Confluent Manager for Apache Flink (CMF). Environment variable "CONFLUENT_CMF_URL" may be set in place of this flag.
       --client-key-path string              Path to client private key for mTLS authentication. Environment variable "CONFLUENT_CMF_CLIENT_KEY_PATH" may be set in place of this flag.
       --client-cert-path string             Path to client cert to be verified by Confluent Manager for Apache Flink. Include for mTLS authentication. Environment variable "CONFLUENT_CMF_CLIENT_CERT_PATH" may be set in place of this flag.

--- a/test/fixtures/output/flink/application/describe-help.golden
+++ b/test/fixtures/output/flink/application/describe-help.golden
@@ -4,7 +4,7 @@ Usage:
   confluent flink application describe <name> [flags]
 
 Flags:
-      --environment string                  REQUIRED: Name of the environment to delete the Flink application from.
+      --environment string                  REQUIRED: Name of the environment to describe the Flink application from.
       --url string                          Base URL of the Confluent Manager for Apache Flink (CMF). Environment variable "CONFLUENT_CMF_URL" may be set in place of this flag.
       --client-key-path string              Path to client private key for mTLS authentication. Environment variable "CONFLUENT_CMF_CLIENT_KEY_PATH" may be set in place of this flag.
       --client-cert-path string             Path to client cert to be verified by Confluent Manager for Apache Flink. Include for mTLS authentication. Environment variable "CONFLUENT_CMF_CLIENT_CERT_PATH" may be set in place of this flag.

--- a/test/fixtures/output/flink/application/describe-no-environment.golden
+++ b/test/fixtures/output/flink/application/describe-no-environment.golden
@@ -3,7 +3,7 @@ Usage:
   confluent flink application describe <name> [flags]
 
 Flags:
-      --environment string                  REQUIRED: Name of the environment to delete the Flink application from.
+      --environment string                  REQUIRED: Name of the environment to describe the Flink application from.
       --url string                          Base URL of the Confluent Manager for Apache Flink (CMF). Environment variable "CONFLUENT_CMF_URL" may be set in place of this flag.
       --client-key-path string              Path to client private key for mTLS authentication. Environment variable "CONFLUENT_CMF_CLIENT_KEY_PATH" may be set in place of this flag.
       --client-cert-path string             Path to client cert to be verified by Confluent Manager for Apache Flink. Include for mTLS authentication. Environment variable "CONFLUENT_CMF_CLIENT_CERT_PATH" may be set in place of this flag.

--- a/test/fixtures/output/flink/application/forward-negative-port.golden
+++ b/test/fixtures/output/flink/application/forward-negative-port.golden
@@ -3,7 +3,7 @@ Usage:
   confluent flink application web-ui-forward <name> [flags]
 
 Flags:
-      --environment string                  Name of the environment to delete the Flink application from.
+      --environment string                  Name of the environment to forward the Flink application from.
       --url string                          Base URL of the Confluent Manager for Apache Flink (CMF). Environment variable "CONFLUENT_CMF_URL" may be set in place of this flag.
       --client-key-path string              Path to client private key for mTLS authentication. Environment variable "CONFLUENT_CMF_CLIENT_KEY_PATH" may be set in place of this flag.
       --client-cert-path string             Path to client cert to be verified by Confluent Manager for Apache Flink. Include for mTLS authentication. Environment variable "CONFLUENT_CMF_CLIENT_CERT_PATH" may be set in place of this flag.

--- a/test/fixtures/output/flink/application/list-env-missing.golden
+++ b/test/fixtures/output/flink/application/list-env-missing.golden
@@ -3,7 +3,7 @@ Usage:
   confluent flink application list [flags]
 
 Flags:
-      --environment string                  REQUIRED: Name of the environment to delete the Flink application from.
+      --environment string                  REQUIRED: Name of the environment to list the Flink application from.
       --url string                          Base URL of the Confluent Manager for Apache Flink (CMF). Environment variable "CONFLUENT_CMF_URL" may be set in place of this flag.
       --client-key-path string              Path to client private key for mTLS authentication. Environment variable "CONFLUENT_CMF_CLIENT_KEY_PATH" may be set in place of this flag.
       --client-cert-path string             Path to client cert to be verified by Confluent Manager for Apache Flink. Include for mTLS authentication. Environment variable "CONFLUENT_CMF_CLIENT_CERT_PATH" may be set in place of this flag.

--- a/test/fixtures/output/flink/application/list-help-onprem.golden
+++ b/test/fixtures/output/flink/application/list-help-onprem.golden
@@ -4,7 +4,7 @@ Usage:
   confluent flink application list [flags]
 
 Flags:
-      --environment string                  REQUIRED: Name of the environment to delete the Flink application from.
+      --environment string                  REQUIRED: Name of the environment to list the Flink application from.
       --url string                          Base URL of the Confluent Manager for Apache Flink (CMF). Environment variable "CONFLUENT_CMF_URL" may be set in place of this flag.
       --client-key-path string              Path to client private key for mTLS authentication. Environment variable "CONFLUENT_CMF_CLIENT_KEY_PATH" may be set in place of this flag.
       --client-cert-path string             Path to client cert to be verified by Confluent Manager for Apache Flink. Include for mTLS authentication. Environment variable "CONFLUENT_CMF_CLIENT_CERT_PATH" may be set in place of this flag.

--- a/test/fixtures/output/flink/application/list-help.golden
+++ b/test/fixtures/output/flink/application/list-help.golden
@@ -4,7 +4,7 @@ Usage:
   confluent flink application list [flags]
 
 Flags:
-      --environment string                  REQUIRED: Name of the environment to delete the Flink application from.
+      --environment string                  REQUIRED: Name of the environment to list the Flink application from.
       --url string                          Base URL of the Confluent Manager for Apache Flink (CMF). Environment variable "CONFLUENT_CMF_URL" may be set in place of this flag.
       --client-key-path string              Path to client private key for mTLS authentication. Environment variable "CONFLUENT_CMF_CLIENT_KEY_PATH" may be set in place of this flag.
       --client-cert-path string             Path to client cert to be verified by Confluent Manager for Apache Flink. Include for mTLS authentication. Environment variable "CONFLUENT_CMF_CLIENT_CERT_PATH" may be set in place of this flag.

--- a/test/fixtures/output/flink/application/update-help-onprem.golden
+++ b/test/fixtures/output/flink/application/update-help-onprem.golden
@@ -4,7 +4,7 @@ Usage:
   confluent flink application update <resourceFilePath> [flags]
 
 Flags:
-      --environment string                  REQUIRED: Name of the environment to delete the Flink application from.
+      --environment string                  REQUIRED: Name of the environment to update the Flink application from.
       --url string                          Base URL of the Confluent Manager for Apache Flink (CMF). Environment variable "CONFLUENT_CMF_URL" may be set in place of this flag.
       --client-key-path string              Path to client private key for mTLS authentication. Environment variable "CONFLUENT_CMF_CLIENT_KEY_PATH" may be set in place of this flag.
       --client-cert-path string             Path to client cert to be verified by Confluent Manager for Apache Flink. Include for mTLS authentication. Environment variable "CONFLUENT_CMF_CLIENT_CERT_PATH" may be set in place of this flag.

--- a/test/fixtures/output/flink/application/update-help.golden
+++ b/test/fixtures/output/flink/application/update-help.golden
@@ -4,7 +4,7 @@ Usage:
   confluent flink application update <resourceFilePath> [flags]
 
 Flags:
-      --environment string                  REQUIRED: Name of the environment to delete the Flink application from.
+      --environment string                  REQUIRED: Name of the environment to update the Flink application from.
       --url string                          Base URL of the Confluent Manager for Apache Flink (CMF). Environment variable "CONFLUENT_CMF_URL" may be set in place of this flag.
       --client-key-path string              Path to client private key for mTLS authentication. Environment variable "CONFLUENT_CMF_CLIENT_KEY_PATH" may be set in place of this flag.
       --client-cert-path string             Path to client cert to be verified by Confluent Manager for Apache Flink. Include for mTLS authentication. Environment variable "CONFLUENT_CMF_CLIENT_CERT_PATH" may be set in place of this flag.

--- a/test/fixtures/output/flink/application/web-ui-forward-help-onprem.golden
+++ b/test/fixtures/output/flink/application/web-ui-forward-help-onprem.golden
@@ -4,7 +4,7 @@ Usage:
   confluent flink application web-ui-forward <name> [flags]
 
 Flags:
-      --environment string                  REQUIRED: Name of the environment to delete the Flink application from.
+      --environment string                  REQUIRED: Name of the environment to forward the Flink application from.
       --url string                          Base URL of the Confluent Manager for Apache Flink (CMF). Environment variable "CONFLUENT_CMF_URL" may be set in place of this flag.
       --client-key-path string              Path to client private key for mTLS authentication. Environment variable "CONFLUENT_CMF_CLIENT_KEY_PATH" may be set in place of this flag.
       --client-cert-path string             Path to client cert to be verified by Confluent Manager for Apache Flink. Include for mTLS authentication. Environment variable "CONFLUENT_CMF_CLIENT_CERT_PATH" may be set in place of this flag.

--- a/test/fixtures/output/flink/application/web-ui-forward-help.golden
+++ b/test/fixtures/output/flink/application/web-ui-forward-help.golden
@@ -4,7 +4,7 @@ Usage:
   confluent flink application web-ui-forward <name> [flags]
 
 Flags:
-      --environment string                  REQUIRED: Name of the environment to delete the Flink application from.
+      --environment string                  REQUIRED: Name of the environment to forward the Flink application from.
       --url string                          Base URL of the Confluent Manager for Apache Flink (CMF). Environment variable "CONFLUENT_CMF_URL" may be set in place of this flag.
       --client-key-path string              Path to client private key for mTLS authentication. Environment variable "CONFLUENT_CMF_CLIENT_KEY_PATH" may be set in place of this flag.
       --client-cert-path string             Path to client cert to be verified by Confluent Manager for Apache Flink. Include for mTLS authentication. Environment variable "CONFLUENT_CMF_CLIENT_CERT_PATH" may be set in place of this flag.


### PR DESCRIPTION
Release Notes
-------------

Bug Fixes
- For CP Flink commands, use the appropriate verb in the `--environment` flag description.

Checklist
---------
- [ ] Leave this box unchecked if features are not yet available in production

What
----
Looks like  the --environment flag always used the verb 'delete'. Use appropriate verb everywhere.

References
----------
<!--
Copy and paste links to tickets, related PRs, GitHub issues, etc.
-->

Test & Review
-------------

Updated .golden files accordingly (hopefully)