### PR TITLE
feat(am-5157): certificate pool resource owner 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/confluentinc/ccloud-sdk-go-v2/byok v0.0.2
 	github.com/confluentinc/ccloud-sdk-go-v2/ccl v0.4.0
 	github.com/confluentinc/ccloud-sdk-go-v2/cdx v0.0.5
-	github.com/confluentinc/ccloud-sdk-go-v2/certificate-authority v0.0.0-20240921001517-750d06dd7c27
+	github.com/confluentinc/ccloud-sdk-go-v2/certificate-authority v0.0.2
 	github.com/confluentinc/ccloud-sdk-go-v2/cli v0.3.0
 	github.com/confluentinc/ccloud-sdk-go-v2/cmk v0.21.0
 	github.com/confluentinc/ccloud-sdk-go-v2/connect v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -202,6 +202,8 @@ github.com/confluentinc/ccloud-sdk-go-v2/cdx v0.0.5 h1:w0Z2hFxg8ng8gycWKRZFdus1R
 github.com/confluentinc/ccloud-sdk-go-v2/cdx v0.0.5/go.mod h1:L8U9xs2duASJnjIYkwGrSbZNpApsbh+vlxsJlZMHJPA=
 github.com/confluentinc/ccloud-sdk-go-v2/certificate-authority v0.0.0-20240921001517-750d06dd7c27 h1:prbOJKQGZ6VgBFRDN3mzE942apQnlS5d68L7HyA2Gz8=
 github.com/confluentinc/ccloud-sdk-go-v2/certificate-authority v0.0.0-20240921001517-750d06dd7c27/go.mod h1:xqB2YHUtcYF5cbwctSDzXoYw0YXaawj13d0lzcvphEA=
+github.com/confluentinc/ccloud-sdk-go-v2/certificate-authority v0.0.2 h1:stsiO1JIRX6ITdw4DCsidQ0w7uhsyKDsYXwzxvi14GI=
+github.com/confluentinc/ccloud-sdk-go-v2/certificate-authority v0.0.2/go.mod h1:OU1RGuP2y5l54jX5rA++QBAKeRvSa7GmkfNgJvB9J6M=
 github.com/confluentinc/ccloud-sdk-go-v2/cli v0.3.0 h1:OOFNqtZN3Spuzz4TX6K6JfDM7zNDIE6BE1TtK78jFHQ=
 github.com/confluentinc/ccloud-sdk-go-v2/cli v0.3.0/go.mod h1:Mv0WTsBXUfKjmF+r2t2Dv/xJzZf17shhf5J1cttU2Qo=
 github.com/confluentinc/ccloud-sdk-go-v2/cmk v0.21.0 h1:ioG3TsP8FwskPtwitfGfvBgTdprYKutHB0oxG5F4Dj8=

--- a/go.sum
+++ b/go.sum
@@ -200,8 +200,6 @@ github.com/confluentinc/ccloud-sdk-go-v2/ccl v0.4.0 h1:dUFB7PM/eQbI/AhRHyMh4Pd7x
 github.com/confluentinc/ccloud-sdk-go-v2/ccl v0.4.0/go.mod h1:SJdOAgzigkv8NbZo6+8N1isiZ/HXTg+TOtQg1o1PhKY=
 github.com/confluentinc/ccloud-sdk-go-v2/cdx v0.0.5 h1:w0Z2hFxg8ng8gycWKRZFdus1R+q8D/I5AmN06NZso5s=
 github.com/confluentinc/ccloud-sdk-go-v2/cdx v0.0.5/go.mod h1:L8U9xs2duASJnjIYkwGrSbZNpApsbh+vlxsJlZMHJPA=
-github.com/confluentinc/ccloud-sdk-go-v2/certificate-authority v0.0.0-20240921001517-750d06dd7c27 h1:prbOJKQGZ6VgBFRDN3mzE942apQnlS5d68L7HyA2Gz8=
-github.com/confluentinc/ccloud-sdk-go-v2/certificate-authority v0.0.0-20240921001517-750d06dd7c27/go.mod h1:xqB2YHUtcYF5cbwctSDzXoYw0YXaawj13d0lzcvphEA=
 github.com/confluentinc/ccloud-sdk-go-v2/certificate-authority v0.0.2 h1:stsiO1JIRX6ITdw4DCsidQ0w7uhsyKDsYXwzxvi14GI=
 github.com/confluentinc/ccloud-sdk-go-v2/certificate-authority v0.0.2/go.mod h1:OU1RGuP2y5l54jX5rA++QBAKeRvSa7GmkfNgJvB9J6M=
 github.com/confluentinc/ccloud-sdk-go-v2/cli v0.3.0 h1:OOFNqtZN3Spuzz4TX6K6JfDM7zNDIE6BE1TtK78jFHQ=

--- a/internal/iam/command_certificate_pool.go
+++ b/internal/iam/command_certificate_pool.go
@@ -33,7 +33,7 @@ func newCertificatePoolCommand(cfg *config.Config, prerunner pcmd.PreRunner) *co
 
 	c := &certificatePoolCommand{pcmd.NewAuthenticatedCLICommand(cmd, prerunner)}
 
-	cmd.AddCommand(c.newCreateCommand())
+	cmd.AddCommand(c.newCreateCommand(cfg))
 	cmd.AddCommand(c.newDeleteCommand())
 	cmd.AddCommand(c.newDescribeCommand())
 	cmd.AddCommand(c.newListCommand())

--- a/internal/iam/command_certificate_pool_create.go
+++ b/internal/iam/command_certificate_pool_create.go
@@ -1,14 +1,14 @@
 package iam
 
 import (
-	"github.com/confluentinc/cli/v4/pkg/config"
-	"github.com/confluentinc/cli/v4/pkg/featureflags"
 	"github.com/spf13/cobra"
 
 	certificateauthorityv2 "github.com/confluentinc/ccloud-sdk-go-v2/certificate-authority/v2"
 
 	pcmd "github.com/confluentinc/cli/v4/pkg/cmd"
+	"github.com/confluentinc/cli/v4/pkg/config"
 	"github.com/confluentinc/cli/v4/pkg/examples"
+	"github.com/confluentinc/cli/v4/pkg/featureflags"
 )
 
 func (c *certificatePoolCommand) newCreateCommand(cfg *config.Config) *cobra.Command {

--- a/pkg/ccloudv2/certificate_authority.go
+++ b/pkg/ccloudv2/certificate_authority.go
@@ -75,8 +75,11 @@ func (c *Client) executeListCertificateAuthorities(pageToken string) (certificat
 	return req.Execute()
 }
 
-func (c *Client) CreateCertificatePool(certificatePool certificateauthorityv2.IamV2CertificateIdentityPool, provider string) (certificateauthorityv2.IamV2CertificateIdentityPool, error) {
-	resp, httpResp, err := c.CertificateAuthorityClient.CertificateIdentityPoolsIamV2Api.CreateIamV2CertificateIdentityPool(c.certificatePoolApiContext(), provider).IamV2CertificateIdentityPool(certificatePool).Execute()
+func (c *Client) CreateCertificatePool(certificatePool certificateauthorityv2.IamV2CertificateIdentityPool, provider string, resourceOwner string) (certificateauthorityv2.IamV2CertificateIdentityPool, error) {
+	resp, httpResp, err := c.CertificateAuthorityClient.CertificateIdentityPoolsIamV2Api.
+		CreateIamV2CertificateIdentityPool(c.certificatePoolApiContext(), provider).
+		AssignedResourceOwner(resourceOwner).
+		IamV2CertificateIdentityPool(certificatePool).Execute()
 	return resp, errors.CatchCCloudV2Error(err, httpResp)
 }
 

--- a/test/fixtures/output/iam/certificate-pool/create-help.golden
+++ b/test/fixtures/output/iam/certificate-pool/create-help.golden
@@ -15,6 +15,7 @@ Flags:
       --external-identifier string   External Identifier for this pool.
       --context string               CLI context name.
   -o, --output string                Specify the output format as "human", "json", or "yaml". (default "human")
+      --resource-owner string        The resource ID of the principal who will be assigned resource owner on the created resource. Principal can be a "user", "group-mapping", "service-account", or "identity-pool".
 
 Global Flags:
   -h, --help            Show help for this command.


### PR DESCRIPTION
Checklist
---------
<!-- 
Check each item below to ensure high-quality CLI development practices are followed. PR approval will not be granted until the checklist is fully reviewed.
For detailed instructions, please refer to this Confluence page: https://confluentinc.atlassian.net/wiki/spaces/AEGI/pages/3949592874/
-->
- [X] I have successfully built and used a custom CLI binary, without linter issues from this PR.
- [X] I have clearly specified in the `What` section below whether this PR applies to Confluent Cloud, Confluent Platform, or both. 
- [X] I have verified this PR in Confluent Cloud pre-prod or production environment, if applicable.
- [N/A] I have verified this PR in Confluent Platform on-premises environment, if applicable.
- [X] I have attached manual CLI verification results or screenshots in the `Test & Review` section below.
- [X] I have added appropriate CLI integration or unit tests for any new or updated commands and functionality.
- [X] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [X] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [X] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [ ] Confluent Cloud prod
  - [X] Confluent Cloud stag
  - [ ] Confluent Platform
  - [ ] Check this box if the feature is enabled for certain organizations only

What
----
This PR adds the resource owner flag option on create for certificate pools. The flag is optional and currently hidden by a feature flag. 

Blast Radius
----
Since this feature is not yet released, there should be no impact to the customer. 

References
----------
https://confluentinc.atlassian.net/browse/AM-5170 

Test & Review
-------------
Additional resource owner flag shown below 
```
Usage:
  confluent iam certificate-pool create <name> [flags]

Examples:
Create a certificate pool named "pool-123".

  $ confluent iam certificate-pool create pool-123 --provider provider-123 --description "new description"

Flags:
      --provider string              REQUIRED: ID of this pool's certificate authority.
      --description string           Description of the certificate pool.
      --filter string                A supported Common Expression Language (CEL) filter expression. (default "true")
      --external-identifier string   External Identifier for this pool.
      --context string               CLI context name.
  -o, --output string                Specify the output format as "human", "json", or "yaml". (default "human")
      --resource-owner string        The resource ID of the principal who will be assigned resource owner on the created resource. Principal can be a "user", "group-mapping", "service-account", or "identity-pool".

Global Flags:
  -h, --help            Show help for this command.
      --unsafe-trace    Equivalent to -vvvv, but also log HTTP requests and responses which might contain plaintext secrets.
  -v, --verbose count   Increase verbosity (-v for warn, -vv for info, -vvv for debug, -vvvv for trace).

```
Assigned Resource Owner
```
./dist/confluent_darwin_arm64/confluent iam certificate-pool create swathitest --provider op-Gdl --external-identifier SHA1 --resource-owner  u-stgc2xjvr2
+---------------------+------------+
| ID                  | pool-Jxx0  |
| Name                | swathitest |
| Description         |            |
| External Identifier | SHA1       |
| Filter              | true       |
+---------------------+------------+
```