### PR TITLE
Add options for LOW/HIGH availability in cluster create CLI commands

### DIFF
--- a/internal/kafka/command_cluster.go
+++ b/internal/kafka/command_cluster.go
@@ -2,37 +2,31 @@ package kafka
 
 import (
 	"fmt"
-
 	"github.com/spf13/cobra"
 
 	pcmd "github.com/confluentinc/cli/v4/pkg/cmd"
 	"github.com/confluentinc/cli/v4/pkg/config"
 )
 
-const (
-	singleZone       = "single-zone"
-	multiZone        = "multi-zone"
-	lowAvailability  = "SINGLE_ZONE"
-	highAvailability = "MULTI_ZONE"
-	low              = "LOW"
-	high             = "HIGH"
-)
-
 var availabilitiesToHuman = map[string]string{
-	lowAvailability:  singleZone,
-	highAvailability: multiZone,
-	low:              singleZone,
-	high:             multiZone,
+	"SINGLE_ZONE": "single-zone",
+	"MULTI_ZONE":  "multi-zone",
+	"LOW":         "low",
+	"HIGH":        "high",
 }
 
 var availabilitiesToModel = map[string]string{
-	singleZone: lowAvailability,
-	multiZone:  highAvailability,
+	"single-zone": "SINGLE_ZONE",
+	"multi-zone":  "MULTI_ZONE",
+	"low":         "LOW",
+	"high":        "HIGH",
 }
 
 var availabilitiesToFreightModel = map[string]string{
-	singleZone: low,
-	multiZone:  high,
+	"single-zone": "LOW",
+	"multi-zone":  "HIGH",
+	"low":         "LOW",
+	"high":        "HIGH",
 }
 
 type clusterCommand struct {

--- a/internal/kafka/command_cluster.go
+++ b/internal/kafka/command_cluster.go
@@ -2,6 +2,7 @@ package kafka
 
 import (
 	"fmt"
+
 	"github.com/spf13/cobra"
 
 	pcmd "github.com/confluentinc/cli/v4/pkg/cmd"
@@ -16,8 +17,8 @@ var availabilitiesToModel = map[string]string{
 }
 
 var availabilitiesToFreightModel = map[string]string{
-	"single-zone": "LOW",  // TODO: This mapping are deprecated and will be removed in v5
-	"multi-zone":  "HIGH", // TODO: This mapping are deprecated and will be removed in v5
+	"single-zone": "LOW",  // TODO: This mapping is deprecated and will be removed in v5
+	"multi-zone":  "HIGH", // TODO: This mapping is deprecated and will be removed in v5
 	"low":         "LOW",
 	"high":        "HIGH",
 }

--- a/internal/kafka/command_cluster.go
+++ b/internal/kafka/command_cluster.go
@@ -23,8 +23,8 @@ var availabilitiesToModel = map[string]string{
 }
 
 var availabilitiesToFreightModel = map[string]string{
-	"single-zone": "LOW",
-	"multi-zone":  "HIGH",
+	"single-zone": "LOW",  // TODO: This mapping are deprecated and will be removed in v5
+	"multi-zone":  "HIGH", // TODO: This mapping are deprecated and will be removed in v5
 	"low":         "LOW",
 	"high":        "HIGH",
 }

--- a/internal/kafka/command_cluster.go
+++ b/internal/kafka/command_cluster.go
@@ -8,13 +8,6 @@ import (
 	"github.com/confluentinc/cli/v4/pkg/config"
 )
 
-var availabilitiesToHuman = map[string]string{
-	"SINGLE_ZONE": "single-zone",
-	"MULTI_ZONE":  "multi-zone",
-	"LOW":         "low",
-	"HIGH":        "high",
-}
-
 var availabilitiesToModel = map[string]string{
 	"single-zone": "SINGLE_ZONE",
 	"multi-zone":  "MULTI_ZONE",

--- a/internal/kafka/command_cluster_create.go
+++ b/internal/kafka/command_cluster_create.go
@@ -44,6 +44,10 @@ func (c *clusterCommand) newCreateCommand() *cobra.Command {
 				Code: "confluent kafka cluster create my-cluster --cloud aws --region us-west-2 --type dedicated --cku 1 --byok cck-a123z",
 			},
 			examples.Example{
+				Text: "Create a new freight cluster that uses a customer-managed encryption key in AWS:",
+				Code: "confluent kafka cluster create my-cluster --cloud aws --region us-west-2 --type freight --cku 1 --byok cck-a123z --availability high",
+			},
+			examples.Example{
 				Text: "For more information, see https://docs.confluent.io/current/cloud/clusters/byok-encrypted-clusters.html.",
 			},
 		),
@@ -175,7 +179,7 @@ func stringToAvailability(s string, sku ccstructs.Sku) (string, error) {
 	}
 	return "", errors.NewErrorWithSuggestions(
 		fmt.Sprintf("invalid value \"%s\" for `--availability` flag", s),
-		fmt.Sprintf("Allowed values for `--availability` flag are: %s, %s.", singleZone, multiZone),
+		fmt.Sprintf("Allowed values for `--availability` flag are: %s, %s, %s, %s.", "single-zone", "multi-zone", "low", "high"),
 	)
 }
 

--- a/internal/kafka/command_cluster_create.go
+++ b/internal/kafka/command_cluster_create.go
@@ -44,7 +44,7 @@ func (c *clusterCommand) newCreateCommand() *cobra.Command {
 				Code: "confluent kafka cluster create my-cluster --cloud aws --region us-west-2 --type dedicated --cku 1 --byok cck-a123z",
 			},
 			examples.Example{
-				Text: "Create a new freight cluster that uses a customer-managed encryption key in AWS:",
+				Text: "Create a new Freight cluster that uses a customer-managed encryption key in AWS:",
 				Code: "confluent kafka cluster create my-cluster --cloud aws --region us-west-2 --type freight --cku 1 --byok cck-a123z --availability high",
 			},
 			examples.Example{
@@ -172,15 +172,19 @@ func stringToAvailability(s string, sku ccstructs.Sku) (string, error) {
 		if modelAvailability, ok := availabilitiesToFreightModel[s]; ok {
 			return modelAvailability, nil
 		}
+		return "", errors.NewErrorWithSuggestions(
+			fmt.Sprintf("invalid value \"%s\" for `--availability` flag", s),
+			fmt.Sprintf("Allowed values for `--availability` flag are: %s, %s.", "low", "high"),
+		)
 	} else {
 		if modelAvailability, ok := availabilitiesToModel[s]; ok {
 			return modelAvailability, nil
 		}
+		return "", errors.NewErrorWithSuggestions(
+			fmt.Sprintf("invalid value \"%s\" for `--availability` flag", s),
+			fmt.Sprintf("Allowed values for `--availability` flag are: %s, %s, %s, %s.", "single-zone", "multi-zone", "low", "high"),
+		)
 	}
-	return "", errors.NewErrorWithSuggestions(
-		fmt.Sprintf("invalid value \"%s\" for `--availability` flag", s),
-		fmt.Sprintf("Allowed values for `--availability` flag are: %s, %s, %s, %s.", "single-zone", "multi-zone", "low", "high"),
-	)
 }
 
 func stringToSku(skuType string) (ccstructs.Sku, error) {

--- a/internal/kafka/command_cluster_create.go
+++ b/internal/kafka/command_cluster_create.go
@@ -26,6 +26,11 @@ const (
 	skuDedicated  = "dedicated"
 )
 
+var (
+	allowedEnterpriseAvailabilities = []string{"single-zone", "multi-zone", "low", "high"}
+	allowedFreightAvailabilities    = []string{"low", "high"}
+)
+
 func (c *clusterCommand) newCreateCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:         "create <name>",
@@ -174,7 +179,7 @@ func stringToAvailability(s string, sku ccstructs.Sku) (string, error) {
 		}
 		return "", errors.NewErrorWithSuggestions(
 			fmt.Sprintf("invalid value \"%s\" for `--availability` flag", s),
-			fmt.Sprintf("Allowed values for `--availability` flag are: %s, %s.", "low", "high"),
+			fmt.Sprintf("Allowed values for `--availability` flag are: %s.", utils.ArrayToCommaDelimitedString(allowedFreightAvailabilities, "or")),
 		)
 	} else {
 		if modelAvailability, ok := availabilitiesToModel[s]; ok {
@@ -182,7 +187,7 @@ func stringToAvailability(s string, sku ccstructs.Sku) (string, error) {
 		}
 		return "", errors.NewErrorWithSuggestions(
 			fmt.Sprintf("invalid value \"%s\" for `--availability` flag", s),
-			fmt.Sprintf("Allowed values for `--availability` flag are: %s, %s, %s, %s.", "single-zone", "multi-zone", "low", "high"),
+			fmt.Sprintf("Allowed values for `--availability` flag are: %s.", utils.ArrayToCommaDelimitedString(allowedEnterpriseAvailabilities, "or")),
 		)
 	}
 }

--- a/internal/kafka/command_cluster_describe.go
+++ b/internal/kafka/command_cluster_describe.go
@@ -132,7 +132,7 @@ func convertClusterToDescribeStruct(cluster *cmkv2.CmkV2Cluster, ctx *config.Con
 		Storage:            clusterStorage,
 		Cloud:              strings.ToLower(cluster.Spec.GetCloud()),
 		Region:             cluster.Spec.GetRegion(),
-		Availability:       availabilitiesToHuman[cluster.Spec.GetAvailability()],
+		Availability:       ccloudv2.ToLower(cluster.Spec.GetAvailability()),
 		Network:            cluster.Spec.Network.GetId(),
 		Status:             getCmkClusterStatus(cluster),
 		Endpoint:           cluster.Spec.GetKafkaBootstrapEndpoint(),

--- a/internal/kafka/command_cluster_test.go
+++ b/internal/kafka/command_cluster_test.go
@@ -43,7 +43,7 @@ var cmkByokCluster = cmkv2.CmkV2Cluster{
 		Cloud:        cmkv2.PtrString("gcp"),
 		Region:       cmkv2.PtrString("us-central1"),
 		Config:       setCmkClusterConfig("dedicated", 1),
-		Availability: cmkv2.PtrString(lowAvailability),
+		Availability: cmkv2.PtrString("SINGLE_ZONE"),
 	},
 	Id: cmkv2.PtrString("lkc-xyz"),
 	Status: &cmkv2.CmkV2ClusterStatus{

--- a/internal/kafka/command_cluster_update.go
+++ b/internal/kafka/command_cluster_update.go
@@ -102,7 +102,7 @@ func (c *clusterCommand) validateResize(cku int32, currentCluster *cmkv2.CmkV2Cl
 		return 0, fmt.Errorf("failed to update Kafka cluster: cluster resize is only supported on dedicated clusters")
 	}
 	// Durability Checks
-	if currentCluster.Spec.GetAvailability() == highAvailability && cku <= 1 {
+	if currentCluster.Spec.GetAvailability() == "MULTI_ZONE" && cku <= 1 {
 		return 0, fmt.Errorf("`--cku` value must be greater than 1 for high durability")
 	}
 	if cku == 0 {

--- a/pkg/kafka/utils.go
+++ b/pkg/kafka/utils.go
@@ -2,6 +2,6 @@ package kafka
 
 var (
 	Clouds         = []string{"aws", "azure", "gcp"}
-	Availabilities = []string{"single-zone", "multi-zone"}
+	Availabilities = []string{"single-zone", "multi-zone", "low", "high"}
 	Types          = []string{"basic", "standard", "enterprise", "freight", "dedicated"}
 )

--- a/test/fixtures/output/kafka/1.golden
+++ b/test/fixtures/output/kafka/1.golden
@@ -11,12 +11,16 @@ Create a new dedicated cluster that uses a customer-managed encryption key in AW
 
   $ confluent kafka cluster create my-cluster --cloud aws --region us-west-2 --type dedicated --cku 1 --byok cck-a123z
 
+Create a new freight cluster that uses a customer-managed encryption key in AWS:
+
+  $ confluent kafka cluster create my-cluster --cloud aws --region us-west-2 --type freight --cku 1 --byok cck-a123z --availability high
+
 For more information, see https://docs.confluent.io/current/cloud/clusters/byok-encrypted-clusters.html.
 
 Flags:
       --cloud string          Specify the cloud provider as "aws", "azure", or "gcp".
       --region string         Cloud region for Kafka (use "confluent kafka region list" to see all).
-      --availability string   Specify the availability of the cluster as "single-zone" or "multi-zone". (default "single-zone")
+      --availability string   Specify the availability of the cluster as "single-zone", "multi-zone", "low", or "high". (default "single-zone")
       --type string           Specify the type of the Kafka cluster as "basic", "standard", "enterprise", "freight", or "dedicated". (default "basic")
       --cku int               Number of Confluent Kafka Units (non-negative). Required for Kafka clusters of type "dedicated".
       --byok string           Confluent Cloud Key ID of a registered encryption key (use "confluent byok create" to register a key).

--- a/test/fixtures/output/kafka/1.golden
+++ b/test/fixtures/output/kafka/1.golden
@@ -11,7 +11,7 @@ Create a new dedicated cluster that uses a customer-managed encryption key in AW
 
   $ confluent kafka cluster create my-cluster --cloud aws --region us-west-2 --type dedicated --cku 1 --byok cck-a123z
 
-Create a new freight cluster that uses a customer-managed encryption key in AWS:
+Create a new Freight cluster that uses a customer-managed encryption key in AWS:
 
   $ confluent kafka cluster create my-cluster --cloud aws --region us-west-2 --type freight --cku 1 --byok cck-a123z --availability high
 

--- a/test/fixtures/output/kafka/cluster/create-availability-zone-error.golden
+++ b/test/fixtures/output/kafka/cluster/create-availability-zone-error.golden
@@ -1,4 +1,4 @@
 Error: invalid value "oops-zone" for `--availability` flag
 
 Suggestions:
-    Allowed values for `--availability` flag are: single-zone, multi-zone, low, high.
+    Allowed values for `--availability` flag are: "single-zone", "multi-zone", "low", or "high".

--- a/test/fixtures/output/kafka/cluster/create-availability-zone-error.golden
+++ b/test/fixtures/output/kafka/cluster/create-availability-zone-error.golden
@@ -1,4 +1,4 @@
 Error: invalid value "oops-zone" for `--availability` flag
 
 Suggestions:
-    Allowed values for `--availability` flag are: single-zone, multi-zone.
+    Allowed values for `--availability` flag are: single-zone, multi-zone, low, high.

--- a/test/fixtures/output/kafka/cluster/create-freight-low.golden
+++ b/test/fixtures/output/kafka/cluster/create-freight-low.golden
@@ -9,7 +9,7 @@ It may take up to 5 minutes for the Kafka cluster to be ready.
 | Storage              | Infinite                  |
 | Cloud                | aws                       |
 | Region               | us-east-1                 |
-| Availability         | single-zone               |
+| Availability         | low                       |
 | Status               | PROVISIONING              |
 | Endpoint             | SASL_SSL://kafka-endpoint |
 | REST Endpoint        | https://pkc-endpoint      |

--- a/test/fixtures/output/kafka/cluster/create-freight.golden
+++ b/test/fixtures/output/kafka/cluster/create-freight.golden
@@ -9,7 +9,7 @@ It may take up to 5 minutes for the Kafka cluster to be ready.
 | Storage              | Infinite                  |
 | Cloud                | aws                       |
 | Region               | us-east-1                 |
-| Availability         | multi-zone                |
+| Availability         | high                      |
 | Status               | PROVISIONING              |
 | Endpoint             | SASL_SSL://kafka-endpoint |
 | REST Endpoint        | https://pkc-endpoint      |

--- a/test/fixtures/output/kafka/cluster/create-help.golden
+++ b/test/fixtures/output/kafka/cluster/create-help.golden
@@ -14,12 +14,16 @@ Create a new dedicated cluster that uses a customer-managed encryption key in AW
 
   $ confluent kafka cluster create my-cluster --cloud aws --region us-west-2 --type dedicated --cku 1 --byok cck-a123z
 
+Create a new freight cluster that uses a customer-managed encryption key in AWS:
+
+  $ confluent kafka cluster create my-cluster --cloud aws --region us-west-2 --type freight --cku 1 --byok cck-a123z --availability high
+
 For more information, see https://docs.confluent.io/current/cloud/clusters/byok-encrypted-clusters.html.
 
 Flags:
       --cloud string          REQUIRED: Specify the cloud provider as "aws", "azure", or "gcp".
       --region string         REQUIRED: Cloud region for Kafka (use "confluent kafka region list" to see all).
-      --availability string   Specify the availability of the cluster as "single-zone" or "multi-zone". (default "single-zone")
+      --availability string   Specify the availability of the cluster as "single-zone", "multi-zone", "low", or "high". (default "single-zone")
       --type string           Specify the type of the Kafka cluster as "basic", "standard", "enterprise", "freight", or "dedicated". (default "basic")
       --cku int               Number of Confluent Kafka Units (non-negative). Required for Kafka clusters of type "dedicated".
       --byok string           Confluent Cloud Key ID of a registered encryption key (use "confluent byok create" to register a key).

--- a/test/fixtures/output/kafka/cluster/create-help.golden
+++ b/test/fixtures/output/kafka/cluster/create-help.golden
@@ -14,7 +14,7 @@ Create a new dedicated cluster that uses a customer-managed encryption key in AW
 
   $ confluent kafka cluster create my-cluster --cloud aws --region us-west-2 --type dedicated --cku 1 --byok cck-a123z
 
-Create a new freight cluster that uses a customer-managed encryption key in AWS:
+Create a new Freight cluster that uses a customer-managed encryption key in AWS:
 
   $ confluent kafka cluster create my-cluster --cloud aws --region us-west-2 --type freight --cku 1 --byok cck-a123z --availability high
 

--- a/test/fixtures/output/kafka/create-availability-autocomplete.golden
+++ b/test/fixtures/output/kafka/create-availability-autocomplete.golden
@@ -1,4 +1,6 @@
 single-zone
 multi-zone
+low
+high
 :4
 Completion ended with directive: ShellCompDirectiveNoFileComp


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- PLACEHOLDER

New Features
- PLACEHOLDER

Bug Fixes
- Fixed "For `confluent kafka cluster create command`, it showed as single-zone/multi-zone availability instead of high/low for Freight clusters"

Checklist
---------
<!-- 
Check each item below to ensure high-quality CLI development practices are followed. PR approval will not be granted until the checklist is fully reviewed.
For detailed instructions, please refer to this Confluence page: https://confluentinc.atlassian.net/wiki/spaces/AEGI/pages/3949592874/
-->
- [x] I have successfully built and used a custom CLI binary, without linter issues from this PR.
- [x] I have clearly specified in the `What` section below whether this PR applies to Confluent Cloud, Confluent Platform, or both. 
- [x] I have verified this PR in Confluent Cloud pre-prod or production environment, if applicable.
- [ ] I have verified this PR in Confluent Platform on-premises environment, if applicable.
- [x] I have attached manual CLI verification results or screenshots in the `Test & Review` section below.
- [x] I have added appropriate CLI integration or unit tests for any new or updated commands and functionality.
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [x] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [ ] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [ ] Confluent Cloud prod
  - [ ] Confluent Cloud stag
  - [ ] Confluent Platform
  - [ ] Check this box if the feature is enabled for certain organizations only

What
----
<!--
Briefly describe **what** you have changed and **why** these changes are necessary.
Optionally include: 
- The problem being solved or the feature being added. 
- The implementation strategy or approach taken. 
- Key technical details, design decisions, or any additional context reviewers should be aware of.
-->
DOCS-28660: Add new availability type attribute value options (LOW/HIGH) for Enterprise clusters
Done
 

The availability attribute of multi-tenant clusters was changed to LOW/HIGH , and earlier it used to be SINGLE_ZONE, & MULTI_ZONE 

Different cluster types have different valid options and even the same cluster type might have different valid options based on when the org was created.

LOW/HIGH options for Standard and Enterprise clusters created after 4/16

LOW option only for Basic clusters created after 4/16

The CLI and Terraform interfaces should support four availability options - LOW, HIGH, SINGLE_ZONE, MULTI_ZONE  and let the backend APIs do the final validation

Blast Radius
----
<!--
The Blast Radius section should include information on what will be the customer(s) impact if something goes wrong or unexpectedly, 
adding this section will trigger the PR author to think about the impact from product perspective, examples can be:
- Confluent Cloud customers who are using confluent kafka topic any subcommand will be blocked.
- Confluent Cloud customers who are using confluent kafka topic list commands will be blocked.
- Confluent Platform customers who are using --schema flag will be impacted.
- All customers who are using SSO to login will be impacted.
-->
There are no breaking changes. Changes are localized to the availability flag of confluent kafka cluster create

References
----------
<!-- Include links to relevant resources for this PR, such as: 
- Related GitHub issues 
- Tickets (JIRA, etc.) 
- Internal documentation or design specs 
- Other related PRs 
Copy and paste the links below for easy reference.
-->
https://confluentinc.atlassian.net/browse/CLI-3152

Test & Review
-------------
<!-- Has this PR been tested? If so, explain **how** it was tested. Include: 
- Steps taken to verify the changes. 
- Links to manual verification documents, logs, or screenshots to save reviewers' time. 
- Any additional notes on testing (e.g., environments used, edge cases tested). 
- Screenshot showing successful resource creation, updates etc.
Example: - [Manual Verification Document](https://docs.google.com/document/d/1GwXz9hNOkub_Br-2nssoYWCf6elZBvwo7TMhCNYinwE/edit?tab=t.0#heading=h.dvbi09ntxjw6)
-->
**High**:
￼
![Screenshot 2025-02-21 at 4 10 09 PM](https://github.com/user-attachments/assets/05ee6772-3eea-4c51-957e-2ca9c5b5e779)

**LOW**:
￼
![Screenshot 2025-02-21 at 4 11 09 PM](https://github.com/user-attachments/assets/b4a66871-ddc7-4131-9e93-1361535ea67b)


**Single-zone:**
￼
![Screenshot 2025-02-21 at 4 11 41 PM](https://github.com/user-attachments/assets/1180be53-1742-4102-810d-fd51f50d5e79)

**Multi-zone**:
￼
![Screenshot 2025-02-21 at 4 12 02 PM](https://github.com/user-attachments/assets/ec514b9c-7cb3-47c9-b684-e58aadcec63d)


**All in UI:**
![Screenshot 2025-02-21 at 4 15 24 PM](https://github.com/user-attachments/assets/f476e517-6522-4451-a335-931cc6b55318)

￼
