### PR TITLE
DGS-20003 Asyncapi correctly parse union avro types

### DIFF
--- a/internal/asyncapi/command_export.go
+++ b/internal/asyncapi/command_export.go
@@ -335,7 +335,66 @@ func (c *command) getMessageExamples(consumer *ckgo.Consumer, topicName, content
 	if err := json.Unmarshal([]byte(jsonMessage), &jsonObject); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal JSON message: %v", err)
 	}
+
+	if valueFormat == "avro" {
+		processUnionTypes(jsonObject)
+	}
+
 	return jsonObject, nil
+}
+
+// Valid avro types
+var avroTypes = map[string]bool{
+	"string":  true,
+	"array":   true,
+	"int":     true,
+	"long":    true,
+	"float":   true,
+	"double":  true,
+	"boolean": true,
+	"null":    true,
+	"bytes":   true,
+}
+
+// processUnionTypes recursively processes the message map to handle union types
+func processUnionTypes(m map[string]any) {
+	for k, v := range m {
+		switch val := v.(type) {
+		case map[string]any:
+			// Handle Avro union types
+			if len(val) == 1 {
+				for typeName, actualValue := range val {
+					if avroTypes[typeName] {
+						m[k] = actualValue
+						continue
+					}
+				}
+			}
+			// Handle arrays
+			if arrayVal, ok := val["array"]; ok {
+				if array, ok := arrayVal.([]any); ok {
+					for i, item := range array {
+						if itemMap, ok := item.(map[string]any); ok {
+							processUnionTypes(itemMap)
+							array[i] = itemMap
+						}
+					}
+					m[k] = array
+					continue
+				}
+			}
+			// Process nested maps
+			processUnionTypes(val)
+		case []any:
+			// Handle arrays that might contain union types
+			for i, item := range val {
+				if itemMap, ok := item.(map[string]any); ok {
+					processUnionTypes(itemMap)
+					val[i] = itemMap
+				}
+			}
+		}
+	}
 }
 
 func (c *command) getBindings(topicName string) (*bindings, error) {


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Bug Fixes
- `asyncapi export` correctly handles Avro union types in examples output

Checklist
---------
<!-- 
Check each item below to ensure high-quality CLI development practices are followed. PR approval will not be granted until the checklist is fully reviewed.
For detailed instructions, please refer to this Confluence page: https://confluentinc.atlassian.net/wiki/spaces/AEGI/pages/3949592874/
-->
- [x] I have successfully built and used a custom CLI binary, without linter issues from this PR.
- [x] I have clearly specified in the `What` section below whether this PR applies to Confluent Cloud, Confluent Platform, or both. 
- [x] I have verified this PR in Confluent Cloud pre-prod or production environment, if applicable.
- [ ] I have verified this PR in Confluent Platform on-premises environment, if applicable.
- [x] I have attached manual CLI verification results or screenshots in the `Test & Review` section below.
- [x] I have added appropriate CLI integration or unit tests for any new or updated commands and functionality.
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [x] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [x] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [x] Confluent Cloud prod
  - [x] Confluent Cloud stag
  - [ ] Confluent Platform
  - [ ] Check this box if the feature is enabled for certain organizations only

What
----
<!--
Briefly describe **what** you have changed and **why** these changes are necessary.
Optionally include: 
- The problem being solved or the feature being added. 
- The implementation strategy or approach taken. 
- Key technical details, design decisions, or any additional context reviewers should be aware of.
-->

CC only
If you use consume example flag in asyncapi and have a union type defined in avro, the resulting example will likely not match the asyncapi expected format.
For example, here is a union type definition (meaning it can be of multiple types):
```
        - default: null
          name: exampleField
          type:
          - "null"
          - string
```
Here is what we put in the example:
```
          exampleField:
            string: "exampleString"
```

Asyncapi syntax checker will mark this invalid because of the `string:` part being present. This PR removes all maps which use an avro type as the key, which in this case means just outputting `exampleField: "exampleString"`

There is also a block to deal with arrays for the same reason

Blast Radius
----
<!--
The Blast Radius section should include information on what will be the customer(s) impact if something goes wrong or unexpectedly, 
adding this section will trigger the PR author to think about the impact from product perspective, examples can be:
- Confluent Cloud customers who are using confluent kafka topic any subcommand will be blocked.
- Confluent Cloud customers who are using confluent kafka topic list commands will be blocked.
- Confluent Platform customers who are using --schema flag will be impacted.
- All customers who are using SSO to login will be impacted.
-->

CC customers calling `asyncapi export` with `--consume-examples` and `--value-type avro` would be affected

References
----------
<!-- Include links to relevant resources for this PR, such as: 
- Related GitHub issues 
- Tickets (JIRA, etc.) 
- Internal documentation or design specs 
- Other related PRs 
Copy and paste the links below for easy reference.
-->

Test & Review
-------------
<!-- Has this PR been tested? If so, explain **how** it was tested. Include: 
- Steps taken to verify the changes. 
- Links to manual verification documents, logs, or screenshots to save reviewers' time. 
- Any additional notes on testing (e.g., environments used, edge cases tested). 
- Screenshot showing successful resource creation, updates etc.
Example: - [Manual Verification Document](https://docs.google.com/document/d/1GwXz9hNOkub_Br-2nssoYWCf6elZBvwo7TMhCNYinwE/edit?tab=t.0#heading=h.dvbi09ntxjw6)
-->

Tested against customer schema with this problem (not gonna post).
Example described in `What` also tested:
Before change output
```
examples:
...
          exampleField:
            string: "exampleString"
```
After change output (passes syntax check on https://studio.asyncapi.com/)
```
examples:
...
          exampleField: "exampleString"
```
