### PR TITLE
CC-34734: Add status field for connect artifact outputs

### DIFF
--- a/internal/connect/command_artifact.go
+++ b/internal/connect/command_artifact.go
@@ -22,6 +22,7 @@ type artifactOut struct {
 	Cloud         string `human:"Cloud" serialized:"cloud"`
 	Environment   string `human:"Environment" serialized:"environment"`
 	ContentFormat string `human:"Content Format" serialized:"content_format"`
+	Status        string `human:"Status" serialized:"status"`
 }
 
 func newArtifactCommand(cfg *config.Config, prerunner pcmd.PreRunner) *cobra.Command {
@@ -42,17 +43,22 @@ func newArtifactCommand(cfg *config.Config, prerunner pcmd.PreRunner) *cobra.Com
 	return cmd
 }
 
-func printArtifactTable(cmd *cobra.Command, artifact camv1.CamV1ConnectArtifact) error {
-	table := output.NewTable(cmd)
-
-	table.Add(&artifactOut{
+func convertToArtifactOut(artifact camv1.CamV1ConnectArtifact) *artifactOut {
+	return &artifactOut{
 		Id:            artifact.GetId(),
 		Name:          artifact.Spec.GetDisplayName(),
 		Description:   artifact.Spec.GetDescription(),
 		Cloud:         artifact.Spec.GetCloud(),
 		Environment:   artifact.Spec.GetEnvironment(),
 		ContentFormat: artifact.Spec.GetContentFormat(),
-	})
+		Status:        artifact.Status.GetPhase(),
+	}
+}
+
+func printArtifactTable(cmd *cobra.Command, artifact camv1.CamV1ConnectArtifact) error {
+	table := output.NewTable(cmd)
+
+	table.Add(convertToArtifactOut(artifact))
 
 	return table.Print()
 }

--- a/internal/connect/command_artifact_list.go
+++ b/internal/connect/command_artifact_list.go
@@ -56,14 +56,7 @@ func (c *artifactCommand) list(cmd *cobra.Command, _ []string) error {
 	list := output.NewList(cmd)
 	list.Sort(false)
 	for _, artifact := range artifacts {
-		list.Add(&artifactOut{
-			Id:            artifact.GetId(),
-			Name:          artifact.Spec.GetDisplayName(),
-			Description:   artifact.Spec.GetDescription(),
-			Cloud:         artifact.Spec.GetCloud(),
-			Environment:   artifact.Spec.GetEnvironment(),
-			ContentFormat: artifact.Spec.GetContentFormat(),
-		})
+		list.Add(convertToArtifactOut(artifact))
 	}
 
 	list.Sort(true)

--- a/test/fixtures/output/connect/artifact/create-jar.golden
+++ b/test/fixtures/output/connect/artifact/create-jar.golden
@@ -5,4 +5,5 @@
 | Cloud          | AWS                     |
 | Environment    | env-123456              |
 | Content Format | JAR                     |
+| Status         | PROCESSING              |
 +----------------+-------------------------+

--- a/test/fixtures/output/connect/artifact/create-zip.golden
+++ b/test/fixtures/output/connect/artifact/create-zip.golden
@@ -5,4 +5,5 @@
 | Cloud          | AWS                     |
 | Environment    | env-123456              |
 | Content Format | ZIP                     |
+| Status         | PROCESSING              |
 +----------------+-------------------------+

--- a/test/fixtures/output/connect/artifact/describe-jar.golden
+++ b/test/fixtures/output/connect/artifact/describe-jar.golden
@@ -5,4 +5,5 @@
 | Cloud          | AWS                     |
 | Environment    | env-123456              |
 | Content Format | JAR                     |
+| Status         | READY                   |
 +----------------+-------------------------+

--- a/test/fixtures/output/connect/artifact/describe-json.golden
+++ b/test/fixtures/output/connect/artifact/describe-json.golden
@@ -4,5 +4,6 @@
   "description": "new-jar-artifact",
   "cloud": "AWS",
   "environment": "env-123456",
-  "content_format": "JAR"
+  "content_format": "JAR",
+  "status": "READY"
 }

--- a/test/fixtures/output/connect/artifact/describe-yaml.golden
+++ b/test/fixtures/output/connect/artifact/describe-yaml.golden
@@ -4,3 +4,4 @@ description: new-jar-artifact
 cloud: AWS
 environment: env-123456
 content_format: JAR
+status: READY

--- a/test/fixtures/output/connect/artifact/describe-zip.golden
+++ b/test/fixtures/output/connect/artifact/describe-zip.golden
@@ -5,4 +5,5 @@
 | Cloud          | AWS                     |
 | Environment    | env-123456              |
 | Content Format | ZIP                     |
+| Status         | PROCESSING              |
 +----------------+-------------------------+

--- a/test/fixtures/output/connect/artifact/list-json.golden
+++ b/test/fixtures/output/connect/artifact/list-json.golden
@@ -5,7 +5,8 @@
     "description": "new-jar-artifact",
     "cloud": "AWS",
     "environment": "env-123456",
-    "content_format": "JAR"
+    "content_format": "JAR",
+    "status": "READY"
   },
   {
     "id": "cfa-zip123",
@@ -13,6 +14,7 @@
     "description": "new-zip-artifact",
     "cloud": "AWS",
     "environment": "env-123456",
-    "content_format": "ZIP"
+    "content_format": "ZIP",
+    "status": "PROCESSING"
   }
 ]

--- a/test/fixtures/output/connect/artifact/list-yaml.golden
+++ b/test/fixtures/output/connect/artifact/list-yaml.golden
@@ -4,9 +4,11 @@
   cloud: AWS
   environment: env-123456
   content_format: JAR
+  status: READY
 - id: cfa-zip123
   name: my-connect-artifact-zip
   description: new-zip-artifact
   cloud: AWS
   environment: env-123456
   content_format: ZIP
+  status: PROCESSING

--- a/test/fixtures/output/connect/artifact/list.golden
+++ b/test/fixtures/output/connect/artifact/list.golden
@@ -1,4 +1,4 @@
-      ID     |          Name           |   Description    | Cloud | Environment | Content Format  
--------------+-------------------------+------------------+-------+-------------+-----------------
-  cfa-jar123 | my-connect-artifact-jar | new-jar-artifact | AWS   | env-123456  | JAR             
-  cfa-zip123 | my-connect-artifact-zip | new-zip-artifact | AWS   | env-123456  | ZIP             
+      ID     |          Name           |   Description    | Cloud | Environment | Content Format |   Status    
+-------------+-------------------------+------------------+-------+-------------+----------------+-------------
+  cfa-jar123 | my-connect-artifact-jar | new-jar-artifact | AWS   | env-123456  | JAR            | READY       
+  cfa-zip123 | my-connect-artifact-zip | new-zip-artifact | AWS   | env-123456  | ZIP            | PROCESSING  

--- a/test/test-server/connect_handler.go
+++ b/test/test-server/connect_handler.go
@@ -37,6 +37,10 @@ func handleConnectArtifacts(t *testing.T) http.HandlerFunc {
 				artifact.Spec.SetContentFormat("ZIP")
 			}
 
+			artifact.Status = &camv1.CamV1ConnectArtifactStatus{
+				Phase: "PROCESSING",
+			}
+
 			artifactStore[artifact.GetId()] = *artifact
 
 			err := json.NewEncoder(w).Encode(artifact)
@@ -44,6 +48,11 @@ func handleConnectArtifacts(t *testing.T) http.HandlerFunc {
 		case http.MethodGet:
 			var artifacts []camv1.CamV1ConnectArtifact
 			for _, artifact := range artifactStore {
+				if artifact.GetId() == "cfa-jar123" {
+					artifact.Status = &camv1.CamV1ConnectArtifactStatus{
+						Phase: "READY",
+					}
+				}
 				artifacts = append(artifacts, artifact)
 			}
 
@@ -68,6 +77,11 @@ func handleConnectArtifactId(t *testing.T) http.HandlerFunc {
 				return
 			}
 
+			if id == "cfa-jar123" {
+				artifact.Status = &camv1.CamV1ConnectArtifactStatus{
+					Phase: "READY",
+				}
+			}
 			err := json.NewEncoder(w).Encode(artifact)
 			require.NoError(t, err)
 		case http.MethodDelete:


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

New Features
- Add missing artifact status field to show current processing state in confluent connect artifact [create | describe | list] commands.

Checklist
---------
<!-- 
Check each item below to ensure high-quality CLI development practices are followed. PR approval will not be granted until the checklist is fully reviewed.
For detailed instructions, please refer to this Confluence page: https://confluentinc.atlassian.net/wiki/spaces/AEGI/pages/3949592874/
-->
- [X] I have successfully built and used a custom CLI binary, without linter issues from this PR.
- [X] I have clearly specified in the `What` section below whether this PR applies to Confluent Cloud, Confluent Platform, or both. 
- [X] I have verified this PR in Confluent Cloud pre-prod or production environment, if applicable.
- [ ] I have verified this PR in Confluent Platform on-premises environment, if applicable.
- [X] I have attached manual CLI verification results or screenshots in the `Test & Review` section below.
- [X] I have added appropriate CLI integration or unit tests for any new or updated commands and functionality.
- [X] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [X] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [X] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [ ] Confluent Cloud prod
  - [X] Confluent Cloud stag
  - [ ] Confluent Platform
  - [X] Check this box if the feature is enabled for certain organizations only

## What

Added status field to Connect Artifact CLI outputs to display the current processing state of artifacts.

**Changes:**
- Added `Status` field to artifact output structure showing values like "PROCESSING" or "READY"
- Updated all Connect Artifact commands (create, list, describe) to display status information
- Updated test fixtures and test server to properly handle status field in all output formats (human, JSON, YAML)

This enhancement provides users with visibility into the processing state of their Connect Artifacts, allowing them to understand when artifacts are ready for use.

## Blast Radius

Low-Medium - This is a new feature that adds a status column/field to Connect Artifact command outputs. Existing functionality remains unchanged, but output format is slightly modified with the additional status information. Users may need to adjust any automated parsing of CLI output to account for the new status field.

## References

- CC-34734

## Test & Review

- All integration tests pass with updated fixtures
- Verified status display across all output formats (table, JSON, YAML)

<details>
<summary>Create Artifact</summary>

```
❯ ./dist/confluent_darwin_arm64_v8.0/confluent connect artifact create mukka-smt --cloud aws --environment env-pjr09 --description "testing" --artifact-file transforms-0.3.0-SNAPSHOT.zip
+----------------+--------------------------------+
| ID             | cca-stgc57r33n                 |
| Name           | mukka-smt                      |
| Description    | testing.                        |
| Cloud          | aws                            |
| Environment    | env-pjr09                      |
| Content Format | ZIP                            |
| Status         | PROCESSING                     |
+----------------+--------------------------------+             
```

after a while 

```
❯ ./dist/confluent_darwin_arm64_v8.0/confluent connect artifact describe cca-stgc57r33n --environment env-pjr09y --cloud aws -ojson
{
  "id": "cca-stgc57r33n",
  "name": "mukka-smt",
  "description": "testing",
  "cloud": "aws",
  "environment": "env-pjr09",
  "content_format": "ZIP",
  "status": "READY"
}
```
</details>


<details>
<summary>List Artifacts</summary>

```
❯ ./dist/confluent_darwin_arm64_v8.0/confluent connect artifact list --environment env-pjr09y --cloud aws                   
        ID       |             Name             |          Description           | Cloud | Environment | Content Format |         Status          
-----------------+------------------------------+--------------------------------+-------+-------------+----------------+-------------------------
  cca-stgc0x1g8p | xyz                          | Inspect testing                | aws   | env-pjr09   | JAR            | READY                   
  cca-stgc1277gz | abc                          | A simple SMT                   | aws   | env-pjr09   | JAR            | WAITING_FOR_PROCESSING  
  cca-stgc22o772 | stax                         | A simple SMT                   | aws   | env-pjr09   | JAR            | FAILED                                   
  cca-stgcj5dp92 | mukka-smt-test               | Inspect testing                | aws   | env-pjr09   | ZIP            | PROCESSING                
```
</details>


<details>
<summary>Describe Artifact (table)</summary>

```
❯ ./dist/confluent_darwin_arm64_v8.0/confluent connect artifact describe cca-stgc57xgw2 --environment env-pjr09y --cloud aws
+----------------+--------------------------------+
| ID             | cca-stgc57xgw2                 |
| Name           | snp-csmt                       |
| Description    | A simple SMT which inserts     |
|                | uuid                           |
| Cloud          | aws                            |
| Environment    | env-pjr09y                     |
| Content Format | JAR                            |
| Status         | WAITING_FOR_PROCESSING         |
+----------------+--------------------------------+
```

</details>


<details>
<summary>Describe Artifact (yaml)</summary>

```
❯ ./dist/confluent_darwin_arm64_v8.0/confluent connect artifact describe cca-stgc22o772 --environment env-pjr09y --cloud aws -oyaml 
id: cca-stgc22o772
name: stax
description: A simple SMT which inserts uuid
cloud: aws
environment: env-pjr09y
content_format: JAR
status: FAILED
```

</details>