### PR TITLE
[CLI-3542] Fix infinite page token loop for `confluent kafka quota list`

### DIFF
--- a/pkg/ccloudv2/kafka_quotas.go
+++ b/pkg/ccloudv2/kafka_quotas.go
@@ -29,13 +29,12 @@ func (c *Client) ListKafkaQuotas(clusterId, envId string) ([]kafkaquotasv1.Kafka
 	done := false
 	pageToken := ""
 	for !done {
-		page, httpResp, err := c.listQuotas(clusterId, envId, pageToken)
+		page, httpResp, err := c.executeListQuotas(clusterId, envId, pageToken)
 		if err != nil {
 			return nil, errors.CatchCCloudV2Error(err, httpResp)
 		}
 		list = append(list, page.GetData()...)
 
-		// nextPageUrlStringNullable is nil for the last page
 		pageToken, done, err = extractNextPageToken(page.GetMetadata().Next)
 		if err != nil {
 			return nil, err
@@ -44,10 +43,10 @@ func (c *Client) ListKafkaQuotas(clusterId, envId string) ([]kafkaquotasv1.Kafka
 	return list, nil
 }
 
-func (c *Client) listQuotas(clusterId, envId, pageToken string) (kafkaquotasv1.KafkaQuotasV1ClientQuotaList, *http.Response, error) {
+func (c *Client) executeListQuotas(clusterId, envId, pageToken string) (kafkaquotasv1.KafkaQuotasV1ClientQuotaList, *http.Response, error) {
 	req := c.KafkaQuotasClient.ClientQuotasKafkaQuotasV1Api.ListKafkaQuotasV1ClientQuotas(c.kafkaQuotasContext()).PageSize(ccloudV2ListPageSize).SpecCluster(clusterId).Environment(envId)
 	if pageToken != "" {
-		req.PageToken(pageToken)
+		req = req.PageToken(pageToken)
 	}
 	return req.Execute()
 }


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- PLACEHOLDER

New Features
- PLACEHOLDER

Bug Fixes
- `confluent kafka quota list` now works when a cluster has more than 100 quotas

Checklist
---------
<!-- 
Check each item below to ensure high-quality CLI development practices are followed. PR approval will not be granted until the checklist is fully reviewed.
For detailed instructions, please refer to this Confluence page: https://confluentinc.atlassian.net/wiki/spaces/AEGI/pages/3949592874/
-->
- [x] I have successfully built and used a custom CLI binary, without linter issues from this PR.
- [x] I have clearly specified in the `What` section below whether this PR applies to Confluent Cloud, Confluent Platform, or both. 
- [x] I have verified this PR in Confluent Cloud pre-prod or production environment, if applicable.
- [ ] I have verified this PR in Confluent Platform on-premises environment, if applicable.
- [x] I have attached manual CLI verification results or screenshots in the `Test & Review` section below.
- [ ] I have added appropriate CLI integration or unit tests for any new or updated commands and functionality.
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [x] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [x] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [x] Confluent Cloud prod
  - [ ] Confluent Cloud stag
  - [ ] Confluent Platform
  - [ ] Check this box if the feature is enabled for certain organizations only

What
----
For Confluent Cloud.

The `req.PageToken(pageToken)` function call returns a new request with the page token set. The current code discards this value, which means that we send requests without the page token.

If the initial response contains a next page token, this causes an infinite loop where we continuously call the first page of results.

Blast Radius
----
`confluent kafka quota list` would be affected

References
----------
<!-- Include links to relevant resources for this PR, such as: 
- Related GitHub issues 
- Tickets (JIRA, etc.) 
- Internal documentation or design specs 
- Other related PRs 
Copy and paste the links below for easy reference.
-->

Test & Review
-------------
https://docs.google.com/document/d/1Xy7HLe7Sc5BMLuEJ7NPGvGgfe6dFyf2f3Ycr738elKo/edit?usp=sharing
