### PR TITLE
[AM-5230] Add support for kafka IPF CRUD

### DIFF
--- a/internal/iam/command_ipfilter.go
+++ b/internal/iam/command_ipfilter.go
@@ -56,7 +56,7 @@ func printIpFilter(cmd *cobra.Command, ipFilter iamipfilteringv2.IamV2IpFilter) 
 		ResourceScope: ipFilter.GetResourceScope(),
 		IpGroups:      ipGroupIds,
 	}
-	if ipFilter.OperationGroups != nil {
+	if ipFilter.GetOperationGroups() != nil {
 		sort.Strings(*ipFilter.OperationGroups)
 	}
 	filterOut.OperationGroups = ipFilter.GetOperationGroups()

--- a/internal/iam/command_ipfilter.go
+++ b/internal/iam/command_ipfilter.go
@@ -45,7 +45,7 @@ func newIpFilterCommand(cfg *config.Config, prerunner pcmd.PreRunner) *cobra.Com
 	return cmd
 }
 
-func printIpFilter(cmd *cobra.Command, ipFilter iamipfilteringv2.IamV2IpFilter, isSrEnabled, isFlinkEnabled, isKafkaEnabled bool) error {
+func printIpFilter(cmd *cobra.Command, ipFilter iamipfilteringv2.IamV2IpFilter) error {
 	ipGroupIds := convertIpGroupsToIds(ipFilter.GetIpGroups())
 	slices.Sort(ipGroupIds)
 	table := output.NewTable(cmd)
@@ -53,15 +53,13 @@ func printIpFilter(cmd *cobra.Command, ipFilter iamipfilteringv2.IamV2IpFilter, 
 		ID:            ipFilter.GetId(),
 		Name:          ipFilter.GetFilterName(),
 		ResourceGroup: ipFilter.GetResourceGroup(),
+		ResourceScope: ipFilter.GetResourceScope(),
 		IpGroups:      ipGroupIds,
 	}
-	if isSrEnabled || isFlinkEnabled || isKafkaEnabled {
-		filterOut.ResourceScope = ipFilter.GetResourceScope()
-		if ipFilter.OperationGroups != nil {
-			sort.Strings(*ipFilter.OperationGroups)
-		}
-		filterOut.OperationGroups = ipFilter.GetOperationGroups()
+	if ipFilter.OperationGroups != nil {
+		sort.Strings(*ipFilter.OperationGroups)
 	}
+	filterOut.OperationGroups = ipFilter.GetOperationGroups()
 	table.Add(filterOut)
 	return table.Print()
 }

--- a/internal/iam/command_ipfilter.go
+++ b/internal/iam/command_ipfilter.go
@@ -49,17 +49,17 @@ func printIpFilter(cmd *cobra.Command, ipFilter iamipfilteringv2.IamV2IpFilter) 
 	ipGroupIds := convertIpGroupsToIds(ipFilter.GetIpGroups())
 	slices.Sort(ipGroupIds)
 	table := output.NewTable(cmd)
-	filterOut := &ipFilterOut{
-		ID:            ipFilter.GetId(),
-		Name:          ipFilter.GetFilterName(),
-		ResourceGroup: ipFilter.GetResourceGroup(),
-		ResourceScope: ipFilter.GetResourceScope(),
-		IpGroups:      ipGroupIds,
-	}
 	if ipFilter.GetOperationGroups() != nil {
 		sort.Strings(*ipFilter.OperationGroups)
 	}
-	filterOut.OperationGroups = ipFilter.GetOperationGroups()
+	filterOut := &ipFilterOut{
+		ID:              ipFilter.GetId(),
+		Name:            ipFilter.GetFilterName(),
+		ResourceGroup:   ipFilter.GetResourceGroup(),
+		IpGroups:        ipGroupIds,
+		OperationGroups: ipFilter.GetOperationGroups(),
+		ResourceScope:   ipFilter.GetResourceScope(),
+	}
 	table.Add(filterOut)
 	return table.Print()
 }

--- a/internal/iam/command_ipfilter.go
+++ b/internal/iam/command_ipfilter.go
@@ -39,7 +39,7 @@ func newIpFilterCommand(cfg *config.Config, prerunner pcmd.PreRunner) *cobra.Com
 	cmd.AddCommand(c.newCreateCommand(cfg))
 	cmd.AddCommand(c.newDeleteCommand())
 	cmd.AddCommand(c.newDescribeCommand())
-	cmd.AddCommand(c.newListCommand(cfg))
+	cmd.AddCommand(c.newListCommand())
 	cmd.AddCommand(c.newUpdateCommand(cfg))
 
 	return cmd

--- a/internal/iam/command_ipfilter.go
+++ b/internal/iam/command_ipfilter.go
@@ -45,7 +45,7 @@ func newIpFilterCommand(cfg *config.Config, prerunner pcmd.PreRunner) *cobra.Com
 	return cmd
 }
 
-func printIpFilter(cmd *cobra.Command, ipFilter iamipfilteringv2.IamV2IpFilter, isSrEnabled, isFlinkEnabled bool) error {
+func printIpFilter(cmd *cobra.Command, ipFilter iamipfilteringv2.IamV2IpFilter, isSrEnabled, isFlinkEnabled, isKafkaEnabled bool) error {
 	ipGroupIds := convertIpGroupsToIds(ipFilter.GetIpGroups())
 	slices.Sort(ipGroupIds)
 	table := output.NewTable(cmd)
@@ -55,7 +55,7 @@ func printIpFilter(cmd *cobra.Command, ipFilter iamipfilteringv2.IamV2IpFilter, 
 		ResourceGroup: ipFilter.GetResourceGroup(),
 		IpGroups:      ipGroupIds,
 	}
-	if isSrEnabled || isFlinkEnabled {
+	if isSrEnabled || isFlinkEnabled || isKafkaEnabled {
 		filterOut.ResourceScope = ipFilter.GetResourceScope()
 		if ipFilter.OperationGroups != nil {
 			sort.Strings(*ipFilter.OperationGroups)

--- a/internal/iam/command_ipfilter_create.go
+++ b/internal/iam/command_ipfilter_create.go
@@ -25,45 +25,24 @@ func (c *ipFilterCommand) newCreateCommand(cfg *config.Config) *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		RunE:  c.create,
 	}
-	isSrEnabled := cfg.IsTest || (cfg.Context() != nil && featureflags.Manager.BoolVariation("auth.ip_filter.sr.cli.enabled", cfg.Context(), featureflags.GetCcloudLaunchDarklyClient(cfg.Context().PlatformName), true, false))
-	isFlinkEnabled := cfg.IsTest || (cfg.Context() != nil && featureflags.Manager.BoolVariation("auth.ip_filter.flink.cli.enabled", cfg.Context(), featureflags.GetCcloudLaunchDarklyClient(cfg.Context().PlatformName), true, false))
 	isKafkaEnabled := cfg.IsTest || (cfg.Context() != nil && featureflags.Manager.BoolVariation("auth.ip_filter.kafka.cli.enabled", cfg.Context(), featureflags.GetCcloudLaunchDarklyClient(cfg.Context().PlatformName), true, false))
-	if isSrEnabled || isFlinkEnabled || isKafkaEnabled {
-		cmd.Example = examples.BuildExampleString(
-			examples.Example{
-				Text: `Create an IP filter named "demo-ip-filter" with operation group "management" and IP groups "ipg-12345" and "ipg-67890":`,
-				Code: "confluent iam ip-filter create demo-ip-filter --operations management --ip-groups ipg-12345,ipg-67890",
-			},
-		)
-	} else {
-		cmd.Example = examples.BuildExampleString(
-			examples.Example{
-				Text: `Create an IP filter named "demo-ip-filter" with resource group "management" and IP groups "ipg-12345" and "ipg-67890":`,
-				Code: "confluent iam ip-filter create demo-ip-filter --resource-group management --ip-groups ipg-12345,ipg-67890",
-			},
-		)
-	}
-	pcmd.AddResourceGroupFlag(cmd, isSrEnabled, isFlinkEnabled, isKafkaEnabled)
+	cmd.Example = examples.BuildExampleString(
+		examples.Example{
+			Text: `Create an IP filter named "demo-ip-filter" with operation group "management" and IP groups "ipg-12345" and "ipg-67890":`,
+			Code: "confluent iam ip-filter create demo-ip-filter --operations management --ip-groups ipg-12345,ipg-67890",
+		},
+	)
+	pcmd.AddResourceGroupFlag(cmd)
 	cmd.Flags().StringSlice("ip-groups", []string{}, "A comma-separated list of IP group IDs.")
-	if isSrEnabled || isFlinkEnabled || isKafkaEnabled {
-		cmd.Flags().String("environment", "", "Identifier of the environment for which this filter applies. Without this flag, applies only to the organization.")
-		opGroups := []string{"MANAGEMENT"}
-		if isSrEnabled {
-			opGroups = append(opGroups, "SCHEMA")
-		}
-		if isFlinkEnabled {
-			opGroups = append(opGroups, "FLINK")
-		}
-		if isKafkaEnabled {
-			opGroups = append(opGroups, "KAFKA_MANAGEMENT", "KAFKA_DATA")
-		}
-		cmd.Flags().StringSlice("operations", nil, fmt.Sprintf("A comma-separated list of operation groups: %s.", utils.ArrayToCommaDelimitedString(opGroups, "or")))
-		cmd.Flags().Bool("no-public-networks", false, "Use in place of ip-groups to reference the no public networks IP Group.")
-		cmd.MarkFlagsMutuallyExclusive("ip-groups", "no-public-networks")
-		cmd.MarkFlagsMutuallyExclusive("resource-group", "operations")
-	} else {
-		cobra.CheckErr(cmd.MarkFlagRequired("ip-groups"))
+	cmd.Flags().String("environment", "", "Identifier of the environment for which this filter applies. Without this flag, applies only to the organization.")
+	opGroups := []string{"MANAGEMENT", "SCHEMA", "FLINK"}
+	if isKafkaEnabled {
+		opGroups = append(opGroups, "KAFKA_MANAGEMENT", "KAFKA_DATA")
 	}
+	cmd.Flags().StringSlice("operations", nil, fmt.Sprintf("A comma-separated list of operation groups: %s.", utils.ArrayToCommaDelimitedString(opGroups, "or")))
+	cmd.Flags().Bool("no-public-networks", false, "Use in place of ip-groups to reference the no public networks IP Group.")
+	cmd.MarkFlagsMutuallyExclusive("ip-groups", "no-public-networks")
+	cmd.MarkFlagsMutuallyExclusive("resource-group", "operations")
 	pcmd.AddContextFlag(cmd, c.CLICommand)
 	pcmd.AddOutputFlag(cmd)
 
@@ -81,37 +60,31 @@ func (c *ipFilterCommand) create(cmd *cobra.Command, args []string) error {
 	}
 	resourceScope := ""
 	operationGroups := []string{}
-	ldClient := featureflags.GetCcloudLaunchDarklyClient(c.Context.PlatformName)
-	isSrEnabled := c.Config.IsTest || featureflags.Manager.BoolVariation("auth.ip_filter.sr.cli.enabled", c.Context, ldClient, true, false)
-	isFlinkEnabled := c.Config.IsTest || featureflags.Manager.BoolVariation("auth.ip_filter.flink.cli.enabled", c.Context, ldClient, true, false)
-	isKafkaEnabled := c.Config.IsTest || featureflags.Manager.BoolVariation("auth.ip_filter.kafka.cli.enabled", c.Context, ldClient, true, false)
-	if isSrEnabled || isFlinkEnabled || isKafkaEnabled {
-		orgId := c.Context.GetCurrentOrganization()
-		environment, err := cmd.Flags().GetString("environment")
-		if err != nil {
-			return err
-		}
-		if environment != "" {
-			resourceScope = fmt.Sprintf(resourceScopeStr, orgId, environment)
-		}
-		operationGroups, err = cmd.Flags().GetStringSlice("operations")
-		if err != nil {
-			return err
-		}
-		if len(operationGroups) == 0 && resourceGroup == "multiple" {
-			operationGroups = []string{"MANAGEMENT"}
-		}
-		if resourceGroup == "management" {
-			operationGroups = []string{"MANAGEMENT"}
-			resourceGroup = "multiple"
-		}
-		npnGroup, err := cmd.Flags().GetBool("no-public-networks")
-		if err != nil {
-			return err
-		}
-		if npnGroup {
-			ipGroups = []string{"ipg-none"}
-		}
+	orgId := c.Context.GetCurrentOrganization()
+	environment, err := cmd.Flags().GetString("environment")
+	if err != nil {
+		return err
+	}
+	if environment != "" {
+		resourceScope = fmt.Sprintf(resourceScopeStr, orgId, environment)
+	}
+	operationGroups, err = cmd.Flags().GetStringSlice("operations")
+	if err != nil {
+		return err
+	}
+	if len(operationGroups) == 0 && resourceGroup == "multiple" {
+		operationGroups = []string{"MANAGEMENT"}
+	}
+	if resourceGroup == "management" {
+		operationGroups = []string{"MANAGEMENT"}
+		resourceGroup = "multiple"
+	}
+	npnGroup, err := cmd.Flags().GetBool("no-public-networks")
+	if err != nil {
+		return err
+	}
+	if npnGroup {
+		ipGroups = []string{"ipg-none"}
 	}
 
 	// Convert the IP group IDs into IP group objects
@@ -150,5 +123,5 @@ func (c *ipFilterCommand) create(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	return printIpFilter(cmd, filter, isSrEnabled, isFlinkEnabled, isKafkaEnabled)
+	return printIpFilter(cmd, filter)
 }

--- a/internal/iam/command_ipfilter_create.go
+++ b/internal/iam/command_ipfilter_create.go
@@ -45,7 +45,7 @@ func (c *ipFilterCommand) newCreateCommand(cfg *config.Config) *cobra.Command {
 	}
 	pcmd.AddResourceGroupFlag(cmd, isSrEnabled, isFlinkEnabled, isKafkaEnabled)
 	cmd.Flags().StringSlice("ip-groups", []string{}, "A comma-separated list of IP group IDs.")
-	if isSrEnabled || isFlinkEnabled {
+	if isSrEnabled || isFlinkEnabled || isKafkaEnabled {
 		cmd.Flags().String("environment", "", "Identifier of the environment for which this filter applies. Without this flag, applies only to the organization.")
 		opGroups := []string{"MANAGEMENT"}
 		if isSrEnabled {

--- a/internal/iam/command_ipfilter_describe.go
+++ b/internal/iam/command_ipfilter_describe.go
@@ -4,7 +4,6 @@ import (
 	"github.com/spf13/cobra"
 
 	pcmd "github.com/confluentinc/cli/v4/pkg/cmd"
-	"github.com/confluentinc/cli/v4/pkg/featureflags"
 )
 
 func (c *ipFilterCommand) newDescribeCommand() *cobra.Command {
@@ -26,9 +25,5 @@ func (c *ipFilterCommand) describe(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	ldClient := featureflags.GetCcloudLaunchDarklyClient(c.Context.PlatformName)
-	isSrEnabled := c.Config.IsTest || featureflags.Manager.BoolVariation("auth.ip_filter.sr.cli.enabled", c.Context, ldClient, true, false)
-	isFlinkEnabled := c.Config.IsTest || featureflags.Manager.BoolVariation("auth.ip_filter.flink.cli.enabled", c.Context, ldClient, true, false)
-	isKafkaEnabled := c.Config.IsTest || featureflags.Manager.BoolVariation("auth.ip_filter.kafka.cli.enabled", c.Context, ldClient, true, false)
-	return printIpFilter(cmd, filter, isSrEnabled, isFlinkEnabled, isKafkaEnabled)
+	return printIpFilter(cmd, filter)
 }

--- a/internal/iam/command_ipfilter_describe.go
+++ b/internal/iam/command_ipfilter_describe.go
@@ -29,5 +29,6 @@ func (c *ipFilterCommand) describe(cmd *cobra.Command, args []string) error {
 	ldClient := featureflags.GetCcloudLaunchDarklyClient(c.Context.PlatformName)
 	isSrEnabled := c.Config.IsTest || featureflags.Manager.BoolVariation("auth.ip_filter.sr.cli.enabled", c.Context, ldClient, true, false)
 	isFlinkEnabled := c.Config.IsTest || featureflags.Manager.BoolVariation("auth.ip_filter.flink.cli.enabled", c.Context, ldClient, true, false)
-	return printIpFilter(cmd, filter, isSrEnabled, isFlinkEnabled)
+	isKafkaEnabled := c.Config.IsTest || featureflags.Manager.BoolVariation("auth.ip_filter.kafka.cli.enabled", c.Context, ldClient, true, false)
+	return printIpFilter(cmd, filter, isSrEnabled, isFlinkEnabled, isKafkaEnabled)
 }

--- a/internal/iam/command_ipfilter_list.go
+++ b/internal/iam/command_ipfilter_list.go
@@ -10,11 +10,10 @@ import (
 	iamipfilteringv2 "github.com/confluentinc/ccloud-sdk-go-v2/iam-ip-filtering/v2"
 
 	pcmd "github.com/confluentinc/cli/v4/pkg/cmd"
-	"github.com/confluentinc/cli/v4/pkg/config"
 	"github.com/confluentinc/cli/v4/pkg/output"
 )
 
-func (c *ipFilterCommand) newListCommand(cfg *config.Config) *cobra.Command {
+func (c *ipFilterCommand) newListCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List IP filters.",

--- a/internal/iam/command_ipfilter_list.go
+++ b/internal/iam/command_ipfilter_list.go
@@ -54,17 +54,17 @@ func (c *ipFilterCommand) list(cmd *cobra.Command, _ []string) error {
 	}
 	list := output.NewList(cmd)
 	for _, filter := range ipFilters {
-		filterOut := ipFilterOut{
-			ID:            filter.GetId(),
-			Name:          filter.GetFilterName(),
-			ResourceGroup: filter.GetResourceGroup(),
-			ResourceScope: filter.GetResourceScope(),
-			IpGroups:      convertIpGroupObjectsToIpGroupIds(filter),
-		}
-		if filter.OperationGroups != nil {
+		if filter.GetOperationGroups() != nil {
 			sort.Strings(*filter.OperationGroups)
 		}
-		filterOut.OperationGroups = filter.GetOperationGroups()
+		filterOut := ipFilterOut{
+			ID:              filter.GetId(),
+			Name:            filter.GetFilterName(),
+			ResourceGroup:   filter.GetResourceGroup(),
+			ResourceScope:   filter.GetResourceScope(),
+			IpGroups:        convertIpGroupObjectsToIpGroupIds(filter),
+			OperationGroups: filter.GetOperationGroups(),
+		}
 		list.Add(&filterOut)
 	}
 	return list.Print()

--- a/internal/iam/command_ipfilter_list.go
+++ b/internal/iam/command_ipfilter_list.go
@@ -11,7 +11,6 @@ import (
 
 	pcmd "github.com/confluentinc/cli/v4/pkg/cmd"
 	"github.com/confluentinc/cli/v4/pkg/config"
-	"github.com/confluentinc/cli/v4/pkg/featureflags"
 	"github.com/confluentinc/cli/v4/pkg/output"
 )
 
@@ -22,13 +21,8 @@ func (c *ipFilterCommand) newListCommand(cfg *config.Config) *cobra.Command {
 		Args:  cobra.NoArgs,
 		RunE:  c.list,
 	}
-	isSrEnabled := cfg.IsTest || (cfg.Context() != nil && featureflags.Manager.BoolVariation("auth.ip_filter.sr.cli.enabled", cfg.Context(), featureflags.GetCcloudLaunchDarklyClient(cfg.Context().PlatformName), true, false))
-	isFlinkEnabled := cfg.IsTest || (cfg.Context() != nil && featureflags.Manager.BoolVariation("auth.ip_filter.flink.cli.enabled", cfg.Context(), featureflags.GetCcloudLaunchDarklyClient(cfg.Context().PlatformName), true, false))
-	isKafkaEnabled := cfg.IsTest || (cfg.Context() != nil && featureflags.Manager.BoolVariation("auth.ip_filter.kafka.cli.enabled", cfg.Context(), featureflags.GetCcloudLaunchDarklyClient(cfg.Context().PlatformName), true, false))
-	if isSrEnabled || isFlinkEnabled || isKafkaEnabled {
-		cmd.Flags().String("environment", "", "Identifier of the environment for which this filter applies. Without this flag, applies only to the organization.")
-		cmd.Flags().Bool("include-parent-scopes", false, "Include organization scoped filters when listing filters in an environment.")
-	}
+	cmd.Flags().String("environment", "", "Identifier of the environment for which this filter applies. Without this flag, applies only to the organization.")
+	cmd.Flags().Bool("include-parent-scopes", false, "Include organization scoped filters when listing filters in an environment.")
 
 	pcmd.AddContextFlag(cmd, c.CLICommand)
 	pcmd.AddOutputFlag(cmd)
@@ -38,38 +32,26 @@ func (c *ipFilterCommand) newListCommand(cfg *config.Config) *cobra.Command {
 
 func (c *ipFilterCommand) list(cmd *cobra.Command, _ []string) error {
 	var ipFilters []iamipfilteringv2.IamV2IpFilter
-	ldClient := featureflags.GetCcloudLaunchDarklyClient(c.Context.PlatformName)
-	isSrEnabled := c.Config.IsTest || featureflags.Manager.BoolVariation("auth.ip_filter.sr.cli.enabled", c.Context, ldClient, true, false)
-	isFlinkEnabled := c.Config.IsTest || featureflags.Manager.BoolVariation("auth.ip_filter.flink.cli.enabled", c.Context, ldClient, true, false)
-	isKafkaEnabled := c.Config.IsTest || featureflags.Manager.BoolVariation("auth.ip_filter.kafka.cli.enabled", c.Context, ldClient, true, false)
-	if isSrEnabled || isFlinkEnabled || isKafkaEnabled {
-		orgId := c.Context.GetCurrentOrganization()
-		environment, err := cmd.Flags().GetString("environment")
-		if err != nil {
-			return err
-		}
-		resourceScope := ""
-		if environment != "" {
-			resourceScope = fmt.Sprintf(resourceScopeStr, orgId, environment)
-		}
-		includeParentScopes, err := cmd.Flags().GetBool("include-parent-scopes")
-		if err != nil {
-			return err
-		}
-		parentScopes := ""
-		if cmd.Flags().Changed("include-parent-scopes") {
-			parentScopes = strconv.FormatBool(includeParentScopes)
-		}
-		ipFilters, err = c.V2Client.ListIamIpFilters(resourceScope, parentScopes)
-		if err != nil {
-			return err
-		}
-	} else {
-		var err error
-		ipFilters, err = c.V2Client.ListIamIpFilters("", "")
-		if err != nil {
-			return err
-		}
+	orgId := c.Context.GetCurrentOrganization()
+	environment, err := cmd.Flags().GetString("environment")
+	if err != nil {
+		return err
+	}
+	resourceScope := ""
+	if environment != "" {
+		resourceScope = fmt.Sprintf(resourceScopeStr, orgId, environment)
+	}
+	includeParentScopes, err := cmd.Flags().GetBool("include-parent-scopes")
+	if err != nil {
+		return err
+	}
+	parentScopes := ""
+	if cmd.Flags().Changed("include-parent-scopes") {
+		parentScopes = strconv.FormatBool(includeParentScopes)
+	}
+	ipFilters, err = c.V2Client.ListIamIpFilters(resourceScope, parentScopes)
+	if err != nil {
+		return err
 	}
 	list := output.NewList(cmd)
 	for _, filter := range ipFilters {
@@ -77,15 +59,13 @@ func (c *ipFilterCommand) list(cmd *cobra.Command, _ []string) error {
 			ID:            filter.GetId(),
 			Name:          filter.GetFilterName(),
 			ResourceGroup: filter.GetResourceGroup(),
+			ResourceScope: filter.GetResourceScope(),
 			IpGroups:      convertIpGroupObjectsToIpGroupIds(filter),
 		}
-		if isSrEnabled || isFlinkEnabled || isKafkaEnabled {
-			filterOut.ResourceScope = filter.GetResourceScope()
-			if filter.OperationGroups != nil {
-				sort.Strings(*filter.OperationGroups)
-			}
-			filterOut.OperationGroups = filter.GetOperationGroups()
+		if filter.OperationGroups != nil {
+			sort.Strings(*filter.OperationGroups)
 		}
+		filterOut.OperationGroups = filter.GetOperationGroups()
 		list.Add(&filterOut)
 	}
 	return list.Print()

--- a/internal/iam/command_ipfilter_list.go
+++ b/internal/iam/command_ipfilter_list.go
@@ -24,14 +24,9 @@ func (c *ipFilterCommand) newListCommand(cfg *config.Config) *cobra.Command {
 	}
 	isSrEnabled := cfg.IsTest || (cfg.Context() != nil && featureflags.Manager.BoolVariation("auth.ip_filter.sr.cli.enabled", cfg.Context(), featureflags.GetCcloudLaunchDarklyClient(cfg.Context().PlatformName), true, false))
 	isFlinkEnabled := cfg.IsTest || (cfg.Context() != nil && featureflags.Manager.BoolVariation("auth.ip_filter.flink.cli.enabled", cfg.Context(), featureflags.GetCcloudLaunchDarklyClient(cfg.Context().PlatformName), true, false))
-<<<<<<< Updated upstream
-	if isSrEnabled || isFlinkEnabled {
-		cmd.Flags().String("environment", "", "Identifier of the environment for which this filter applies. Without this flag, applies only to the organization.")
-=======
 	isKafkaEnabled := cfg.IsTest || (cfg.Context() != nil && featureflags.Manager.BoolVariation("auth.ip_filter.kafka.cli.enabled", cfg.Context(), featureflags.GetCcloudLaunchDarklyClient(cfg.Context().PlatformName), true, false))
 	if isSrEnabled || isFlinkEnabled || isKafkaEnabled {
-		cmd.Flags().String("environment", "", "Id of the environment for which this filter applies. By default will apply to the org only.")
->>>>>>> Stashed changes
+		cmd.Flags().String("environment", "", "Identifier of the environment for which this filter applies. Without this flag, applies only to the organization.")
 		cmd.Flags().Bool("include-parent-scopes", false, "Include organization scoped filters when listing filters in an environment.")
 	}
 

--- a/internal/iam/command_ipfilter_list.go
+++ b/internal/iam/command_ipfilter_list.go
@@ -24,8 +24,14 @@ func (c *ipFilterCommand) newListCommand(cfg *config.Config) *cobra.Command {
 	}
 	isSrEnabled := cfg.IsTest || (cfg.Context() != nil && featureflags.Manager.BoolVariation("auth.ip_filter.sr.cli.enabled", cfg.Context(), featureflags.GetCcloudLaunchDarklyClient(cfg.Context().PlatformName), true, false))
 	isFlinkEnabled := cfg.IsTest || (cfg.Context() != nil && featureflags.Manager.BoolVariation("auth.ip_filter.flink.cli.enabled", cfg.Context(), featureflags.GetCcloudLaunchDarklyClient(cfg.Context().PlatformName), true, false))
+<<<<<<< Updated upstream
 	if isSrEnabled || isFlinkEnabled {
 		cmd.Flags().String("environment", "", "Identifier of the environment for which this filter applies. Without this flag, applies only to the organization.")
+=======
+	isKafkaEnabled := cfg.IsTest || (cfg.Context() != nil && featureflags.Manager.BoolVariation("auth.ip_filter.kafka.cli.enabled", cfg.Context(), featureflags.GetCcloudLaunchDarklyClient(cfg.Context().PlatformName), true, false))
+	if isSrEnabled || isFlinkEnabled || isKafkaEnabled {
+		cmd.Flags().String("environment", "", "Id of the environment for which this filter applies. By default will apply to the org only.")
+>>>>>>> Stashed changes
 		cmd.Flags().Bool("include-parent-scopes", false, "Include organization scoped filters when listing filters in an environment.")
 	}
 
@@ -40,7 +46,8 @@ func (c *ipFilterCommand) list(cmd *cobra.Command, _ []string) error {
 	ldClient := featureflags.GetCcloudLaunchDarklyClient(c.Context.PlatformName)
 	isSrEnabled := c.Config.IsTest || featureflags.Manager.BoolVariation("auth.ip_filter.sr.cli.enabled", c.Context, ldClient, true, false)
 	isFlinkEnabled := c.Config.IsTest || featureflags.Manager.BoolVariation("auth.ip_filter.flink.cli.enabled", c.Context, ldClient, true, false)
-	if isSrEnabled || isFlinkEnabled {
+	isKafkaEnabled := c.Config.IsTest || featureflags.Manager.BoolVariation("auth.ip_filter.kafka.cli.enabled", c.Context, ldClient, true, false)
+	if isSrEnabled || isFlinkEnabled || isKafkaEnabled {
 		orgId := c.Context.GetCurrentOrganization()
 		environment, err := cmd.Flags().GetString("environment")
 		if err != nil {
@@ -77,7 +84,7 @@ func (c *ipFilterCommand) list(cmd *cobra.Command, _ []string) error {
 			ResourceGroup: filter.GetResourceGroup(),
 			IpGroups:      convertIpGroupObjectsToIpGroupIds(filter),
 		}
-		if isSrEnabled || isFlinkEnabled {
+		if isSrEnabled || isFlinkEnabled || isKafkaEnabled {
 			filterOut.ResourceScope = filter.GetResourceScope()
 			if filter.OperationGroups != nil {
 				sort.Strings(*filter.OperationGroups)

--- a/internal/iam/command_ipfilter_update.go
+++ b/internal/iam/command_ipfilter_update.go
@@ -25,46 +25,25 @@ func (c *ipFilterCommand) newUpdateCommand(cfg *config.Config) *cobra.Command {
 		ValidArgsFunction: pcmd.NewValidArgsFunction(c.validArgs),
 		RunE:              c.update,
 	}
-	isSrEnabled := cfg.IsTest || (cfg.Context() != nil && featureflags.Manager.BoolVariation("auth.ip_filter.sr.cli.enabled", cfg.Context(), featureflags.GetCcloudLaunchDarklyClient(cfg.Context().PlatformName), true, false))
-	isFlinkEnabled := cfg.IsTest || (cfg.Context() != nil && featureflags.Manager.BoolVariation("auth.ip_filter.flink.cli.enabled", cfg.Context(), featureflags.GetCcloudLaunchDarklyClient(cfg.Context().PlatformName), true, false))
 	isKafkaEnabled := cfg.IsTest || (cfg.Context() != nil && featureflags.Manager.BoolVariation("auth.ip_filter.kafka.cli.enabled", cfg.Context(), featureflags.GetCcloudLaunchDarklyClient(cfg.Context().PlatformName), true, false))
-	if isSrEnabled || isFlinkEnabled || isKafkaEnabled {
-		operationGroups := []string{}
-		if isSrEnabled {
-			operationGroups = append(operationGroups, "SCHEMA")
-		}
-		if isFlinkEnabled {
-			operationGroups = append(operationGroups, "FLINK")
-		}
-		if isKafkaEnabled {
-			operationGroups = append(operationGroups, "KAFKA_MANAGEMENT", "KAFKA_DATA")
-		}
-		cmd.Example = examples.BuildExampleString(
-			examples.Example{
-				Text: `Update the name and add an IP group and operation group to IP filter "ipf-abcde":`,
-				Code: fmt.Sprintf(`confluent iam ip-filter update ipf-abcde --name "New Filter Name" --add-ip-groups ipg-12345 --add-operation-groups %s`, strings.Join(operationGroups, ",")),
-			},
-		)
-	} else {
-		cmd.Example = examples.BuildExampleString(
-			examples.Example{
-				Text: `Update the name and add an IP group to IP filter "ipf-abcde":`,
-				Code: `confluent iam ip-filter update ipf-abcde --name "New Filter Name" --add-ip-groups ipg-12345`,
-			},
-		)
+	operationGroups := []string{"SCHEMA", "FLINK"}
+	if isKafkaEnabled {
+		operationGroups = append(operationGroups, "KAFKA_MANAGEMENT", "KAFKA_DATA")
 	}
+	cmd.Example = examples.BuildExampleString(
+		examples.Example{
+			Text: `Update the name and add an IP group and operation group to IP filter "ipf-abcde":`,
+			Code: fmt.Sprintf(`confluent iam ip-filter update ipf-abcde --name "New Filter Name" --add-ip-groups ipg-12345 --add-operation-groups %s`, strings.Join(operationGroups, ",")),
+		},
+	)
 	cmd.Flags().String("name", "", "Updated name of the IP filter.")
-	pcmd.AddResourceGroupFlag(cmd, isSrEnabled, isFlinkEnabled, isKafkaEnabled)
+	pcmd.AddResourceGroupFlag(cmd)
 
 	cmd.Flags().StringSlice("add-ip-groups", []string{}, "A comma-separated list of IP groups to add.")
 	cmd.Flags().StringSlice("remove-ip-groups", []string{}, "A comma-separated list of IP groups to remove.")
-	if isSrEnabled || isFlinkEnabled {
-		cmd.Flags().StringSlice("add-operation-groups", []string{}, "A comma-separated list of operation groups to add.")
-		cmd.Flags().StringSlice("remove-operation-groups", []string{}, "A comma-separated list of operation groups to remove.")
-		cmd.MarkFlagsOneRequired("name", "resource-group", "add-ip-groups", "remove-ip-groups", "add-operation-groups", "remove-operation-groups")
-	} else {
-		cmd.MarkFlagsOneRequired("name", "resource-group", "add-ip-groups", "remove-ip-groups")
-	}
+	cmd.Flags().StringSlice("add-operation-groups", []string{}, "A comma-separated list of operation groups to add.")
+	cmd.Flags().StringSlice("remove-operation-groups", []string{}, "A comma-separated list of operation groups to remove.")
+	cmd.MarkFlagsOneRequired("name", "resource-group", "add-ip-groups", "remove-ip-groups", "add-operation-groups", "remove-operation-groups")
 	pcmd.AddContextFlag(cmd, c.CLICommand)
 	pcmd.AddOutputFlag(cmd)
 
@@ -133,29 +112,23 @@ func (c *ipFilterCommand) update(cmd *cobra.Command, args []string) error {
 	}
 
 	updateIpFilter.IpGroups = &IpGroupIdObjects
-	ldClient := featureflags.GetCcloudLaunchDarklyClient(c.Context.PlatformName)
-	isSrEnabled := c.Config.IsTest || featureflags.Manager.BoolVariation("auth.ip_filter.sr.cli.enabled", c.Context, ldClient, true, false)
-	isFlinkEnabled := c.Config.IsTest || featureflags.Manager.BoolVariation("auth.ip_filter.flink.cli.enabled", c.Context, ldClient, true, false)
-	isKafkaEnabled := c.Config.IsTest || featureflags.Manager.BoolVariation("auth.ip_filter.kafka.cli.enabled", c.Context, ldClient, true, false)
-	if isSrEnabled || isFlinkEnabled || isKafkaEnabled {
-		addOperationGroups, err := cmd.Flags().GetStringSlice("add-operation-groups")
-		if err != nil {
-			return err
-		}
-
-		removeOperationGroups, err := cmd.Flags().GetStringSlice("remove-operation-groups")
-		if err != nil {
-			return err
-		}
-		newOperationGroups, warnings := types.AddAndRemove(currentOperationGroups, addOperationGroups, removeOperationGroups)
-		for _, warning := range warnings {
-			output.ErrPrintf(c.Config.EnableColor, "[WARN] %s\n", warning)
-		}
-		if len(newOperationGroups) == 0 && resourceGroup == "multiple" {
-			newOperationGroups = []string{"MANAGEMENT"}
-		}
-		updateIpFilter.OperationGroups = &newOperationGroups
+	addOperationGroups, err := cmd.Flags().GetStringSlice("add-operation-groups")
+	if err != nil {
+		return err
 	}
+
+	removeOperationGroups, err := cmd.Flags().GetStringSlice("remove-operation-groups")
+	if err != nil {
+		return err
+	}
+	newOperationGroups, warnings := types.AddAndRemove(currentOperationGroups, addOperationGroups, removeOperationGroups)
+	for _, warning := range warnings {
+		output.ErrPrintf(c.Config.EnableColor, "[WARN] %s\n", warning)
+	}
+	if len(newOperationGroups) == 0 && resourceGroup == "multiple" {
+		newOperationGroups = []string{"MANAGEMENT"}
+	}
+	updateIpFilter.OperationGroups = &newOperationGroups
 
 	filter, err := c.V2Client.UpdateIamIpFilter(updateIpFilter, currentIpFilterId)
 	if err != nil {
@@ -179,5 +152,5 @@ func (c *ipFilterCommand) update(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	return printIpFilter(cmd, filter, isSrEnabled, isFlinkEnabled, isKafkaEnabled)
+	return printIpFilter(cmd, filter)
 }

--- a/internal/iam/command_ipfilter_update.go
+++ b/internal/iam/command_ipfilter_update.go
@@ -128,7 +128,7 @@ func (c *ipFilterCommand) update(cmd *cobra.Command, args []string) error {
 	if len(newOperationGroups) == 0 && resourceGroup == "multiple" {
 		newOperationGroups = []string{"MANAGEMENT"}
 	}
-	updateIpFilter.OperationGroups = &newOperationGroups
+	updateIpFilter.SetOperationGroups(newOperationGroups)
 
 	filter, err := c.V2Client.UpdateIamIpFilter(updateIpFilter, currentIpFilterId)
 	if err != nil {

--- a/pkg/cmd/flags.go
+++ b/pkg/cmd/flags.go
@@ -375,14 +375,9 @@ func AutocompleteIdentityPools(client *ccloudv2.Client, providerId string) []str
 	return suggestions
 }
 
-func AddResourceGroupFlag(cmd *cobra.Command, isSrEnabled, isFlinkEnabled, isKafkaEnabled bool) {
-	var arr []string = []string{"management"}
-	if isSrEnabled || isFlinkEnabled || isKafkaEnabled {
-		arr = append(arr, "multiple")
-		cmd.Flags().String("resource-group", "multiple", fmt.Sprintf("Name of resource group: %s.", utils.ArrayToCommaDelimitedString(arr, "or")))
-	} else {
-		cmd.Flags().String("resource-group", "management", "Name of resource group. Currently, only \"management\" is supported.")
-	}
+func AddResourceGroupFlag(cmd *cobra.Command) {
+	var arr []string = []string{"management", "multiple"}
+	cmd.Flags().String("resource-group", "multiple", fmt.Sprintf("Name of resource group: %s.", utils.ArrayToCommaDelimitedString(arr, "or")))
 	RegisterFlagCompletionFunc(cmd, "resource-group", func(_ *cobra.Command, _ []string) []string {
 		return arr
 	})

--- a/pkg/cmd/flags.go
+++ b/pkg/cmd/flags.go
@@ -375,9 +375,9 @@ func AutocompleteIdentityPools(client *ccloudv2.Client, providerId string) []str
 	return suggestions
 }
 
-func AddResourceGroupFlag(cmd *cobra.Command, isSrEnabled, isFlinkEnabled bool) {
+func AddResourceGroupFlag(cmd *cobra.Command, isSrEnabled, isFlinkEnabled, isKafkaEnabled bool) {
 	var arr []string = []string{"management"}
-	if isSrEnabled || isFlinkEnabled {
+	if isSrEnabled || isFlinkEnabled || isKafkaEnabled {
 		arr = append(arr, "multiple")
 		cmd.Flags().String("resource-group", "multiple", fmt.Sprintf("Name of resource group: %s.", utils.ArrayToCommaDelimitedString(arr, "or")))
 	} else {

--- a/test/fixtures/output/iam/ip-filter/create-help.golden
+++ b/test/fixtures/output/iam/ip-filter/create-help.golden
@@ -11,8 +11,13 @@ Create an IP filter named "demo-ip-filter" with operation group "management" and
 Flags:
       --resource-group string   Name of resource group: "management" or "multiple". (default "multiple")
       --ip-groups strings       A comma-separated list of IP group IDs.
+<<<<<<< Updated upstream
       --environment string      Identifier of the environment for which this filter applies. Without this flag, applies only to the organization.
       --operations strings      A comma-separated list of operation groups: "MANAGEMENT", "SCHEMA", or "FLINK".
+=======
+      --environment string      Id of the environment for which this filter applies. By default will apply to the organization only.
+      --operations strings      A comma-separated list of operation groups: "MANAGEMENT", "SCHEMA", "FLINK", "KAFKA_MANAGEMENT", or "KAFKA_DATA".
+>>>>>>> Stashed changes
       --no-public-networks      Use in place of ip-groups to reference the no public networks IP Group.
       --context string          CLI context name.
   -o, --output string           Specify the output format as "human", "json", or "yaml". (default "human")

--- a/test/fixtures/output/iam/ip-filter/create-help.golden
+++ b/test/fixtures/output/iam/ip-filter/create-help.golden
@@ -11,13 +11,8 @@ Create an IP filter named "demo-ip-filter" with operation group "management" and
 Flags:
       --resource-group string   Name of resource group: "management" or "multiple". (default "multiple")
       --ip-groups strings       A comma-separated list of IP group IDs.
-<<<<<<< Updated upstream
       --environment string      Identifier of the environment for which this filter applies. Without this flag, applies only to the organization.
-      --operations strings      A comma-separated list of operation groups: "MANAGEMENT", "SCHEMA", or "FLINK".
-=======
-      --environment string      Id of the environment for which this filter applies. By default will apply to the organization only.
       --operations strings      A comma-separated list of operation groups: "MANAGEMENT", "SCHEMA", "FLINK", "KAFKA_MANAGEMENT", or "KAFKA_DATA".
->>>>>>> Stashed changes
       --no-public-networks      Use in place of ip-groups to reference the no public networks IP Group.
       --context string          CLI context name.
   -o, --output string           Specify the output format as "human", "json", or "yaml". (default "human")

--- a/test/fixtures/output/iam/ip-filter/update-add-kafka-operation-group.golden
+++ b/test/fixtures/output/iam/ip-filter/update-add-kafka-operation-group.golden
@@ -1,0 +1,9 @@
++------------------+-------------------------------------------+
+| ID               | ipf-34dq3                                 |
+| Name             | demo-ip-filter                            |
+| Resource Group   | multiple                                  |
+| IP Groups        | ipg-12345, ipg-abcde                      |
+| Operation Groups | KAFKA_DATA, KAFKA_MANAGEMENT,             |
+|                  | MANAGEMENT, SCHEMA                        |
+| Resource Scope   | crn://confluent.cloud/organization=org123 |
++------------------+-------------------------------------------+

--- a/test/fixtures/output/iam/ip-filter/update-help.golden
+++ b/test/fixtures/output/iam/ip-filter/update-help.golden
@@ -6,7 +6,7 @@ Usage:
 Examples:
 Update the name and add an IP group and operation group to IP filter "ipf-abcde":
 
-  $ confluent iam ip-filter update ipf-abcde --name "New Filter Name" --add-ip-groups ipg-12345 --add-operation-groups SCHEMA,FLINK
+  $ confluent iam ip-filter update ipf-abcde --name "New Filter Name" --add-ip-groups ipg-12345 --add-operation-groups SCHEMA,FLINK,KAFKA_MANAGEMENT,KAFKA_DATA
 
 Flags:
       --name string                       Updated name of the IP filter.

--- a/test/fixtures/output/iam/ip-filter/update-remove-kafka-operation-group.golden
+++ b/test/fixtures/output/iam/ip-filter/update-remove-kafka-operation-group.golden
@@ -1,0 +1,8 @@
++------------------+-------------------------------------------+
+| ID               | ipf-34dq3                                 |
+| Name             | demo-ip-filter                            |
+| Resource Group   | multiple                                  |
+| IP Groups        | ipg-12345, ipg-abcde                      |
+| Operation Groups | MANAGEMENT                                |
+| Resource Scope   | crn://confluent.cloud/organization=org123 |
++------------------+-------------------------------------------+

--- a/test/iam_test.go
+++ b/test/iam_test.go
@@ -420,6 +420,8 @@ func (s *CLITestSuite) TestIamIpFilter() {
 		{args: "iam ip-filter update ipf-34dq4 --remove-operation-groups SCHEMA", fixture: "iam/ip-filter/update-remove-operation-group.golden"},
 		{args: "iam ip-filter update ipf-34dq4 --resource-group multiple --add-operation-groups FLINK", fixture: "iam/ip-filter/update-add-flink-operation-group.golden"},
 		{args: "iam ip-filter update ipf-34dq6 --remove-operation-groups SCHEMA,FLINK", fixture: "iam/ip-filter/update-remove-sr-and-flink-operation-group.golden"},
+		{args: "iam ip-filter update ipf-34dq4 --resource-group multiple --add-operation-groups KAFKA_MANAGEMENT,KAFKA_DATA", fixture: "iam/ip-filter/update-add-kafka-operation-group.golden"},
+		{args: "iam ip-filter update ipf-34dq7 --remove-operation-groups KAFKA_MANAGEMENT,KAFKA_DATA", fixture: "iam/ip-filter/update-remove-kafka-operation-group.golden"},
 	}
 
 	for _, test := range tests {

--- a/test/test-server/iam_handlers.go
+++ b/test/test-server/iam_handlers.go
@@ -661,6 +661,8 @@ func handleIamIpFilter(t *testing.T) http.HandlerFunc {
 				operationGroups = []string{"MANAGEMENT", "SCHEMA"}
 			} else if filterId == "ipf-34dq6" {
 				operationGroups = []string{"MANAGEMENT", "SCHEMA", "FLINK"}
+			} else if filterId == "ipf-34dq7" {
+				operationGroups = []string{"KAFKA_MANAGEMENT", "KAFKA_DATA"}
 			} else {
 				operationGroups = []string{"MANAGEMENT"}
 			}


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- PLACEHOLDER

New Features
- PLACEHOLDER

Bug Fixes
- PLACEHOLDER

Checklist
---------
<!-- 
Check each item below to ensure high-quality CLI development practices are followed. PR approval will not be granted until the checklist is fully reviewed.
For detailed instructions, please refer to this Confluence page: https://confluentinc.atlassian.net/wiki/spaces/AEGI/pages/3949592874/
-->
- [x] I have successfully built and used a custom CLI binary, without linter issues from this PR.
- [x] I have clearly specified in the `What` section below whether this PR applies to Confluent Cloud, Confluent Platform, or both. 
- [x] I have verified this PR in Confluent Cloud pre-prod or production environment, if applicable.
- [ ] I have verified this PR in Confluent Platform on-premises environment, if applicable.
- [x] I have attached manual CLI verification results or screenshots in the `Test & Review` section below.
- [x] I have added appropriate CLI integration or unit tests for any new or updated commands and functionality.
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [x] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [x] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [ ] Confluent Cloud prod
  - [x] Confluent Cloud stag
  - [ ] Confluent Platform
  - [ ] Check this box if the feature is enabled for certain organizations only

What
----
- Added support for Kafka IP Filter operation groups, KAFKA_MANAGEMENT and KAFKA_DATA (this is for Confluent Cloud).
- Removed SR and Flink IP Filter flags as they are GA'ed

<!--
Briefly describe **what** you have changed and **why** these changes are necessary.
Optionally include: 
- The problem being solved or the feature being added. 
- The implementation strategy or approach taken. 
- Key technical details, design decisions, or any additional context reviewers should be aware of.
-->

Blast Radius
----
Confluent Cloud customers who are using confluent ip filter commands could be impacted. (Note that the changes are behind an LD flag and are not on in prod)
<!--
The Blast Radius section should include information on what will be the customer(s) impact if something goes wrong or unexpectedly, 
adding this section will trigger the PR author to think about the impact from product perspective, examples can be:
- Confluent Cloud customers who are using confluent kafka topic any subcommand will be blocked.
- Confluent Cloud customers who are using confluent kafka topic list commands will be blocked.
- Confluent Platform customers who are using --schema flag will be impacted.
- All customers who are using SSO to login will be impacted.
-->

References
----------
https://confluentinc.atlassian.net/wiki/spaces/~785802079/pages/3703473045
<!-- Include links to relevant resources for this PR, such as: 
- Related GitHub issues 
- Tickets (JIRA, etc.) 
- Internal documentation or design specs 
- Other related PRs 
Copy and paste the links below for easy reference.
-->

Test & Review
-------------
Create
```
» dist/confluent_darwin_arm64/confluent iam ip-filter create demo-ip-filter-kafka --operations KAFKA_MANAGEMENT --ip-groups ipg-wng6n 

+------------------+-------------------------------------------------------------------------+
| ID               | ipf-e01ng                                                               |
| Name             | demo-ip-filter-kafka                                                    |
| Resource Group   | multiple                                                                |
| IP Groups        | ipg-wng6n                                                               |
| Operation Groups | KAFKA_MANAGEMENT                                                        |
| Resource Scope   | crn://confluent.cloud/organization=95f28072-7f59-4f3a-989f-676aba7d25bf |
+------------------+-------------------------------------------------------------------------+

» dist/confluent_darwin_arm64/confluent iam ip-filter create not-working-ip-filter --operations "UNKNOWN" --ip-groups ipg-wng6n
Error: Operation Group is not supported. Please refer to the API documentation for a list of valid operation groups: https://docs.confluent.io/cloud/current/api.html#tag/IP-Filters-(iamv2).
```

Describe
```
» dist/confluent_darwin_arm64/confluent iam ip-filter describe ipf-e01ng                                                                                

+------------------+-------------------------------------------------------------------------+
| ID               | ipf-e01ng                                                               |
| Name             | demo-ip-filter-kafka                                                    |
| Resource Group   | multiple                                                                |
| IP Groups        | ipg-wng6n                                                               |
| Operation Groups | KAFKA_DATA, KAFKA_MANAGEMENT                                            |
| Resource Scope   | crn://confluent.cloud/organization=95f28072-7f59-4f3a-989f-676aba7d25bf |
+------------------+-------------------------------------------------------------------------+
```

List
```
» dist/confluent_darwin_arm64/confluent iam ip-filter list                                                                                              

     ID     |         Name         | Resource Group | IP Groups | Operation Groups |                             Resource Scope                               
------------+----------------------+----------------+-----------+------------------+--------------------------------------------------------------------------
  ipf-e01ng | demo-ip-filter-kafka | multiple       | ipg-wng6n | KAFKA_MANAGEMENT | crn://confluent.cloud/organization=95f28072-7f59-4f3a-989f-676aba7d25bf 
```

Update
```
» dist/confluent_darwin_arm64/confluent iam ip-filter update ipf-e01ng --resource-group multiple --add-operation-groups KAFKA_DATA

+------------------+-------------------------------------------------------------------------+
| ID               | ipf-e01ng                                                               |
| Name             | demo-ip-filter-kafka                                                    |
| Resource Group   | multiple                                                                |
| IP Groups        | ipg-wng6n                                                               |
| Operation Groups | KAFKA_DATA, KAFKA_MANAGEMENT                                            |
| Resource Scope   | crn://confluent.cloud/organization=95f28072-7f59-4f3a-989f-676aba7d25bf |
+------------------+-------------------------------------------------------------------------+

» dist/confluent_darwin_arm64/confluent iam ip-filter update ipf-e01ng --remove-operation-groups KAFKA_DATA                                          

+------------------+-------------------------------------------------------------------------+
| ID               | ipf-e01ng                                                               |
| Name             | demo-ip-filter-kafka                                                    |
| Resource Group   | multiple                                                                |
| IP Groups        | ipg-wng6n                                                               |
| Operation Groups | KAFKA_MANAGEMENT                                                        |
| Resource Scope   | crn://confluent.cloud/organization=95f28072-7f59-4f3a-989f-676aba7d25bf |
+------------------+-------------------------------------------------------------------------+

```
Delete
```
» dist/confluent_darwin_arm64/confluent iam ip-filter delete ipf-e01ng                                                                                                          
Deleted IP filter "ipf-e01ng".

» dist/confluent_darwin_arm64/confluent iam ip-filter list                                                                                                                        
None found.
```

<!-- Has this PR been tested? If so, explain **how** it was tested. Include: 
- Steps taken to verify the changes. 
- Links to manual verification documents, logs, or screenshots to save reviewers' time. 
- Any additional notes on testing (e.g., environments used, edge cases tested). 
- Screenshot showing successful resource creation, updates etc.
Example: - [Manual Verification Document](https://docs.google.com/document/d/1GwXz9hNOkub_Br-2nssoYWCf6elZBvwo7TMhCNYinwE/edit?tab=t.0#heading=h.dvbi09ntxjw6)
-->
