### PR TITLE
[FRT-918] Flink artifact cli should return artifact by created desc order

### DIFF
--- a/internal/flink/command_artifact_list.go
+++ b/internal/flink/command_artifact_list.go
@@ -69,6 +69,7 @@ func (c *command) list(cmd *cobra.Command, _ []string) error {
 	}
 
 	list := output.NewList(cmd)
+	list.Sort(false)
 	for _, artifact := range artifacts {
 		list.Add(&artifactOutList{
 			Name:        artifact.GetDisplayName(),


### PR DESCRIPTION
Release Notes
-------------

Bug Fixes
- Artifacts are already returned in DESC order from the endpoint, so we want to avoid extra sorting on the CLI side

Checklist
---------
<!-- 
Check each item below to ensure high-quality CLI development practices are followed. PR approval will not be granted until the checklist is fully reviewed.
For detailed instructions, please refer to this Confluence page: https://confluentinc.atlassian.net/wiki/spaces/AEGI/pages/3949592874/
-->
- [X] I have successfully built and used a custom CLI binary, without linter issues from this PR.
- [x] I have clearly specified in the `What` section below whether this PR applies to Confluent Cloud, Confluent Platform, or both. 
- [x] I have verified this PR in Confluent Cloud pre-prod or production environment, if applicable.
- [x] I have verified this PR in Confluent Platform on-premises environment, if applicable.
- [x] I have attached manual CLI verification results or screenshots in the `Test & Review` section below.
- [x] I have added appropriate CLI integration or unit tests for any new or updated commands and functionality.
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [x] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [x] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [x] Confluent Cloud prod
  - [x] Confluent Cloud stag
  - [ ] Confluent Platform
  - [ ] Check this box if the feature is enabled for certain organizations only

What
----
<!--
Briefly describe **what** you have changed and **why** these changes are necessary.
Optionally include: 
- The problem being solved or the feature being added. 
- The implementation strategy or approach taken. 
- Key technical details, design decisions, or any additional context reviewers should be aware of.
-->

Blast Radius
----
No impact, only the order of the list results chandes


References
----------
<!-- Include links to relevant resources for this PR, such as: 
- Related GitHub issues 
- Tickets (JIRA, etc.) 
- Internal documentation or design specs 
- Other related PRs 
Copy and paste the links below for easy reference.
-->

Test & Review
-------------
<!-- Has this PR been tested? If so, explain **how** it was tested. Include: 
- Steps taken to verify the changes. 
- Links to manual verification documents, logs, or screenshots to save reviewers' time. 
- Any additional notes on testing (e.g., environments used, edge cases tested). 
- Screenshot showing successful resource creation, updates etc.
Example: - [Manual Verification Document](https://docs.google.com/document/d/1GwXz9hNOkub_Br-2nssoYWCf6elZBvwo7TMhCNYinwE/edit?tab=t.0#heading=h.dvbi09ntxjw6)
-->

```
❯ dist/confluent_$(go env GOOS)_$(go env GOARCH)/confluent  flink artifact list --cloud AWS --region us-west-2 --environment env-devc33qr20
        ID       |                         Name                         | Cloud |  Region   |  Environment   |           Timestamp              --region us-west-2 --environment env-devc33qr20                                                                                    ✔  14s  1.22.7   16:57:42 
-----------------+------------------------------------------------------+-------+-----------+----------------+---------------------------------
  cfa-devcq22nvp | byang-python-test4                                   | AWS   | us-west-2 | env-devc33qr20 | 2025-01-28 23:24:27.386733      
                 |                                                      |       |           |                | +0000 UTC                       
  cfa-devco3366x | nico-hello-with-log                                  | AWS   | us-west-2 | env-devc33qr20 | 2025-01-23 17:17:01.418504      
                 |                                                      |       |           |                | +0000 UTC                       
  cfa-devck8qdz2 | ziru-cli-test-function-persistent                    | AWS   | us-west-2 | env-devc33qr20 | 2025-01-03 16:27:21.85212  
  ```
