### PR TITLE
Improve CLI performance when feature flags are enabled

### DIFF
--- a/internal/ccpm/command.go
+++ b/internal/ccpm/command.go
@@ -5,7 +5,6 @@ import (
 
 	pcmd "github.com/confluentinc/cli/v4/pkg/cmd"
 	"github.com/confluentinc/cli/v4/pkg/config"
-	"github.com/confluentinc/cli/v4/pkg/featureflags"
 )
 
 func New(cfg *config.Config, prerunner pcmd.PreRunner) *cobra.Command {
@@ -13,7 +12,6 @@ func New(cfg *config.Config, prerunner pcmd.PreRunner) *cobra.Command {
 		Use:         "ccpm",
 		Short:       "Manage custom Connect plugin management (CCPM).",
 		Annotations: map[string]string{pcmd.RunRequirement: pcmd.RequireNonAPIKeyCloudLogin},
-		Hidden:      !(cfg.IsTest || featureflags.Manager.BoolVariation("custom-connect.plugin.enabled", cfg.Context(), config.CliLaunchDarklyClient, true, false)),
 	}
 
 	cmd.AddCommand(newPluginCommand(prerunner))

--- a/internal/connect/command_artifact.go
+++ b/internal/connect/command_artifact.go
@@ -7,7 +7,6 @@ import (
 
 	pcmd "github.com/confluentinc/cli/v4/pkg/cmd"
 	"github.com/confluentinc/cli/v4/pkg/config"
-	"github.com/confluentinc/cli/v4/pkg/featureflags"
 	"github.com/confluentinc/cli/v4/pkg/output"
 )
 
@@ -30,7 +29,6 @@ func newArtifactCommand(cfg *config.Config, prerunner pcmd.PreRunner) *cobra.Com
 		Use:         "artifact",
 		Short:       "Manage Connect artifacts.",
 		Annotations: map[string]string{pcmd.RunRequirement: pcmd.RequireNonAPIKeyCloudLogin},
-		Hidden:      !(cfg.IsTest || featureflags.Manager.BoolVariation("connect.artifact.enabled", cfg.Context(), config.CliLaunchDarklyClient, true, false)),
 	}
 
 	c := &artifactCommand{pcmd.NewAuthenticatedCLICommand(cmd, prerunner)}

--- a/internal/flink/command_shell.go
+++ b/internal/flink/command_shell.go
@@ -43,7 +43,7 @@ func (c *command) newShellCommand(prerunner pcmd.PreRunner, cfg *config.Config) 
 		pcmd.AddEnvironmentFlag(cmd, c.AuthenticatedCLICommand)
 		pcmd.AddContextFlag(cmd, c.CLICommand)
 
-		if featureflags.Manager.BoolVariation("cli.flink.internal", c.Context, config.CliLaunchDarklyClient, true, false) {
+		if featureflags.Manager.BoolVariation("cli.flink.internal", cfg.Context(), config.CliLaunchDarklyClient, true, false) {
 			cmd.Flags().StringSlice("config-key", []string{}, "App option keys for local mode.")
 			cmd.Flags().StringSlice("config-value", []string{}, "App option values for local mode.")
 		}

--- a/pkg/featureflags/feature_flags.go
+++ b/pkg/featureflags/feature_flags.go
@@ -56,6 +56,11 @@ type launchDarklyManager struct {
 	version               *version.Version
 }
 
+var ( // cache retrieved flags in memory before they're written to file as an optimization
+	retrievedCliFlags    = make(map[string]any)
+	retrievedCCloudFlags = make(map[string]any)
+)
+
 func Init(cfg *config.Config) {
 	cliBasePath := fmt.Sprintf(baseURL, auth.CCloudURL, cliTestEnvClientId)
 	ccloudBasePath := fmt.Sprintf(baseURL, auth.CCloudURL, ccloudProdEnvClientId)
@@ -147,7 +152,14 @@ func (ld *launchDarklyManager) generalVariation(key string, ctx *config.Context,
 	// Check if cached flags are for same auth status (anon or not anon) as current ctx so that we know the values are valid based on targeting
 	var flagVals map[string]any
 	var err error
-	if !areCachedFlagsAvailable(ctx, user, client, key) {
+	if areCachedFlagsAvailable(ctx, user, client, key) {
+		flagVals = ctx.GetLDFlags(client)
+	} else if areCurrentFlagsAvailable(client, key) { // if the flag is not cached but we've already retrieved the newest flag values for the current user, check those maps first
+		flagVals = getCurrentFlags(client, key)
+		if shouldCache {
+			writeFlagsToConfig(ctx, key, flagVals, user, client)
+		}
+	} else {
 		flagVals, err = ld.fetchFlags(user, client)
 		if err != nil {
 			log.CliLogger.Debug(err.Error())
@@ -156,8 +168,6 @@ func (ld *launchDarklyManager) generalVariation(key string, ctx *config.Context,
 		if shouldCache {
 			writeFlagsToConfig(ctx, key, flagVals, user, client)
 		}
-	} else {
-		flagVals = ctx.GetLDFlags(client)
 	}
 	if _, ok := flagVals[key]; ok {
 		return flagVals[key]
@@ -181,9 +191,11 @@ func (ld *launchDarklyManager) fetchFlags(user lduser.User, client config.Launch
 	switch client {
 	case config.CcloudProdLaunchDarklyClient, config.CcloudStagLaunchDarklyClient, config.CcloudDevelLaunchDarklyClient:
 		resp, err = ld.ccloudClient.New().Get(fmt.Sprintf(userPath, userEnc)).Receive(&flagVals, err)
+		retrievedCCloudFlags = flagVals
 	// default is "cli" client
 	default:
 		resp, err = ld.cliClient.New().Get(fmt.Sprintf(userPath, userEnc)).Receive(&flagVals, err)
+		retrievedCliFlags = flagVals
 	}
 	if err != nil {
 		log.CliLogger.Debug(resp)
@@ -200,6 +212,11 @@ func (ld *launchDarklyManager) fetchFlags(user lduser.User, client config.Launch
 
 func areCachedFlagsAvailable(ctx *config.Context, user lduser.User, client config.LaunchDarklyClient, key string) bool {
 	if ctx == nil || ctx.FeatureFlags == nil {
+		if ctx == nil {
+			log.CliLogger.Infof("No cached value for feature flag %s found: login context is empty.", key)
+		} else if ctx.FeatureFlags == nil {
+			log.CliLogger.Infof("No cached value for feature flag %s found: config does not contain feature flags.", key)
+		}
 		return false
 	}
 
@@ -207,6 +224,7 @@ func areCachedFlagsAvailable(ctx *config.Context, user lduser.User, client confi
 
 	// only use cached flags if they were fetched for the same LD User
 	if !flags.User.Equal(user) {
+		log.CliLogger.Infof("No cached value for feature flag %s found: current cached flags were retrieved for a different user.", key)
 		return false
 	}
 
@@ -214,10 +232,12 @@ func areCachedFlagsAvailable(ctx *config.Context, user lduser.User, client confi
 	case config.CcloudDevelLaunchDarklyClient, config.CcloudStagLaunchDarklyClient, config.CcloudProdLaunchDarklyClient:
 		// for ccloud only single keys are stored, so we need to check if the specific flag is present
 		if _, ok := flags.CcloudValues[key]; !ok {
+			log.CliLogger.Infof("No cached value for feature flag %s found: cached ccloud flags do not contain this flag.", key)
 			return false
 		}
 	default:
 		if _, ok := flags.CliValues[key]; !ok {
+			log.CliLogger.Infof("No cached value for feature flag %s found: cached cli flags do not contain this flag.", key)
 			return false
 		}
 	}
@@ -243,14 +263,6 @@ func (ld *launchDarklyManager) contextToLDUser(ctx *config.Context) lduser.User 
 
 	if ld.version != nil && ld.version.Version != "" {
 		custom.Set("cli.version", ldvalue.String(ld.version.Version))
-	}
-
-	if ld.Command != nil {
-		custom.Set("cli.command", ldvalue.String(ld.Command.CommandPath()))
-	}
-
-	if ld.flags != nil {
-		custom.Set("cli.flags", ldvalue.CopyArbitraryValue(ld.flags))
 	}
 
 	if ctx == nil {
@@ -312,4 +324,24 @@ func writeFlagsToConfig(ctx *config.Context, key string, vals map[string]any, us
 	ctx.FeatureFlags.User = user
 
 	_ = ctx.Save()
+}
+
+func areCurrentFlagsAvailable(client config.LaunchDarklyClient, key string) bool {
+	switch client {
+	case config.CcloudDevelLaunchDarklyClient, config.CcloudStagLaunchDarklyClient, config.CcloudProdLaunchDarklyClient:
+		_, ok := retrievedCCloudFlags[key]
+		return ok
+	default:
+		_, ok := retrievedCliFlags[key]
+		return ok
+	}
+}
+
+func getCurrentFlags(client config.LaunchDarklyClient, key string) map[string]any {
+	switch client {
+	case config.CcloudDevelLaunchDarklyClient, config.CcloudStagLaunchDarklyClient, config.CcloudProdLaunchDarklyClient:
+		return retrievedCCloudFlags
+	default:
+		return retrievedCliFlags
+	}
 }


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- PLACEHOLDER

New Features
- PLACEHOLDER

Bug Fixes
- PLACEHOLDER

Checklist
---------
<!-- 
Check each item below to ensure high-quality CLI development practices are followed. PR approval will not be granted until the checklist is fully reviewed.
For detailed instructions, please refer to this Confluence page: https://confluentinc.atlassian.net/wiki/spaces/AEGI/pages/3949592874/
-->
- [ ] I have successfully built and used a custom CLI binary, without linter issues from this PR.
- [ ] I have clearly specified in the `What` section below whether this PR applies to Confluent Cloud, Confluent Platform, or both. 
- [ ] I have verified this PR in Confluent Cloud pre-prod or production environment, if applicable.
- [ ] I have verified this PR in Confluent Platform on-premises environment, if applicable.
- [ ] I have attached manual CLI verification results or screenshots in the `Test & Review` section below.
- [ ] I have added appropriate CLI integration or unit tests for any new or updated commands and functionality.
- [ ] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [ ] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [ ] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [ ] Confluent Cloud prod
  - [ ] Confluent Cloud stag
  - [ ] Confluent Platform
  - [ ] Check this box if the feature is enabled for certain organizations only

What
----
Retrieving feature flags currently adds ~ .5s to every command while logged in and ~ 1s on every command while logged out.

Caching feature flags in the config file is supposed to prevent this, but a collection of bugs are causing a handful of feature flags to not be cached properly.

This PR is intended to fix the following bugs:
- The `custom-connect.plugin.enabled` and `connect.artifact.enabled` are pulling from the wrong LD project and hence not read properly and not cached
  - Instead of switching to the correct client, we can just remove the flags entirely because they are no longer needed
- `cli.flink.internal` is passing an empty context to the `BoolVariation` function, causing the cached value to not be read
- Both the first flag encountered in the code and the `cli.disable` flag are never read from cache
  - Caused by the CLI modifying the LD user profile to add the `cli.command` and `cli.flags` attributes mid run, so that the current LD user no longer matches the cached user.
- No flags are cached when the user is logged out, causing the CLI to waste significant time retrieving every `cli.*` flag on every command

Blast Radius
----
<!--
The Blast Radius section should include information on what will be the customer(s) impact if something goes wrong or unexpectedly, 
adding this section will trigger the PR author to think about the impact from product perspective, examples can be:
- Confluent Cloud customers who are using confluent kafka topic any subcommand will be blocked.
- Confluent Cloud customers who are using confluent kafka topic list commands will be blocked.
- Confluent Platform customers who are using --schema flag will be impacted.
- All customers who are using SSO to login will be impacted.
-->

References
----------
<!-- Include links to relevant resources for this PR, such as: 
- Related GitHub issues 
- Tickets (JIRA, etc.) 
- Internal documentation or design specs 
- Other related PRs 
Copy and paste the links below for easy reference.
-->

Test & Review
-------------
<!-- Has this PR been tested? If so, explain **how** it was tested. Include: 
- Steps taken to verify the changes. 
- Links to manual verification documents, logs, or screenshots to save reviewers' time. 
- Any additional notes on testing (e.g., environments used, edge cases tested). 
- Screenshot showing successful resource creation, updates etc.
Example: - [Manual Verification Document](https://docs.google.com/document/d/1GwXz9hNOkub_Br-2nssoYWCf6elZBvwo7TMhCNYinwE/edit?tab=t.0#heading=h.dvbi09ntxjw6)
-->
