### PR TITLE
[CLI-3486] Update references of 'confluent admin ...' to 'confluent billing ...'

### DIFF
--- a/internal/billing/command_payment_describe.go
+++ b/internal/billing/command_payment_describe.go
@@ -35,7 +35,7 @@ func (c *command) describe(_ *cobra.Command, _ []string) error {
 	}
 
 	if card == nil {
-		output.Println(c.Config.EnableColor, "No credit card found. Add one using `confluent admin payment update`.")
+		output.Println(c.Config.EnableColor, "No credit card found. Add one using `confluent billing payment update`.")
 
 		ldClient := featureflags.GetCcloudLaunchDarklyClient(c.Context.PlatformName)
 		if featureflags.Manager.BoolVariation("cloud_growth.marketplace_linking_advertisement_experiment.enable", c.Context, ldClient, true, false) {

--- a/internal/login/command.go
+++ b/internal/login/command.go
@@ -199,7 +199,7 @@ func (c *command) printRemainingFreeCredit(client *ccloudv1.Client, currentOrg *
 	// only print remaining free credit if there is any unexpired promo code and there is no payment method yet
 	if remainingFreeCredit > 0 {
 		output.ErrPrintf(c.Config.EnableColor, "Free credits: $%.2f USD remaining\n", billing.ConvertToUSD(remainingFreeCredit))
-		output.ErrPrintln(c.Config.EnableColor, "You are currently using a free trial version of Confluent Cloud. Add a payment method with `confluent admin payment update` to avoid an interruption in service once your trial ends.")
+		output.ErrPrintln(c.Config.EnableColor, "You are currently using a free trial version of Confluent Cloud. Add a payment method with `confluent billing payment update` to avoid an interruption in service once your trial ends.")
 	}
 }
 

--- a/pkg/cmd/ANNOTATIONS.md
+++ b/pkg/cmd/ANNOTATIONS.md
@@ -4,18 +4,18 @@ Occasionally, we want to restrict commands to be used only when the user is logg
 We use [Cobra](https://github.com/spf13/cobra) annotations to label commands as Cloud-only or On-Prem-only.
 Applying an annotation to a parent command will recursively apply the same annotation to its children.
 
-For example, the `confluent admin` commands have been labeled as Cloud-only:
+For example, the `confluent billing` commands have been labeled as Cloud-only:
 
 ```go
 cmd := &cobra.Command{
-    Use:         "admin",
-    Short:       "Perform administrative tasks for the current organization.",
+    Use:         "billing",
+    Short:       "Perform billing administrative tasks for the current organization.",
     Args:        cobra.NoArgs,
     Annotations: map[string]string{annotations.RunRequirement: annotations.RequireCloudLogin},
 }
 ```
 
-Trying to use any `confluent admin` command results in the following error:
+Trying to use any `confluent billing` command results in the following error:
 
-    $ confluent admin payment describe
+    $ confluent billing payment describe
     Error: you must log in to Confluent Cloud to use this command

--- a/pkg/errors/error_message.go
+++ b/pkg/errors/error_message.go
@@ -10,7 +10,7 @@ const (
 	ByokKeyNotFoundSuggestions        = "Ensure the self-managed key exists and has not been deleted, or register a new key via `confluent byok register`."
 	DeleteResourceErrorMsg            = `failed to delete %s "%s": %w`
 	EndOfFreeTrialErrorMsg            = `organization "%s" has been suspended because your free trial has ended`
-	EndOfFreeTrialSuggestions         = "To continue using Confluent Cloud, please enter a credit card with `confluent admin payment update` or claim a promo code with `confluent admin promo add`. To enter payment via the UI, please go to https://confluent.cloud/login."
+	EndOfFreeTrialSuggestions         = "To continue using Confluent Cloud, please enter a credit card with `confluent billing payment update` or claim a promo code with `confluent billing promo add`. To enter payment via the UI, please go to https://confluent.cloud/login."
 	EnsureCpSixPlusSuggestions        = "Ensure that you are running against MDS with CP 6.0+."
 	ExactlyOneSetErrorMsg             = "exactly one of %v must be set"
 	ListResourceSuggestions           = "List available %s with `%s list`."

--- a/test/login_test.go
+++ b/test/login_test.go
@@ -33,7 +33,7 @@ func (s *CLITestSuite) TestLogin_VariousOrgSuspensionStatus() {
 		output := runCommand(t, testBin, env, args, 0, "")
 		require.Contains(t, output, loggedInAsWithOrgOutput)
 		require.Contains(t, output, loggedInEnvOutput)
-		require.Contains(t, output, "Free credits: $40.00 USD remaining\nYou are currently using a free trial version of Confluent Cloud. Add a payment method with `confluent admin payment update` to avoid an interruption in service once your trial ends.\n")
+		require.Contains(t, output, "Free credits: $40.00 USD remaining\nYou are currently using a free trial version of Confluent Cloud. Add a payment method with `confluent billing payment update` to avoid an interruption in service once your trial ends.\n")
 	})
 
 	s.T().Run("non-free-trial organization login", func(t *testing.T) {

--- a/test/test-server/ccloud_handlers.go
+++ b/test/test-server/ccloud_handlers.go
@@ -161,7 +161,7 @@ func handleLoginRealm(t *testing.T) http.HandlerFunc {
 func handlePaymentInfo(t *testing.T) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		switch r.Method {
-		case http.MethodPost: // admin payment update
+		case http.MethodPost: // billing payment update
 			req := &ccloudv1.UpdatePaymentInfoRequest{}
 			err := ccstructs.UnmarshalJSON(r.Body, req)
 			require.NoError(t, err)
@@ -170,7 +170,7 @@ func handlePaymentInfo(t *testing.T) http.HandlerFunc {
 			res := &ccloudv1.UpdatePaymentInfoReply{}
 			err = json.NewEncoder(w).Encode(res)
 			require.NoError(t, err)
-		case http.MethodGet: // admin payment describe
+		case http.MethodGet: // billing payment describe
 			res := ccloudv1.GetPaymentInfoReply{
 				Card: &ccloudv1.Card{
 					Cardholder: "Miles Todzo",


### PR DESCRIPTION
Release Notes
-------------

Breaking Changes
- PLACEHOLDER

New Features
- PLACEHOLDER

Bug Fixes
- PLACEHOLDER

Checklist
---------
<!-- 
Check each item below to ensure high-quality CLI development practices are followed. PR approval will not be granted until the checklist is fully reviewed.
For detailed instructions, please refer to this Confluence page: https://confluentinc.atlassian.net/wiki/spaces/AEGI/pages/3949592874/
-->
- [ ] I have successfully built and used a custom CLI binary, without linter issues from this PR.
- [ ] I have clearly specified in the `What` section below whether this PR applies to Confluent Cloud, Confluent Platform, or both. 
- [ ] I have verified this PR in Confluent Cloud pre-prod or production environment, if applicable.
- [ ] I have verified this PR in Confluent Platform on-premises environment, if applicable.
- [ ] I have attached manual CLI verification results or screenshots in the `Test & Review` section below.
- [ ] I have added appropriate CLI integration or unit tests for any new or updated commands and functionality.
- [ ] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [ ] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [ ] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [ ] Confluent Cloud prod
  - [ ] Confluent Cloud stag
  - [ ] Confluent Platform
  - [ ] Check this box if the feature is enabled for certain organizations only

What
----
Several commands still reference `confluent admin ...` which has moved to `confluent billing ...`. This PR is to update the references of `confluent admin ...`  to `confluent billing ...`.


Blast Radius
----
<!--
The Blast Radius section should include information on what will be the customer(s) impact if something goes wrong or unexpectedly, 
adding this section will trigger the PR author to think about the impact from product perspective, examples can be:
- Confluent Cloud customers who are using confluent kafka topic any subcommand will be blocked.
- Confluent Cloud customers who are using confluent kafka topic list commands will be blocked.
- Confluent Platform customers who are using --schema flag will be impacted.
- All customers who are using SSO to login will be impacted.
-->

References
----------
https://confluentinc.atlassian.net/browse/CLI-3486

Test & Review
-------------
- `make build` and `make lint` succeeded 
- `make unit-test` passed