### PR TITLE
[CLI-3283] Allow schema-registry commands to be used without login

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,7 @@ go.work.sum
 # Icon must end with two \r
 Icon
 
+
 # Thumbnails
 ._*
 

--- a/.gitignore
+++ b/.gitignore
@@ -55,8 +55,7 @@ go.work.sum
 .LSOverride
 
 # Icon must end with two \r
-Icon
-
+Icon
 
 # Thumbnails
 ._*

--- a/.gitignore
+++ b/.gitignore
@@ -55,7 +55,8 @@ go.work.sum
 .LSOverride
 
 # Icon must end with two \r
-Icon
+Icon
+
 
 # Thumbnails
 ._*
@@ -79,6 +80,7 @@ Temporary Items
 #
 # Global/JetBrains Gitignore
 #
+.idea/
 
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
 # Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839

--- a/.gitignore
+++ b/.gitignore
@@ -57,7 +57,6 @@ go.work.sum
 # Icon must end with two \r
 Icon
 
-
 # Thumbnails
 ._*
 
@@ -80,7 +79,6 @@ Temporary Items
 #
 # Global/JetBrains Gitignore
 #
-.idea/
 
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
 # Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839

--- a/internal/schema-registry/command.go
+++ b/internal/schema-registry/command.go
@@ -16,10 +16,9 @@ type command struct {
 
 func New(cfg *config.Config, prerunner pcmd.PreRunner) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:         "schema-registry",
-		Aliases:     []string{"sr"},
-		Short:       "Manage Schema Registry.",
-		Annotations: map[string]string{pcmd.RunRequirement: pcmd.RequireNonAPIKeyCloudLoginOrOnPremLogin},
+		Use:     "schema-registry",
+		Aliases: []string{"sr"},
+		Short:   "Manage Schema Registry.",
 	}
 
 	c := &command{}

--- a/internal/schema-registry/command_cluster.go
+++ b/internal/schema-registry/command_cluster.go
@@ -3,14 +3,12 @@ package schemaregistry
 import (
 	"github.com/spf13/cobra"
 
-	pcmd "github.com/confluentinc/cli/v4/pkg/cmd"
 	"github.com/confluentinc/cli/v4/pkg/config"
 )
 
 func (c *command) newClusterCommand(cfg *config.Config) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:         "cluster",
-		Annotations: map[string]string{pcmd.RunRequirement: pcmd.RequireCloudLoginOrOnPremLogin},
+		Use: "cluster",
 	}
 
 	if cfg.IsCloudLogin() {

--- a/internal/schema-registry/command_configuration.go
+++ b/internal/schema-registry/command_configuration.go
@@ -7,7 +7,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/tidwall/pretty"
 
-	pcmd "github.com/confluentinc/cli/v4/pkg/cmd"
 	"github.com/confluentinc/cli/v4/pkg/config"
 )
 
@@ -22,10 +21,9 @@ type configOut struct {
 
 func (c *command) newConfigurationCommand(cfg *config.Config) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:         "configuration",
-		Aliases:     []string{"config"},
-		Short:       "Manage Schema Registry configuration.",
-		Annotations: map[string]string{pcmd.RunRequirement: pcmd.RequireCloudLoginOrOnPremLogin},
+		Use:     "configuration",
+		Aliases: []string{"config"},
+		Short:   "Manage Schema Registry configuration.",
 	}
 
 	cmd.AddCommand(c.newConfigurationDeleteCommand(cfg))

--- a/internal/schema-registry/command_dek.go
+++ b/internal/schema-registry/command_dek.go
@@ -5,16 +5,14 @@ import (
 
 	srsdk "github.com/confluentinc/schema-registry-sdk-go"
 
-	pcmd "github.com/confluentinc/cli/v4/pkg/cmd"
 	"github.com/confluentinc/cli/v4/pkg/config"
 	"github.com/confluentinc/cli/v4/pkg/output"
 )
 
 func (c *command) newDekCommand(cfg *config.Config) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:         "dek",
-		Short:       "Manage Schema Registry Data Encryption Keys (DEKs).",
-		Annotations: map[string]string{pcmd.RunRequirement: pcmd.RequireCloudLoginOrOnPremLogin},
+		Use:   "dek",
+		Short: "Manage Schema Registry Data Encryption Keys (DEKs).",
 	}
 
 	cmd.AddCommand(c.newDekCreateCommand(cfg))

--- a/internal/schema-registry/command_exporter.go
+++ b/internal/schema-registry/command_exporter.go
@@ -14,9 +14,8 @@ const exporterActionMsg = "%s schema exporter \"%s\".\n"
 
 func (c *command) newExporterCommand(cfg *config.Config) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:         "exporter",
-		Short:       "Manage Schema Registry exporters.",
-		Annotations: map[string]string{pcmd.RunRequirement: pcmd.RequireCloudLoginOrOnPremLogin},
+		Use:   "exporter",
+		Short: "Manage Schema Registry exporters.",
 	}
 
 	cmd.AddCommand(c.newExporterCreateCommand(cfg))

--- a/internal/schema-registry/command_kek.go
+++ b/internal/schema-registry/command_kek.go
@@ -5,7 +5,6 @@ import (
 
 	srsdk "github.com/confluentinc/schema-registry-sdk-go"
 
-	pcmd "github.com/confluentinc/cli/v4/pkg/cmd"
 	"github.com/confluentinc/cli/v4/pkg/config"
 	"github.com/confluentinc/cli/v4/pkg/errors"
 	"github.com/confluentinc/cli/v4/pkg/output"
@@ -18,9 +17,8 @@ const (
 
 func (c *command) newKekCommand(cfg *config.Config) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:         "kek",
-		Short:       "Manage Schema Registry Key Encryption Keys (KEKs).",
-		Annotations: map[string]string{pcmd.RunRequirement: pcmd.RequireCloudLoginOrOnPremLogin},
+		Use:   "kek",
+		Short: "Manage Schema Registry Key Encryption Keys (KEKs).",
 	}
 
 	cmd.AddCommand(c.newKekCreateCommand(cfg))

--- a/internal/schema-registry/command_schema.go
+++ b/internal/schema-registry/command_schema.go
@@ -6,16 +6,14 @@ import (
 
 	"github.com/spf13/cobra"
 
-	pcmd "github.com/confluentinc/cli/v4/pkg/cmd"
 	"github.com/confluentinc/cli/v4/pkg/config"
 	"github.com/confluentinc/cli/v4/pkg/errors"
 )
 
 func (c *command) newSchemaCommand(cfg *config.Config) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:         "schema",
-		Short:       "Manage Schema Registry schemas.",
-		Annotations: map[string]string{pcmd.RunRequirement: pcmd.RequireCloudLoginOrOnPremLogin},
+		Use:   "schema",
+		Short: "Manage Schema Registry schemas.",
 	}
 
 	cmd.AddCommand(c.newSchemaCompatibilityCommand(cfg))

--- a/internal/schema-registry/command_subject.go
+++ b/internal/schema-registry/command_subject.go
@@ -3,15 +3,13 @@ package schemaregistry
 import (
 	"github.com/spf13/cobra"
 
-	pcmd "github.com/confluentinc/cli/v4/pkg/cmd"
 	"github.com/confluentinc/cli/v4/pkg/config"
 )
 
 func (c *command) newSubjectCommand(cfg *config.Config) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:         "subject",
-		Short:       "Manage Schema Registry subjects.",
-		Annotations: map[string]string{pcmd.RunRequirement: pcmd.RequireCloudLoginOrOnPremLogin},
+		Use:   "subject",
+		Short: "Manage Schema Registry subjects.",
 	}
 
 	cmd.AddCommand(c.newSubjectDescribeCommand(cfg))


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- PLACEHOLDER

New Features
- PLACEHOLDER

Bug Fixes
- PLACEHOLDER

Checklist
---------
<!-- 
Check each item below to ensure high-quality CLI development practices are followed. PR approval will not be granted until the checklist is fully reviewed.
For detailed instructions, please refer to this Confluence page: https://confluentinc.atlassian.net/wiki/spaces/AEGI/pages/3949592874/
-->
- [x] I have successfully built and used a custom CLI binary, without linter issues from this PR.
- [x] I have clearly specified in the `What` section below whether this PR applies to Confluent Cloud, Confluent Platform, or both. 
- [x] I have verified this PR in Confluent Cloud pre-prod or production environment, if applicable.
- [ ] I have verified this PR in Confluent Platform on-premises environment, if applicable.
- [x] I have attached manual CLI verification results or screenshots in the `Test & Review` section below.
- [ ] I have added appropriate CLI integration or unit tests for any new or updated commands and functionality.
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [x] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [x] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [x] Confluent Cloud prod
  - [x] Confluent Cloud stag
  - [ ] Confluent Platform
  - [ ] Check this box if the feature is enabled for certain organizations only

What
----
<!--
Briefly describe **what** you have changed and **why** these changes are necessary.
Optionally include: 
- The problem being solved or the feature being added. 
- The implementation strategy or approach taken. 
- Key technical details, design decisions, or any additional context reviewers should be aware of.
-->
Allow `schema-registry` commands to be used without login

Blast Radius
----
<!--
The Blast Radius section should include information on what will be the customer(s) impact if something goes wrong or unexpectedly, 
adding this section will trigger the PR author to think about the impact from product perspective, examples can be:
- Confluent Cloud customers who are using confluent kafka topic any subcommand will be blocked.
- Confluent Cloud customers who are using confluent kafka topic list commands will be blocked.
- Confluent Platform customers who are using --schema flag will be impacted.
- All customers who are using SSO to login will be impacted.
-->
Users trying to run the schema-registry command without logging in

References
----------
<!-- Include links to relevant resources for this PR, such as: 
- Related GitHub issues 
- Tickets (JIRA, etc.) 
- Internal documentation or design specs 
- Other related PRs 
Copy and paste the links below for easy reference.
-->
https://confluentinc.atlassian.net/browse/CLI-3283

Test & Review
-------------
<!-- Has this PR been tested? If so, explain **how** it was tested. Include: 
- Steps taken to verify the changes. 
- Links to manual verification documents, logs, or screenshots to save reviewers' time. 
- Any additional notes on testing (e.g., environments used, edge cases tested). 
- Screenshot showing successful resource creation, updates etc.
Example: - [Manual Verification Document](https://docs.google.com/document/d/1GwXz9hNOkub_Br-2nssoYWCf6elZBvwo7TMhCNYinwE/edit?tab=t.0#heading=h.dvbi09ntxjw6)
-->
Tested manually
Output for the schema registry command (not logged in):
<img width="1075" alt="image" src="https://github.com/user-attachments/assets/c8b3c28c-8e3c-489a-a3a2-3cd031ce1a0f" />

Output for the schema registry DEK command (not logged in):
<img width="1038" alt="image" src="https://github.com/user-attachments/assets/508c5c95-c101-4f94-9e1a-3de73629d709" />
