### PR TITLE
AM-5152: Update `confluent rbac role list` integration test format to reflect a real API call

### DIFF
--- a/internal/iam/command_rbac_role_list.go
+++ b/internal/iam/command_rbac_role_list.go
@@ -2,10 +2,9 @@ package iam
 
 import (
 	"github.com/antihax/optional"
-	"github.com/spf13/cobra"
-
 	pcmd "github.com/confluentinc/cli/v4/pkg/cmd"
 	"github.com/confluentinc/cli/v4/pkg/output"
+	"github.com/spf13/cobra"
 )
 
 func (c *roleCommand) newListCommand() *cobra.Command {

--- a/internal/iam/command_rbac_role_list.go
+++ b/internal/iam/command_rbac_role_list.go
@@ -2,9 +2,10 @@ package iam
 
 import (
 	"github.com/antihax/optional"
+	"github.com/spf13/cobra"
+
 	pcmd "github.com/confluentinc/cli/v4/pkg/cmd"
 	"github.com/confluentinc/cli/v4/pkg/output"
-	"github.com/spf13/cobra"
 )
 
 func (c *roleCommand) newListCommand() *cobra.Command {

--- a/test/fixtures/output/iam/rbac/role/list-cloud.golden
+++ b/test/fixtures/output/iam/rbac/role/list-cloud.golden
@@ -1,1397 +1,296 @@
-           Name          |                               Access Policy                                
--------------------------+----------------------------------------------------------------------------
-  CCloudRoleBindingAdmin | [                                                                          
-                         |   {                                                                        
-                         |     "bindingScope": "root",                                                
-                         |     "bindWithResource": false,                                             
-                         |     "allowedOperations": [                                                 
-                         |       {                                                                    
-                         |         "resourceType": "SecurityMetadata",                                
-                         |         "operations": ["Describe", "Alter"]                                
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "Organization",                                    
-                         |         "operations": ["AlterAccess", "DescribeAccess"]                    
-                         |       }                                                                    
-                         |     ]                                                                      
-                         |   }                                                                        
-                         | ]                                                                          
-                         |                                                                            
-  CCloudRoleBindingAdmin | [                                                                          
-                         |   {                                                                        
-                         |     "bindingScope": "root",                                                
-                         |     "bindWithResource": false,                                             
-                         |     "allowedOperations": [                                                 
-                         |       {                                                                    
-                         |         "resourceType": "SecurityMetadata",                                
-                         |         "operations": ["Describe", "Alter"]                                
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "Organization",                                    
-                         |         "operations": ["AlterAccess", "DescribeAccess"]                    
-                         |       }                                                                    
-                         |     ]                                                                      
-                         |   }                                                                        
-                         | ]                                                                          
-                         |                                                                            
-  CCloudRoleBindingAdmin | [                                                                          
-                         |   {                                                                        
-                         |     "bindingScope": "root",                                                
-                         |     "bindWithResource": false,                                             
-                         |     "allowedOperations": [                                                 
-                         |       {                                                                    
-                         |         "resourceType": "SecurityMetadata",                                
-                         |         "operations": ["Describe", "Alter"]                                
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "Organization",                                    
-                         |         "operations": ["AlterAccess", "DescribeAccess"]                    
-                         |       }                                                                    
-                         |     ]                                                                      
-                         |   }                                                                        
-                         | ]                                                                          
-                         |                                                                            
-  CCloudRoleBindingAdmin | [                                                                          
-                         |   {                                                                        
-                         |     "bindingScope": "root",                                                
-                         |     "bindWithResource": false,                                             
-                         |     "allowedOperations": [                                                 
-                         |       {                                                                    
-                         |         "resourceType": "SecurityMetadata",                                
-                         |         "operations": ["Describe", "Alter"]                                
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "Organization",                                    
-                         |         "operations": ["AlterAccess", "DescribeAccess"]                    
-                         |       }                                                                    
-                         |     ]                                                                      
-                         |   }                                                                        
-                         | ]                                                                          
-                         |                                                                            
-  CloudClusterAdmin      | [                                                                          
-                         |   {                                                                        
-                         |     "bindingScope": "cluster",                                             
-                         |     "bindWithResource": false,                                             
-                         |     "allowedOperations": [                                                 
-                         |       {                                                                    
-                         |         "resourceType": "Topic",                                           
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "KsqlCluster",                                     
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "Subject",                                         
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "Connector",                                       
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "NetworkAccess",                                   
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "ClusterMetric",                                   
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "Cluster",                                         
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "ClusterApiKey",                                   
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "SecurityMetadata",                                
-                         |         "operations": ["Describe", "Alter"]                                
-                         |       }                                                                    
-                         |     ]                                                                      
-                         |   },                                                                       
-                         |   {                                                                        
-                         |     "bindingScope": "organization",                                        
-                         |     "bindWithResource": false,                                             
-                         |     "allowedOperations": [                                                 
-                         |       {                                                                    
-                         |         "resourceType": "SupportPlan",                                     
-                         |         "operations": ["Describe"]                                         
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "User",                                            
-                         |         "operations": ["Describe", "Invite"]                               
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "ServiceAccount",                                  
-                         |         "operations": ["Describe"]                                         
-                         |       }                                                                    
-                         |     ]                                                                      
-                         |   }                                                                        
-                         | ]                                                                          
-                         |                                                                            
-  CloudClusterAdmin      | [                                                                          
-                         |   {                                                                        
-                         |     "bindingScope": "cluster",                                             
-                         |     "bindWithResource": false,                                             
-                         |     "allowedOperations": [                                                 
-                         |       {                                                                    
-                         |         "resourceType": "Topic",                                           
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "KsqlCluster",                                     
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "Subject",                                         
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "Connector",                                       
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "NetworkAccess",                                   
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "ClusterMetric",                                   
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "Cluster",                                         
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "ClusterApiKey",                                   
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "SecurityMetadata",                                
-                         |         "operations": ["Describe", "Alter"]                                
-                         |       }                                                                    
-                         |     ]                                                                      
-                         |   },                                                                       
-                         |   {                                                                        
-                         |     "bindingScope": "organization",                                        
-                         |     "bindWithResource": false,                                             
-                         |     "allowedOperations": [                                                 
-                         |       {                                                                    
-                         |         "resourceType": "SupportPlan",                                     
-                         |         "operations": ["Describe"]                                         
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "User",                                            
-                         |         "operations": ["Describe", "Invite"]                               
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "ServiceAccount",                                  
-                         |         "operations": ["Describe"]                                         
-                         |       }                                                                    
-                         |     ]                                                                      
-                         |   }                                                                        
-                         | ]                                                                          
-                         |                                                                            
-  CloudClusterAdmin      | [                                                                          
-                         |   {                                                                        
-                         |     "bindingScope": "cluster",                                             
-                         |     "bindWithResource": false,                                             
-                         |     "allowedOperations": [                                                 
-                         |       {                                                                    
-                         |         "resourceType": "Topic",                                           
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "KsqlCluster",                                     
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "Subject",                                         
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "Connector",                                       
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "NetworkAccess",                                   
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "ClusterMetric",                                   
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "Cluster",                                         
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "ClusterApiKey",                                   
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "SecurityMetadata",                                
-                         |         "operations": ["Describe", "Alter"]                                
-                         |       }                                                                    
-                         |     ]                                                                      
-                         |   },                                                                       
-                         |   {                                                                        
-                         |     "bindingScope": "organization",                                        
-                         |     "bindWithResource": false,                                             
-                         |     "allowedOperations": [                                                 
-                         |       {                                                                    
-                         |         "resourceType": "SupportPlan",                                     
-                         |         "operations": ["Describe"]                                         
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "User",                                            
-                         |         "operations": ["Describe", "Invite"]                               
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "ServiceAccount",                                  
-                         |         "operations": ["Describe"]                                         
-                         |       }                                                                    
-                         |     ]                                                                      
-                         |   }                                                                        
-                         | ]                                                                          
-                         |                                                                            
-  CloudClusterAdmin      | [                                                                          
-                         |   {                                                                        
-                         |     "bindingScope": "cluster",                                             
-                         |     "bindWithResource": false,                                             
-                         |     "allowedOperations": [                                                 
-                         |       {                                                                    
-                         |         "resourceType": "Topic",                                           
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "KsqlCluster",                                     
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "Subject",                                         
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "Connector",                                       
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "NetworkAccess",                                   
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "ClusterMetric",                                   
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "Cluster",                                         
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "ClusterApiKey",                                   
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "SecurityMetadata",                                
-                         |         "operations": ["Describe", "Alter"]                                
-                         |       }                                                                    
-                         |     ]                                                                      
-                         |   },                                                                       
-                         |   {                                                                        
-                         |     "bindingScope": "organization",                                        
-                         |     "bindWithResource": false,                                             
-                         |     "allowedOperations": [                                                 
-                         |       {                                                                    
-                         |         "resourceType": "SupportPlan",                                     
-                         |         "operations": ["Describe"]                                         
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "User",                                            
-                         |         "operations": ["Describe", "Invite"]                               
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "ServiceAccount",                                  
-                         |         "operations": ["Describe"]                                         
-                         |       }                                                                    
-                         |     ]                                                                      
-                         |   }                                                                        
-                         | ]                                                                          
-                         |                                                                            
-  DataDiscovery          | [                                                                          
-                         |   {                                                                        
-                         |     "bindingScope": "environment",                                         
-                         |     "bindWithResource": false,                                             
-                         |     "allowedOperations": [                                                 
-                         |       {                                                                    
-                         |         "resourceType": "CatalogTagDefinition",                            
-                         |         "operations": ["Read"]                                             
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "Topic",                                           
-                         |         "operations": ["ReadCatalog"]                                      
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "Subject",                                         
-                         |         "operations": ["Read", "ReadCatalog", "ReadCompatibility"]         
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "CatalogBusinessMetadataDefinition",               
-                         |         "operations": ["Read"]                                             
-                         |       }                                                                    
-                         |     ]                                                                      
-                         |   }                                                                        
-                         | ]                                                                          
-                         |                                                                            
-  DataSteward            | [                                                                          
-                         |   {                                                                        
-                         |     "bindingScope": "environment",                                         
-                         |     "bindWithResource": false,                                             
-                         |     "allowedOperations": [                                                 
-                         |       {                                                                    
-                         |         "resourceType": "CatalogTagDefinition",                            
-                         |         "operations": ["Read", "Write", "Delete"]                          
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "Topic",                                           
-                         |         "operations": ["ReadCatalog", "WriteCatalog"]                      
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "Subject",                                         
-                         |         "operations": [                                                    
-                         |           "Delete",                                                        
-                         |           "Read",                                                          
-                         |           "ReadCatalog",                                                   
-                         |           "ReadCompatibility",                                             
-                         |           "Write",                                                         
-                         |           "WriteCatalog",                                                  
-                         |           "WriteCompatibility"                                             
-                         |         ]                                                                  
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "CatalogBusinessMetadataDefinition",               
-                         |         "operations": ["Read", "Write", "Delete"]                          
-                         |       }                                                                    
-                         |     ]                                                                      
-                         |   }                                                                        
-                         | ]                                                                          
-                         |                                                                            
-  DeveloperManage        | [                                                                          
-                         |   {                                                                        
-                         |     "bindingScope": "cloud-cluster",                                       
-                         |     "bindWithResource": false,                                             
-                         |     "allowedOperations": [                                                 
-                         |       {                                                                    
-                         |         "resourceType": "CloudCluster",                                    
-                         |         "operations": ["Describe"]                                         
-                         |       }                                                                    
-                         |     ]                                                                      
-                         |   },                                                                       
-                         |   {                                                                        
-                         |     "bindingScope": "cluster",                                             
-                         |     "bindWithResource": false,                                             
-                         |     "allowedOperations": [                                                 
-                         |       {                                                                    
-                         |         "resourceType": "Cluster",                                         
-                         |         "operations": ["View", "AccessWithToken"]                          
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "OwnKafkaClusterApiKey",                           
-                         |         "operations": ["Describe", "Alter", "Delete", "Create"]            
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "OwnClusterApiKey",                                
-                         |         "operations": ["Describe", "Alter", "Delete", "Create"]            
-                         |       }                                                                    
-                         |     ]                                                                      
-                         |   },                                                                       
-                         |   {                                                                        
-                         |     "bindingScope": "cluster",                                             
-                         |     "bindWithResource": true,                                              
-                         |     "allowedOperations": [                                                 
-                         |       {                                                                    
-                         |         "resourceType": "Topic",                                           
-                         |         "operations": ["Delete", "Describe", "Create", "DescribeConfigs"]  
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "Cluster",                                         
-                         |         "operations": ["Create", "DescribeConfigs"]                        
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "TransactionalId",                                 
-                         |         "operations": ["Describe"]                                         
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "Group",                                           
-                         |         "operations": ["Describe", "Delete"]                               
-                         |       }                                                                    
-                         |     ]                                                                      
-                         |   }                                                                        
-                         | ]                                                                          
-                         |                                                                            
-  EnvironmentAdmin       | [                                                                          
-                         |   {                                                                        
-                         |     "bindingScope": "ENVIRONMENT",                                         
-                         |     "bindWithResource": false,                                             
-                         |     "allowedOperations": [                                                 
-                         |       {                                                                    
-                         |         "resourceType": "SecurityMetadata",                                
-                         |         "operations": ["Describe", "Alter"]                                
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "ClusterApiKey",                                   
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "Connector",                                       
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "NetworkAccess",                                   
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "KsqlCluster",                                     
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "Environment",                                     
-                         |         "operations": [                                                    
-                         |           "Alter",                                                         
-                         |           "Delete",                                                        
-                         |           "AlterAccess",                                                   
-                         |           "CreateKafkaCluster",                                            
-                         |           "DescribeAccess"                                                 
-                         |         ]                                                                  
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "Subject",                                         
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "NetworkConfig",                                   
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "ClusterMetric",                                   
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "Cluster",                                         
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "SchemaRegistry",                                  
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "NetworkRegion",                                   
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "Deployment",                                      
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "Topic",                                           
-                         |         "operations": ["All"]                                              
-                         |       }                                                                    
-                         |     ]                                                                      
-                         |   },                                                                       
-                         |   {                                                                        
-                         |     "bindingScope": "organization",                                        
-                         |     "bindWithResource": false,                                             
-                         |     "allowedOperations": [                                                 
-                         |       {                                                                    
-                         |         "resourceType": "User",                                            
-                         |         "operations": ["Describe", "Invite"]                               
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "ServiceAccount",                                  
-                         |         "operations": ["Describe"]                                         
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "SupportPlan",                                     
-                         |         "operations": ["Describe"]                                         
-                         |       }                                                                    
-                         |     ]                                                                      
-                         |   }                                                                        
-                         | ]                                                                          
-                         |                                                                            
-  EnvironmentAdmin       | [                                                                          
-                         |   {                                                                        
-                         |     "bindingScope": "ENVIRONMENT",                                         
-                         |     "bindWithResource": false,                                             
-                         |     "allowedOperations": [                                                 
-                         |       {                                                                    
-                         |         "resourceType": "SecurityMetadata",                                
-                         |         "operations": ["Describe", "Alter"]                                
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "ClusterApiKey",                                   
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "Connector",                                       
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "NetworkAccess",                                   
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "KsqlCluster",                                     
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "Environment",                                     
-                         |         "operations": [                                                    
-                         |           "Alter",                                                         
-                         |           "Delete",                                                        
-                         |           "AlterAccess",                                                   
-                         |           "CreateKafkaCluster",                                            
-                         |           "DescribeAccess"                                                 
-                         |         ]                                                                  
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "Subject",                                         
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "NetworkConfig",                                   
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "ClusterMetric",                                   
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "Cluster",                                         
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "SchemaRegistry",                                  
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "NetworkRegion",                                   
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "Deployment",                                      
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "Topic",                                           
-                         |         "operations": ["All"]                                              
-                         |       }                                                                    
-                         |     ]                                                                      
-                         |   },                                                                       
-                         |   {                                                                        
-                         |     "bindingScope": "organization",                                        
-                         |     "bindWithResource": false,                                             
-                         |     "allowedOperations": [                                                 
-                         |       {                                                                    
-                         |         "resourceType": "User",                                            
-                         |         "operations": ["Describe", "Invite"]                               
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "ServiceAccount",                                  
-                         |         "operations": ["Describe"]                                         
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "SupportPlan",                                     
-                         |         "operations": ["Describe"]                                         
-                         |       }                                                                    
-                         |     ]                                                                      
-                         |   }                                                                        
-                         | ]                                                                          
-                         |                                                                            
-  EnvironmentAdmin       | [                                                                          
-                         |   {                                                                        
-                         |     "bindingScope": "ENVIRONMENT",                                         
-                         |     "bindWithResource": false,                                             
-                         |     "allowedOperations": [                                                 
-                         |       {                                                                    
-                         |         "resourceType": "SecurityMetadata",                                
-                         |         "operations": ["Describe", "Alter"]                                
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "ClusterApiKey",                                   
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "Connector",                                       
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "NetworkAccess",                                   
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "KsqlCluster",                                     
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "Environment",                                     
-                         |         "operations": [                                                    
-                         |           "Alter",                                                         
-                         |           "Delete",                                                        
-                         |           "AlterAccess",                                                   
-                         |           "CreateKafkaCluster",                                            
-                         |           "DescribeAccess"                                                 
-                         |         ]                                                                  
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "Subject",                                         
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "NetworkConfig",                                   
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "ClusterMetric",                                   
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "Cluster",                                         
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "SchemaRegistry",                                  
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "NetworkRegion",                                   
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "Deployment",                                      
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "Topic",                                           
-                         |         "operations": ["All"]                                              
-                         |       }                                                                    
-                         |     ]                                                                      
-                         |   },                                                                       
-                         |   {                                                                        
-                         |     "bindingScope": "organization",                                        
-                         |     "bindWithResource": false,                                             
-                         |     "allowedOperations": [                                                 
-                         |       {                                                                    
-                         |         "resourceType": "User",                                            
-                         |         "operations": ["Describe", "Invite"]                               
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "ServiceAccount",                                  
-                         |         "operations": ["Describe"]                                         
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "SupportPlan",                                     
-                         |         "operations": ["Describe"]                                         
-                         |       }                                                                    
-                         |     ]                                                                      
-                         |   }                                                                        
-                         | ]                                                                          
-                         |                                                                            
-  EnvironmentAdmin       | [                                                                          
-                         |   {                                                                        
-                         |     "bindingScope": "ENVIRONMENT",                                         
-                         |     "bindWithResource": false,                                             
-                         |     "allowedOperations": [                                                 
-                         |       {                                                                    
-                         |         "resourceType": "SecurityMetadata",                                
-                         |         "operations": ["Describe", "Alter"]                                
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "ClusterApiKey",                                   
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "Connector",                                       
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "NetworkAccess",                                   
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "KsqlCluster",                                     
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "Environment",                                     
-                         |         "operations": [                                                    
-                         |           "Alter",                                                         
-                         |           "Delete",                                                        
-                         |           "AlterAccess",                                                   
-                         |           "CreateKafkaCluster",                                            
-                         |           "DescribeAccess"                                                 
-                         |         ]                                                                  
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "Subject",                                         
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "NetworkConfig",                                   
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "ClusterMetric",                                   
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "Cluster",                                         
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "SchemaRegistry",                                  
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "NetworkRegion",                                   
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "Deployment",                                      
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "Topic",                                           
-                         |         "operations": ["All"]                                              
-                         |       }                                                                    
-                         |     ]                                                                      
-                         |   },                                                                       
-                         |   {                                                                        
-                         |     "bindingScope": "organization",                                        
-                         |     "bindWithResource": false,                                             
-                         |     "allowedOperations": [                                                 
-                         |       {                                                                    
-                         |         "resourceType": "User",                                            
-                         |         "operations": ["Describe", "Invite"]                               
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "ServiceAccount",                                  
-                         |         "operations": ["Describe"]                                         
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "SupportPlan",                                     
-                         |         "operations": ["Describe"]                                         
-                         |       }                                                                    
-                         |     ]                                                                      
-                         |   }                                                                        
-                         | ]                                                                          
-                         |                                                                            
-  OrganizationAdmin      | [                                                                          
-                         |   {                                                                        
-                         |     "bindingScope": "organization",                                        
-                         |     "bindWithResource": false,                                             
-                         |     "allowedOperations": [                                                 
-                         |       {                                                                    
-                         |         "resourceType": "Topic",                                           
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "NetworkConfig",                                   
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "SecurityMetadata",                                
-                         |         "operations": ["Describe", "Alter"]                                
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "Billing",                                         
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "ClusterApiKey",                                   
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "Deployment",                                      
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "SchemaRegistry",                                  
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "KsqlCluster",                                     
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "CloudApiKey",                                     
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "NetworkAccess",                                   
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "SecuritySSO",                                     
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "SupportPlan",                                     
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "Connector",                                       
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "ClusterMetric",                                   
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "ServiceAccount",                                  
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "Subject",                                         
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "Cluster",                                         
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "Environment",                                     
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "NetworkRegion",                                   
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "Organization",                                    
-                         |         "operations": [                                                    
-                         |           "Alter",                                                         
-                         |           "CreateEnvironment",                                             
-                         |           "AlterAccess",                                                   
-                         |           "DescribeAccess"                                                 
-                         |         ]                                                                  
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "User",                                            
-                         |         "operations": ["All"]                                              
-                         |       }                                                                    
-                         |     ]                                                                      
-                         |   }                                                                        
-                         | ]                                                                          
-                         |                                                                            
-  OrganizationAdmin      | [                                                                          
-                         |   {                                                                        
-                         |     "bindingScope": "organization",                                        
-                         |     "bindWithResource": false,                                             
-                         |     "allowedOperations": [                                                 
-                         |       {                                                                    
-                         |         "resourceType": "Topic",                                           
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "NetworkConfig",                                   
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "SecurityMetadata",                                
-                         |         "operations": ["Describe", "Alter"]                                
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "Billing",                                         
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "ClusterApiKey",                                   
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "Deployment",                                      
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "SchemaRegistry",                                  
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "KsqlCluster",                                     
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "CloudApiKey",                                     
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "NetworkAccess",                                   
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "SecuritySSO",                                     
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "SupportPlan",                                     
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "Connector",                                       
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "ClusterMetric",                                   
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "ServiceAccount",                                  
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "Subject",                                         
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "Cluster",                                         
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "Environment",                                     
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "NetworkRegion",                                   
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "Organization",                                    
-                         |         "operations": [                                                    
-                         |           "Alter",                                                         
-                         |           "CreateEnvironment",                                             
-                         |           "AlterAccess",                                                   
-                         |           "DescribeAccess"                                                 
-                         |         ]                                                                  
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "User",                                            
-                         |         "operations": ["All"]                                              
-                         |       }                                                                    
-                         |     ]                                                                      
-                         |   }                                                                        
-                         | ]                                                                          
-                         |                                                                            
-  OrganizationAdmin      | [                                                                          
-                         |   {                                                                        
-                         |     "bindingScope": "organization",                                        
-                         |     "bindWithResource": false,                                             
-                         |     "allowedOperations": [                                                 
-                         |       {                                                                    
-                         |         "resourceType": "Topic",                                           
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "NetworkConfig",                                   
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "SecurityMetadata",                                
-                         |         "operations": ["Describe", "Alter"]                                
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "Billing",                                         
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "ClusterApiKey",                                   
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "Deployment",                                      
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "SchemaRegistry",                                  
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "KsqlCluster",                                     
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "CloudApiKey",                                     
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "NetworkAccess",                                   
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "SecuritySSO",                                     
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "SupportPlan",                                     
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "Connector",                                       
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "ClusterMetric",                                   
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "ServiceAccount",                                  
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "Subject",                                         
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "Cluster",                                         
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "Environment",                                     
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "NetworkRegion",                                   
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "Organization",                                    
-                         |         "operations": [                                                    
-                         |           "Alter",                                                         
-                         |           "CreateEnvironment",                                             
-                         |           "AlterAccess",                                                   
-                         |           "DescribeAccess"                                                 
-                         |         ]                                                                  
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "User",                                            
-                         |         "operations": ["All"]                                              
-                         |       }                                                                    
-                         |     ]                                                                      
-                         |   }                                                                        
-                         | ]                                                                          
-                         |                                                                            
-  OrganizationAdmin      | [                                                                          
-                         |   {                                                                        
-                         |     "bindingScope": "organization",                                        
-                         |     "bindWithResource": false,                                             
-                         |     "allowedOperations": [                                                 
-                         |       {                                                                    
-                         |         "resourceType": "Topic",                                           
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "NetworkConfig",                                   
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "SecurityMetadata",                                
-                         |         "operations": ["Describe", "Alter"]                                
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "Billing",                                         
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "ClusterApiKey",                                   
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "Deployment",                                      
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "SchemaRegistry",                                  
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "KsqlCluster",                                     
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "CloudApiKey",                                     
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "NetworkAccess",                                   
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "SecuritySSO",                                     
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "SupportPlan",                                     
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "Connector",                                       
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "ClusterMetric",                                   
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "ServiceAccount",                                  
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "Subject",                                         
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "Cluster",                                         
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "Environment",                                     
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "NetworkRegion",                                   
-                         |         "operations": ["All"]                                              
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "Organization",                                    
-                         |         "operations": [                                                    
-                         |           "Alter",                                                         
-                         |           "CreateEnvironment",                                             
-                         |           "AlterAccess",                                                   
-                         |           "DescribeAccess"                                                 
-                         |         ]                                                                  
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "User",                                            
-                         |         "operations": ["All"]                                              
-                         |       }                                                                    
-                         |     ]                                                                      
-                         |   }                                                                        
-                         | ]                                                                          
-                         |                                                                            
-  ResourceOwner          | [                                                                          
-                         |   {                                                                        
-                         |     "bindingScope": "cloud-cluster",                                       
-                         |     "bindWithResource": false,                                             
-                         |     "allowedOperations": [                                                 
-                         |       {                                                                    
-                         |         "resourceType": "CloudCluster",                                    
-                         |         "operations": ["Describe"]                                         
-                         |       }                                                                    
-                         |     ]                                                                      
-                         |   },                                                                       
-                         |   {                                                                        
-                         |     "bindingScope": "cluster",                                             
-                         |     "bindWithResource": true,                                              
-                         |     "allowedOperations": [                                                 
-                         |       {                                                                    
-                         |         "resourceType": "Topic",                                           
-                         |         "operations": [                                                    
-                         |           "Create",                                                        
-                         |           "Delete",                                                        
-                         |           "Read",                                                          
-                         |           "Write",                                                         
-                         |           "Describe",                                                      
-                         |           "DescribeConfigs",                                               
-                         |           "Alter",                                                         
-                         |           "AlterConfigs",                                                  
-                         |           "DescribeAccess",                                                
-                         |           "AlterAccess"                                                    
-                         |         ]                                                                  
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "Group",                                           
-                         |         "operations": [                                                    
-                         |           "Read",                                                          
-                         |           "Describe",                                                      
-                         |           "Delete",                                                        
-                         |           "DescribeAccess",                                                
-                         |           "AlterAccess"                                                    
-                         |         ]                                                                  
-                         |       }                                                                    
-                         |     ]                                                                      
-                         |   }                                                                        
-                         | ]                                                                          
-                         |                                                                            
-  ResourceOwner          | [                                                                          
-                         |   {                                                                        
-                         |     "bindingScope": "cloud-cluster",                                       
-                         |     "bindWithResource": false,                                             
-                         |     "allowedOperations": [                                                 
-                         |       {                                                                    
-                         |         "resourceType": "CloudCluster",                                    
-                         |         "operations": ["Describe"]                                         
-                         |       }                                                                    
-                         |     ]                                                                      
-                         |   },                                                                       
-                         |   {                                                                        
-                         |     "bindingScope": "cluster",                                             
-                         |     "bindWithResource": true,                                              
-                         |     "allowedOperations": [                                                 
-                         |       {                                                                    
-                         |         "resourceType": "Topic",                                           
-                         |         "operations": [                                                    
-                         |           "Create",                                                        
-                         |           "Delete",                                                        
-                         |           "Read",                                                          
-                         |           "Write",                                                         
-                         |           "Describe",                                                      
-                         |           "DescribeConfigs",                                               
-                         |           "Alter",                                                         
-                         |           "AlterConfigs",                                                  
-                         |           "DescribeAccess",                                                
-                         |           "AlterAccess"                                                    
-                         |         ]                                                                  
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "Group",                                           
-                         |         "operations": [                                                    
-                         |           "Read",                                                          
-                         |           "Describe",                                                      
-                         |           "Delete",                                                        
-                         |           "DescribeAccess",                                                
-                         |           "AlterAccess"                                                    
-                         |         ]                                                                  
-                         |       }                                                                    
-                         |     ]                                                                      
-                         |   }                                                                        
-                         | ]                                                                          
-                         |                                                                            
-  ResourceOwner          | [                                                                          
-                         |   {                                                                        
-                         |     "bindingScope": "cloud-cluster",                                       
-                         |     "bindWithResource": false,                                             
-                         |     "allowedOperations": [                                                 
-                         |       {                                                                    
-                         |         "resourceType": "CloudCluster",                                    
-                         |         "operations": ["Describe"]                                         
-                         |       }                                                                    
-                         |     ]                                                                      
-                         |   },                                                                       
-                         |   {                                                                        
-                         |     "bindingScope": "cluster",                                             
-                         |     "bindWithResource": true,                                              
-                         |     "allowedOperations": [                                                 
-                         |       {                                                                    
-                         |         "resourceType": "Topic",                                           
-                         |         "operations": [                                                    
-                         |           "Create",                                                        
-                         |           "Delete",                                                        
-                         |           "Read",                                                          
-                         |           "Write",                                                         
-                         |           "Describe",                                                      
-                         |           "DescribeConfigs",                                               
-                         |           "Alter",                                                         
-                         |           "AlterConfigs",                                                  
-                         |           "DescribeAccess",                                                
-                         |           "AlterAccess"                                                    
-                         |         ]                                                                  
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "Group",                                           
-                         |         "operations": [                                                    
-                         |           "Read",                                                          
-                         |           "Describe",                                                      
-                         |           "Delete",                                                        
-                         |           "DescribeAccess",                                                
-                         |           "AlterAccess"                                                    
-                         |         ]                                                                  
-                         |       }                                                                    
-                         |     ]                                                                      
-                         |   }                                                                        
-                         | ]                                                                          
-                         |                                                                            
-  ResourceOwner          | [                                                                          
-                         |   {                                                                        
-                         |     "bindingScope": "cloud-cluster",                                       
-                         |     "bindWithResource": false,                                             
-                         |     "allowedOperations": [                                                 
-                         |       {                                                                    
-                         |         "resourceType": "CloudCluster",                                    
-                         |         "operations": ["Describe"]                                         
-                         |       }                                                                    
-                         |     ]                                                                      
-                         |   },                                                                       
-                         |   {                                                                        
-                         |     "bindingScope": "cluster",                                             
-                         |     "bindWithResource": true,                                              
-                         |     "allowedOperations": [                                                 
-                         |       {                                                                    
-                         |         "resourceType": "Topic",                                           
-                         |         "operations": [                                                    
-                         |           "Create",                                                        
-                         |           "Delete",                                                        
-                         |           "Read",                                                          
-                         |           "Write",                                                         
-                         |           "Describe",                                                      
-                         |           "DescribeConfigs",                                               
-                         |           "Alter",                                                         
-                         |           "AlterConfigs",                                                  
-                         |           "DescribeAccess",                                                
-                         |           "AlterAccess"                                                    
-                         |         ]                                                                  
-                         |       },                                                                   
-                         |       {                                                                    
-                         |         "resourceType": "Group",                                           
-                         |         "operations": [                                                    
-                         |           "Read",                                                          
-                         |           "Describe",                                                      
-                         |           "Delete",                                                        
-                         |           "DescribeAccess",                                                
-                         |           "AlterAccess"                                                    
-                         |         ]                                                                  
-                         |       }                                                                    
-                         |     ]                                                                      
-                         |   }                                                                        
-                         | ]                                                                          
-                         |                                                                            
-  ResourceOwner          | [                                                                          
-                         |   {                                                                        
-                         |     "bindingScope": "ksql-cluster",                                        
-                         |     "bindWithResource": true,                                              
-                         |     "allowedOperations": [                                                 
-                         |       {                                                                    
-                         |         "resourceType": "KsqlCluster",                                     
-                         |         "operations": [                                                    
-                         |           "Describe",                                                      
-                         |           "AlterAccess",                                                   
-                         |           "Contribute",                                                    
-                         |           "DescribeAccess",                                                
-                         |           "Terminate"                                                      
-                         |         ]                                                                  
-                         |       }                                                                    
-                         |     ]                                                                      
-                         |   }                                                                        
-                         | ]                                                                          
-                         |                                                                            
-  ResourceOwner          | [                                                                          
-                         |   {                                                                        
-                         |     "bindingScope": "schema-registry-cluster",                             
-                         |     "bindWithResource": true,                                              
-                         |     "allowedOperations": [                                                 
-                         |       {                                                                    
-                         |         "resourceType": "Subject",                                         
-                         |         "operations": [                                                    
-                         |           "Delete",                                                        
-                         |           "Read",                                                          
-                         |           "Write",                                                         
-                         |           "ReadCompatibility",                                             
-                         |           "AlterAccess",                                                   
-                         |           "WriteCompatibility",                                            
-                         |           "DescribeAccess"                                                 
-                         |         ]                                                                  
-                         |       }                                                                    
-                         |     ]                                                                      
-                         |   }                                                                        
-                         | ]                                                                          
-                         |                                                                            
+        Name        |                Access Policy                  
+--------------------+-----------------------------------------------
+  CloudClusterAdmin | [                                             
+                    |   {                                           
+                    |     "bindingScope": "cluster",                
+                    |     "bindWithResource": false,                
+                    |     "allowedOperations": [                    
+                    |       {                                       
+                    |         "resourceType": "Topic",              
+                    |         "operations": ["All"]                 
+                    |       },                                      
+                    |       {                                       
+                    |         "resourceType": "KsqlCluster",        
+                    |         "operations": ["All"]                 
+                    |       },                                      
+                    |       {                                       
+                    |         "resourceType": "Subject",            
+                    |         "operations": ["All"]                 
+                    |       },                                      
+                    |       {                                       
+                    |         "resourceType": "Connector",          
+                    |         "operations": ["All"]                 
+                    |       },                                      
+                    |       {                                       
+                    |         "resourceType": "NetworkAccess",      
+                    |         "operations": ["All"]                 
+                    |       },                                      
+                    |       {                                       
+                    |         "resourceType": "ClusterMetric",      
+                    |         "operations": ["All"]                 
+                    |       },                                      
+                    |       {                                       
+                    |         "resourceType": "Cluster",            
+                    |         "operations": ["All"]                 
+                    |       },                                      
+                    |       {                                       
+                    |         "resourceType": "ClusterApiKey",      
+                    |         "operations": ["All"]                 
+                    |       },                                      
+                    |       {                                       
+                    |         "resourceType": "SecurityMetadata",   
+                    |         "operations": ["Describe", "Alter"]   
+                    |       }                                       
+                    |     ]                                         
+                    |   },                                          
+                    |   {                                           
+                    |     "bindingScope": "organization",           
+                    |     "bindWithResource": false,                
+                    |     "allowedOperations": [                    
+                    |       {                                       
+                    |         "resourceType": "SupportPlan",        
+                    |         "operations": ["Describe"]            
+                    |       },                                      
+                    |       {                                       
+                    |         "resourceType": "User",               
+                    |         "operations": ["Describe", "Invite"]  
+                    |       },                                      
+                    |       {                                       
+                    |         "resourceType": "ServiceAccount",     
+                    |         "operations": ["Describe"]            
+                    |       }                                       
+                    |     ]                                         
+                    |   }                                           
+                    | ]                                             
+                    |                                               
+  EnvironmentAdmin  | [                                             
+                    |   {                                           
+                    |     "bindingScope": "ENVIRONMENT",            
+                    |     "bindWithResource": false,                
+                    |     "allowedOperations": [                    
+                    |       {                                       
+                    |         "resourceType": "SecurityMetadata",   
+                    |         "operations": ["Describe", "Alter"]   
+                    |       },                                      
+                    |       {                                       
+                    |         "resourceType": "ClusterApiKey",      
+                    |         "operations": ["All"]                 
+                    |       },                                      
+                    |       {                                       
+                    |         "resourceType": "Connector",          
+                    |         "operations": ["All"]                 
+                    |       },                                      
+                    |       {                                       
+                    |         "resourceType": "NetworkAccess",      
+                    |         "operations": ["All"]                 
+                    |       },                                      
+                    |       {                                       
+                    |         "resourceType": "KsqlCluster",        
+                    |         "operations": ["All"]                 
+                    |       },                                      
+                    |       {                                       
+                    |         "resourceType": "Environment",        
+                    |         "operations": [                       
+                    |           "Alter",                            
+                    |           "Delete",                           
+                    |           "AlterAccess",                      
+                    |           "CreateKafkaCluster",               
+                    |           "DescribeAccess"                    
+                    |         ]                                     
+                    |       },                                      
+                    |       {                                       
+                    |         "resourceType": "Subject",            
+                    |         "operations": ["All"]                 
+                    |       },                                      
+                    |       {                                       
+                    |         "resourceType": "NetworkConfig",      
+                    |         "operations": ["All"]                 
+                    |       },                                      
+                    |       {                                       
+                    |         "resourceType": "ClusterMetric",      
+                    |         "operations": ["All"]                 
+                    |       },                                      
+                    |       {                                       
+                    |         "resourceType": "Cluster",            
+                    |         "operations": ["All"]                 
+                    |       },                                      
+                    |       {                                       
+                    |         "resourceType": "SchemaRegistry",     
+                    |         "operations": ["All"]                 
+                    |       },                                      
+                    |       {                                       
+                    |         "resourceType": "NetworkRegion",      
+                    |         "operations": ["All"]                 
+                    |       },                                      
+                    |       {                                       
+                    |         "resourceType": "Deployment",         
+                    |         "operations": ["All"]                 
+                    |       },                                      
+                    |       {                                       
+                    |         "resourceType": "Topic",              
+                    |         "operations": ["All"]                 
+                    |       }                                       
+                    |     ]                                         
+                    |   },                                          
+                    |   {                                           
+                    |     "bindingScope": "organization",           
+                    |     "bindWithResource": false,                
+                    |     "allowedOperations": [                    
+                    |       {                                       
+                    |         "resourceType": "User",               
+                    |         "operations": ["Describe", "Invite"]  
+                    |       },                                      
+                    |       {                                       
+                    |         "resourceType": "ServiceAccount",     
+                    |         "operations": ["Describe"]            
+                    |       },                                      
+                    |       {                                       
+                    |         "resourceType": "SupportPlan",        
+                    |         "operations": ["Describe"]            
+                    |       }                                       
+                    |     ]                                         
+                    |   }                                           
+                    | ]                                             
+                    |                                               
+  OrganizationAdmin | [                                             
+                    |   {                                           
+                    |     "bindingScope": "organization",           
+                    |     "bindWithResource": false,                
+                    |     "allowedOperations": [                    
+                    |       {                                       
+                    |         "resourceType": "Topic",              
+                    |         "operations": ["All"]                 
+                    |       },                                      
+                    |       {                                       
+                    |         "resourceType": "NetworkConfig",      
+                    |         "operations": ["All"]                 
+                    |       },                                      
+                    |       {                                       
+                    |         "resourceType": "SecurityMetadata",   
+                    |         "operations": ["Describe", "Alter"]   
+                    |       },                                      
+                    |       {                                       
+                    |         "resourceType": "Billing",            
+                    |         "operations": ["All"]                 
+                    |       },                                      
+                    |       {                                       
+                    |         "resourceType": "ClusterApiKey",      
+                    |         "operations": ["All"]                 
+                    |       },                                      
+                    |       {                                       
+                    |         "resourceType": "Deployment",         
+                    |         "operations": ["All"]                 
+                    |       },                                      
+                    |       {                                       
+                    |         "resourceType": "SchemaRegistry",     
+                    |         "operations": ["All"]                 
+                    |       },                                      
+                    |       {                                       
+                    |         "resourceType": "KsqlCluster",        
+                    |         "operations": ["All"]                 
+                    |       },                                      
+                    |       {                                       
+                    |         "resourceType": "CloudApiKey",        
+                    |         "operations": ["All"]                 
+                    |       },                                      
+                    |       {                                       
+                    |         "resourceType": "NetworkAccess",      
+                    |         "operations": ["All"]                 
+                    |       },                                      
+                    |       {                                       
+                    |         "resourceType": "SecuritySSO",        
+                    |         "operations": ["All"]                 
+                    |       },                                      
+                    |       {                                       
+                    |         "resourceType": "SupportPlan",        
+                    |         "operations": ["All"]                 
+                    |       },                                      
+                    |       {                                       
+                    |         "resourceType": "Connector",          
+                    |         "operations": ["All"]                 
+                    |       },                                      
+                    |       {                                       
+                    |         "resourceType": "ClusterMetric",      
+                    |         "operations": ["All"]                 
+                    |       },                                      
+                    |       {                                       
+                    |         "resourceType": "ServiceAccount",     
+                    |         "operations": ["All"]                 
+                    |       },                                      
+                    |       {                                       
+                    |         "resourceType": "Subject",            
+                    |         "operations": ["All"]                 
+                    |       },                                      
+                    |       {                                       
+                    |         "resourceType": "Cluster",            
+                    |         "operations": ["All"]                 
+                    |       },                                      
+                    |       {                                       
+                    |         "resourceType": "Environment",        
+                    |         "operations": ["All"]                 
+                    |       },                                      
+                    |       {                                       
+                    |         "resourceType": "NetworkRegion",      
+                    |         "operations": ["All"]                 
+                    |       },                                      
+                    |       {                                       
+                    |         "resourceType": "Organization",       
+                    |         "operations": [                       
+                    |           "Alter",                            
+                    |           "CreateEnvironment",                
+                    |           "AlterAccess",                      
+                    |           "DescribeAccess"                    
+                    |         ]                                     
+                    |       },                                      
+                    |       {                                       
+                    |         "resourceType": "User",               
+                    |         "operations": ["All"]                 
+                    |       }                                       
+                    |     ]                                         
+                    |   }                                           
+                    | ]                                             
+                    |                                               
+  ResourceOwner     | [                                             
+                    |   {                                           
+                    |     "bindingScope": "cloud-cluster",          
+                    |     "bindWithResource": false,                
+                    |     "allowedOperations": [                    
+                    |       {                                       
+                    |         "resourceType": "CloudCluster",       
+                    |         "operations": ["Describe"]            
+                    |       }                                       
+                    |     ]                                         
+                    |   },                                          
+                    |   {                                           
+                    |     "bindingScope": "cluster",                
+                    |     "bindWithResource": true,                 
+                    |     "allowedOperations": [                    
+                    |       {                                       
+                    |         "resourceType": "Topic",              
+                    |         "operations": [                       
+                    |           "Create",                           
+                    |           "Delete",                           
+                    |           "Read",                             
+                    |           "Write",                            
+                    |           "Describe",                         
+                    |           "DescribeConfigs",                  
+                    |           "Alter",                            
+                    |           "AlterConfigs",                     
+                    |           "DescribeAccess",                   
+                    |           "AlterAccess"                       
+                    |         ]                                     
+                    |       },                                      
+                    |       {                                       
+                    |         "resourceType": "Group",              
+                    |         "operations": [                       
+                    |           "Read",                             
+                    |           "Describe",                         
+                    |           "Delete",                           
+                    |           "DescribeAccess",                   
+                    |           "AlterAccess"                       
+                    |         ]                                     
+                    |       }                                       
+                    |     ]                                         
+                    |   }                                           
+                    | ]                                             
+                    |                                               


### PR DESCRIPTION
Release Notes
-------------
This PR will not introduce any changes to a user of the Confluent CLI. This only updates one of our integration tests.

Checklist
---------
- [x] I have successfully built and used a custom CLI binary, without linter issues from this PR.
- [x] I have clearly specified in the `What` section below whether this PR applies to Confluent Cloud, Confluent Platform, or both. 
- [x] I have verified this PR in Confluent Cloud pre-prod or production environment, if applicable.
- [x] I have verified this PR in Confluent Platform on-premises environment, if applicable.
- [x] I have attached manual CLI verification results or screenshots in the `Test & Review` section below.
- [x] I have added appropriate CLI integration or unit tests for any new or updated commands and functionality.
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [x] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [x] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [x] Confluent Cloud prod
  - [x] Confluent Cloud stag
  - [ ] Confluent Platform
  - [ ] Check this box if the feature is enabled for certain organizations only

What
----
The `confluent rbac role list` test was improperly formatted. This test was setup in a way to call multiple namespaces containing different roles in a single test. Over time, this test degraded and was setup to call the same namespace multiple times, resulting in the test showing a duplicated list of roles. This initial testing strategy came from a concept that customers could query our list endpoint for different role namespaces. The two issues with this are:
1. We have migrated from this strategy, and now the default call to our RBAC list API returns all production roles across *all* namespaces
2. The CLI did not have the ability to query on a per-namespace basis anyways, making this functionality pointless. 

This test should not have a comprehensive list of all production roles, as that wouldn't really be testing anything of value and would require constant updates. Instead, this test has been modified to only return a few of our roles in a single namespace, which allows us to ensure the *formatting* of the output is correct, which is all we can gain from this test anyways. 

Blast Radius
----
There is no end-user blast radius associated with this change, as it only touches an integration test and no public feature.

References
----------
[Previous CLI list update PR](https://github.com/confluentinc/cli/pull/3014)
[AM-5152
](https://confluentinc.atlassian.net/browse/AM-5152)

Test & Review
-------------
The rbac cloud-list tests were updated to demonstrate these changes in behavior.
