### PR TITLE
Update flag wording based on docs review

### DIFF
--- a/internal/iam/command_ipfilter_create.go
+++ b/internal/iam/command_ipfilter_create.go
@@ -45,7 +45,7 @@ func (c *ipFilterCommand) newCreateCommand(cfg *config.Config) *cobra.Command {
 	pcmd.AddResourceGroupFlag(cmd, isSrEnabled, isFlinkEnabled)
 	cmd.Flags().StringSlice("ip-groups", []string{}, "A comma-separated list of IP group IDs.")
 	if isSrEnabled || isFlinkEnabled {
-		cmd.Flags().String("environment", "", "Id of the environment for which this filter applies. By default will apply to the organization only.")
+		cmd.Flags().String("environment", "", "Identifier of the environment for which this filter applies. Without this flag, applies only to the organization.")
 		opGroups := []string{"MANAGEMENT"}
 		if isSrEnabled {
 			opGroups = append(opGroups, "SCHEMA")

--- a/internal/iam/command_ipfilter_list.go
+++ b/internal/iam/command_ipfilter_list.go
@@ -25,7 +25,7 @@ func (c *ipFilterCommand) newListCommand(cfg *config.Config) *cobra.Command {
 	isSrEnabled := cfg.IsTest || (cfg.Context() != nil && featureflags.Manager.BoolVariation("auth.ip_filter.sr.cli.enabled", cfg.Context(), featureflags.GetCcloudLaunchDarklyClient(cfg.Context().PlatformName), true, false))
 	isFlinkEnabled := cfg.IsTest || (cfg.Context() != nil && featureflags.Manager.BoolVariation("auth.ip_filter.flink.cli.enabled", cfg.Context(), featureflags.GetCcloudLaunchDarklyClient(cfg.Context().PlatformName), true, false))
 	if isSrEnabled || isFlinkEnabled {
-		cmd.Flags().String("environment", "", "Id of the environment for which this filter applies. By default will apply to the org only.")
+		cmd.Flags().String("environment", "", "Identifier of the environment for which this filter applies. Without this flag, applies only to the organization.")
 		cmd.Flags().Bool("include-parent-scopes", false, "Include organization scoped filters when listing filters in an environment.")
 	}
 

--- a/test/fixtures/output/iam/ip-filter/create-help.golden
+++ b/test/fixtures/output/iam/ip-filter/create-help.golden
@@ -11,7 +11,7 @@ Create an IP filter named "demo-ip-filter" with operation group "management" and
 Flags:
       --resource-group string   Name of resource group: "management" or "multiple". (default "multiple")
       --ip-groups strings       A comma-separated list of IP group IDs.
-      --environment string      Id of the environment for which this filter applies. By default will apply to the organization only.
+      --environment string      Identifier of the environment for which this filter applies. Without this flag, applies only to the organization.
       --operations strings      A comma-separated list of operation groups: "MANAGEMENT", "SCHEMA", or "FLINK".
       --no-public-networks      Use in place of ip-groups to reference the no public networks IP Group.
       --context string          CLI context name.

--- a/test/fixtures/output/iam/ip-filter/list-help.golden
+++ b/test/fixtures/output/iam/ip-filter/list-help.golden
@@ -4,7 +4,7 @@ Usage:
   confluent iam ip-filter list [flags]
 
 Flags:
-      --environment string      Id of the environment for which this filter applies. By default will apply to the org only.
+      --environment string      Identifier of the environment for which this filter applies. Without this flag, applies only to the organization.
       --include-parent-scopes   Include organization scoped filters when listing filters in an environment.
       --context string          CLI context name.
   -o, --output string           Specify the output format as "human", "json", or "yaml". (default "human")


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- PLACEHOLDER

New Features
- PLACEHOLDER

Bug Fixes
- PLACEHOLDER

Checklist
---------
<!-- 
Check each item below to ensure high-quality CLI development practices are followed. PR approval will not be granted until the checklist is fully reviewed.
For detailed instructions, please refer to this Confluence page: https://confluentinc.atlassian.net/wiki/spaces/AEGI/pages/3949592874/
-->
- [x] I have successfully built and used a custom CLI binary, without linter issues from this PR.
- [x] I have clearly specified in the `What` section below whether this PR applies to Confluent Cloud, Confluent Platform, or both. 
- [ ] I have verified this PR in Confluent Cloud pre-prod or production environment, if applicable.
- [ ] I have verified this PR in Confluent Platform on-premises environment, if applicable.
- [ ] I have attached manual CLI verification results or screenshots in the `Test & Review` section below.
- [x] I have added appropriate CLI integration or unit tests for any new or updated commands and functionality.
  - Updated golden files
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [x] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [ ] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [ ] Confluent Cloud prod
  - [ ] Confluent Cloud stag
  - [ ] Confluent Platform
  - [ ] Check this box if the feature is enabled for certain organizations only

What
----
A wording change to `--environment` flag for the Cloud `confluent iam ip-filter` commands based on docs feedback from v4.15.0 release.

Blast Radius
----
None. Just a docs update.

References
----------
https://github.com/confluentinc/docs-confluent-cli/pull/951

Test & Review
-------------
integration tests and linter still pass.