### PR TITLE
fix: ip filtering description fixes

### DIFF
--- a/internal/iam/command_ipfilter_create.go
+++ b/internal/iam/command_ipfilter_create.go
@@ -44,7 +44,7 @@ func (c *ipFilterCommand) newCreateCommand(cfg *config.Config) *cobra.Command {
 	pcmd.AddResourceGroupFlag(isSrEnabled, cmd)
 	cmd.Flags().StringSlice("ip-groups", []string{}, "A comma-separated list of IP group IDs.")
 	if isSrEnabled {
-		cmd.Flags().String("environment", "", "Name of the environment for which this filter applies. By default will apply to the organization only.")
+		cmd.Flags().String("environment", "", "Id of the environment for which this filter applies. By default will apply to the organization only.")
 		cmd.Flags().StringSlice("operations", nil, fmt.Sprintf("A comma-separated list of operation groups: %s.", utils.ArrayToCommaDelimitedString([]string{"MANAGEMENT", "SCHEMA"}, "or")))
 		cmd.Flags().Bool("no-public-networks", false, "Use in place of ip-groups to reference the no public networks IP Group.")
 		cmd.MarkFlagsMutuallyExclusive("ip-groups", "no-public-networks")

--- a/internal/iam/command_ipfilter_list.go
+++ b/internal/iam/command_ipfilter_list.go
@@ -23,8 +23,8 @@ func (c *ipFilterCommand) newListCommand(cfg *config.Config) *cobra.Command {
 		RunE:  c.list,
 	}
 	if cfg.IsTest || (cfg.Context() != nil && featureflags.Manager.BoolVariation("auth.ip_filter.sr.cli.enabled", cfg.Context(), featureflags.GetCcloudLaunchDarklyClient(cfg.Context().PlatformName), true, false)) {
-		cmd.Flags().String("environment", "", "Name of the environment for which this filter applies. By default will apply to the org only.")
-		cmd.Flags().Bool("include-parent-scopes", true, "If an environment is specified, include organization scoped filters.")
+		cmd.Flags().String("environment", "", "Id of the environment for which this filter applies. By default will apply to the org only.")
+		cmd.Flags().Bool("include-parent-scopes", false, "Include organization scoped filters when listing filters in an environment.")
 	}
 
 	pcmd.AddContextFlag(cmd, c.CLICommand)

--- a/test/fixtures/output/iam/ip-filter/create-help.golden
+++ b/test/fixtures/output/iam/ip-filter/create-help.golden
@@ -11,7 +11,7 @@ Create an IP filter named "demo-ip-filter" with operation group "management" and
 Flags:
       --resource-group string   Name of resource group: "management" or "multiple". (default "multiple")
       --ip-groups strings       A comma-separated list of IP group IDs.
-      --environment string      Name of the environment for which this filter applies. By default will apply to the organization only.
+      --environment string      Id of the environment for which this filter applies. By default will apply to the organization only.
       --operations strings      A comma-separated list of operation groups: "MANAGEMENT" or "SCHEMA".
       --no-public-networks      Use in place of ip-groups to reference the no public networks IP Group.
       --context string          CLI context name.

--- a/test/fixtures/output/iam/ip-filter/list-help.golden
+++ b/test/fixtures/output/iam/ip-filter/list-help.golden
@@ -4,8 +4,8 @@ Usage:
   confluent iam ip-filter list [flags]
 
 Flags:
-      --environment string      Name of the environment for which this filter applies. By default will apply to the org only.
-      --include-parent-scopes   If an environment is specified, include organization scoped filters. (default true)
+      --environment string      Id of the environment for which this filter applies. By default will apply to the org only.
+      --include-parent-scopes   Include organization scoped filters when listing filters in an environment.
       --context string          CLI context name.
   -o, --output string           Specify the output format as "human", "json", or "yaml". (default "human")
 


### PR DESCRIPTION
Checklist
---------
<!-- 
Check each item below to ensure high-quality CLI development practices are followed. PR approval will not be granted until the checklist is fully reviewed.
For detailed instructions, please refer to this Confluence page: https://confluentinc.atlassian.net/wiki/spaces/AEGI/pages/3949592874/
-->
- [X] I have successfully built and used a custom CLI binary, without linter issues from this PR.
- [X] I have clearly specified in the `What` section below whether this PR applies to Confluent Cloud, Confluent Platform, or both. 
- [X] I have verified this PR in Confluent Cloud pre-prod or production environment, if applicable.
- [N/A] I have verified this PR in Confluent Platform on-premises environment, if applicable.
- [X] I have attached manual CLI verification results or screenshots in the `Test & Review` section below.
- [X] I have added appropriate CLI integration or unit tests for any new or updated commands and functionality.
- [X] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [X] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [X] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [ ] Confluent Cloud prod
  - [X] Confluent Cloud stag
  - [ ] Confluent Platform
  - [ ] Check this box if the feature is enabled for certain organizations only

What
----
Two changes
- Description for the --environment flag 
- Description for the --include-parent-scopes flag: the default for this one shouldn't really matter since it's evaluating if the flag changed (added vs. removed): https://github.com/confluentinc/cli/blob/main/internal/iam/command_ipfilter_list.go#L55 but the description should reflect it correctly. 

Blast Radius
----
All the flags modified here are behind a feature flag which is not turned on in production so there should be no impact if any issues arise. 

References
----------
https://confluentinc.atlassian.net/wiki/spaces/SECENG/pages/4025123742/IP+Filtering+for+SR+CLI+Quality+Review

Test & Review
-------------
Updated Description for environment and include-parent-scopes. 
./dist/confluent_darwin_arm64/confluent iam ip-filter list --help
```
List IP filters.

Usage:
  confluent iam ip-filter list [flags]

Flags:
      --environment string      Id of the environment for which this filter applies. By default will apply to the org only.
      --include-parent-scopes   Include organization scoped filters when listing filters in an environment.
      --context string          CLI context name.
  -o, --output string           Specify the output format as "human", "json", or "yaml". (default "human")

Global Flags:
  -h, --help            Show help for this command.
      --unsafe-trace    Equivalent to -vvvv, but also log HTTP requests and responses which might contain plaintext secrets.
  -v, --verbose count   Increase verbosity (-v for warn, -vv for info, -vvv for debug, -vvvv for trace).
```
Updated description for environment.
 ./dist/confluent_darwin_arm64/confluent iam ip-filter create --help
```
Create an IP filter.

Usage:
  confluent iam ip-filter create <name> [flags]

Examples:
Create an IP filter named "demo-ip-filter" with operation group "management" and IP groups "ipg-12345" and "ipg-67890":

  $ confluent iam ip-filter create demo-ip-filter --operations management --ip-groups ipg-12345,ipg-67890

Flags:
      --resource-group string   Name of resource group: "management" or "multiple". (default "multiple")
      --ip-groups strings       A comma-separated list of IP group IDs.
      --environment string      Id of the environment for which this filter applies. By default will apply to the organization only.
      --operations strings      A comma-separated list of operation groups: "MANAGEMENT" or "SCHEMA".
      --no-public-networks      Use in place of ip-groups to reference the no public networks IP Group.
      --context string          CLI context name.
  -o, --output string           Specify the output format as "human", "json", or "yaml". (default "human")

Global Flags:
  -h, --help            Show help for this command.
      --unsafe-trace    Equivalent to -vvvv, but also log HTTP requests and responses which might contain plaintext secrets.
  -v, --verbose count   Increase verbosity (-v for warn, -vv for info, -vvv for debug, -vvvv for trace).
```
Confirming no breakage for include-parent-scopes.
./dist/confluent_darwin_arm64/confluent iam ip-filter list --environment env-12v9qj
```
     ID     |  Name  | Resource Group | IP Groups |  Operation Groups  |                                         Resource Scope                                          
------------+--------+----------------+-----------+--------------------+-------------------------------------------------------------------------------------------------
  ipf-34xre | rg-mng | multiple       | ipg-3qg5e | MANAGEMENT, SCHEMA | crn://confluent.cloud/organization=26bdbe6b-0c1b-4d25-a6e6-7bcc4d0932e3/environment=env-12v9qj 
```
./dist/confluent_darwin_arm64/confluent iam ip-filter list --environment env-12v9qj --include-parent-scopes
```
     ID     |        Name        | Resource Group | IP Groups |  Operation Groups  |                                         Resource Scope                                          
------------+--------------------+----------------+-----------+--------------------+-------------------------------------------------------------------------------------------------
  ipf-34xre | rg-mng             | multiple       | ipg-3qg5e | MANAGEMENT, SCHEMA | crn://confluent.cloud/organization=26bdbe6b-0c1b-4d25-a6e6-7bcc4d0932e3/environment=env-12v9qj  
  ipf-e2j8w | swathi-test-filter | multiple       | ipg-3qg5e | MANAGEMENT         | crn://confluent.cloud/organization=26bdbe6b-0c1b-4d25-a6e6-7bcc4d0932e3                         
  ipf-wv0d3 | demo-ip-filter     | multiple       | ipg-3qg5e | MANAGEMENT, SCHEMA | crn://confluent.cloud/organization=26bdbe6b-0c1b-4d25-a6e6-7bcc4d0932e3                         
  ipf-wx8j3 | new_filter         | multiple       | ipg-3qg5e | MANAGEMENT         | crn://confluent.cloud/organization=26bdbe6b-0c1b-4d25-a6e6-7bcc4d0932e3      
```