### PR TITLE
[CLI-3385] Fix on-prem Flink dependence on feature flag

### DIFF
--- a/internal/command.go
+++ b/internal/command.go
@@ -115,6 +115,7 @@ func NewConfluentCommand(cfg *config.Config) *cobra.Command {
 	cmd.AddCommand(ccl.New(cfg, prerunner))
 	cmd.AddCommand(environment.New(prerunner))
 	cmd.AddCommand(feedback.New(prerunner))
+	cmd.AddCommand(flink.New(cfg, prerunner))
 	cmd.AddCommand(iam.New(cfg, prerunner))
 	cmd.AddCommand(kafka.New(cfg, prerunner))
 	cmd.AddCommand(ksql.New(cfg, prerunner))
@@ -138,9 +139,6 @@ func NewConfluentCommand(cfg *config.Config) *cobra.Command {
 	_ = cfg.ParseFlagsIntoConfig(cmd)
 	if cfg.IsTest || featureflags.Manager.BoolVariation("cli.ai.enable", cfg.Context(), config.CliLaunchDarklyClient, true, false) {
 		cmd.AddCommand(ai.New(prerunner))
-	}
-	if cfg.IsTest || featureflags.Manager.BoolVariation("cli.flink", cfg.Context(), config.CliLaunchDarklyClient, true, false) {
-		cmd.AddCommand(flink.New(cfg, prerunner))
 	}
 
 	changeDefaults(cmd, cfg)

--- a/internal/flink/command.go
+++ b/internal/flink/command.go
@@ -27,19 +27,23 @@ func New(cfg *config.Config, prerunner pcmd.PreRunner) *cobra.Command {
 		cmd.PersistentPreRunE = prerunner.Anonymous(c.AuthenticatedCLICommand.CLICommand, false)
 	}
 
-	// Cloud Specific Commands
-	if cfg.IsTest || featureflags.Manager.BoolVariation("cli.flink.connection", cfg.Context(), config.CliLaunchDarklyClient, true, false) {
-		cmd.AddCommand(c.newConnectionCommand())
-	}
-
+	// On-Prem Specific Commands
 	cmd.AddCommand(c.newApplicationCommand())
-	cmd.AddCommand(c.newArtifactCommand())
-	cmd.AddCommand(c.newComputePoolCommand())
-	cmd.AddCommand(c.newConnectivityTypeCommand())
 	cmd.AddCommand(c.newEnvironmentCommand())
-	cmd.AddCommand(c.newRegionCommand())
-	cmd.AddCommand(c.newShellCommand(prerunner))
-	cmd.AddCommand(c.newStatementCommand())
+
+	// Cloud Specific Commands
+	if cfg.IsTest || featureflags.Manager.BoolVariation("cli.flink", cfg.Context(), config.CliLaunchDarklyClient, true, false) {
+		if cfg.IsTest || featureflags.Manager.BoolVariation("cli.flink.connection", cfg.Context(), config.CliLaunchDarklyClient, true, false) {
+			cmd.AddCommand(c.newConnectionCommand())
+		}
+
+		cmd.AddCommand(c.newArtifactCommand())
+		cmd.AddCommand(c.newComputePoolCommand())
+		cmd.AddCommand(c.newConnectivityTypeCommand())
+		cmd.AddCommand(c.newRegionCommand())
+		cmd.AddCommand(c.newShellCommand(prerunner))
+		cmd.AddCommand(c.newStatementCommand())
+	}
 
 	return cmd
 }


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- PLACEHOLDER

New Features
- PLACEHOLDER

Bug Fixes
- On-premises `confluent flink` commands are no longer incorrectly gated behind a feature flag

Checklist
---------
<!-- 
Check each item below to ensure high-quality CLI development practices are followed. PR approval will not be granted until the checklist is fully reviewed.
For detailed instructions, please refer to this Confluence page: https://confluentinc.atlassian.net/wiki/spaces/AEGI/pages/3949592874/
-->
- [x] I have successfully built and used a custom CLI binary, without linter issues from this PR.
- [x] I have clearly specified in the `What` section below whether this PR applies to Confluent Cloud, Confluent Platform, or both. 
- [x] I have verified this PR in Confluent Cloud pre-prod or production environment, if applicable.
Tested the interface after logging into Cloud
- [x] I have verified this PR in Confluent Platform on-premises environment, if applicable.
Tested the interface after logging out of Cloud (these on-prem commands are available on cloud logout).
- [x] I have attached manual CLI verification results or screenshots in the `Test & Review` section below.
- [ ] I have added appropriate CLI integration or unit tests for any new or updated commands and functionality.
N/A: tests bypass feature flags
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [x] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [x] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [x] Confluent Cloud prod
  - [x] Confluent Cloud stag
  - [x] Confluent Platform
  - [ ] Check this box if the feature is enabled for certain organizations only

What
----
Currently, the entire `confluent flink` command group is behind the `cli.flink` feature flag. However, this flag should only apply to Cloud Flink commands.

On-premises environments often do not have network access to `confluent.cloud`, and so they cannot retrieve the feature flags. The result is the on-prem only `confluent flink application` and `confluent flink environment` commands are not usable.

This PR puts only the Cloud commands behind the feature flag.

Blast Radius
----
Blast radius should be minimal to none, as this change only increases visibility for a subset of Flink commands.

References
----------
https://confluentinc.atlassian.net/browse/CLI-3385

Test & Review
-------------
Performed manual testing using `confluent configuration update disable_feature_flags [true | false]` to emulate feature flag availability.

**CURRENT RELEASE**
Feature flag _available_; cloud logout:
```
confluent flink -h
Manage Apache Flink.

Usage:
  confluent flink [command]

Available Commands:
  application       Manage Flink applications.
  environment       Manage Flink environments.

Global Flags:
  -h, --help            Show help for this command.
      --unsafe-trace    Equivalent to -vvvv, but also log HTTP requests and responses which might contain plaintext secrets.
  -v, --verbose count   Increase verbosity (-v for warn, -vv for info, -vvv for debug, -vvvv for trace).

Use "confluent flink [command] --help" for more information about a command.
```
Feature flag _available_; cloud login:
```
confluent flink -h                                        
Manage Apache Flink.

Usage:
  confluent flink [command]

Available Commands:
  artifact          Manage Flink UDF artifacts.
  compute-pool      Manage Flink compute pools.
  connection        Manage Flink connections.
  connectivity-type Manage Flink connectivity type.
  region            List Flink regions.
  shell             Start Flink interactive SQL client.
  statement         Manage Flink SQL statements.

Global Flags:
  -h, --help            Show help for this command.
      --unsafe-trace    Equivalent to -vvvv, but also log HTTP requests and responses which might contain plaintext secrets.
  -v, --verbose count   Increase verbosity (-v for warn, -vv for info, -vvv for debug, -vvvv for trace).

Use "confluent flink [command] --help" for more information about a command.
```
Feature flag _disabled_; cloud logout:
```
confluent flink -h                                       
Error: unknown command "flink" for "confluent"
Run 'confluent --help' for usage.
```
Feature flag _disabled_; cloud login:
```
confluent flink -h                                       
Error: unknown command "flink" for "confluent"
Run 'confluent --help' for usage.
```

**THIS PR**
Feature flag _available_; cloud logout:
```
confluent flink -h                                        
Manage Apache Flink.

Usage:
  confluent flink [command]

Available Commands:
  application       Manage Flink applications.
  environment       Manage Flink environments.

Global Flags:
  -h, --help            Show help for this command.
      --unsafe-trace    Equivalent to -vvvv, but also log HTTP requests and responses which might contain plaintext secrets.
  -v, --verbose count   Increase verbosity (-v for warn, -vv for info, -vvv for debug, -vvvv for trace).

Use "confluent flink [command] --help" for more information about a command.
```
Feature flag _available_; cloud login:
```
confluent flink -h
Manage Apache Flink.

Usage:
  confluent flink [command]

Available Commands:
  artifact          Manage Flink UDF artifacts.
  compute-pool      Manage Flink compute pools.
  connection        Manage Flink connections.
  connectivity-type Manage Flink connectivity type.
  region            List Flink regions.
  shell             Start Flink interactive SQL client.
  statement         Manage Flink SQL statements.

Global Flags:
  -h, --help            Show help for this command.
      --unsafe-trace    Equivalent to -vvvv, but also log HTTP requests and responses which might contain plaintext secrets.
  -v, --verbose count   Increase verbosity (-v for warn, -vv for info, -vvv for debug, -vvvv for trace).

Use "confluent flink [command] --help" for more information about a command.
```
Feature flag _disabled_; cloud logout:
```
confluent flink -h                                        
Manage Apache Flink.

Usage:
  confluent flink [command]

Available Commands:
  application Manage Flink applications.
  environment Manage Flink environments.

Global Flags:
  -h, --help            Show help for this command.
      --unsafe-trace    Equivalent to -vvvv, but also log HTTP requests and responses which might contain plaintext secrets.
  -v, --verbose count   Increase verbosity (-v for warn, -vv for info, -vvv for debug, -vvvv for trace).

Use "confluent flink [command] --help" for more information about a command.
```
Feature flag _disabled_; cloud login:
```
confluent flink -h
Manage Apache Flink.

Usage:

Global Flags:
  -h, --help            Show help for this command.
      --unsafe-trace    Equivalent to -vvvv, but also log HTTP requests and responses which might contain plaintext secrets.
  -v, --verbose count   Increase verbosity (-v for warn, -vv for info, -vvv for debug, -vvvv for trace).
```