### PR TITLE
[CLI-3544] Only set `consumer.interceptor.classes` and `producer.interceptor.classes` for Confluent Platform 7.9 or lower

### DIFF
--- a/internal/local/command_services.go
+++ b/internal/local/command_services.go
@@ -467,7 +467,7 @@ func (c *command) getConfig(service string) (map[string]string, error) {
 		config["dataDir"] = data
 	}
 
-	if isCP && slices.Contains([]string{"connect", "kafka-rest", "ksql-server", "schema-registry"}, service) {
+	if isCP && slices.Contains([]string{"connect", "kafka-rest", "ksql-server", "schema-registry"}, service) && zookeeperMode {
 		config["consumer.interceptor.classes"] = "io.confluent.monitoring.clients.interceptor.MonitoringConsumerInterceptor"
 		config["producer.interceptor.classes"] = "io.confluent.monitoring.clients.interceptor.MonitoringProducerInterceptor"
 	}


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- PLACEHOLDER

New Features
- PLACEHOLDER

Bug Fixes
- `confluent local services` no longer sets `consumer.interceptor.classes` and `producer.interceptor.classes` configuration options by default when used with Confluent Platform 8.0

Checklist
---------
<!-- 
Check each item below to ensure high-quality CLI development practices are followed. PR approval will not be granted until the checklist is fully reviewed.
For detailed instructions, please refer to this Confluence page: https://confluentinc.atlassian.net/wiki/spaces/AEGI/pages/3949592874/
-->
- [x] I have successfully built and used a custom CLI binary, without linter issues from this PR.
- [x] I have clearly specified in the `What` section below whether this PR applies to Confluent Cloud, Confluent Platform, or both. 
- [ ] I have verified this PR in Confluent Cloud pre-prod or production environment, if applicable.
- [x] I have verified this PR in Confluent Platform on-premises environment, if applicable.
- [x] I have attached manual CLI verification results or screenshots in the `Test & Review` section below.
- [ ] I have added appropriate CLI integration or unit tests for any new or updated commands and functionality.
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [x] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [x] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [ ] Confluent Cloud prod
  - [ ] Confluent Cloud stag
  - [x] Confluent Platform
  - [ ] Check this box if the feature is enabled for certain organizations only

What
----
For Confluent Platform.

These configs rely on a jar file that ships with Control Center, so we need to remove these configs when running with 8.0 (but keep them when running in 7.9 or lower).

Since we're using ZK for 7.9 or lower and KRaft for 8.0 and above, this PR implements this change by only setting these configs when running in ZK mode.

Blast Radius
----
This change is applied to the following local services: connect, kafka rest, ksql, and schema registry.

Blast radius should be minimal since these configuration options are optional.

References
----------
<!-- Include links to relevant resources for this PR, such as: 
- Related GitHub issues 
- Tickets (JIRA, etc.) 
- Internal documentation or design specs 
- Other related PRs 
Copy and paste the links below for easy reference.
-->

Test & Review
-------------
Test results: https://docs.google.com/document/d/1ROkpDEMn_jcmLmnHFQ9dW6OvmS4cm9oV0a2W70JlunY/edit?usp=sharing
