### PR TITLE
DGS-19545 Output asyncapi examples as yaml instead of string

### DIFF
--- a/internal/asyncapi/account_details.go
+++ b/internal/asyncapi/account_details.go
@@ -28,7 +28,7 @@ type channelDetails struct {
 	topicLevelTags          []spec.Tag
 	schemaLevelTags         []spec.Tag
 	bindings                *bindings
-	example                 any
+	examples                map[string]any
 }
 
 type accountDetails struct {
@@ -132,8 +132,9 @@ func (d *accountDetails) buildMessageEntity() *spec.MessageEntity {
 	// Name
 	entityProducer.WithName(msgName(d.channelDetails.currentTopic.GetTopicName()))
 	// Example
-	if d.channelDetails.example != nil {
-		entityProducer.WithExamples(spec.MessageOneOf1OneOf1ExamplesItems{Payload: &d.channelDetails.example})
+	if d.channelDetails.examples != nil && d.channelDetails.examples[d.channelDetails.currentTopic.GetTopicName()] != nil {
+		topicExample := d.channelDetails.examples[d.channelDetails.currentTopic.GetTopicName()]
+		entityProducer.WithExamples(spec.MessageOneOf1OneOf1ExamplesItems{Payload: &topicExample})
 	}
 	if d.channelDetails.bindings != nil {
 		entityProducer.WithBindings(d.channelDetails.bindings.messageBinding)


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Bug Fixes
- `confluent asyncapi export` flag `--consume-examples` outputs as YAML to match asyncapi documentation
- `confluent asyncapi export` flag `--consume-examples` works with multiple topics

Checklist
---------
<!-- 
Check each item below to ensure high-quality CLI development practices are followed. PR approval will not be granted until the checklist is fully reviewed.
For detailed instructions, please refer to this Confluence page: https://confluentinc.atlassian.net/wiki/spaces/AEGI/pages/3949592874/
-->
- [x] I have successfully built and used a custom CLI binary, without linter issues from this PR.
- [x] I have clearly specified in the `What` section below whether this PR applies to Confluent Cloud, Confluent Platform, or both. 
- [x] I have verified this PR in Confluent Cloud pre-prod or production environment, if applicable.
- [x] I have verified this PR in Confluent Platform on-premises environment, if applicable.
- [x] I have attached manual CLI verification results or screenshots in the `Test & Review` section below.
- [ ] I have added appropriate CLI integration or unit tests for any new or updated commands and functionality.
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [x] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [x] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [x] Confluent Cloud prod
  - [x] Confluent Cloud stag
  - [x] Confluent Platform
  - [ ] Check this box if the feature is enabled for certain organizations only

What
----
<!--
Briefly describe **what** you have changed and **why** these changes are necessary.
Optionally include: 
- The problem being solved or the feature being added. 
- The implementation strategy or approach taken. 
- Key technical details, design decisions, or any additional context reviewers should be aware of.
-->

Asyncapi is only CP currently
- Previously we output examples from --consume-examples flag as a string instead of YAML format, which makes it incompatible with asyncapi documentation. Brought up by a customer https://confluentinc.atlassian.net/browse/DGS-19545
- Also previously we are only storing 1 example even if they have multiple topics? Now stores an example per topic


Blast Radius
----
<!--
The Blast Radius section should include information on what will be the customer(s) impact if something goes wrong or unexpectedly, 
adding this section will trigger the PR author to think about the impact from product perspective, examples can be:
- Confluent Cloud customers who are using confluent kafka topic any subcommand will be blocked.
- Confluent Cloud customers who are using confluent kafka topic list commands will be blocked.
- Confluent Platform customers who are using --schema flag will be impacted.
- All customers who are using SSO to login will be impacted.
-->

If something goes wrong, --consume-examples flag may not work correctly. But its currently rather broken due to the bugs being fixed 😄 

References
----------
<!-- Include links to relevant resources for this PR, such as: 
- Related GitHub issues 
- Tickets (JIRA, etc.) 
- Internal documentation or design specs 
- Other related PRs 
Copy and paste the links below for easy reference.
-->

Test & Review
-------------
<!-- Has this PR been tested? If so, explain **how** it was tested. Include: 
- Steps taken to verify the changes. 
- Links to manual verification documents, logs, or screenshots to save reviewers' time. 
- Any additional notes on testing (e.g., environments used, edge cases tested). 
- Screenshot showing successful resource creation, updates etc.
Example: - [Manual Verification Document](https://docs.google.com/document/d/1GwXz9hNOkub_Br-2nssoYWCf6elZBvwo7TMhCNYinwE/edit?tab=t.0#heading=h.dvbi09ntxjw6)
-->

Tested manually. At some point, we should work on adding better unit/integration testing for these calls

```
 examples:
      - payload:
          my_field1: 123
          my_field2: 456.78
          my_field3: Hello, world!
```

Previously, this would look like

```
      examples:
      - payload: '{"my_field1":123,"my_field2":456.78,"my_field3":"Hello, world!"}'
```
