### PR TITLE
[CLI-3152] Add options for LOW/HIGH availability in cluster create CL…

### DIFF
--- a/internal/kafka/command_cluster.go
+++ b/internal/kafka/command_cluster.go
@@ -10,29 +10,35 @@ import (
 )
 
 const (
-	singleZone       = "single-zone"
-	multiZone        = "multi-zone"
-	lowAvailability  = "SINGLE_ZONE"
-	highAvailability = "MULTI_ZONE"
-	low              = "LOW"
-	high             = "HIGH"
+	singleZone             = "single-zone"
+	multiZone              = "multi-zone"
+	singleZoneAvailability = "SINGLE_ZONE"
+	multiZoneAvailability  = "MULTI_ZONE"
+	low                    = "low"
+	high                   = "high"
+	lowAvailability        = "LOW"
+	highAvailability       = "HIGH"
 )
 
 var availabilitiesToHuman = map[string]string{
-	lowAvailability:  singleZone,
-	highAvailability: multiZone,
-	low:              singleZone,
-	high:             multiZone,
+	singleZoneAvailability: singleZone,
+	multiZoneAvailability:  multiZone,
+	lowAvailability:        low,
+	highAvailability:       high,
 }
 
 var availabilitiesToModel = map[string]string{
-	singleZone: lowAvailability,
-	multiZone:  highAvailability,
+	singleZone: singleZoneAvailability,
+	multiZone:  multiZoneAvailability,
+	low:        lowAvailability,
+	high:       highAvailability,
 }
 
 var availabilitiesToFreightModel = map[string]string{
 	singleZone: low,
 	multiZone:  high,
+	low:        lowAvailability,
+	high:       highAvailability,
 }
 
 type clusterCommand struct {

--- a/internal/kafka/command_cluster_create.go
+++ b/internal/kafka/command_cluster_create.go
@@ -175,7 +175,7 @@ func stringToAvailability(s string, sku ccstructs.Sku) (string, error) {
 	}
 	return "", errors.NewErrorWithSuggestions(
 		fmt.Sprintf("invalid value \"%s\" for `--availability` flag", s),
-		fmt.Sprintf("Allowed values for `--availability` flag are: %s, %s.", singleZone, multiZone),
+		fmt.Sprintf("Allowed values for `--availability` flag are: %s, %s, %s, %s.", singleZone, multiZone, low, high),
 	)
 }
 

--- a/internal/kafka/command_cluster_test.go
+++ b/internal/kafka/command_cluster_test.go
@@ -43,7 +43,7 @@ var cmkByokCluster = cmkv2.CmkV2Cluster{
 		Cloud:        cmkv2.PtrString("gcp"),
 		Region:       cmkv2.PtrString("us-central1"),
 		Config:       setCmkClusterConfig("dedicated", 1),
-		Availability: cmkv2.PtrString(lowAvailability),
+		Availability: cmkv2.PtrString(singleZoneAvailability),
 	},
 	Id: cmkv2.PtrString("lkc-xyz"),
 	Status: &cmkv2.CmkV2ClusterStatus{


### PR DESCRIPTION
…I commands

Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- I changed the existing lowAvailability/highAvailability to being single(multi)ZoneAvailability as that was confusing given the changes requested

New Features
- You can now create via the CLI kafka clusters with availability options of low and high in addition to single and multi zone. We let the backend do the validation.

Bug Fixes
- PLACEHOLDER

Checklist
---------
<!-- 
Check each item below to ensure high-quality CLI development practices are followed. PR approval will not be granted until the checklist is fully reviewed.
For detailed instructions, please refer to this Confluence page: https://confluentinc.atlassian.net/wiki/spaces/AEGI/pages/3949592874/
-->
- [x] I have successfully built and used a custom CLI binary, without linter issues from this PR.
- [x] I have clearly specified in the `What` section below whether this PR applies to Confluent Cloud, Confluent Platform, or both. 
- [x] I have verified this PR in Confluent Cloud pre-prod or production environment, if applicable.
- [ ] I have verified this PR in Confluent Platform on-premises environment, if applicable.
- [x] I have attached manual CLI verification results or screenshots in the `Test & Review` section below.
- [ ] I have added appropriate CLI integration or unit tests for any new or updated commands and functionality.
- [ ] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [x] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [x] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [x] Confluent Cloud prod
  - [x] Confluent Cloud stag
  - [ ] Confluent Platform
  - [ ] Check this box if the feature is enabled for certain organizations only

What
----
<!--
Briefly describe **what** you have changed and **why** these changes are necessary.
Optionally include: 
- The problem being solved or the feature being added. 
- The implementation strategy or approach taken. 
- Key technical details, design decisions, or any additional context reviewers should be aware of.
-->
The availability attribute for multi-tenant clusters has been changed. Previously, the options were SINGLE_ZONE and MULTI_ZONE. Now, they have been updated to include LOW and HIGH.[1](https://confluentinc.atlassian.net/browse/CLI-3152#:~:text=The%20availability%20attribute%20of%20multi%2Dtenant%20clusters%20was%20changed%20to%20LOW%2FHIGH%20%2C%20and%20earlier%20it%20used%20to%20be%20SINGLE_ZONE%2C%20&%20MULTI_ZONE)[2](https://docs.confluent.io/cloud/current/clusters/cluster-types.html)

Different cluster types have different valid options based on when the organization was created:[1](https://confluentinc.atlassian.net/browse/CLI-3152#:~:text=The%20availability%20attribute%20of%20multi%2Dtenant%20clusters%20was%20changed%20to%20LOW%2FHIGH%20%2C%20and%20earlier%20it%20used%20to%20be%20SINGLE_ZONE%2C%20&%20MULTI_ZONE)[2](https://docs.confluent.io/cloud/current/clusters/cluster-types.html)

Standard and Enterprise clusters created after 4/16 have LOW and HIGH options.[1](https://confluentinc.atlassian.net/browse/CLI-3152#:~:text=The%20availability%20attribute%20of%20multi%2Dtenant%20clusters%20was%20changed%20to%20LOW%2FHIGH%20%2C%20and%20earlier%20it%20used%20to%20be%20SINGLE_ZONE%2C%20&%20MULTI_ZONE)
Basic clusters created after 4/16 have only the LOW option.[1](https://confluentinc.atlassian.net/browse/CLI-3152#:~:text=The%20availability%20attribute%20of%20multi%2Dtenant%20clusters%20was%20changed%20to%20LOW%2FHIGH%20%2C%20and%20earlier%20it%20used%20to%20be%20SINGLE_ZONE%2C%20&%20MULTI_ZONE)
For this update, the CLI and Terraform interfaces should support four availability options: LOW, HIGH, SINGLE_ZONE, and MULTI_ZONE. The backend APIs will handle the final validation.[1](https://confluentinc.atlassian.net/browse/CLI-3152#:~:text=The%20availability%20attribute%20of%20multi%2Dtenant%20clusters%20was%20changed%20to%20LOW%2FHIGH%20%2C%20and%20earlier%20it%20used%20to%20be%20SINGLE_ZONE%2C%20&%20MULTI_ZONE)

Blast Radius
----
<!--
The Blast Radius section should include information on what will be the customer(s) impact if something goes wrong or unexpectedly, 
adding this section will trigger the PR author to think about the impact from product perspective, examples can be:
- Confluent Cloud customers who are using confluent kafka topic any subcommand will be blocked.
- Confluent Cloud customers who are using confluent kafka topic list commands will be blocked.
- Confluent Platform customers who are using --schema flag will be impacted.
- All customers who are using SSO to login will be impacted.
-->
Confluent Cloud customers who are using confluent kafka cluster create --availability flag could have an issue with single-zone, multi-zone if something was wrong here

References
----------
<!-- Include links to relevant resources for this PR, such as: 
- Related GitHub issues 
- Tickets (JIRA, etc.) 
- Internal documentation or design specs 
- Other related PRs 
Copy and paste the links below for easy reference.
-->
https://confluentinc.atlassian.net/browse/CLI-3152

Test & Review
-------------
<!-- Has this PR been tested? If so, explain **how** it was tested. Include: 
- Steps taken to verify the changes. 
- Links to manual verification documents, logs, or screenshots to save reviewers' time. 
- Any additional notes on testing (e.g., environments used, edge cases tested). 
- Screenshot showing successful resource creation, updates etc.
Example: - [Manual Verification Document](https://docs.google.com/document/d/1GwXz9hNOkub_Br-2nssoYWCf6elZBvwo7TMhCNYinwE/edit?tab=t.0#heading=h.dvbi09ntxjw6)
-->
Manual testing against the CLI targeted at DEV CC:
![Pasted Graphic](https://github.com/user-attachments/assets/b2980861-8057-467e-912a-ae6526ab085e)

![Screenshot 2025-02-19 at 9 56 54 AM](https://github.com/user-attachments/assets/968969d1-e2c8-4bd3-a8dc-342a3d1a144d)

![Screenshot 2025-02-19 at 9 57 16 AM](https://github.com/user-attachments/assets/e7a0bab7-7620-4312-9c77-2e55787ccb06)

![Screenshot 2025-02-19 at 9 57 33 AM](https://github.com/user-attachments/assets/b5bf5294-b8ac-43e3-82cf-bc0277d66a58)
