### PR TITLE
[FSE-215] Update lsp client and expose documentUri

### DIFF
--- a/pkg/flink/lsp/completer_test.go
+++ b/pkg/flink/lsp/completer_test.go
@@ -45,8 +45,9 @@ func TestLSPdidOpen(t *testing.T) {
 
 	lspClient := &LSPClient{conn: conn}
 	require.Nil(t, lspClient.documentURI)
-	err := lspClient.DidOpen()
+	docUri, err := lspClient.DidOpen()
 	require.NotNil(t, lspClient.documentURI)
+	require.Equal(t, docUri, *lspClient.documentURI)
 	require.NoError(t, err)
 }
 
@@ -56,14 +57,14 @@ func TestLSPdidOpenCallErr(t *testing.T) {
 
 	lspClient := &LSPClient{conn: conn}
 	require.Nil(t, lspClient.documentURI)
-	err := lspClient.DidOpen()
+	_, err := lspClient.DidOpen()
 	require.Nil(t, lspClient.documentURI)
 	require.Error(t, err)
 }
 
 func TestLSPdidOpenNoConnErr(t *testing.T) {
 	lspClient := &LSPClient{conn: nil}
-	err := lspClient.DidOpen()
+	_, err := lspClient.DidOpen()
 	require.Error(t, err)
 }
 

--- a/pkg/flink/lsp/lsp.go
+++ b/pkg/flink/lsp/lsp.go
@@ -42,6 +42,7 @@ func NewLSPClientImpl(conn types.JSONRpcConn) *LSPClient {
 }
 
 func (c *LSPClient) Initialize() (*lsp.InitializeResult, error) {
+	log.CliLogger.Debugf("Initialize called")
 	var resp lsp.InitializeResult
 
 	initializeParams := lsp.InitializeParams{}
@@ -59,7 +60,9 @@ func (c *LSPClient) Initialize() (*lsp.InitializeResult, error) {
 	return &resp, err
 }
 
-func (c *LSPClient) DidOpen() error {
+func (c *LSPClient) DidOpen() (lsp.DocumentURI, error) {
+	log.CliLogger.Debugf("DidOpen called")
+
 	var resp interface{}
 
 	documentURI := lsp.DocumentURI("temp_session_" + uuid.New().String() + ".sql")
@@ -86,6 +89,7 @@ func (c *LSPClient) DidOpen() error {
 }
 
 func (c *LSPClient) DidChange(newText string) error {
+	log.CliLogger.Debugf("DidChange called")
 	if c.conn == nil || c.documentURI == nil {
 		return errors.New("connection to LSP server not established/nil")
 	}
@@ -111,6 +115,7 @@ func (c *LSPClient) DidChange(newText string) error {
 }
 
 func (c *LSPClient) DidChangeConfiguration(settings any) error {
+	log.CliLogger.Debugf("DidChangeConfiguration called")
 	if c.conn == nil {
 		return errors.New("connection to LSP server not established/nil")
 	}
@@ -129,6 +134,7 @@ func (c *LSPClient) DidChangeConfiguration(settings any) error {
 }
 
 func (c *LSPClient) Completion(position lsp.Position) (lsp.CompletionList, error) {
+	log.CliLogger.Debugf("Completion called")
 	var resp lsp.CompletionList
 
 	if c.conn == nil || c.documentURI == nil {
@@ -153,6 +159,7 @@ func (c *LSPClient) Completion(position lsp.Position) (lsp.CompletionList, error
 }
 
 func (c *LSPClient) ShutdownAndExit() {
+	log.CliLogger.Debugf("ShutdownAndExit called")
 	if c.conn == nil {
 		return
 	}

--- a/pkg/flink/lsp/lsp_handler.go
+++ b/pkg/flink/lsp/lsp_handler.go
@@ -14,6 +14,8 @@ type LSPHandler struct {
 
 //  All we do here is to pass the request to the channel since the controller that has to process and do something with the request is the InputController
 func (h *LSPHandler) Handle(ctx context.Context, conn *jsonrpc2.Conn, req *jsonrpc2.Request) {
+	log.CliLogger.Debugf("Received lsp message with method: %s", req.Method)
+
 	select {
 	case h.handlerCh <- req:
 		// Successfully sent the request


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Checklist
---------
<!-- 
Check each item below to ensure high-quality CLI development practices are followed. PR approval will not be granted until the checklist is fully reviewed.
For detailed instructions, please refer to this Confluence page: https://confluentinc.atlassian.net/wiki/spaces/AEGI/pages/3949592874/
-->
- [x] I have successfully built and used a custom CLI binary, without linter issues from this PR.
- [x] I have clearly specified in the `What` section below whether this PR applies to Confluent Cloud, Confluent Platform, or both. 
- [x] I have verified this PR in Confluent Cloud pre-prod or production environment, if applicable.
- [x] I have verified this PR in Confluent Platform on-premises environment, if applicable.
- [x] I have attached manual CLI verification results or screenshots in the `Test & Review` section below.
- [x] I have added appropriate CLI integration or unit tests for any new or updated commands and functionality.
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [x] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [x] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [x] Confluent Cloud prod
  - [x] Confluent Cloud stag
  - [ ] Confluent Platform
  - [ ] Check this box if the feature is enabled for certain organizations only

What
----
<!--
Briefly describe **what** you have changed and **why** these changes are necessary.
Optionally include: 
- The problem being solved or the feature being added. 
- The implementation strategy or approach taken. 
- Key technical details, design decisions, or any additional context reviewers should be aware of.
-->
Updated the lsp client to expose the document uri opened. We can now log this value and use it for debugging. Also complemented an old error message with a common private networking issue.

Blast Radius
----
<!--
The Blast Radius section should include information on what will be the customer(s) impact if something goes wrong or unexpectedly, 
adding this section will trigger the PR author to think about the impact from product perspective, examples can be:
- Confluent Cloud customers who are using confluent kafka topic any subcommand will be blocked.
- Confluent Cloud customers who are using confluent kafka topic list commands will be blocked.
- Confluent Platform customers who are using --schema flag will be impacted.
- All customers who are using SSO to login will be impacted.
-->
Only debugging, no impact.

References
----------
<!-- Include links to relevant resources for this PR, such as: 
- Related GitHub issues 
- Tickets (JIRA, etc.) 
- Internal documentation or design specs 
- Other related PRs 
Copy and paste the links below for easy reference.
-->
FSE-215

Test & Review
-------------
<!-- Has this PR been tested? If so, explain **how** it was tested. Include: 
- Steps taken to verify the changes. 
- Links to manual verification documents, logs, or screenshots to save reviewers' time. 
- Any additional notes on testing (e.g., environments used, edge cases tested). 
- Screenshot showing successful resource creation, updates etc.
Example: - [Manual Verification Document](https://docs.google.com/document/d/1GwXz9hNOkub_Br-2nssoYWCf6elZBvwo7TMhCNYinwE/edit?tab=t.0#heading=h.dvbi09ntxjw6)
-->
Since only refactoring/logs, I've manually tested the changes with the -vvvv flag