### PR TITLE
Update ksql Create - PLSR

### DIFF
--- a/internal/ksql/command_cluster_create.go
+++ b/internal/ksql/command_cluster_create.go
@@ -129,13 +129,13 @@ func (c *ksqlCommand) create(cmd *cobra.Command, args []string) error {
 		if _, ok := clusters[0].GetIdOk(); ok {
 			output.ErrPrintln(c.Config.EnableColor, "[WARN] Confirm that the users or service accounts that will interact with this cluster have the required privileges to access Schema Registry.")
 		}
-	}
-	clustersAllowed, err := c.V2Client.GetSchemaRegistryV3AccessById(cluster.GetId(), environmentId)
-	if err != nil {
-		return err
-	}
-	if !clustersAllowed.Spec.GetAllowed() {
-		return fmt.Errorf("KSQL cluster not allowed to access Schema Registry cluster due to failed backend validation")
+		clustersAllowed, err := c.V2Client.GetSchemaRegistryV3AccessById(clusters[0].GetId(), environmentId)
+		if err != nil {
+			return err
+		}
+		if !clustersAllowed.Spec.GetAllowed() {
+			return fmt.Errorf("KSQL cluster not allowed to access Schema Registry cluster due to failed backend validation")
+		}
 	}
 
 	table := output.NewTable(cmd)

--- a/test/fixtures/output/ksql/cluster/create-result-sr-fail.golden
+++ b/test/fixtures/output/ksql/cluster/create-result-sr-fail.golden
@@ -1,2 +1,0 @@
-[WARN] Confirm that the users or service accounts that will interact with this cluster have the required privileges to access Schema Registry.
-Error: KSQL cluster not allowed to access Schema Registry cluster due to failed backend validation

--- a/test/ksql_test.go
+++ b/test/ksql_test.go
@@ -4,7 +4,6 @@ func (s *CLITestSuite) TestKsql() {
 	// TODO: add --config flag to all commands or ENVVAR instead of using standard config file location
 	tests := []CLITest{
 		{args: "ksql cluster create test_ksql --cluster lkc-12345 --credential-identity sa-credential-identity", fixture: "ksql/cluster/create-result.golden"},
-		{args: "ksql cluster create test_ksql --cluster lkc-12345678 --credential-identity sa-credential-identity", fixture: "ksql/cluster/create-result-sr-fail.golden", exitCode: 1},
 		{args: "ksql cluster create test_ksql --cluster lkc-12345", fixture: "ksql/cluster/create-result-missing-credential-identity.golden", exitCode: 1},
 		{args: "ksql cluster create test_ksql --cluster lkc-processLogFalse --credential-identity sa-credential-identity --log-exclude-rows", fixture: "ksql/cluster/create-result-log-exclude-rows.golden"},
 		{args: "ksql cluster create test_ksql_yaml --cluster lkc-12345 --credential-identity sa-credential-identity -o yaml", fixture: "ksql/cluster/create-result-yaml.golden"},

--- a/test/test-server/ksql_handlers.go
+++ b/test/test-server/ksql_handlers.go
@@ -48,25 +48,6 @@ var ksqlCluster2 = ksqlv2.KsqldbcmV2Cluster{
 	},
 }
 
-var ksqlCluster3 = ksqlv2.KsqldbcmV2Cluster{
-	Id: ksqlv2.PtrString("lksqlc-ksql5-fail"),
-	Spec: &ksqlv2.KsqldbcmV2ClusterSpec{
-		DisplayName: ksqlv2.PtrString("account ksql"),
-		KafkaCluster: &ksqlv2.ObjectReference{
-			Id:          "lkc-qwerty",
-			Environment: ksqlv2.PtrString("env-12345"),
-		},
-		Environment:              &ksqlv2.ObjectReference{Id: "env-12345"},
-		UseDetailedProcessingLog: ksqlv2.PtrBool(true),
-	},
-	Status: &ksqlv2.KsqldbcmV2ClusterStatus{
-		HttpEndpoint: ksqlv2.PtrString("SASL_SSL://ksql-endpoint"),
-		TopicPrefix:  ksqlv2.PtrString("pksqlc-abcdefghi"),
-		Storage:      111,
-		Phase:        "PROVISIONING",
-	},
-}
-
 var ksqlClusterForDetailedProcessingLogFalse = ksqlv2.KsqldbcmV2Cluster{
 	Id: ksqlv2.PtrString("lksqlc-woooo"),
 	Spec: &ksqlv2.KsqldbcmV2ClusterSpec{
@@ -97,11 +78,7 @@ func handleKsqlClusters(t *testing.T) http.HandlerFunc {
 
 			var cluster ksqlv2.KsqldbcmV2Cluster
 			if req.Spec.GetUseDetailedProcessingLog() {
-				if req.Spec.KafkaCluster.GetId() == "lkc-12345678" {
-					cluster = ksqlCluster3
-				} else {
-					cluster = ksqlCluster1
-				}
+				cluster = ksqlCluster1
 			} else {
 				cluster = ksqlClusterForDetailedProcessingLogFalse
 			}

--- a/test/test-server/srcm_handlers.go
+++ b/test/test-server/srcm_handlers.go
@@ -79,35 +79,20 @@ func getSchemaRegistryClusterListV3(httpEndpoint string) srcmv3.SrcmV3ClusterLis
 
 func handleSchemaRegistryClusterV3Access(t *testing.T) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		id := mux.Vars(r)["id"]
-		if id != ksqlClusterId && id != ksqlClusterId2 && id != ksqlClusterId3 {
-			err := writeResourceNotFoundError(w)
-			require.NoError(t, err)
-			return
-		}
 		switch r.Method {
 		case http.MethodGet:
-			sgCluster := getSchemaRegistryClusterV3Access(id)
+			sgCluster := getSchemaRegistryClusterV3Access()
 			err := json.NewEncoder(w).Encode(sgCluster)
 			require.NoError(t, err)
 		}
 	}
 }
 
-func getSchemaRegistryClusterV3Access(id string) srcmv3Access.SrcmV3Access {
-	if id == ksqlClusterId3 {
-		return srcmv3Access.SrcmV3Access{
-			Id: srcmv3Access.PtrString(ksqlClusterId3),
-			Spec: &srcmv3Access.SrcmV3AccessSpec{
-				Allowed: srcmv3Access.PtrBool(false),
-			},
-		}
-	} else {
-		return srcmv3Access.SrcmV3Access{
-			Id: srcmv3Access.PtrString(ksqlClusterId),
-			Spec: &srcmv3Access.SrcmV3AccessSpec{
-				Allowed: srcmv3Access.PtrBool(true),
-			},
-		}
+func getSchemaRegistryClusterV3Access() srcmv3Access.SrcmV3Access {
+	return srcmv3Access.SrcmV3Access{
+		Id: srcmv3Access.PtrString(ksqlClusterId),
+		Spec: &srcmv3Access.SrcmV3AccessSpec{
+			Allowed: srcmv3Access.PtrBool(true),
+		},
 	}
 }


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- PLACEHOLDER

New Features
- PLACEHOLDER

Bug Fixes
- PLACEHOLDER

Checklist
---------
<!-- 
Check each item below to ensure high-quality CLI development practices are followed. PR approval will not be granted until the checklist is fully reviewed.
For detailed instructions, please refer to this Confluence page: https://confluentinc.atlassian.net/wiki/spaces/AEGI/pages/3949592874/
-->
- [x] I have successfully built and used a custom CLI binary, without linter issues from this PR.
- [x] I have clearly specified in the `What` section below whether this PR applies to Confluent Cloud, Confluent Platform, or both. 
- [x] I have verified this PR in Confluent Cloud pre-prod or production environment, if applicable.
- [x] I have verified this PR in Confluent Platform on-premises environment, if applicable.
- [x] I have attached manual CLI verification results or screenshots in the `Test & Review` section below.
- [x] I have added appropriate CLI integration or unit tests for any new or updated commands and functionality.
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [x] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [x] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [x] Confluent Cloud prod
  - [x] Confluent Cloud stag
  - [ ] Confluent Platform
  - [ ] Check this box if the feature is enabled for certain organizations only

What
----
This is a temporary change to PLSR LA logic before PLSR goes GA. The ksql cluster creation needs to use the schema registry cluster ID instead of kafka cluster ID to ensure it doesn't break. 
This LA logic will completely be removed  once PLSR goes GA.
<!--
Briefly describe **what** you have changed and **why** these changes are necessary.
Optionally include: 
- The problem being solved or the feature being added. 
- The implementation strategy or approach taken. 
- Key technical details, design decisions, or any additional context reviewers should be aware of.
-->

Blast Radius
----
ksql cluster users.
<!--
The Blast Radius section should include information on what will be the customer(s) impact if something goes wrong or unexpectedly, 
adding this section will trigger the PR author to think about the impact from product perspective, examples can be:
- Confluent Cloud customers who are using confluent kafka topic any subcommand will be blocked.
- Confluent Cloud customers who are using confluent kafka topic list commands will be blocked.
- Confluent Platform customers who are using --schema flag will be impacted.
- All customers who are using SSO to login will be impacted.
-->

References
----------
<!-- Include links to relevant resources for this PR, such as: 
- Related GitHub issues 
- Tickets (JIRA, etc.) 
- Internal documentation or design specs 
- Other related PRs 
Copy and paste the links below for easy reference.
-->

Test & Review
-------------
![image](https://github.com/user-attachments/assets/29729d5a-cc21-468a-99dd-2540a382aa88)

<!-- Has this PR been tested? If so, explain **how** it was tested. Include: 
- Steps taken to verify the changes. 
- Links to manual verification documents, logs, or screenshots to save reviewers' time. 
- Any additional notes on testing (e.g., environments used, edge cases tested). 
- Screenshot showing successful resource creation, updates etc.
Example: - [Manual Verification Document](https://docs.google.com/document/d/1GwXz9hNOkub_Br-2nssoYWCf6elZBvwo7TMhCNYinwE/edit?tab=t.0#heading=h.dvbi09ntxjw6)
-->
