### PR TITLE
[CLI-3383] allows passing in statement properties via CLI

### DIFF
--- a/internal/flink/command_statement_create.go
+++ b/internal/flink/command_statement_create.go
@@ -14,6 +14,7 @@ import (
 	"github.com/confluentinc/cli/v4/pkg/flink/config"
 	"github.com/confluentinc/cli/v4/pkg/flink/types"
 	"github.com/confluentinc/cli/v4/pkg/output"
+	"github.com/confluentinc/cli/v4/pkg/properties"
 	"github.com/confluentinc/cli/v4/pkg/retry"
 )
 
@@ -29,8 +30,8 @@ func (c *command) newStatementCreateCommand() *cobra.Command {
 				Code: `confluent flink statement create --sql "SELECT * FROM table;"`,
 			},
 			examples.Example{
-				Text: `Create a Flink SQL statement named "my-statement" in compute pool "lfcp-123456" with service account "sa-123456" and using Kafka cluster "my-cluster" as the default database.`,
-				Code: `confluent flink statement create my-statement --sql "SELECT * FROM my-topic;" --compute-pool lfcp-123456 --service-account sa-123456 --database my-cluster`,
+				Text: `Create a Flink SQL statement named "my-statement" in compute pool "lfcp-123456" with service account "sa-123456", using Kafka cluster "my-cluster" as the default database, and with additional properties.`,
+				Code: `confluent flink statement create my-statement --sql "SELECT * FROM my-topic;" --compute-pool lfcp-123456 --service-account sa-123456 --database my-cluster --property property1=value1,property2=value2`,
 			},
 		),
 	}
@@ -40,6 +41,7 @@ func (c *command) newStatementCreateCommand() *cobra.Command {
 	pcmd.AddServiceAccountFlag(cmd, c.AuthenticatedCLICommand)
 	c.addDatabaseFlag(cmd)
 	cmd.Flags().Bool("wait", false, "Block until the statement is running or has failed.")
+	cmd.Flags().StringSlice("property", []string{}, "A mechanism to pass properties in the form key=value when creating a Flink statement.")
 	pcmd.AddEnvironmentFlag(cmd, c.AuthenticatedCLICommand)
 	pcmd.AddContextFlag(cmd, c.CLICommand)
 	pcmd.AddOutputFlag(cmd)
@@ -83,16 +85,28 @@ func (c *command) statementCreate(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	properties := map[string]string{config.KeyCatalog: environment.GetDisplayName()}
+	statementProperties := map[string]string{config.KeyCatalog: environment.GetDisplayName()}
 	if database != "" {
-		properties[config.KeyDatabase] = database
+		statementProperties[config.KeyDatabase] = database
+	}
+
+	// Parse custom properties if provided
+	configs, err := cmd.Flags().GetStringSlice("property")
+	if len(configs) > 0 {
+		configMap, err := properties.ConfigSliceToMap(configs)
+		if err != nil {
+			return err
+		}
+		for key, value := range configMap {
+			statementProperties[key] = value
+		}
 	}
 
 	statement := flinkgatewayv1.SqlV1Statement{
 		Name: flinkgatewayv1.PtrString(name),
 		Spec: &flinkgatewayv1.SqlV1StatementSpec{
 			Statement:     flinkgatewayv1.PtrString(sql),
-			Properties:    &properties,
+			Properties:    &statementProperties,
 			ComputePoolId: flinkgatewayv1.PtrString(computePool),
 		},
 	}

--- a/test/fixtures/output/flink/statement/create-help.golden
+++ b/test/fixtures/output/flink/statement/create-help.golden
@@ -8,9 +8,9 @@ Create a Flink SQL statement in the current compute pool.
 
   $ confluent flink statement create --sql "SELECT * FROM table;"
 
-Create a Flink SQL statement named "my-statement" in compute pool "lfcp-123456" with service account "sa-123456" and using Kafka cluster "my-cluster" as the default database.
+Create a Flink SQL statement named "my-statement" in compute pool "lfcp-123456" with service account "sa-123456", using Kafka cluster "my-cluster" as the default database, and with additional properties.
 
-  $ confluent flink statement create my-statement --sql "SELECT * FROM my-topic;" --compute-pool lfcp-123456 --service-account sa-123456 --database my-cluster
+  $ confluent flink statement create my-statement --sql "SELECT * FROM my-topic;" --compute-pool lfcp-123456 --service-account sa-123456 --database my-cluster --property property1=value1,property2=value2
 
 Flags:
       --sql string               REQUIRED: The Flink SQL statement.
@@ -18,6 +18,7 @@ Flags:
       --service-account string   Service account ID.
       --database string          The database which will be used as the default database. When using Kafka, this is the cluster ID.
       --wait                     Block until the statement is running or has failed.
+      --property strings         A mechanism to pass properties in the form key=value when creating a Flink statement.
       --environment string       Environment ID.
       --context string           CLI context name.
   -o, --output string            Specify the output format as "human", "json", or "yaml". (default "human")

--- a/test/fixtures/output/flink/statement/create-invalid-property.golden
+++ b/test/fixtures/output/flink/statement/create-invalid-property.golden
@@ -1,0 +1,1 @@
+Error: failed to parse "key=value" pattern from configuration: invalid-format

--- a/test/fixtures/output/flink/statement/create-with-properties.golden
+++ b/test/fixtures/output/flink/statement/create-with-properties.golden
@@ -1,0 +1,7 @@
++---------------+-------------------------------+
+| Creation Date | 2023-01-01 00:00:00 +0000 UTC |
+| Name          | my-statement                  |
+| Statement     | INSERT * INTO table;          |
+| Compute Pool  | lfcp-123456                   |
+| Status        | PENDING                       |
++---------------+-------------------------------+

--- a/test/flink_test.go
+++ b/test/flink_test.go
@@ -310,6 +310,8 @@ func (s *CLITestSuite) TestFlinkStatementCreate() {
 		{args: `flink statement create my-statement --sql "INSERT * INTO table;" --compute-pool lfcp-123456`, fixture: "flink/statement/create-service-account-warning.golden"},
 		{args: `flink statement create my-statement --sql "INSERT * INTO table;" --compute-pool lfcp-123456 --service-account sa-123456 --wait`, fixture: "flink/statement/create-wait.golden"},
 		{args: `flink statement create --sql "INSERT * INTO table;" --compute-pool lfcp-123456 --service-account sa-123456 -o yaml`, fixture: "flink/statement/create-no-name-yaml.golden", regex: true},
+		{args: `flink statement create my-statement --sql "INSERT * INTO table;" --compute-pool lfcp-123456 --service-account sa-123456 --property property1=value1,property2=value2`, fixture: "flink/statement/create-with-properties.golden"},
+		{args: `flink statement create my-statement --sql "INSERT * INTO table;" --compute-pool lfcp-123456 --service-account sa-123456 --property invalid-format,property1=value1`, fixture: "flink/statement/create-invalid-property.golden", exitCode: 1},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Release Notes
-------------
Allows users to pass in arbitrary statement properties from the flink statement create cli command
--property "key1=val1,key2=val2,key3=val3"

Closes https://confluentinc.atlassian.net/browse/CLI-3383

Checklist
---------
- [x] I have successfully built and used a custom CLI binary, without linter issues from this PR.
- [x] I have clearly specified in the `What` section below whether this PR applies to Confluent Cloud, Confluent Platform, or both. 
- [x] I have verified this PR in Confluent Cloud pre-prod or production environment, if applicable.
- [ ] I have verified this PR in Confluent Platform on-premises environment, if applicable.
- [x] I have attached manual CLI verification results or screenshots in the `Test & Review` section below.
- [x] I have added appropriate CLI integration or unit tests for any new or updated commands and functionality.
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [x] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [x] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [x] Confluent Cloud prod
  - [x] Confluent Cloud stag
  - [ ] Confluent Platform
  - [ ] Check this box if the feature is enabled for certain organizations only

What
----
Allows users to pass in arbitrary statement properties from the flink statement create cli command
--property "key1=val1,key2=val2,key3=val3"

Closes https://confluentinc.atlassian.net/browse/CLI-3383

Blast Radius
----
Minimal blast radius

References
----------
Allows users to pass in arbitrary statement properties from the flink statement create cli command
--property "key1=val1,key2=val2,key3=val3"

Closes https://confluentinc.atlassian.net/browse/CLI-3383

Test & Review
-------------
Built the Binary and tested against Prod CCloud

Create statement no property field
```
szhang@Q3X1FKYP41 confluent_darwin_arm64 % ./confluent flink statement create --compute-pool lfcp-0m02kp --environment env-xmzdkk --database lkc-7kmyz1 --sql "select 1"              
No Flink endpoint is specified, defaulting to public endpoint: `https://flink.us-west-2.aws.confluent.cloud`
+---------------+------------------------------------------------------------+
| Creation Date | 2025-07-23 00:34:40.501056                                 |
|               | +0000 UTC                                                  |
| Name          | cli-2025-07-22-203439-8a9b7362-a815-4642-9dce-20882f3fa3e2 |
| Statement     | select 1                                                   |
| Compute Pool  | lfcp-0m02kp                                                |
| Status        | PENDING                                                    |
+---------------+------------------------------------------------------------+
szhang@Q3X1FKYP41 confluent_darwin_arm64 % ./confluent flink statement describe cli-2025-07-22-203439-8a9b7362-a815-4642-9dce-20882f3fa3e2
No Flink endpoint is specified, defaulting to public endpoint: `https://flink.us-west-2.aws.confluent.cloud`
+--------------------------+------------------------------------------------------------+
| Creation Date            | 2025-07-23 00:34:40.501056                                 |
|                          | +0000 UTC                                                  |
| Name                     | cli-2025-07-22-203439-8a9b7362-a815-4642-9dce-20882f3fa3e2 |
| Statement                | select 1                                                   |
| Compute Pool             | lfcp-0m02kp                                                |
| Status                   | COMPLETED                                                  |
| Latest Offsets           |                                                            |
| Latest Offsets Timestamp | 0001-01-01 00:00:00 +0000 UTC                              |
| Properties               | sql.current-catalog=default                                |
|                          | sql.current-database=lkc-7kmyz1                            |
| Principal                | u-jzxvd2                                                   |
+--------------------------+------------------------------------------------------------+
```

With property flag
```
szhang@Q3X1FKYP41 confluent_darwin_arm64 % ./confluent flink statement create --compute-pool lfcp-0m02kp --environment env-xmzdkk --database lkc-7kmyz1 --sql "select 1" --property "sql.local-time-zone=Asia/Shanghai,sql.inline-result=true"
No Flink endpoint is specified, defaulting to public endpoint: `https://flink.us-west-2.aws.confluent.cloud`
+---------------+------------------------------------------------------------+
| Creation Date | 2025-07-23 00:33:49.552167                                 |
|               | +0000 UTC                                                  |
| Name          | cli-2025-07-22-203348-7fcd8084-4ec3-459b-b3f2-6e2b72350998 |
| Statement     | select 1                                                   |
| Compute Pool  | lfcp-0m02kp                                                |
| Status        | PENDING                                                    |
+---------------+------------------------------------------------------------+
szhang@Q3X1FKYP41 confluent_darwin_arm64 % ./confluent flink statement describe cli-2025-07-22-203348-7fcd8084-4ec3-459b-b3f2-6e2b72350998
No Flink endpoint is specified, defaulting to public endpoint: `https://flink.us-west-2.aws.confluent.cloud`
+--------------------------+------------------------------------------------------------+
| Creation Date            | 2025-07-23 00:33:49.552167                                 |
|                          | +0000 UTC                                                  |
| Name                     | cli-2025-07-22-203348-7fcd8084-4ec3-459b-b3f2-6e2b72350998 |
| Statement                | select 1                                                   |
| Compute Pool             | lfcp-0m02kp                                                |
| Status                   | COMPLETED                                                  |
| Latest Offsets           |                                                            |
| Latest Offsets Timestamp | 0001-01-01 00:00:00 +0000 UTC                              |
| Properties               | sql.current-catalog=default                                |
|                          | sql.current-database=lkc-7kmyz1                            |
|                          | sql.inline-result=true                                     |
|                          | sql.local-time-zone=Asia/Shanghai                          |
| Principal                | u-jzxvd2                                                   |
+--------------------------+------------------------------------------------------------+
```

Failure scenarios (2 bad flag values, 1 where a bad property is passed to the backend)
```
szhang@Q3X1FKYP41 confluent_darwin_arm64 % ./confluent flink statement create --compute-pool lfcp-0m02kp --environment env-xmzdkk --database lkc-7kmyz1 --sql "select 1" --property gibberish
Error: failed to parse "key=value" pattern from configuration: gibberish

szhang@Q3X1FKYP41 confluent_darwin_arm64 % ./confluent flink statement create --compute-pool lfcp-0m02kp --environment env-xmzdkk --database lkc-7kmyz1 --sql "select 1" --property bad-config:true
Error: failed to parse "key=value" pattern from configuration: bad-config:true

szhang@Q3X1FKYP41 confluent_darwin_arm64 % ./confluent flink statement create --compute-pool lfcp-0m02kp --environment env-xmzdkk --database lkc-7kmyz1 --sql "select 1" --property bad-config=true
No Flink endpoint is specified, defaulting to public endpoint: `https://flink.us-west-2.aws.confluent.cloud`
+---------------+------------------------------------------------------------+
| Creation Date | 2025-07-23 00:39:02.445229                                 |
|               | +0000 UTC                                                  |
| Name          | cli-2025-07-22-203901-cc0a424b-fb52-499d-9963-b5d2d86d8e49 |
| Statement     | select 1                                                   |
| Compute Pool  | lfcp-0m02kp                                                |
| Status        | FAILED                                                     |
| Status Detail | Unsupported configuration options found.                   |
|               | Unsupported options: bad-config  Supported                 |
|               | options: sql.current-catalog sql.current-database          |
|               | sql.dry-run sql.inline-result sql.local-time-zone          |
|               | sql.state-ttl sql.tables.scan.bounded.mode                 |
|               | sql.tables.scan.bounded.timestamp-millis                   |
|               | sql.tables.scan.idle-timeout                               |
|               | sql.tables.scan.source-operator-parallelism                |
|               | sql.tables.scan.startup.mode                               |
|               | sql.tables.scan.startup.specific-offsets                   |
|               | sql.tables.scan.startup.timestamp-millis                   |
|               | sql.tables.scan.watermark-alignment.max-allowed-drift      |
+---------------+------------------------------------------------------------+
```
