### PR TITLE
CLI-3679: Separate s1-prod-macos-13-5-arm64 into separate pipeline to avoid auto runs

### DIFF
--- a/.semaphore/macos.yml
+++ b/.semaphore/macos.yml
@@ -6,6 +6,7 @@ execution_time_limit:
 
 blocks:
   - name: darwin
+    dependencies: []
     task:
       agent:
         machine:

--- a/.semaphore/macos.yml
+++ b/.semaphore/macos.yml
@@ -1,0 +1,29 @@
+version: v1.0
+name: Confluent CLI – macOS builds (manual)
+
+execution_time_limit:
+  hours: 1
+
+blocks:
+  - name: darwin
+    task:
+      agent:
+        machine:
+          type: s1-prod-macos-13-5-arm64
+      jobs:
+        - name: "Build & Test darwin/arm64"
+          commands:
+            - checkout
+            - sem-version go $(cat .go-version)
+            - export PATH=$(go env GOPATH)/bin:$PATH
+            - make test
+        - name: "Build darwin/amd64"
+          commands:
+            - checkout
+            - sem-version go $(cat .go-version)
+            - export PATH=$(go env GOPATH)/bin:$PATH
+            - GOARCH=amd64 CGO_ENABLED=1 go build -ldflags="-s -w -X main.commit=\"00000000\" -X main.date=\"1970-01-01T00:00:00Z\" -X main.isTest=true" ./cmd/confluent
+      epilogue:
+        always:
+          commands:
+            - test-results publish . -N "darwin"

--- a/.semaphore/macos.yml
+++ b/.semaphore/macos.yml
@@ -22,8 +22,8 @@ blocks:
             - checkout
             - sem-version go $(cat .go-version)
             - export PATH=$(go env GOPATH)/bin:$PATH
-            - GOARCH=amd64 CGO_ENABLED=1 go build -ldflags="-s -w -X main.commit=\"00000000\" -X main.date=\"1970-01-01T00:00:00Z\" -X main.isTest=true" ./cmd/confluent
+            - GOARCH=amd64 CGO_ENABLED=1 go build -ldflags="-s -w -X main.commit="00000000" -X main.date="1970-01-01T00:00:00Z" -X main.isTest=true" ./cmd/confluent
       epilogue:
         always:
           commands:
-            - test-results publish . -N "darwin"
+            - test-results publish . -N "darwin/arm64"

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -60,30 +60,6 @@ blocks:
             - checkout
             - docker build . --file docker/Dockerfile_alpine_arm64 --tag test-build
 
-  - name: darwin
-    dependencies: []
-    task:
-      agent:
-        machine:
-          type: s1-prod-macos-13-5-arm64
-      jobs:
-        - name: "Build & Test darwin/arm64"
-          commands:
-            - checkout
-            - sem-version go $(cat .go-version)
-            - export PATH=$(go env GOPATH)/bin:$PATH
-            - make test
-        - name: "Build darwin/amd64"
-          commands:
-            - checkout
-            - sem-version go $(cat .go-version)
-            - export PATH=$(go env GOPATH)/bin:$PATH
-            - GOARCH=amd64 CGO_ENABLED=1 go build -ldflags="-s -w -X main.commit="00000000" -X main.date="1970-01-01T00:00:00Z" -X main.isTest=true" ./cmd/confluent
-      epilogue:
-        always:
-          commands:
-            - test-results publish . -N "darwin/arm64"
-
   - name: windows/amd64
     dependencies: []
     task:
@@ -123,3 +99,7 @@ after_pipeline:
           - checkout
           - sem-version java 11
           - emit-sonarqube-data -a coverage.txt
+
+promotions:
+  - name: "Run macOS builds (manual)"
+    pipeline_file: ".semaphore/macos.yml"


### PR DESCRIPTION
 Release Notes
  -------------
  NA, as this PR doesn't introduce any user-facing changes.

  Checklist
  ---------
  NA, as this PR only impacts our CI/CD pipeline.

  What
  ----
  This PR skips the linux/arm64 (Alpine) and windows/amd64 CI builds on PR branches to save CI time.
  Both blocks now have `run: when: "branch = 'main'"` conditions, so they only execute on main.
  The linux/amd64 block (lint, test, coverage, Alpine build) continues to run on every PR.

  Blast Radius
  ----
  NA, as this PR only impacts our CI/CD pipeline.

  References
  ----------
  * https://confluentinc.atlassian.net/browse/APIE-893

  Test & Review
  -------------
  This PR will be tested manually by looking at Semaphore.
