### PR TITLE
[CLI-3499] Add pagination for compute pools

### DIFF
--- a/pkg/ccloudv2/flink.go
+++ b/pkg/ccloudv2/flink.go
@@ -7,7 +7,6 @@ import (
 	flinkv2 "github.com/confluentinc/ccloud-sdk-go-v2/flink/v2"
 
 	"github.com/confluentinc/cli/v4/pkg/errors"
-	"github.com/confluentinc/cli/v4/pkg/resource"
 )
 
 func newFlinkClient(httpClient *http.Client, url, userAgent string, unsafeTrace bool) *flinkv2.APIClient {
@@ -40,21 +39,67 @@ func (c *Client) DescribeFlinkComputePool(id, environment string) (flinkv2.FcpmV
 }
 
 func (c *Client) ListFlinkComputePools(environment, specRegion string) ([]flinkv2.FcpmV2ComputePool, error) {
+	var list []flinkv2.FcpmV2ComputePool
+
+	done := false
+	pageToken := ""
+	for !done {
+		page, httpResp, err := c.executeListFlinkComputePools(environment, specRegion, pageToken)
+		if err != nil {
+			return nil, errors.CatchCCloudV2Error(err, httpResp)
+		}
+		list = append(list, page.GetData()...)
+
+		pageToken, done, err = extractNextPageToken(page.GetMetadata().Next)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return list, nil
+}
+
+func (c *Client) executeListFlinkComputePools(environment, specRegion, pageToken string) (flinkv2.FcpmV2ComputePoolList, *http.Response, error) {
 	req := c.FlinkClient.ComputePoolsFcpmV2Api.ListFcpmV2ComputePools(c.flinkApiContext()).Environment(environment).PageSize(ccloudV2ListPageSize)
 	if specRegion != "" {
 		req = req.SpecRegion(specRegion)
 	}
-	res, httpResp, err := req.Execute()
-	return res.GetData(), errors.CatchCCloudV2ResourceNotFoundError(err, resource.Environment, httpResp)
+	if pageToken != "" {
+		req = req.PageToken(pageToken)
+	}
+	return req.Execute()
 }
 
 func (c *Client) ListFlinkRegions(cloud string) ([]flinkv2.FcpmV2Region, error) {
+	var list []flinkv2.FcpmV2Region
+
+	done := false
+	pageToken := ""
+	for !done {
+		page, httpResp, err := c.executeListFlinkRegions(cloud, pageToken)
+		if err != nil {
+			return nil, errors.CatchCCloudV2Error(err, httpResp)
+		}
+		list = append(list, page.GetData()...)
+
+		pageToken, done, err = extractNextPageToken(page.GetMetadata().Next)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return list, nil
+}
+
+func (c *Client) executeListFlinkRegions(cloud, pageToken string) (flinkv2.FcpmV2RegionList, *http.Response, error) {
 	req := c.FlinkClient.RegionsFcpmV2Api.ListFcpmV2Regions(c.flinkApiContext()).PageSize(ccloudV2ListPageSize)
 	if cloud != "" {
 		req = req.Cloud(cloud)
 	}
-	res, httpResp, err := req.Execute()
-	return res.GetData(), errors.CatchCCloudV2Error(err, httpResp)
+	if pageToken != "" {
+		req = req.PageToken(pageToken)
+	}
+	return req.Execute()
 }
 
 func (c *Client) UpdateFlinkComputePool(id string, update flinkv2.FcpmV2ComputePoolUpdate) (flinkv2.FcpmV2ComputePool, error) {


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- PLACEHOLDER

New Features
- PLACEHOLDER

Bug Fixes
- Fix an issue causing `confluent flink compute-pool list` to sometimes not display all compute pools

Checklist
---------
<!-- 
Check each item below to ensure high-quality CLI development practices are followed. PR approval will not be granted until the checklist is fully reviewed.
For detailed instructions, please refer to this Confluence page: https://confluentinc.atlassian.net/wiki/spaces/AEGI/pages/3949592874/
-->
- [x] I have successfully built and used a custom CLI binary, without linter issues from this PR.
- [x] I have clearly specified in the `What` section below whether this PR applies to Confluent Cloud, Confluent Platform, or both. 
- [x] I have verified this PR in Confluent Cloud pre-prod or production environment, if applicable.
- [ ] I have verified this PR in Confluent Platform on-premises environment, if applicable.
- [x] I have attached manual CLI verification results or screenshots in the `Test & Review` section below.
- [ ] I have added appropriate CLI integration or unit tests for any new or updated commands and functionality.
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [x] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [x] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [x] Confluent Cloud prod
  - [x] Confluent Cloud stag
  - [ ] Confluent Platform
  - [ ] Check this box if the feature is enabled for certain organizations only

What
----
Add missing pagination support for flink compute pools.

Blast Radius
----
The `confluent flink compute-pool list` and `confluent flink region list` commands would be impacted.

References
----------
<!-- Include links to relevant resources for this PR, such as: 
- Related GitHub issues 
- Tickets (JIRA, etc.) 
- Internal documentation or design specs 
- Other related PRs 
Copy and paste the links below for easy reference.
-->

Test & Review
-------------
Listing compute pools with a page size of 2 (I modified the hardcoded value from 100 to 2 for this test):
```
confluent flink compute-pool list               
  Current |     ID      |       Name        | Environment | Current CFU | Max CFU | Cloud |  Region   |   Status     
----------+-------------+-------------------+-------------+-------------+---------+-------+-----------+--------------
          | lfcp-1m1v2v | my-compute-pool-2 | env-ozkw8y  |           0 |       5 | AWS   | us-west-2 | PROVISIONED  
          | lfcp-g7zvqm | my-compute-pool-5 | env-ozkw8y  |           0 |       5 | AWS   | us-west-2 | PROVISIONED  
          | lfcp-n978vd | my-compute-pool-1 | env-ozkw8y  |           0 |       5 | AWS   | us-west-2 | PROVISIONED  
          | lfcp-ojom3o | my-compute-pool-3 | env-ozkw8y  |           0 |       5 | AWS   | us-west-2 | PROVISIONED  
          | lfcp-p3qzgy | my-compute-pool-6 | env-ozkw8y  |           0 |       5 | AWS   | us-east-1 | PROVISIONED  
          | lfcp-qng32m | my-compute-pool-4 | env-ozkw8y  |           0 |       5 | AWS   | us-west-2 | PROVISIONED  
```

Here's parts of the unsafe-trace log showing the calls to get the next pages. I've removed the `data` blocks to hide the organization id (which is in the resource names) and to make it more readable:
```
confluent flink compute-pool list --unsafe-trace
2025/03/25 14:38:06 
GET /fcpm/v2/compute-pools?environment=env-ozkw8y&page_size=2 HTTP/1.1
Host: api.confluent.cloud
User-Agent: Confluent-CLI/v4.20.0-SNAPSHOT-379a8575 (https://confluent.io; support@confluent.io)
Accept: application/json
Authorization: Bearer <redacted>
Accept-Encoding: gzip


2025-03-25T14:38:06.777-0700 [DEBUG] performing request%!(EXTRA string=method, string=GET, string=url, string=https://api.confluent.cloud/fcpm/v2/compute-pools?environment=env-ozkw8y&page_size=2)
2025/03/25 14:38:06 
HTTP/2.0 200 OK
Access-Control-Allow-Credentials: true
Access-Control-Allow-Headers: Authorization,Accept,Origin,DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Content-Range,Range,X-Client-Request-Id,X-Correlation-Id
Access-Control-Allow-Methods: GET,POST,OPTIONS,PUT,DELETE,PATCH
Content-Type: application/json; charset=utf-8
Date: Tue, 25 Mar 2025 21:38:06 GMT
Server: nginx
Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
Vary: Accept-Encoding
X-Content-Type-Options: nosniff
X-Envoy-Upstream-Service-Time: 60
X-Frame-Options: deny
X-Ratelimit-Limit: 40
X-Ratelimit-Remaining: 39
X-Ratelimit-Reset: 1
X-Request-Id: 4c5e50281cceb9e9a232b4752d96b346
X-Xss-Protection: 1; mode=block

{"api_version":"fcpm/v2","data":[...],"kind":"ComputePoolList","metadata":{"first":"","next":"https://api.confluent.cloud/fcpm/v2/compute-pools?page_token=_eyJjdXJzb3IiOiJsZmNwLW45Nzh2ZCIsInBhZ2Vfc2l6ZSI6Mn0%3D\u0026environment=env-ozkw8y"}}
2025/03/25 14:38:06 
GET /fcpm/v2/compute-pools?environment=env-ozkw8y&page_size=2&page_token=_eyJjdXJzb3IiOiJsZmNwLW45Nzh2ZCIsInBhZ2Vfc2l6ZSI6Mn0%3D HTTP/1.1
Host: api.confluent.cloud
User-Agent: Confluent-CLI/v4.20.0-SNAPSHOT-379a8575 (https://confluent.io; support@confluent.io)
Accept: application/json
Authorization: Bearer <redacted>
Accept-Encoding: gzip


2025-03-25T14:38:06.971-0700 [DEBUG] performing request%!(EXTRA string=method, string=GET, string=url, string=https://api.confluent.cloud/fcpm/v2/compute-pools?environment=env-ozkw8y&page_size=2&page_token=_eyJjdXJzb3IiOiJsZmNwLW45Nzh2ZCIsInBhZ2Vfc2l6ZSI6Mn0%3D)
2025/03/25 14:38:07 
HTTP/2.0 200 OK
Access-Control-Allow-Credentials: true
Access-Control-Allow-Headers: Authorization,Accept,Origin,DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Content-Range,Range,X-Client-Request-Id,X-Correlation-Id
Access-Control-Allow-Methods: GET,POST,OPTIONS,PUT,DELETE,PATCH
Content-Type: application/json; charset=utf-8
Date: Tue, 25 Mar 2025 21:38:07 GMT
Server: nginx
Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
Vary: Accept-Encoding
X-Content-Type-Options: nosniff
X-Envoy-Upstream-Service-Time: 60
X-Frame-Options: deny
X-Ratelimit-Limit: 40
X-Ratelimit-Remaining: 39
X-Ratelimit-Reset: 1
X-Request-Id: 4f09f8daa75ef581f326f856c7f27df5
X-Xss-Protection: 1; mode=block

{"api_version":"fcpm/v2","data":[...],"kind":"ComputePoolList","metadata":{"first":"","next":"https://api.confluent.cloud/fcpm/v2/compute-pools?page_token=_eyJjdXJzb3IiOiJsZmNwLXAzcXpneSIsInBhZ2Vfc2l6ZSI6Mn0%3D\u0026environment=env-ozkw8y"}}
2025/03/25 14:38:07 
GET /fcpm/v2/compute-pools?environment=env-ozkw8y&page_size=2&page_token=_eyJjdXJzb3IiOiJsZmNwLXAzcXpneSIsInBhZ2Vfc2l6ZSI6Mn0%3D HTTP/1.1
Host: api.confluent.cloud
User-Agent: Confluent-CLI/v4.20.0-SNAPSHOT-379a8575 (https://confluent.io; support@confluent.io)
Accept: application/json
Authorization: Bearer <redacted>
Accept-Encoding: gzip


2025-03-25T14:38:07.083-0700 [DEBUG] performing request%!(EXTRA string=method, string=GET, string=url, string=https://api.confluent.cloud/fcpm/v2/compute-pools?environment=env-ozkw8y&page_size=2&page_token=_eyJjdXJzb3IiOiJsZmNwLXAzcXpneSIsInBhZ2Vfc2l6ZSI6Mn0%3D)
2025/03/25 14:38:07 
HTTP/2.0 200 OK
Access-Control-Allow-Credentials: true
Access-Control-Allow-Headers: Authorization,Accept,Origin,DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Content-Range,Range,X-Client-Request-Id,X-Correlation-Id
Access-Control-Allow-Methods: GET,POST,OPTIONS,PUT,DELETE,PATCH
Content-Type: application/json; charset=utf-8
Date: Tue, 25 Mar 2025 21:38:07 GMT
Server: nginx
Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
Vary: Accept-Encoding
X-Content-Type-Options: nosniff
X-Envoy-Upstream-Service-Time: 68
X-Frame-Options: deny
X-Ratelimit-Limit: 40
X-Ratelimit-Remaining: 38
X-Ratelimit-Reset: 1
X-Request-Id: a55ed03280e53e0332a0ad002a36c264
X-Xss-Protection: 1; mode=block

{"api_version":"fcpm/v2","data":[...],"kind":"ComputePoolList","metadata":{"first":"","next":""}}
```

Sanity check test to make sure that region filtering still works after code changes (there are 6 compute pools, one in us-east-1 and 5 in us-west-2, so we expect 5 and not 6 with this filter):
```
confluent flink compute-pool list --region us-west-2                           
  Current |     ID      |       Name        | Environment | Current CFU | Max CFU | Cloud |  Region   |   Status     
----------+-------------+-------------------+-------------+-------------+---------+-------+-----------+--------------
          | lfcp-1m1v2v | my-compute-pool-2 | env-ozkw8y  |           0 |       5 | AWS   | us-west-2 | PROVISIONED  
          | lfcp-g7zvqm | my-compute-pool-5 | env-ozkw8y  |           0 |       5 | AWS   | us-west-2 | PROVISIONED  
          | lfcp-n978vd | my-compute-pool-1 | env-ozkw8y  |           0 |       5 | AWS   | us-west-2 | PROVISIONED  
          | lfcp-ojom3o | my-compute-pool-3 | env-ozkw8y  |           0 |       5 | AWS   | us-west-2 | PROVISIONED  
          | lfcp-qng32m | my-compute-pool-4 | env-ozkw8y  |           0 |       5 | AWS   | us-west-2 | PROVISIONED  
```

Pagination code was also updated for `confluent flink region list`, so here's the result of that command (with page size reverted to 100):
```
confluent flink region list               
  Current |              Name              | Cloud |        Region         
----------+--------------------------------+-------+-----------------------
          | Belgium (europe-west1)         | GCP   | europe-west1          
          | Canada (ca-central-1)          | AWS   | ca-central-1          
          | Delhi (asia-south2)            | GCP   | asia-south2           
          | Frankfurt (eu-central-1)       | AWS   | eu-central-1          
          | Frankfurt (europe-west3)       | GCP   | europe-west3          
          | Iowa (centralus)               | AZURE | centralus             
          | Iowa (us-central1)             | GCP   | us-central1           
          | Ireland (eu-west-1)            | AWS   | eu-west-1             
          | Ireland (northeurope)          | AZURE | northeurope           
          | Las Vegas (us-west4)           | GCP   | us-west4              
          | London (eu-west-2)             | AWS   | eu-west-2             
          | London (europe-west2)          | GCP   | europe-west2          
          | Mumbai (ap-south-1)            | AWS   | ap-south-1            
          | Mumbai (asia-south1)           | GCP   | asia-south1           
          | N. Virginia (us-east-1)        | AWS   | us-east-1             
          | N. Virginia (us-east4)         | GCP   | us-east4              
          | Netherlands (westeurope)       | AZURE | westeurope            
          | New South Wales                | AZURE | australiaeast         
          | (australiaeast)                |       |                       
          | Ohio (us-east-2)               | AWS   | us-east-2             
          | Oregon (us-west-2)             | AWS   | us-west-2             
          | Oregon (us-west1)              | GCP   | us-west1              
          | Paris (francecentral)          | AZURE | francecentral         
          | Pune (centralindia)            | AZURE | centralindia          
          | S. Carolina (us-east1)         | GCP   | us-east1              
          | Sao Paulo state (brazilsouth)  | AZURE | brazilsouth           
          | Seoul (ap-northeast-2)         | AWS   | ap-northeast-2        
          | Singapore (ap-southeast-1)     | AWS   | ap-southeast-1        
          | Singapore (asia-southeast1)    | GCP   | asia-southeast1       
          | Singapore (southeastasia)      | AZURE | southeastasia         
          | Sydney (ap-southeast-2)        | AWS   | ap-southeast-2        
          | Sydney (australia-southeast1)  | GCP   | australia-southeast1  
          | São Paulo (sa-east-1)          | AWS   | sa-east-1             
          | Texas (southcentralus)         | AZURE | southcentralus        
          | Virginia (eastus)              | AZURE | eastus                
          | Virginia (eastus2)             | AZURE | eastus2               
          | Washington (westus2)           | AZURE | westus2               
```