### PR TITLE
[MATRIX-611] feat: add couchbase connection

### DIFF
--- a/cmd/lint/main.go
+++ b/cmd/lint/main.go
@@ -216,6 +216,7 @@ var vocabWords = []string{
 	"config",
 	"configs",
 	"consumer.config",
+	"couchbase",
 	"cpp",
 	"crl",
 	"crn",

--- a/pkg/flink/utils.go
+++ b/pkg/flink/utils.go
@@ -1,7 +1,7 @@
 package flink
 
 var (
-	ConnectionTypes             = []string{"openai", "azureml", "azureopenai", "bedrock", "sagemaker", "googleai", "vertexai", "mongodb", "elastic", "pinecone"}
+	ConnectionTypes             = []string{"openai", "azureml", "azureopenai", "bedrock", "sagemaker", "googleai", "vertexai", "mongodb", "elastic", "pinecone", "couchbase"}
 	ConnectionTypeSecretMapping = map[string][]string{
 		"openai":      {"api-key"},
 		"azureml":     {"api-key"},
@@ -13,6 +13,7 @@ var (
 		"mongodb":     {"username", "password"},
 		"elastic":     {"api-key"},
 		"pinecone":    {"api-key"},
+		"couchbase":   {"username", "password"},
 	}
 
 	ConnectionSecretTypeMapping = map[string][]string{
@@ -21,8 +22,8 @@ var (
 		"aws-secret-key":    {"bedrock", "sagemaker"},
 		"aws-session-token": {"bedrock", "sagemaker"},
 		"service-key":       {"vertexai"},
-		"username":          {"mongodb"},
-		"password":          {"mongodb"},
+		"username":          {"mongodb", "couchbase"},
+		"password":          {"mongodb", "couchbase"},
 	}
 
 	ConnectionRequiredSecretMapping = map[string][]string{
@@ -36,6 +37,7 @@ var (
 		"mongodb":     {"username", "password"},
 		"elastic":     {"api-key"},
 		"pinecone":    {"api-key"},
+		"couchbase":   {"username", "password"},
 	}
 	ConnectionSecretBackendKeyMapping = map[string]string{
 		"api-key":           "API_KEY",

--- a/test/fixtures/output/flink/connection/create-help.golden
+++ b/test/fixtures/output/flink/connection/create-help.golden
@@ -11,15 +11,15 @@ Create Flink connection "my-connection" in AWS us-west-2 for OpenAPI with endpoi
 Flags:
       --cloud string               REQUIRED: Specify the cloud provider as "aws", "azure", or "gcp".
       --region string              REQUIRED: Cloud region for Flink (use "confluent flink region list" to see all).
-      --type string                REQUIRED: Specify the connection type as "openai", "azureml", "azureopenai", "bedrock", "sagemaker", "googleai", "vertexai", "mongodb", "elastic", or "pinecone".
+      --type string                REQUIRED: Specify the connection type as "openai", "azureml", "azureopenai", "bedrock", "sagemaker", "googleai", "vertexai", "mongodb", "elastic", "pinecone", or "couchbase".
       --endpoint string            REQUIRED: Specify endpoint for the connection.
       --api-key string             Specify API key for the type: "openai", "azureml", "azureopenai", "googleai", "elastic", or "pinecone".
       --aws-access-key string      Specify access key for the type: "bedrock" or "sagemaker".
       --aws-secret-key string      Specify secret key for the type: "bedrock" or "sagemaker".
       --aws-session-token string   Specify session token for the type: "bedrock" or "sagemaker".
       --service-key string         Specify service key for the type: "vertexai".
-      --username string            Specify username for the type: "mongodb".
-      --password string            Specify password for the type: "mongodb".
+      --username string            Specify username for the type: "mongodb" or "couchbase".
+      --password string            Specify password for the type: "mongodb" or "couchbase".
       --environment string         Environment ID.
   -o, --output string              Specify the output format as "human", "json", or "yaml". (default "human")
 

--- a/test/fixtures/output/flink/connection/create/create-couchbase.golden
+++ b/test/fixtures/output/flink/connection/create/create-couchbase.golden
@@ -1,0 +1,11 @@
++---------------+--------------------------------------------+
+| Creation Date | 2023-01-01 00:00:00 +0000 UTC              |
+| Name          | my-connection                              |
+| Environment   | env-596                                    |
+| Cloud         | aws                                        |
+| Region        | eu-west-1                                  |
+| Type          | COUCHBASE                                  |
+| Endpoint      | https://api.openai.com/v1/chat/completions |
+| Data          | <REDACTED>                                 |
+| Status        | PENDING                                    |
++---------------+--------------------------------------------+

--- a/test/fixtures/output/flink/connection/create/create-wrong-type.golden
+++ b/test/fixtures/output/flink/connection/create/create-wrong-type.golden
@@ -1,4 +1,4 @@
 Error: invalid connection type OPENAI
 
 Suggestions:
-    Specify the connection type as "openai", "azureml", "azureopenai", "bedrock", "sagemaker", "googleai", "vertexai", "mongodb", "elastic", or "pinecone".
+    Specify the connection type as "openai", "azureml", "azureopenai", "bedrock", "sagemaker", "googleai", "vertexai", "mongodb", "elastic", "pinecone", or "couchbase".

--- a/test/fixtures/output/flink/connection/list-help.golden
+++ b/test/fixtures/output/flink/connection/list-help.golden
@@ -7,7 +7,7 @@ Flags:
       --cloud string         REQUIRED: Specify the cloud provider as "aws", "azure", or "gcp".
       --region string        REQUIRED: Cloud region for Flink (use "confluent flink region list" to see all).
       --environment string   Environment ID.
-      --type string          Specify the connection type as "openai", "azureml", "azureopenai", "bedrock", "sagemaker", "googleai", "vertexai", "mongodb", "elastic", or "pinecone".
+      --type string          Specify the connection type as "openai", "azureml", "azureopenai", "bedrock", "sagemaker", "googleai", "vertexai", "mongodb", "elastic", "pinecone", or "couchbase".
   -o, --output string        Specify the output format as "human", "json", or "yaml". (default "human")
 
 Global Flags:

--- a/test/fixtures/output/flink/connection/list/list-failure.golden
+++ b/test/fixtures/output/flink/connection/list/list-failure.golden
@@ -1,4 +1,4 @@
 Error: invalid connection type invalid
 
 Suggestions:
-    Specify the connection type as "openai", "azureml", "azureopenai", "bedrock", "sagemaker", "googleai", "vertexai", "mongodb", "elastic", or "pinecone".
+    Specify the connection type as "openai", "azureml", "azureopenai", "bedrock", "sagemaker", "googleai", "vertexai", "mongodb", "elastic", "pinecone", or "couchbase".

--- a/test/fixtures/output/flink/connection/update-help.golden
+++ b/test/fixtures/output/flink/connection/update-help.golden
@@ -16,8 +16,8 @@ Flags:
       --aws-secret-key string      Specify secret key for the type: "bedrock" or "sagemaker".
       --aws-session-token string   Specify session token for the type: "bedrock" or "sagemaker".
       --service-key string         Specify service key for the type: "vertexai".
-      --username string            Specify username for the type: "mongodb".
-      --password string            Specify password for the type: "mongodb".
+      --username string            Specify username for the type: "mongodb" or "couchbase".
+      --password string            Specify password for the type: "mongodb" or "couchbase".
       --environment string         Environment ID.
   -o, --output string              Specify the output format as "human", "json", or "yaml". (default "human")
 

--- a/test/flink_test.go
+++ b/test/flink_test.go
@@ -150,6 +150,7 @@ func (s *CLITestSuite) TestFlinkConnectionCreateSuccess() {
 		{args: "flink connection create my-connection --cloud aws --region eu-west-1 --type mongodb --endpoint https://api.openai.com/v1/chat/completions --username name --password pass", fixture: "flink/connection/create/create-mongodb.golden"},
 		{args: "flink connection create my-connection --cloud aws --region eu-west-1 --type elastic --endpoint https://api.openai.com/v1/chat/completions --api-key 0000000000000000", fixture: "flink/connection/create/create-elastic.golden"},
 		{args: "flink connection create my-connection --cloud aws --region eu-west-1 --type pinecone --endpoint https://api.openai.com/v1/chat/completions --api-key 0000000000000000", fixture: "flink/connection/create/create-pinecone.golden"},
+		{args: "flink connection create my-connection --cloud aws --region eu-west-1 --type couchbase --endpoint https://api.openai.com/v1/chat/completions --username name --password pass", fixture: "flink/connection/create/create-couchbase.golden"},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Release Notes
-------------
New Features
- Add "couchbase" as a new Flink connection type

Checklist
---------
- [x] I have successfully built and used a custom CLI binary, without linter issues from this PR.
- [x] I have clearly specified in the `What` section below whether this PR applies to Confluent Cloud, Confluent Platform, or both. 
- [x] I have verified this PR in Confluent Cloud pre-prod or production environment, if applicable.
- [ ] I have verified this PR in Confluent Platform on-premises environment, if applicable.
- [x] I have attached manual CLI verification results or screenshots in the `Test & Review` section below.
- [x] I have added appropriate CLI integration or unit tests for any new or updated commands and functionality.
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [x] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [x] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [ ] Confluent Cloud prod
  - [x] Confluent Cloud stag
  - [ ] Confluent Platform
  - [x] Check this box if the feature is enabled for certain organizations only

What
----
Add couchbase as a new flink connection type for Confluent Cloud.

Blast Radius
----
will affect flink connection subcommand.

References
----------

Test & Review
-------------
```
dist/confluent_darwin_arm64_v8.0/confluent flink connection list --cloud aws --region us-west-2 --type couchbase --environment <REDACTED>
          Creation Date          |         Name         |  Environment   | Cloud |  Region   |   Type    |                       Endpoint                       |    Data    | Status | Status Detail  
---------------------------------+----------------------+----------------+-------+-----------+-----------+------------------------------------------------------+------------+--------+----------------
  2025-01-28 18:51:08.610763     | couchbase-connection | <REDACTED> | aws   | us-west-2 | COUCHBASE | couchbases://<REDACTED>.cloud.couchbase.com | <REDACTED> |        |                
  +0000 UTC                      |                      |                |       |           |           |                                                      |            |        |         
```