### PR TITLE
INC-779, CLI-3413: Support `--unsafe-trace` for ccloud-sdk-go-v1-public

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/charmbracelet/glamour v0.7.0
 	github.com/charmbracelet/lipgloss v0.11.0
 	github.com/client9/gospell v0.0.0-20160306015952-90dfc71015df
-	github.com/confluentinc/ccloud-sdk-go-v1-public v0.0.0-20250205171805-d4709871c4f3
+	github.com/confluentinc/ccloud-sdk-go-v1-public v0.0.0-20250314234740-d0fe604c2715
 	github.com/confluentinc/ccloud-sdk-go-v2/ai v0.1.0
 	github.com/confluentinc/ccloud-sdk-go-v2/apikeys v0.4.0
 	github.com/confluentinc/ccloud-sdk-go-v2/billing v0.3.0
@@ -233,7 +233,6 @@ require (
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.0 // indirect
 	github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 // indirect
 	github.com/shopspring/decimal v1.3.1 // indirect
-	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/skeema/knownhosts v1.3.0 // indirect
 	github.com/spf13/afero v1.10.0 // indirect
 	github.com/stoewer/go-strcase v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -186,8 +186,6 @@ github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnht
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/compose-spec/compose-go/v2 v2.1.3 h1:bD67uqLuL/XgkAK6ir3xZvNLFPxPScEi1KW7R5esrLE=
 github.com/compose-spec/compose-go/v2 v2.1.3/go.mod h1:lFN0DrMxIncJGYAXTfWuajfwj5haBJqrBkarHcnjJKc=
-github.com/confluentinc/ccloud-sdk-go-v1-public v0.0.0-20250314232412-8bcc7fe1c6a3 h1:VG48xuWZ+W2x15JZ2S3+B0C3Eu8cRsWEHKUMLy7hfUE=
-github.com/confluentinc/ccloud-sdk-go-v1-public v0.0.0-20250314232412-8bcc7fe1c6a3/go.mod h1:lhebz5+uvzoEFI6lMbEyC7ieMggCxG3HT1gyuJ1yCkc=
 github.com/confluentinc/ccloud-sdk-go-v1-public v0.0.0-20250314234740-d0fe604c2715 h1:/3zsTtTBL/lYYw5fTk27HGRu4miQRNHivxVmNLWSwZc=
 github.com/confluentinc/ccloud-sdk-go-v1-public v0.0.0-20250314234740-d0fe604c2715/go.mod h1:62EMf+5uFEt1BJ2q8WMrUoI9VUSxAbDnmZCGRt/MbA0=
 github.com/confluentinc/ccloud-sdk-go-v2/ai v0.1.0 h1:zSF4OQUJXWH2JeAo9rsq13ibk+JFdzITGR8S7cFMpzw=

--- a/go.sum
+++ b/go.sum
@@ -186,8 +186,10 @@ github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnht
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/compose-spec/compose-go/v2 v2.1.3 h1:bD67uqLuL/XgkAK6ir3xZvNLFPxPScEi1KW7R5esrLE=
 github.com/compose-spec/compose-go/v2 v2.1.3/go.mod h1:lFN0DrMxIncJGYAXTfWuajfwj5haBJqrBkarHcnjJKc=
-github.com/confluentinc/ccloud-sdk-go-v1-public v0.0.0-20250205171805-d4709871c4f3 h1:kAIl8jZxqfa1BQgVG3fjJdnkMtDebf6rIOAo2mnnCLg=
-github.com/confluentinc/ccloud-sdk-go-v1-public v0.0.0-20250205171805-d4709871c4f3/go.mod h1:lhebz5+uvzoEFI6lMbEyC7ieMggCxG3HT1gyuJ1yCkc=
+github.com/confluentinc/ccloud-sdk-go-v1-public v0.0.0-20250314232412-8bcc7fe1c6a3 h1:VG48xuWZ+W2x15JZ2S3+B0C3Eu8cRsWEHKUMLy7hfUE=
+github.com/confluentinc/ccloud-sdk-go-v1-public v0.0.0-20250314232412-8bcc7fe1c6a3/go.mod h1:lhebz5+uvzoEFI6lMbEyC7ieMggCxG3HT1gyuJ1yCkc=
+github.com/confluentinc/ccloud-sdk-go-v1-public v0.0.0-20250314234740-d0fe604c2715 h1:/3zsTtTBL/lYYw5fTk27HGRu4miQRNHivxVmNLWSwZc=
+github.com/confluentinc/ccloud-sdk-go-v1-public v0.0.0-20250314234740-d0fe604c2715/go.mod h1:62EMf+5uFEt1BJ2q8WMrUoI9VUSxAbDnmZCGRt/MbA0=
 github.com/confluentinc/ccloud-sdk-go-v2/ai v0.1.0 h1:zSF4OQUJXWH2JeAo9rsq13ibk+JFdzITGR8S7cFMpzw=
 github.com/confluentinc/ccloud-sdk-go-v2/ai v0.1.0/go.mod h1:DoxqzzF3JzvJr3fWkvCiOHFlE0GoYpozWxFZ1Ud9ntA=
 github.com/confluentinc/ccloud-sdk-go-v2/apikeys v0.4.0 h1:8fWyLwMuy8ec0MVF5Avd54UvbIxhDFhZzanHBVwgxdw=

--- a/internal/kafka/confluent_kafka_configs.go
+++ b/internal/kafka/confluent_kafka_configs.go
@@ -337,7 +337,7 @@ func SetProducerDebugOption(configMap *ckgo.ConfigMap) error {
 	switch log.CliLogger.Level {
 	case log.DEBUG:
 		return configMap.Set("debug=broker, topic, msg, protocol")
-	case log.TRACE:
+	case log.TRACE, log.UNSAFE_TRACE:
 		return configMap.Set("debug=all")
 	}
 	return nil
@@ -347,7 +347,7 @@ func SetConsumerDebugOption(configMap *ckgo.ConfigMap) error {
 	switch log.CliLogger.Level {
 	case log.DEBUG:
 		return configMap.Set("debug=broker, topic, msg, protocol, consumer, cgrp, fetch")
-	case log.TRACE:
+	case log.TRACE, log.UNSAFE_TRACE:
 		return configMap.Set("debug=all")
 	}
 	return nil

--- a/pkg/cmd/prerunner.go
+++ b/pkg/cmd/prerunner.go
@@ -88,17 +88,21 @@ func (r *PreRun) Anonymous(command *CLICommand, willAuthenticate bool) func(*cob
 			featureflags.PrintAnnouncements(r.Config, featureflags.DeprecationNotices, cmd)
 		}
 
+		// 1-4
 		verbosity, err := cmd.Flags().GetCount("verbose")
 		if err != nil {
 			return err
 		}
+
+		// 5
 		unsafeTrace, err := cmd.Flags().GetBool("unsafe-trace")
 		if err != nil {
 			return err
 		}
 		if unsafeTrace {
-			verbosity = int(log.TRACE)
+			verbosity = int(log.UNSAFE_TRACE)
 		}
+
 		log.CliLogger.SetVerbosity(verbosity)
 		log.CliLogger.Flush()
 


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- PLACEHOLDER

New Features
- PLACEHOLDER

Bug Fixes
- Require `--unsafe-trace` to print the HTTP request and response on `confluent login`

Checklist
---------
<!-- 
Check each item below to ensure high-quality CLI development practices are followed. PR approval will not be granted until the checklist is fully reviewed.
For detailed instructions, please refer to this Confluence page: https://confluentinc.atlassian.net/wiki/spaces/AEGI/pages/3949592874/
-->
- [x] I have successfully built and used a custom CLI binary, without linter issues from this PR.
- [x] I have clearly specified in the `What` section below whether this PR applies to Confluent Cloud, Confluent Platform, or both. 
- [x] I have verified this PR in Confluent Cloud pre-prod or production environment, if applicable.
- [x] I have verified this PR in Confluent Platform on-premises environment, if applicable.
- [x] I have attached manual CLI verification results or screenshots in the `Test & Review` section below.
- [ ] I have added appropriate CLI integration or unit tests for any new or updated commands and functionality.
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [x] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [ ] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [ ] Confluent Cloud prod
  - [ ] Confluent Cloud stag
  - [ ] Confluent Platform
  - [ ] Check this box if the feature is enabled for certain organizations only

What
----
Confluent Cloud: `--unsafe-trace` is used to hide HTTP request/response information across the CLI, but was not implemented for `confluent login`, specifically confluentinc/ccloud-sdk-go-v1-public. Add a new logging level to the interface.

Blast Radius
----
<!--
The Blast Radius section should include information on what will be the customer(s) impact if something goes wrong or unexpectedly, 
adding this section will trigger the PR author to think about the impact from product perspective, examples can be:
- Confluent Cloud customers who are using confluent kafka topic any subcommand will be blocked.
- Confluent Cloud customers who are using confluent kafka topic list commands will be blocked.
- Confluent Platform customers who are using --schema flag will be impacted.
- All customers who are using SSO to login will be impacted.
-->
Only output with `-v` or `--unsafe-trace` is affected, which we do not provide any customer guarantees on and should only impact debugging workflows to become more secure.

References
----------
<!-- Include links to relevant resources for this PR, such as: 
- Related GitHub issues 
- Tickets (JIRA, etc.) 
- Internal documentation or design specs 
- Other related PRs 
Copy and paste the links below for easy reference.
-->

Test & Review
-------------
<!-- Has this PR been tested? If so, explain **how** it was tested. Include: 
- Steps taken to verify the changes. 
- Links to manual verification documents, logs, or screenshots to save reviewers' time. 
- Any additional notes on testing (e.g., environments used, edge cases tested). 
- Screenshot showing successful resource creation, updates etc.
Example: - [Manual Verification Document](https://docs.google.com/document/d/1GwXz9hNOkub_Br-2nssoYWCf6elZBvwo7TMhCNYinwE/edit?tab=t.0#heading=h.dvbi09ntxjw6)
-->

Manual verification:
```
% confluent login -vvvv
2025-03-14T17:00:36.562-0700 [TRACE] GET https://packages.confluent.io/confluent-cli/binaries/
2025-03-14T17:00:36.852-0700 [TRACE] h.client.BaseURL: https://confluent.cloud
2025-03-14T17:00:36.852-0700 [TRACE] auth0ClientId: oX2nvSKl5jvBKVgwehZfvR4K8RhsZIEs
2025-03-14T17:00:36.852-0700 [TRACE] h.client.BaseURL: https://confluent.cloud
2025-03-14T17:00:36.853-0700 [TRACE] auth0ClientId: oX2nvSKl5jvBKVgwehZfvR4K8RhsZIEs
2025-03-14T17:00:36.853-0700 [DEBUG] Did not find full credential set from environment variables
Enter your Confluent Cloud credentials:
Email: bstrauch@confluent.io
2025-03-14T17:00:40.440-0700 [TRACE] h.client.BaseURL: https://confluent.cloud
2025-03-14T17:00:40.440-0700 [TRACE] auth0ClientId: oX2nvSKl5jvBKVgwehZfvR4K8RhsZIEs
2025-03-14T17:00:40.876-0700 [TRACE] h.client.BaseURL: https://confluent.cloud
2025-03-14T17:00:40.877-0700 [TRACE] auth0ClientId: oX2nvSKl5jvBKVgwehZfvR4K8RhsZIEs
Password: ****
2025-03-14T17:00:42.154-0700 [DEBUG] Making login request for bstrauch@confluent.io for org id 
Error: incorrect email, password, or organization ID

Suggestions:
    To log into an organization other than the default organization, use the `--organization` flag.
    To skip auto-login and force a username and password prompt, use the `--prompt` flag.
    To avoid session timeouts, non-SSO users can save their credentials with `confluent login --save`.
```

```
% confluent login --unsafe-trace
2025-03-14T17:01:06.759-0700 [DEBUG] Did not find full credential set from environment variables
Enter your Confluent Cloud credentials:
Email: bstrauch@confluent.io
2025-03-14T17:01:10.570-0700 [TRACE] UserService.LoginRealm request: GET https://confluent.cloud/api/login/realm?XXX_sizecache=0&client_id=oX2nvSKl5jvBKVgwehZfvR4K8RhsZIEs&email=bstrauch%40confluent.io
2025-03-14T17:01:10.983-0700 [TRACE] UserService.LoginRealm response: 200 OK X-Request-Id:c0f6a3bf7be3fcab2298a1a94dc56673 Body: {"realm":"ccloud-local","is_sso":false,"error":null,"mfa_required":false}
2025-03-14T17:01:10.983-0700 [TRACE] UserService.LoginRealm request: GET https://confluent.cloud/api/login/realm?XXX_sizecache=0&client_id=oX2nvSKl5jvBKVgwehZfvR4K8RhsZIEs&email=bstrauch%40confluent.io
2025-03-14T17:01:11.373-0700 [TRACE] UserService.LoginRealm response: 200 OK X-Request-Id:14333156e1ac9def6994e491797e518a Body: {"realm":"ccloud-local","is_sso":false,"error":null,"mfa_required":false}
Password: ****
2025-03-14T17:01:12.889-0700 [DEBUG] Making login request for bstrauch@confluent.io for org id 
2025-03-14T17:01:12.890-0700 [TRACE] AuthService.login request: POST https://confluent.cloud/api/sessions Body:{"email":"bstrauch@confluent.io","password":"test"}
2025-03-14T17:01:13.186-0700 [TRACE] AuthService.login response: 401 Unauthorized X-Request-Id:90b24f97634b5a61b27afd605ea9ef0b Body: {"error":{"code":401,"message":"Invalid username or password."}}

Error: incorrect email, password, or organization ID

Suggestions:
    To log into an organization other than the default organization, use the `--organization` flag.
    To skip auto-login and force a username and password prompt, use the `--prompt` flag.
    To avoid session timeouts, non-SSO users can save their credentials with `confluent login --save`.
```