### PR TITLE
feat(AM-5025): workload identity additional resource owner flag 

### DIFF
--- a/cmd/lint/main.go
+++ b/cmd/lint/main.go
@@ -91,6 +91,7 @@ var flagRules = []linter.FlagRule{
 		linter.RequireFlagNameLength(2, 20),
 		linter.ExcludeFlag(
 			"accepted-environments",
+			"add-operation-groups",
 			"azure-subscription",
 			"certificate-authority-path",
 			"certificate-chain-filename",
@@ -100,6 +101,7 @@ var flagRules = []linter.FlagRule{
 			"destination-cluster",
 			"enable-systest-events",
 			"encrypted-key-material",
+			"include-parent-scopes",
 			"max-partition-memory-bytes",
 			"message-send-max-retries",
 			"private-link-access-point",
@@ -107,6 +109,7 @@ var flagRules = []linter.FlagRule{
 			"remote-api-secret",
 			"remote-bootstrap-server",
 			"remote-cluster",
+			"remove-operation-groups",
 			"request-required-acks",
 			"schema-registry-api-key",
 			"schema-registry-api-secret",
@@ -118,9 +121,6 @@ var flagRules = []linter.FlagRule{
 			"source-bootstrap-server",
 			"update-schema-registry",
 			"worker-configurations",
-			"add-operation-groups",
-			"remove-operation-groups",
-			"include-parent-scopes",
 		),
 	),
 	linter.FlagFilter(

--- a/go.mod
+++ b/go.mod
@@ -29,9 +29,9 @@ require (
 	github.com/confluentinc/ccloud-sdk-go-v2/flink v0.9.0
 	github.com/confluentinc/ccloud-sdk-go-v2/flink-artifact v0.3.0
 	github.com/confluentinc/ccloud-sdk-go-v2/flink-gateway v0.17.0
-	github.com/confluentinc/ccloud-sdk-go-v2/iam v0.11.0
+	github.com/confluentinc/ccloud-sdk-go-v2/iam v0.15.0
 	github.com/confluentinc/ccloud-sdk-go-v2/iam-ip-filtering v0.5.0
-	github.com/confluentinc/ccloud-sdk-go-v2/identity-provider v0.2.0
+	github.com/confluentinc/ccloud-sdk-go-v2/identity-provider v0.3.0
 	github.com/confluentinc/ccloud-sdk-go-v2/kafka-quotas v0.4.0
 	github.com/confluentinc/ccloud-sdk-go-v2/kafkarest v0.22.0
 	github.com/confluentinc/ccloud-sdk-go-v2/ksql v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -220,12 +220,12 @@ github.com/confluentinc/ccloud-sdk-go-v2/flink-artifact v0.3.0 h1:DVWL3Y4b5azgCA
 github.com/confluentinc/ccloud-sdk-go-v2/flink-artifact v0.3.0/go.mod h1:P4fdIkI1ynjSvhDEGX283KhtzG51eGHQc5Cqtp7bu1Q=
 github.com/confluentinc/ccloud-sdk-go-v2/flink-gateway v0.17.0 h1:8Y1uXjolI2d5mawcfLn4OfJ81WRMQpjMFWdBm3dLdrk=
 github.com/confluentinc/ccloud-sdk-go-v2/flink-gateway v0.17.0/go.mod h1:cJ6erfVlWSyz6L+2dR46cF2+s5I2r+pTNrPm2fNbcqU=
-github.com/confluentinc/ccloud-sdk-go-v2/iam v0.11.0 h1:ZUAow4L6De1FwYoiwvEodm4lvxc+46wNW+IEAb7K9VU=
-github.com/confluentinc/ccloud-sdk-go-v2/iam v0.11.0/go.mod h1:2Lm82ly9Yh5LLhp8OTnUGqjz4JdIXAZ5a0/u9T+rGGU=
+github.com/confluentinc/ccloud-sdk-go-v2/iam v0.15.0 h1:37Gjdo+0Ev3g2NPEXyiVm7yTT85AlWbjXYRLvq6Aj9E=
+github.com/confluentinc/ccloud-sdk-go-v2/iam v0.15.0/go.mod h1:jnWqax4kM22sutPGMtGmHqe2usgfqYig4UtmHsLENz0=
 github.com/confluentinc/ccloud-sdk-go-v2/iam-ip-filtering v0.5.0 h1:xD7CXcyAqezFnSVFB4U27oWUY4FlbyciVP0ftDIiI18=
 github.com/confluentinc/ccloud-sdk-go-v2/iam-ip-filtering v0.5.0/go.mod h1:uAlz9SscVXU6XkDj2DHCytJcieT8tR0lnMPJMOX1BQ0=
-github.com/confluentinc/ccloud-sdk-go-v2/identity-provider v0.2.0 h1:9TT8UCFRc5zUdsE7UgMz7hqN+2KYnIkBcAKCaiZJrXw=
-github.com/confluentinc/ccloud-sdk-go-v2/identity-provider v0.2.0/go.mod h1:JLmrXfnT2PzcuXHD8a6c2cW1c9LKK7aMsdZjjqxYPEk=
+github.com/confluentinc/ccloud-sdk-go-v2/identity-provider v0.3.0 h1:COUuWIW9GLz/Wq8mgrrvT3Pe78CZSL2mlZkE2vNvkQo=
+github.com/confluentinc/ccloud-sdk-go-v2/identity-provider v0.3.0/go.mod h1:VHpsi0yWBEhN6Hp2oOyGkRaNJjtnaVfYjpbtB8pnNnk=
 github.com/confluentinc/ccloud-sdk-go-v2/kafka-quotas v0.4.0 h1:T9e7lNj/VjxE89+tcpX2RS2NE4rWNWbJjxcO2yehEqM=
 github.com/confluentinc/ccloud-sdk-go-v2/kafka-quotas v0.4.0/go.mod h1:7gqwWFIyj2MAGpL/kf6SGXm/pi2Z6qpMJIjKlgEEhhg=
 github.com/confluentinc/ccloud-sdk-go-v2/kafkarest v0.22.0 h1:nnp7SQnGxhAIcSGSjZd0bjRWWN5qV4TPgsxBRSKKD6M=

--- a/internal/iam/command.go
+++ b/internal/iam/command.go
@@ -2,13 +2,14 @@ package iam
 
 import (
 	"fmt"
-	"github.com/confluentinc/cli/v4/pkg/ccloudv2"
-	"github.com/confluentinc/cli/v4/pkg/utils"
+
 	"github.com/spf13/cobra"
 
+	"github.com/confluentinc/cli/v4/pkg/ccloudv2"
 	pcmd "github.com/confluentinc/cli/v4/pkg/cmd"
 	"github.com/confluentinc/cli/v4/pkg/config"
 	"github.com/confluentinc/cli/v4/pkg/featureflags"
+	"github.com/confluentinc/cli/v4/pkg/utils"
 )
 
 func New(cfg *config.Config, prerunner pcmd.PreRunner) *cobra.Command {

--- a/internal/iam/command.go
+++ b/internal/iam/command.go
@@ -1,6 +1,9 @@
 package iam
 
 import (
+	"fmt"
+	"github.com/confluentinc/cli/v4/pkg/ccloudv2"
+	"github.com/confluentinc/cli/v4/pkg/utils"
 	"github.com/spf13/cobra"
 
 	pcmd "github.com/confluentinc/cli/v4/pkg/cmd"
@@ -38,4 +41,50 @@ func New(cfg *config.Config, prerunner pcmd.PreRunner) *cobra.Command {
 	cmd.AddCommand(newUserCommand(cfg, prerunner))
 
 	return cmd
+}
+
+func addResourceOwnerFlag(cmd *cobra.Command, cliCommand *pcmd.AuthenticatedCLICommand) {
+	items := []string{"user", "group-mapping", "service-account", "identity-pool"}
+	description := fmt.Sprintf("The resource ID of the principal who will be assigned resource owner on the "+
+		"created resource. Principal can be a %s.", utils.ArrayToCommaDelimitedString(items, "or"))
+	cmd.Flags().String("resource-owner", "", description)
+	pcmd.RegisterFlagCompletionFunc(cmd, "resource-owner", func(cmd *cobra.Command, args []string) []string {
+		if err := cmd.PersistentPreRunE(cmd, args); err != nil {
+			return nil
+		}
+
+		return autocompleteResourceOwners(cliCommand.V2Client)
+	})
+}
+func autocompleteResourceOwners(client *ccloudv2.Client) []string {
+	users, err := client.ListIamUsers()
+	if err != nil {
+		return nil
+	}
+	groupMappings, err := client.ListGroupMappings()
+	if err != nil {
+		return nil
+	}
+	serviceAccounts, err := client.ListIamServiceAccounts()
+	if err != nil {
+		return nil
+	}
+
+	suggestions := make([]string, len(users)+len(groupMappings)+len(serviceAccounts))
+	offset := 0
+	for i, user := range users {
+		description := user.GetFullName()
+		suggestions[i] = fmt.Sprintf("%s\t%s", user.GetId(), description)
+	}
+	offset += len(users)
+	for i, groupMapping := range groupMappings {
+		description := fmt.Sprintf("%s: %s", groupMapping.GetDisplayName(), groupMapping.GetDescription())
+		suggestions[i+offset] = fmt.Sprintf("%s\t%s", groupMapping.GetId(), description)
+	}
+	offset += len(groupMappings)
+	for i, serviceAccount := range serviceAccounts {
+		description := fmt.Sprintf("%s: %s", serviceAccount.GetDisplayName(), serviceAccount.GetDisplayName())
+		suggestions[i+offset] = fmt.Sprintf("%s\t%s", serviceAccount.GetId(), description)
+	}
+	return suggestions
 }

--- a/internal/iam/command.go
+++ b/internal/iam/command.go
@@ -35,10 +35,10 @@ func New(cfg *config.Config, prerunner pcmd.PreRunner) *cobra.Command {
 	cmd.AddCommand(newCertificatePoolCommand(cfg, prerunner))
 	cmd.AddCommand(newIpFilterCommand(cfg, prerunner))
 	cmd.AddCommand(newIpGroupCommand(prerunner))
-	cmd.AddCommand(newPoolCommand(prerunner))
+	cmd.AddCommand(newPoolCommand(cfg, prerunner))
 	cmd.AddCommand(newProviderCommand(prerunner))
 	cmd.AddCommand(newRbacCommand(cfg, prerunner))
-	cmd.AddCommand(newServiceAccountCommand(prerunner))
+	cmd.AddCommand(newServiceAccountCommand(cfg, prerunner))
 	cmd.AddCommand(newUserCommand(cfg, prerunner))
 
 	return cmd

--- a/internal/iam/command_pool.go
+++ b/internal/iam/command_pool.go
@@ -1,12 +1,12 @@
 package iam
 
 import (
-	"github.com/confluentinc/cli/v4/pkg/config"
 	"github.com/spf13/cobra"
 
 	identityproviderv2 "github.com/confluentinc/ccloud-sdk-go-v2/identity-provider/v2"
 
 	pcmd "github.com/confluentinc/cli/v4/pkg/cmd"
+	"github.com/confluentinc/cli/v4/pkg/config"
 	"github.com/confluentinc/cli/v4/pkg/output"
 )
 

--- a/internal/iam/command_pool.go
+++ b/internal/iam/command_pool.go
@@ -1,6 +1,7 @@
 package iam
 
 import (
+	"github.com/confluentinc/cli/v4/pkg/config"
 	"github.com/spf13/cobra"
 
 	identityproviderv2 "github.com/confluentinc/ccloud-sdk-go-v2/identity-provider/v2"
@@ -21,7 +22,7 @@ type poolOut struct {
 	Filter        string `human:"Filter" serialized:"filter"`
 }
 
-func newPoolCommand(prerunner pcmd.PreRunner) *cobra.Command {
+func newPoolCommand(cfg *config.Config, prerunner pcmd.PreRunner) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:         "pool",
 		Short:       "Manage identity pools.",
@@ -30,7 +31,7 @@ func newPoolCommand(prerunner pcmd.PreRunner) *cobra.Command {
 
 	c := &poolCommand{pcmd.NewAuthenticatedCLICommand(cmd, prerunner)}
 
-	cmd.AddCommand(c.newCreateCommand())
+	cmd.AddCommand(c.newCreateCommand(cfg))
 	cmd.AddCommand(c.newDeleteCommand())
 	cmd.AddCommand(c.newDescribeCommand())
 	cmd.AddCommand(c.newListCommand())

--- a/internal/iam/command_pool_create.go
+++ b/internal/iam/command_pool_create.go
@@ -26,6 +26,7 @@ func (c *poolCommand) newCreateCommand() *cobra.Command {
 	pcmd.AddProviderFlag(cmd, c.AuthenticatedCLICommand)
 	cmd.Flags().String("identity-claim", "", "Claim specifying the external identity using this identity pool.")
 	cmd.Flags().String("description", "", "Description of the identity pool.")
+	addResourceOwnerFlag(cmd, c.AuthenticatedCLICommand)
 	pcmd.AddFilterFlag(cmd)
 	pcmd.AddContextFlag(cmd, c.CLICommand)
 	pcmd.AddOutputFlag(cmd)
@@ -57,13 +58,18 @@ func (c *poolCommand) create(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	resourceOwner, err := cmd.Flags().GetString("resource-owner")
+	if err != nil {
+		return err
+	}
+
 	createIdentityPool := identityproviderv2.IamV2IdentityPool{
 		DisplayName:   identityproviderv2.PtrString(args[0]),
 		Description:   identityproviderv2.PtrString(description),
 		IdentityClaim: identityproviderv2.PtrString(identityClaim),
 		Filter:        identityproviderv2.PtrString(filter),
 	}
-	pool, err := c.V2Client.CreateIdentityPool(createIdentityPool, provider)
+	pool, err := c.V2Client.CreateIdentityPool(createIdentityPool, provider, resourceOwner)
 	if err != nil {
 		return err
 	}

--- a/internal/iam/command_pool_create.go
+++ b/internal/iam/command_pool_create.go
@@ -1,6 +1,8 @@
 package iam
 
 import (
+	"github.com/confluentinc/cli/v4/pkg/config"
+	"github.com/confluentinc/cli/v4/pkg/featureflags"
 	"github.com/spf13/cobra"
 
 	identityproviderv2 "github.com/confluentinc/ccloud-sdk-go-v2/identity-provider/v2"
@@ -9,7 +11,7 @@ import (
 	"github.com/confluentinc/cli/v4/pkg/examples"
 )
 
-func (c *poolCommand) newCreateCommand() *cobra.Command {
+func (c *poolCommand) newCreateCommand(cfg *config.Config) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create <name>",
 		Short: "Create an identity pool.",
@@ -26,7 +28,12 @@ func (c *poolCommand) newCreateCommand() *cobra.Command {
 	pcmd.AddProviderFlag(cmd, c.AuthenticatedCLICommand)
 	cmd.Flags().String("identity-claim", "", "Claim specifying the external identity using this identity pool.")
 	cmd.Flags().String("description", "", "Description of the identity pool.")
-	addResourceOwnerFlag(cmd, c.AuthenticatedCLICommand)
+	isResourceOwnerEnabled := cfg.IsTest ||
+		(cfg.Context() != nil &&
+			featureflags.Manager.BoolVariation("auth.workload_identity.resource_owner.enabled", cfg.Context(), featureflags.GetCcloudLaunchDarklyClient(cfg.Context().PlatformName), true, false))
+	if isResourceOwnerEnabled {
+		addResourceOwnerFlag(cmd, c.AuthenticatedCLICommand)
+	}
 	pcmd.AddFilterFlag(cmd)
 	pcmd.AddContextFlag(cmd, c.CLICommand)
 	pcmd.AddOutputFlag(cmd)
@@ -58,9 +65,15 @@ func (c *poolCommand) create(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	resourceOwner, err := cmd.Flags().GetString("resource-owner")
-	if err != nil {
-		return err
+	ldClient := featureflags.GetCcloudLaunchDarklyClient(c.Context.PlatformName)
+	isResourceOwnerEnabled := c.Config.IsTest ||
+		featureflags.Manager.BoolVariation("auth.workload_identity.resource_owner.enabled", c.Context, ldClient, true, false)
+	resourceOwner, err := "", nil
+	if isResourceOwnerEnabled {
+		resourceOwner, err = cmd.Flags().GetString("resource-owner")
+		if err != nil {
+			return err
+		}
 	}
 
 	createIdentityPool := identityproviderv2.IamV2IdentityPool{

--- a/internal/iam/command_pool_create.go
+++ b/internal/iam/command_pool_create.go
@@ -1,14 +1,14 @@
 package iam
 
 import (
-	"github.com/confluentinc/cli/v4/pkg/config"
-	"github.com/confluentinc/cli/v4/pkg/featureflags"
 	"github.com/spf13/cobra"
 
 	identityproviderv2 "github.com/confluentinc/ccloud-sdk-go-v2/identity-provider/v2"
 
 	pcmd "github.com/confluentinc/cli/v4/pkg/cmd"
+	"github.com/confluentinc/cli/v4/pkg/config"
 	"github.com/confluentinc/cli/v4/pkg/examples"
+	"github.com/confluentinc/cli/v4/pkg/featureflags"
 )
 
 func (c *poolCommand) newCreateCommand(cfg *config.Config) *cobra.Command {

--- a/internal/iam/command_provider_update.go
+++ b/internal/iam/command_provider_update.go
@@ -45,7 +45,7 @@ func (c *identityProviderCommand) update(cmd *cobra.Command, args []string) erro
 		return err
 	}
 
-	update := identityproviderv2.IamV2IdentityProviderUpdate{Id: identityproviderv2.PtrString(args[0])}
+	update := identityproviderv2.IamV2IdentityProvider{Id: identityproviderv2.PtrString(args[0])}
 	if name != "" {
 		update.DisplayName = identityproviderv2.PtrString(name)
 	}

--- a/internal/iam/command_service_account.go
+++ b/internal/iam/command_service_account.go
@@ -2,6 +2,7 @@ package iam
 
 import (
 	"fmt"
+
 	"github.com/confluentinc/cli/v4/pkg/config"
 
 	"github.com/spf13/cobra"

--- a/internal/iam/command_service_account.go
+++ b/internal/iam/command_service_account.go
@@ -2,6 +2,7 @@ package iam
 
 import (
 	"fmt"
+	"github.com/confluentinc/cli/v4/pkg/config"
 
 	"github.com/spf13/cobra"
 
@@ -21,7 +22,7 @@ type serviceAccountOut struct {
 	Description string `human:"Description" serialized:"description"`
 }
 
-func newServiceAccountCommand(prerunner pcmd.PreRunner) *cobra.Command {
+func newServiceAccountCommand(cfg *config.Config, prerunner pcmd.PreRunner) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:         "service-account",
 		Aliases:     []string{"sa"},
@@ -31,7 +32,7 @@ func newServiceAccountCommand(prerunner pcmd.PreRunner) *cobra.Command {
 
 	c := &serviceAccountCommand{pcmd.NewAuthenticatedCLICommand(cmd, prerunner)}
 
-	cmd.AddCommand(c.newCreateCommand())
+	cmd.AddCommand(c.newCreateCommand(cfg))
 	cmd.AddCommand(c.newDeleteCommand())
 	cmd.AddCommand(c.newDescribeCommand())
 	cmd.AddCommand(c.newListCommand())

--- a/internal/iam/command_service_account.go
+++ b/internal/iam/command_service_account.go
@@ -3,13 +3,12 @@ package iam
 import (
 	"fmt"
 
-	"github.com/confluentinc/cli/v4/pkg/config"
-
 	"github.com/spf13/cobra"
 
 	iamv2 "github.com/confluentinc/ccloud-sdk-go-v2/iam/v2"
 
 	pcmd "github.com/confluentinc/cli/v4/pkg/cmd"
+	"github.com/confluentinc/cli/v4/pkg/config"
 	"github.com/confluentinc/cli/v4/pkg/output"
 )
 

--- a/internal/iam/command_service_account_create.go
+++ b/internal/iam/command_service_account_create.go
@@ -30,6 +30,7 @@ func (c *serviceAccountCommand) newCreateCommand() *cobra.Command {
 	}
 
 	cmd.Flags().String("description", "", "Description of the service account.")
+	addResourceOwnerFlag(cmd, c.AuthenticatedCLICommand)
 	pcmd.AddContextFlag(cmd, c.CLICommand)
 	pcmd.AddOutputFlag(cmd)
 
@@ -50,6 +51,11 @@ func (c *serviceAccountCommand) create(cmd *cobra.Command, args []string) error 
 		return err
 	}
 
+	resourceOwner, err := cmd.Flags().GetString("resource-owner")
+	if err != nil {
+		return err
+	}
+
 	if err := requireLen(description, descriptionLength, "description"); err != nil {
 		return err
 	}
@@ -58,7 +64,7 @@ func (c *serviceAccountCommand) create(cmd *cobra.Command, args []string) error 
 		DisplayName: iamv2.PtrString(name),
 		Description: iamv2.PtrString(description),
 	}
-	serviceAccount, httpResp, err := c.V2Client.CreateIamServiceAccount(createServiceAccount)
+	serviceAccount, httpResp, err := c.V2Client.CreateIamServiceAccount(createServiceAccount, resourceOwner)
 	if err != nil {
 		return errors.CatchServiceNameInUseError(err, httpResp, name)
 	}

--- a/internal/iam/command_service_account_create.go
+++ b/internal/iam/command_service_account_create.go
@@ -1,15 +1,15 @@
 package iam
 
 import (
-	"github.com/confluentinc/cli/v4/pkg/config"
-	"github.com/confluentinc/cli/v4/pkg/featureflags"
 	"github.com/spf13/cobra"
 
 	iamv2 "github.com/confluentinc/ccloud-sdk-go-v2/iam/v2"
 
 	pcmd "github.com/confluentinc/cli/v4/pkg/cmd"
+	"github.com/confluentinc/cli/v4/pkg/config"
 	"github.com/confluentinc/cli/v4/pkg/errors"
 	"github.com/confluentinc/cli/v4/pkg/examples"
+	"github.com/confluentinc/cli/v4/pkg/featureflags"
 )
 
 const (

--- a/internal/iam/command_service_account_update.go
+++ b/internal/iam/command_service_account_update.go
@@ -52,7 +52,7 @@ func (c *serviceAccountCommand) update(cmd *cobra.Command, args []string) error 
 	}
 	serviceAccountId := args[0]
 
-	update := iamv2.IamV2ServiceAccountUpdate{Description: &description}
+	update := iamv2.IamV2ServiceAccount{Description: &description}
 	if _, httpResp, err := c.V2Client.UpdateIamServiceAccount(serviceAccountId, update); err != nil {
 		return errors.CatchServiceAccountNotFoundError(err, httpResp, serviceAccountId)
 	}

--- a/pkg/ccloudv2/iam.go
+++ b/pkg/ccloudv2/iam.go
@@ -25,8 +25,10 @@ func (c *Client) iamApiContext() context.Context {
 
 // iam service-account api calls
 
-func (c *Client) CreateIamServiceAccount(serviceAccount iamv2.IamV2ServiceAccount) (iamv2.IamV2ServiceAccount, *http.Response, error) {
-	return c.IamClient.ServiceAccountsIamV2Api.CreateIamV2ServiceAccount(c.iamApiContext()).IamV2ServiceAccount(serviceAccount).Execute()
+func (c *Client) CreateIamServiceAccount(serviceAccount iamv2.IamV2ServiceAccount, assignedResourceOwner string) (iamv2.IamV2ServiceAccount, *http.Response, error) {
+	return c.IamClient.ServiceAccountsIamV2Api.CreateIamV2ServiceAccount(c.iamApiContext()).
+		AssignedResourceOwner(assignedResourceOwner).
+		IamV2ServiceAccount(serviceAccount).Execute()
 }
 
 func (c *Client) DeleteIamServiceAccount(id string) error {
@@ -38,8 +40,8 @@ func (c *Client) GetIamServiceAccount(id string) (iamv2.IamV2ServiceAccount, *ht
 	return c.IamClient.ServiceAccountsIamV2Api.GetIamV2ServiceAccount(c.iamApiContext(), id).Execute()
 }
 
-func (c *Client) UpdateIamServiceAccount(id string, update iamv2.IamV2ServiceAccountUpdate) (iamv2.IamV2ServiceAccount, *http.Response, error) {
-	return c.IamClient.ServiceAccountsIamV2Api.UpdateIamV2ServiceAccount(c.iamApiContext(), id).IamV2ServiceAccountUpdate(update).Execute()
+func (c *Client) UpdateIamServiceAccount(id string, update iamv2.IamV2ServiceAccount) (iamv2.IamV2ServiceAccount, *http.Response, error) {
+	return c.IamClient.ServiceAccountsIamV2Api.UpdateIamV2ServiceAccount(c.iamApiContext(), id).IamV2ServiceAccount(update).Execute()
 }
 
 func (c *Client) ListIamServiceAccounts() ([]iamv2.IamV2ServiceAccount, error) {

--- a/pkg/ccloudv2/identity_provider.go
+++ b/pkg/ccloudv2/identity_provider.go
@@ -42,8 +42,8 @@ func (c *Client) GetIdentityProvider(id string) (identityproviderv2.IamV2Identit
 	return resp, errors.CatchCCloudV2Error(err, httpResp)
 }
 
-func (c *Client) UpdateIdentityProvider(update identityproviderv2.IamV2IdentityProviderUpdate) (identityproviderv2.IamV2IdentityProvider, error) {
-	resp, httpResp, err := c.IdentityProviderClient.IdentityProvidersIamV2Api.UpdateIamV2IdentityProvider(c.identityProviderApiContext(), *update.Id).IamV2IdentityProviderUpdate(update).Execute()
+func (c *Client) UpdateIdentityProvider(update identityproviderv2.IamV2IdentityProvider) (identityproviderv2.IamV2IdentityProvider, error) {
+	resp, httpResp, err := c.IdentityProviderClient.IdentityProvidersIamV2Api.UpdateIamV2IdentityProvider(c.identityProviderApiContext(), *update.Id).IamV2IdentityProvider(update).Execute()
 	return resp, errors.CatchCCloudV2Error(err, httpResp)
 }
 
@@ -75,8 +75,11 @@ func (c *Client) executeListIdentityProviders(pageToken string) (identityprovide
 	return req.Execute()
 }
 
-func (c *Client) CreateIdentityPool(identityPool identityproviderv2.IamV2IdentityPool, providerId string) (identityproviderv2.IamV2IdentityPool, error) {
-	resp, httpResp, err := c.IdentityProviderClient.IdentityPoolsIamV2Api.CreateIamV2IdentityPool(c.identityPoolApiContext(), providerId).IamV2IdentityPool(identityPool).Execute()
+func (c *Client) CreateIdentityPool(identityPool identityproviderv2.IamV2IdentityPool, providerId string, assignedResourceOwner string) (identityproviderv2.IamV2IdentityPool, error) {
+	resp, httpResp, err := c.IdentityProviderClient.IdentityPoolsIamV2Api.
+		CreateIamV2IdentityPool(c.identityPoolApiContext(), providerId).
+		AssignedResourceOwner(assignedResourceOwner).
+		IamV2IdentityPool(identityPool).Execute()
 	return resp, errors.CatchCCloudV2Error(err, httpResp)
 }
 

--- a/test/fixtures/output/iam/pool/create-help.golden
+++ b/test/fixtures/output/iam/pool/create-help.golden
@@ -12,6 +12,7 @@ Flags:
       --provider string         REQUIRED: ID of this pool's identity provider.
       --identity-claim string   REQUIRED: Claim specifying the external identity using this identity pool.
       --description string      Description of the identity pool.
+      --resource-owner string   The resource ID of the principal who will be assigned resource owner on the created resource. Principal can be a "user", "group-mapping", "service-account", or "identity-pool".
       --filter string           A supported Common Expression Language (CEL) filter expression. (default "true")
       --context string          CLI context name.
   -o, --output string           Specify the output format as "human", "json", or "yaml". (default "human")

--- a/test/fixtures/output/iam/service-account/create-help.golden
+++ b/test/fixtures/output/iam/service-account/create-help.golden
@@ -9,9 +9,10 @@ Create a service account named "my-service-account".
   $ confluent iam service-account create my-service-account --description "new description"
 
 Flags:
-      --description string   REQUIRED: Description of the service account.
-      --context string       CLI context name.
-  -o, --output string        Specify the output format as "human", "json", or "yaml". (default "human")
+      --description string      REQUIRED: Description of the service account.
+      --resource-owner string   The resource ID of the principal who will be assigned resource owner on the created resource. Principal can be a "user", "group-mapping", "service-account", or "identity-pool".
+      --context string          CLI context name.
+  -o, --output string           Specify the output format as "human", "json", or "yaml". (default "human")
 
 Global Flags:
   -h, --help            Show help for this command.

--- a/test/iam_test.go
+++ b/test/iam_test.go
@@ -153,6 +153,7 @@ func (s *CLITestSuite) TestIamRbacRoleBindingList_OnPrem() {
 func (s *CLITestSuite) TestIamServiceAccount() {
 	tests := []CLITest{
 		{args: "iam service-account create human-service --description human-output", fixture: "iam/service-account/create.golden"},
+		{args: "iam service-account create human-service --description human-output --resource-owner u-123", fixture: "iam/service-account/create.golden"},
 		{args: "iam service-account create json-service --description json-output -o json", fixture: "iam/service-account/create-json.golden"},
 		{args: "iam service-account create yaml-service --description yaml-output -o yaml", fixture: "iam/service-account/create-yaml.golden"},
 		{args: "iam service-account delete sa-12345 --force", fixture: "iam/service-account/delete.golden"},

--- a/test/test-server/iam_handlers.go
+++ b/test/test-server/iam_handlers.go
@@ -656,10 +656,10 @@ func handleIamIpGroups(t *testing.T) http.HandlerFunc {
 			err := json.NewEncoder(w).Encode(iamipfilteringv2.IamV2IpGroupList{Data: []iamipfilteringv2.IamV2IpGroup{ipGroup}})
 			require.NoError(t, err)
 		case http.MethodPost:
-			var req iamv2.IamV2IpGroup
+			var req iamipfilteringv2.IamV2IpGroup
 			err := json.NewDecoder(r.Body).Decode(&req)
 			require.NoError(t, err)
-			ipGroup := &iamv2.IamV2IpGroup{
+			ipGroup := &iamipfilteringv2.IamV2IpGroup{
 				Id:         iamv2.PtrString(ipGroupId),
 				GroupName:  req.GroupName,
 				CidrBlocks: req.CidrBlocks,
@@ -675,10 +675,10 @@ func handleIamIpGroup(t *testing.T) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		switch r.Method {
 		case http.MethodPatch:
-			var req iamv2.IamV2IpGroup
+			var req iamipfilteringv2.IamV2IpGroup
 			err := json.NewDecoder(r.Body).Decode(&req)
 			require.NoError(t, err)
-			res := &iamv2.IamV2IpGroup{
+			res := &iamipfilteringv2.IamV2IpGroup{
 				Id:         req.Id,
 				GroupName:  req.GroupName,
 				CidrBlocks: req.CidrBlocks,


### PR DESCRIPTION
Checklist
---------
<!-- 
Check each item below to ensure high-quality CLI development practices are followed. PR approval will not be granted until the checklist is fully reviewed.
For detailed instructions, please refer to this Confluence page: https://confluentinc.atlassian.net/wiki/spaces/AEGI/pages/3949592874/
-->
- [X] I have successfully built and used a custom CLI binary, without linter issues from this PR.
- [X] I have clearly specified in the `What` section below whether this PR applies to Confluent Cloud, Confluent Platform, or both. 
- [X] I have verified this PR in Confluent Cloud pre-prod or production environment, if applicable.
- [N/A] I have verified this PR in Confluent Platform on-premises environment, if applicable.
- [X] I have attached manual CLI verification results or screenshots in the `Test & Review` section below.
- [X] I have added appropriate CLI integration or unit tests for any new or updated commands and functionality.
- [X] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [X] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [X] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [ ] Confluent Cloud prod
  - [X] Confluent Cloud stag
  - [ ] Confluent Platform
  - [ ] Check this box if the feature is enabled for certain organizations only

What
----
Exactly the same as this PR: https://github.com/confluentinc/cli/pull/3005 which we reverted so as not to release these features immediately. 
Added a launchdarkly flag to gate the changes so it doesn't get released immediately. 

Blast Radius
----
Unreleased, no impact. 

References
----------
https://github.com/confluentinc/cli/pull/3005
https://confluentinc.atlassian.net/browse/AM-5025

Test & Review
-------------
Flag enabled in stag, but not in devel. 
**In Devel:** 
![Screenshot 2025-02-04 at 1 02 36 PM](https://github.com/user-attachments/assets/bc6d043d-37df-4ee8-ad11-e5eca523a3f5)

**In Stag (You can see the additional resource owner flag)** 
![Screenshot 2025-02-04 at 1 02 51 PM](https://github.com/user-attachments/assets/4635ee01-6345-4818-8923-d113d1160611)

**In Devel:** 
![Screenshot 2025-02-04 at 1 08 27 PM](https://github.com/user-attachments/assets/4650ec0e-4930-41b8-bdf1-4b79d37f6bf8)

**In stag:** 
![Screenshot 2025-02-04 at 1 09 13 PM](https://github.com/user-attachments/assets/e5218931-11c8-41e1-985d-4a327040e0a4)

