### PR TITLE
HUB-374: Adding deprecation warning message when user installs a deprecated connector version

### DIFF
--- a/internal/connect/command_plugin_install.go
+++ b/internal/connect/command_plugin_install.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/spf13/cobra"
@@ -30,6 +31,7 @@ const (
 	invalidDirectoryErrorMsg       = `plugin directory "%s" does not exist`
 	unexpectedInstallationErrorMsg = "unexpected installation type: %s"
 	workerProcessRegexStr          = `org\.apache\.kafka\.connect\.cli\.Connect(Distributed|Standalone)`
+	deprecatedPluginWarningMsg     = `[WARN] This version of the connector is nearing its end of life and will not be downloadable from %s. Please upgrade to the minimum connector version supported for continued support. Refer https://docs.confluent.io/platform/current/connect/supported-connector-versions-7.8.html#minimum-connector-version-7-8`
 )
 
 type pluginInstallCommand struct {
@@ -95,6 +97,14 @@ func (c *pluginInstallCommand) install(cmd *cobra.Command, args []string) error 
 	pluginManifest, err := getManifest(client, args[0])
 	if err != nil {
 		return err
+	}
+
+	deprecationMsg, err := checkPluginVersionDeprecation(pluginManifest)
+	if err != nil {
+		return err
+	}
+	if deprecationMsg != "" {
+		output.ErrPrintln(c.Config.EnableColor, deprecationMsg)
 	}
 
 	pluginDir, err := getPluginDirFromFlag(cmd)
@@ -478,4 +488,18 @@ func (c *pluginInstallCommand) GetHubClient() (*hub.Client, error) {
 	}
 
 	return hub.NewClient(c.Config.Version.UserAgent, c.Config.IsTest, unsafeTrace), nil
+}
+
+// checkPluginVersionDeprecation checks if the plugin version is nearing its end of life
+// and returns a warning message if it is.
+func checkPluginVersionDeprecation(pluginManifest *cpstructs.Manifest) (string, error) {
+	if pluginManifest.EndOfLifeAt != "" {
+		endOfLifeTimestamp, err := time.Parse(time.RFC3339, pluginManifest.EndOfLifeAt)
+		if err != nil {
+			return "", fmt.Errorf("failed to parse end of life timestamp: %w", err)
+		}
+		return fmt.Sprintf(deprecatedPluginWarningMsg,
+			endOfLifeTimestamp.Format("January 2, 2006")), nil
+	}
+	return "", nil
 }

--- a/internal/connect/command_plugin_install.go
+++ b/internal/connect/command_plugin_install.go
@@ -31,7 +31,7 @@ const (
 	invalidDirectoryErrorMsg       = `plugin directory "%s" does not exist`
 	unexpectedInstallationErrorMsg = "unexpected installation type: %s"
 	workerProcessRegexStr          = `org\.apache\.kafka\.connect\.cli\.Connect(Distributed|Standalone)`
-	deprecatedPluginWarningMsg     = `[WARN] This version of the connector is nearing its end of life and will not be downloadable from %s. Please upgrade to the minimum connector version supported for continued support. Refer https://docs.confluent.io/platform/current/connect/supported-connector-versions-7.8.html#minimum-connector-version-7-8`
+	deprecatedPluginWarningMsg     = `[WARN] This version of the connector is nearing its end of life and will not be downloadable from %s. Please upgrade to the minimum connector version supported for continued support. Refer to https://docs.confluent.io/platform/current/connect/supported-connector-versions-7.8.html#minimum-connector-version-7-8`
 )
 
 type pluginInstallCommand struct {

--- a/pkg/cpstructs/hub_structs.go
+++ b/pkg/cpstructs/hub_structs.go
@@ -1,12 +1,13 @@
 package cpstructs
 
 type Manifest struct {
-	Name     string    `json:"name"`
-	Title    string    `json:"title"`
-	Version  string    `json:"version"`
-	Owner    Owner     `json:"owner"`
-	Archive  Archive   `json:"archive"`
-	Licenses []License `json:"license"`
+	Name        string    `json:"name"`
+	Title       string    `json:"title"`
+	Version     string    `json:"version"`
+	Owner       Owner     `json:"owner"`
+	Archive     Archive   `json:"archive"`
+	Licenses    []License `json:"license"`
+	EndOfLifeAt string    `json:"end_of_life_at"`
 }
 
 type Owner struct {

--- a/test/connect_test.go
+++ b/test/connect_test.go
@@ -129,6 +129,7 @@ func (s *CLITestSuite) TestConnectPluginInstall() {
 
 		{args: "connect plugin install confluentinc/integration-test-plugin:latest --dry-run", env: []string{"CONFLUENT_HOME=" + confluentHome733}, input: "y\ny\ny\n", fixture: "connect/plugin/install/remote.golden"},
 		{args: "connect plugin install confluentinc/integration-test-plugin:0.0.5 --dry-run", env: []string{"CONFLUENT_HOME=" + confluentHome733}, input: "y\ny\ny\n", fixture: "connect/plugin/install/remote-specific-version.golden"},
+		{args: "connect plugin install confluentinc/integration-test-plugin:0.0.4 --dry-run", env: []string{"CONFLUENT_HOME=" + confluentHome733}, input: "y\ny\ny\n", fixture: "connect/plugin/install/remote-specific-version-deprecated.golden"},
 		{args: "connect plugin install confluentinc/dne-connector:latest --dry-run", env: []string{"CONFLUENT_HOME=" + confluentHome733}, fixture: "connect/plugin/install/remote-dne.golden", exitCode: 1},
 		{args: "connect plugin install confluentinc/bad-md5:latest", env: []string{"CONFLUENT_HOME=" + confluentHome733}, input: "y\ny\n", fixture: "connect/plugin/install/remote-bad-md5.golden", exitCode: 1},
 		{args: "connect plugin install confluentinc/bad-sha1:latest", env: []string{"CONFLUENT_HOME=" + confluentHome733}, input: "y\ny\n", fixture: "connect/plugin/install/remote-bad-sha1.golden", exitCode: 1},

--- a/test/fixtures/output/connect/plugin/install/remote-specific-version-deprecated.golden
+++ b/test/fixtures/output/connect/plugin/install/remote-specific-version-deprecated.golden
@@ -1,4 +1,4 @@
-[WARN] This version of the connector is nearing its end of life and will not be downloadable from June 1, 2025. Please upgrade to the minimum connector version supported for continued support. Refer https://docs.confluent.io/platform/current/connect/supported-connector-versions-7.8.html#minimum-connector-version-7-8
+[WARN] This version of the connector is nearing its end of life and will not be downloadable from June 1, 2025. Please upgrade to the minimum connector version supported for continued support. Refer to https://docs.confluent.io/platform/current/connect/supported-connector-versions-7.8.html#minimum-connector-version-7-8
 Using the only available Confluent Platform installation at "test/fixtures/input/connect/confluent-7.3.3".
 Do you want to install this plugin into "test/fixtures/input/connect/confluent-7.3.3/share/confluent-hub-components"? (y/n): 
 License: Apache License 2.0 (https://www.apache.org/licenses/LICENSE-2.0)

--- a/test/fixtures/output/connect/plugin/install/remote-specific-version-deprecated.golden
+++ b/test/fixtures/output/connect/plugin/install/remote-specific-version-deprecated.golden
@@ -1,0 +1,17 @@
+[WARN] This version of the connector is nearing its end of life and will not be downloadable from June 1, 2025. Please upgrade to the minimum connector version supported for continued support. Refer https://docs.confluent.io/platform/current/connect/supported-connector-versions-7.8.html#minimum-connector-version-7-8
+Using the only available Confluent Platform installation at "test/fixtures/input/connect/confluent-7.3.3".
+Do you want to install this plugin into "test/fixtures/input/connect/confluent-7.3.3/share/confluent-hub-components"? (y/n): 
+License: Apache License 2.0 (https://www.apache.org/licenses/LICENSE-2.0)
+I agree to this software license agreement. (y/n): 
+[DRY RUN] Installing Integration Test Plugin 0.0.4, provided by Confluent, Inc.
+
+Detected the following worker configuration files:
+    |                                         Path                                         | Description  
+----+--------------------------------------------------------------------------------------+--------------
+  1 | test/fixtures/input/connect/confluent-7.3.3/etc/kafka/connect-distributed.properties | Standard     
+  2 | test/fixtures/input/connect/confluent-7.3.3/etc/kafka/connect-standalone.properties  | Standard     
+Do you want to update all detected config files? (y/n): [DRY RUN] Adding plugin installation directory to the plugin path in the following files:
+	* test/fixtures/input/connect/confluent-7.3.3/etc/kafka/connect-distributed.properties
+	* test/fixtures/input/connect/confluent-7.3.3/etc/kafka/connect-standalone.properties
+
+[DRY RUN] Installed Integration Test Plugin 0.0.4.


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

New Features
- Confluent Platform: Adds a new WARN message when installing a self-managed connector version that has been deprecated and marked for End-of-Life by Confluent. This message will be shown when `confluent connect plugin install` command is run for a deprecated plugin. The WARN message, however, will have no impact on the plugin installation. 

Checklist
---------
<!-- 
Check each item below to ensure high-quality CLI development practices are followed. PR approval will not be granted until the checklist is fully reviewed.
For detailed instructions, please refer to this Confluence page: https://confluentinc.atlassian.net/wiki/spaces/AEGI/pages/3949592874/
-->
- [x] I have successfully built and used a custom CLI binary, without linter issues from this PR.
- [x] I have clearly specified in the `What` section below whether this PR applies to Confluent Cloud, Confluent Platform, or both. 
- [ ] I have verified this PR in Confluent Cloud pre-prod or production environment, if applicable.
- [x] I have verified this PR in Confluent Platform on-premises environment, if applicable.
- [x] I have attached manual CLI verification results or screenshots in the `Test & Review` section below.
- [x] I have added appropriate CLI integration or unit tests for any new or updated commands and functionality.
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [x] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [ ] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [ ] Confluent Cloud prod
  - [ ] Confluent Cloud stag
  - [x] Confluent Platform
  - [ ] Check this box if the feature is enabled for certain organizations only

What
----
<!--
Briefly describe **what** you have changed and **why** these changes are necessary.
Optionally include: 
- The problem being solved or the feature being added. 
- The implementation strategy or approach taken. 
- Key technical details, design decisions, or any additional context reviewers should be aware of.
-->
- This PR applies to Confluent Platform.
- As part of Connector Lifecycle Policy, we want to warn users if they are installing a connector version that has been deprecated and is marked for End of Life. See the requirements here - https://confluentinc.atlassian.net/browse/INIT-8736
- Implementation wise, we've updated the Hub REST API to expose deprecation information field `end_of_life_at` (and others) which can be used by clients to determine if a given plugin version has been deprecated or not.
- The CLI code has been updated to make use of `end_of_life_at` field and show a warning message to users who are installing a version which is nearing EOL.
- What happens when EOL date is reached? The given plugin version will be removed from the Hub API itself, along with its archive download links.
- Why are we using a hard-coded reference doc link for CP 7.8 supported connector versions? In its current state, the Hub API has no knowledge of CP version being used by the customer and neither does the CLI. In near future with Hub revamp, we intend to add this knowledge in Hub so that it can be used by clients to make _CP aware_ decisions about deprecation. In short, the current implementation is mainly being done for CP 7.8 and will be generalized with advances in Hub planned for later this year.

Blast Radius
----
<!--
The Blast Radius section should include information on what will be the customer(s) impact if something goes wrong or unexpectedly, 
adding this section will trigger the PR author to think about the impact from product perspective, examples can be:
- Confluent Cloud customers who are using confluent kafka topic any subcommand will be blocked.
- Confluent Cloud customers who are using confluent kafka topic list commands will be blocked.
- Confluent Platform customers who are using --schema flag will be impacted.
- All customers who are using SSO to login will be impacted.
-->
- Blast radius is very minimal but it will be limited to Confluent Platform customers since we're slightly modifying the plugin installation command used for self-managed connector versions.

References
----------
<!-- Include links to relevant resources for this PR, such as: 
- Related GitHub issues 
- Tickets (JIRA, etc.) 
- Internal documentation or design specs 
- Other related PRs 
Copy and paste the links below for easy reference.
-->
- Product Jira - https://confluentinc.atlassian.net/browse/INIT-8736
- Connector Lifecycle Policy - https://confluentinc.atlassian.net/wiki/x/fwb4uQ
- Wiki for changes in Hub API - https://confluentinc.atlassian.net/wiki/x/7QSC_g
- CLI changes Jira - https://confluentinc.atlassian.net/browse/HUB-374

Test & Review
-------------
<!-- Has this PR been tested? If so, explain **how** it was tested. Include: 
- Steps taken to verify the changes. 
- Links to manual verification documents, logs, or screenshots to save reviewers' time. 
- Any additional notes on testing (e.g., environments used, edge cases tested). 
- Screenshot showing successful resource creation, updates etc.
Example: - [Manual Verification Document](https://docs.google.com/document/d/1GwXz9hNOkub_Br-2nssoYWCf6elZBvwo7TMhCNYinwE/edit?tab=t.0#heading=h.dvbi09ntxjw6)
-->
1. Unit tests and integration tests
2. Manual test by building CLI locally and pointing to non-prod Hub API (see screenshot with WARN message)
![image](https://github.com/user-attachments/assets/deeac411-5478-4d9d-87cf-a21faf4494a8)

