### PR TITLE
[MATRIX-1006] added sse endpoint as optional key for MCP_SERVER

### DIFF
--- a/cmd/lint/main.go
+++ b/cmd/lint/main.go
@@ -306,6 +306,7 @@ var vocabWords = []string{
 	"siv",
 	"springboot",
 	"sql",
+	"sse",
 	"ssl",
 	"sso",
 	"subresource",

--- a/internal/flink/command_connection.go
+++ b/internal/flink/command_connection.go
@@ -95,6 +95,7 @@ func AddConnectionSecretFlags(cmd *cobra.Command) {
 	cmd.Flags().String("client-id", "", fmt.Sprintf("Specify OAuth2 client ID for the type: %s.", utils.ArrayToCommaDelimitedString(flink.ConnectionSecretTypeMapping["client-id"], "or")))
 	cmd.Flags().String("client-secret", "", fmt.Sprintf("Specify OAuth2 client secret for the type: %s.", utils.ArrayToCommaDelimitedString(flink.ConnectionSecretTypeMapping["client-secret"], "or")))
 	cmd.Flags().String("scope", "", fmt.Sprintf("Specify OAuth2 scope for the type: %s.", utils.ArrayToCommaDelimitedString(flink.ConnectionSecretTypeMapping["scope"], "or")))
+	cmd.Flags().String("sse-endpoint", "", fmt.Sprintf("Specify SSE endpoint for the type: %s.", utils.ArrayToCommaDelimitedString(flink.ConnectionSecretTypeMapping["sse-endpoint"], "or")))
 	cmd.MarkFlagsRequiredTogether("username", "password")
 	cmd.MarkFlagsRequiredTogether("aws-access-key", "aws-secret-key")
 	cmd.MarkFlagsRequiredTogether("token-endpoint", "client-id", "client-secret", "scope")

--- a/pkg/flink/utils.go
+++ b/pkg/flink/utils.go
@@ -16,7 +16,7 @@ var (
 		"couchbase":      {"username", "password"},
 		"confluent_jdbc": {"username", "password"},
 		"rest":           {"username", "password", "token", "token-endpoint", "client-id", "client-secret", "scope"},
-		"mcp_server":     {"api-key", "token", "token-endpoint", "client-id", "client-secret", "scope"},
+		"mcp_server":     {"api-key", "token", "token-endpoint", "client-id", "client-secret", "scope", "sse-endpoint"},
 	}
 
 	ConnectionSecretTypeMapping = map[string][]string{
@@ -32,6 +32,7 @@ var (
 		"client-id":         {"rest", "mcp_server"},
 		"client-secret":     {"rest", "mcp_server"},
 		"scope":             {"rest", "mcp_server"},
+		"sse-endpoint":      {"mcp_server"},
 	}
 
 	ConnectionRequiredSecretMapping = map[string][]string{
@@ -69,5 +70,6 @@ var (
 		"client-id":         "OAUTH2_CLIENT_ID",
 		"client-secret":     "OAUTH2_CLIENT_SECRET",
 		"scope":             "OAUTH2_SCOPE",
+		"sse-endpoint":      "SSE_ENDPOINT",
 	}
 )

--- a/test/flink_test.go
+++ b/test/flink_test.go
@@ -173,9 +173,9 @@ func (s *CLITestSuite) TestFlinkConnectionCreateSuccess() {
 		{args: "flink connection create my-connection --cloud aws --region eu-west-1 --type rest --endpoint https://api.example.com --username name --password pass", fixture: "flink/connection/create/create-rest.golden"},
 		{args: "flink connection create my-connection --cloud aws --region eu-west-1 --type rest --endpoint https://api.example.com --token-endpoint https://api.example.com/auth --client-id clientId --client-secret secret --scope test_scope", fixture: "flink/connection/create/create-rest.golden"},
 		{args: "flink connection create my-connection --cloud aws --region eu-west-1 --type rest --endpoint https://api.example.com --token token", fixture: "flink/connection/create/create-rest.golden"},
-		{args: "flink connection create my-connection --cloud aws --region eu-west-1 --type mcp_server --endpoint https://api.example.com --api-key api_key", fixture: "flink/connection/create/create-mcp_server.golden"},
+		{args: "flink connection create my-connection --cloud aws --region eu-west-1 --type mcp_server --endpoint https://api.example.com --api-key api_key --sse-endpoint sse", fixture: "flink/connection/create/create-mcp_server.golden"},
 		{args: "flink connection create my-connection --cloud aws --region eu-west-1 --type mcp_server --endpoint https://api.example.com --token-endpoint https://api.example.com/auth --client-id clientId --client-secret secret --scope test_scope", fixture: "flink/connection/create/create-mcp_server.golden"},
-		{args: "flink connection create my-connection --cloud aws --region eu-west-1 --type mcp_server --endpoint https://api.example.com --token token", fixture: "flink/connection/create/create-mcp_server.golden"},
+		{args: "flink connection create my-connection --cloud aws --region eu-west-1 --type mcp_server --endpoint https://api.example.com --token token --sse-endpoint /sse", fixture: "flink/connection/create/create-mcp_server.golden"},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- PLACEHOLDER

New Features
- PLACEHOLDER

Bug Fixes
- PLACEHOLDER

Checklist
---------
<!-- 
Check each item below to ensure high-quality CLI development practices are followed. PR approval will not be granted until the checklist is fully reviewed.
For detailed instructions, please refer to this Confluence page: https://confluentinc.atlassian.net/wiki/spaces/AEGI/pages/3949592874/
-->
- [ ] I have successfully built and used a custom CLI binary, without linter issues from this PR.
- [ ] I have clearly specified in the `What` section below whether this PR applies to Confluent Cloud, Confluent Platform, or both. 
- [ ] I have verified this PR in Confluent Cloud pre-prod or production environment, if applicable.
- [ ] I have verified this PR in Confluent Platform on-premises environment, if applicable.
- [ ] I have attached manual CLI verification results or screenshots in the `Test & Review` section below.
- [ ] I have added appropriate CLI integration or unit tests for any new or updated commands and functionality.
- [ ] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [ ] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [ ] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [ ] Confluent Cloud prod
  - [ ] Confluent Cloud stag
  - [ ] Confluent Platform
  - [ ] Check this box if the feature is enabled for certain organizations only

What
----
User should have the option to provdie SSE endpoint. Though industry standard endpoint is /sse for sse initialization request it can be different. Added option falg sse-endpoint for MCP_SERVER type connection 

Blast Radius
----
<!--
Should not affect anything as it is an optional key and has MCP_SERVER has not been released yet
-->

References
----------
<!-- Include links to relevant resources for this PR, such as: 
- Related GitHub issues 
- Tickets (JIRA, etc.) 
- Internal documentation or design specs 
- Other related PRs 
Copy and paste the links below for easy reference.
-->

Test & Review
-------------
There are already existing tests for this functionality modified those to test new flag as well
