### PR TITLE
Roll back destination link from on-prem `kafka link create`

### DIFF
--- a/internal/kafka/command_link_describe_onprem.go
+++ b/internal/kafka/command_link_describe_onprem.go
@@ -42,6 +42,6 @@ func (c *linkCommand) describeOnPrem(cmd *cobra.Command, args []string) error {
 
 	table := output.NewTable(cmd)
 	table.Add(newLinkOnPrem(data, ""))
-	table.Filter(getListFields(false))
+	table.Filter(getListFieldsOnPrem(false))
 	return table.Print()
 }

--- a/internal/kafka/command_link_list_onprem.go
+++ b/internal/kafka/command_link_list_onprem.go
@@ -78,6 +78,6 @@ func (c *linkCommand) listOnPrem(cmd *cobra.Command, _ []string) error {
 			list.Add(newLinkOnPrem(link, ""))
 		}
 	}
-	list.Filter(getListFields(includeTopics))
+	list.Filter(getListFieldsOnPrem(includeTopics))
 	return list.Print()
 }

--- a/test/fixtures/output/kafka/link/create-destination-link-onprem.golden
+++ b/test/fixtures/output/kafka/link/create-destination-link-onprem.golden
@@ -1,6 +1,1 @@
-Created cluster link "destination_initiated_link" with configs:
-"bootstrap.servers"="my-host:1234"
-"link.mode"="DESTINATION"
-"sasl.mechanism"="PLAIN"
-"security.protocol"="SASL_SSL"
-
+Error: only source-initiated or bidirectional links can be created for Confluent Platform from the CLI

--- a/test/fixtures/output/kafka/link/create-help-onprem.golden
+++ b/test/fixtures/output/kafka/link/create-help-onprem.golden
@@ -12,17 +12,11 @@ Create a source cluster link using command line flags.
 
   $ confluent kafka link create my-link --destination-cluster 123456789 --destination-bootstrap-server my-host:1234 --destination-api-key remote-key --destination-api-secret remote-secret --source-api-key local-key --source-api-secret local-secret --config link.mode=SOURCE,connection.mode=OUTBOUND
 
-Create a destination cluster link using command line flags.
-
-  $ confluent kafka link create my-link --source-cluster 123456789 --source-bootstrap-server my-host:1234 --source-api-key remote-key --source-api-secret remote-secret --config link.mode=DESTINATION,connection.mode=INBOUND
-
 Create a bidirectional cluster link using command line flags.
 
   $ confluent kafka link create my-link --remote-cluster 123456789 --remote-bootstrap-server my-host:1234 --remote-api-key remote-key --remote-api-secret remote-secret --local-api-key local-key --local-api-secret local-secret --config link.mode=BIDIRECTIONAL
 
 Flags:
-      --source-cluster string                 Source cluster ID.
-      --source-bootstrap-server string        Bootstrap server address of the source cluster. Can alternatively be set in the configuration file using key "bootstrap.servers".
       --destination-cluster string            Destination cluster ID.
       --destination-bootstrap-server string   Bootstrap server address of the destination cluster. Can alternatively be set in the configuration file using key "bootstrap.servers".
       --remote-cluster string                 Remote cluster ID for bidirectional cluster links.

--- a/test/fixtures/output/kafka/link/describe-error-onprem.golden
+++ b/test/fixtures/output/kafka/link/describe-error-onprem.golden
@@ -1,10 +1,5 @@
-+---------------------+--------------------------------+
-| Name                | link-3                         |
-| Source Cluster      |                                |
-| Destination Cluster | cluster-2                      |
-| Remote Cluster      | cluster-2                      |
-| State               | UNAVAILABLE                    |
-| Error               | AUTHENTICATION_ERROR           |
-| Error Message       | Please check your API key and  |
-|                     | secret                         |
-+---------------------+--------------------------------+
++---------------------+-----------+
+| Name                | link-3    |
+| Destination Cluster | cluster-2 |
+| Remote Cluster      | cluster-2 |
++---------------------+-----------+

--- a/test/fixtures/output/kafka/link/describe-onprem.golden
+++ b/test/fixtures/output/kafka/link/describe-onprem.golden
@@ -1,7 +1,5 @@
 +---------------------+-----------+
 | Name                | link-1    |
-| Source Cluster      |           |
 | Destination Cluster | cluster-2 |
 | Remote Cluster      | cluster-2 |
-| State               | ACTIVE    |
 +---------------------+-----------+

--- a/test/fixtures/output/kafka/link/list-error-onprem.golden
+++ b/test/fixtures/output/kafka/link/list-error-onprem.golden
@@ -1,8 +1,7 @@
-   Name  | Source Cluster | Destination Cluster | Remote Cluster |    State    |        Error         |         Error Message           
----------+----------------+---------------------+----------------+-------------+----------------------+---------------------------------
-  link-1 | cluster-1      | cluster-2           |                |             |                      |                                 
-  link-2 | cluster-1      | cluster-2           |                | AVAILABLE   |                      |                                 
-  link-3 | cluster-1      | cluster-2           |                | UNAVAILABLE | AUTHENTICATION_ERROR | Please check your API key and   
-         |                |                     |                |             |                      | secret.                         
-  link-4 |                |                     | cluster-2      |             |                      |                                 
-  link-5 |                |                     | cluster-2      |             |                      |                                 
+   Name  | Destination Cluster | Remote Cluster  
+---------+---------------------+-----------------
+  link-1 | cluster-2           |                 
+  link-2 | cluster-2           |                 
+  link-3 | cluster-2           |                 
+  link-4 |                     | cluster-2       
+  link-5 |                     | cluster-2       

--- a/test/kafka_test.go
+++ b/test/kafka_test.go
@@ -346,7 +346,7 @@ func (s *CLITestSuite) TestKafkaLink() {
 	tests = []CLITest{
 		{args: "kafka link create bidirectional_link --remote-cluster lkc-abc123 --remote-bootstrap-server SASL_SSL://pkc-12345.us-west-2.aws.confluent.cloud:9092 --remote-api-key remoteKey --remote-api-secret remoteSecret --local-api-key localUser --local-api-secret localPassword --config " + getCreateBidirectionalLinkConfigFile(), fixture: "kafka/link/create-bidirectional-link-onprem.golden"},
 		{args: "kafka link create source_initiated_link --destination-cluster 123456789 --destination-bootstrap-server my-host:1234 --source-api-key sourceKey --source-api-secret sourceSecret --destination-api-key destinationKey --destination-api-secret destinationSecret --config link.mode=SOURCE", fixture: "kafka/link/create-source-link-onprem.golden"},
-		{args: "kafka link create destination_initiated_link --source-cluster 123456789 --source-bootstrap-server my-host:1234 --source-api-key destinationKey --source-api-secret destinationSecret --config link.mode=DESTINATION", fixture: "kafka/link/create-destination-link-onprem.golden"},
+		{args: "kafka link create destination_initiated_link --source-cluster 123456789 --source-bootstrap-server my-host:1234 --source-api-key destinationKey --source-api-secret destinationSecret --config link.mode=DESTINATION", fixture: "kafka/link/create-destination-link-onprem.golden", exitCode: 1},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- PLACEHOLDER

New Features
- PLACEHOLDER

Bug Fixes
- PLACEHOLDER

Checklist
---------
<!-- 
Check each item below to ensure high-quality CLI development practices are followed. PR approval will not be granted until the checklist is fully reviewed.
For detailed instructions, please refer to this Confluence page: https://confluentinc.atlassian.net/wiki/spaces/AEGI/pages/3949592874/
-->
- [x] I have successfully built and used a custom CLI binary, without linter issues from this PR.
- [x] I have clearly specified in the `What` section below whether this PR applies to Confluent Cloud, Confluent Platform, or both. 
- [ ] I have verified this PR in Confluent Cloud pre-prod or production environment, if applicable.
- [x] I have verified this PR in Confluent Platform on-premises environment, if applicable.
- [x] I have attached manual CLI verification results or screenshots in the `Test & Review` section below.
- [x] I have added appropriate CLI integration or unit tests for any new or updated commands and functionality.
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [x] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [x] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [ ] Confluent Cloud prod
  - [ ] Confluent Cloud stag
  - [x] Confluent Platform
  - [ ] Check this box if the feature is enabled for certain organizations only

What
----
Re-implement the block on destination links, but don't remove the flags (because the common functions will still call these flags before the code reaches the destination link block), so that we surface the correct error. So instead, this PR hides those flags.

Also roll back the addition of all new output fields for describe and link except for "Remote Cluster" (used by bidirectional link).

Blast Radius
----
Zero, this is rolling back an addition that hasn't made it into a release yet.

References
----------
<!-- Include links to relevant resources for this PR, such as: 
- Related GitHub issues 
- Tickets (JIRA, etc.) 
- Internal documentation or design specs 
- Other related PRs 
Copy and paste the links below for easy reference.
-->

Test & Review
-------------
https://docs.google.com/document/d/1aHcFoNgZaOrFQH2ZKgxvMmMGyT_ugMRe5U9cmwxdhW8/edit?usp=sharing
