### PR TITLE
Fix `make build` on Linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,11 +7,12 @@ build:
 ifneq "" "$(findstring NT,$(shell uname))" # windows
 	CC=gcc CXX=g++ $(MAKE) cli-builder
 else ifneq (,$(findstring Linux,$(shell uname)))
-	ifneq (,$(findstring musl,$(shell ldd --version))) # linux (musl)
+    # Warning: make won't treat nested ifs as makefile directives if you use tabs instead of spaces
+    ifneq (,$(findstring musl,$(shell ldd --version))) # linux (musl)
 		CC=gcc CXX=g++ TAGS=musl $(MAKE) cli-builder
-	else # linux (glibc)
+    else # linux (glibc)
 		CC=gcc CXX=g++ $(MAKE) cli-builder
-	endif
+    endif
 else # darwin
 	$(MAKE) cli-builder
 endif

--- a/debian/patches/standard_build_layout.patch
+++ b/debian/patches/standard_build_layout.patch
@@ -1,6 +1,6 @@
---- cli/Makefile	2025-05-16 17:41:03.292396500 -0700
-+++ debian/Makefile	2025-05-02 12:16:18.573532006 -0700
-@@ -1,142 +1,163 @@
+--- cli/Makefile	2025-08-14 15:47:56.963229451 -0700
++++ debian/Makefile	2025-07-11 14:06:22.180812125 -0700
+@@ -1,143 +1,163 @@
 -SHELL := /bin/bash
 -GORELEASER_VERSION := v1.21.2
 +SHELL=/bin/bash
@@ -11,11 +11,12 @@
 -ifneq "" "$(findstring NT,$(shell uname))" # windows
 -	CC=gcc CXX=g++ $(MAKE) cli-builder
 -else ifneq (,$(findstring Linux,$(shell uname)))
--	ifneq (,$(findstring musl,$(shell ldd --version))) # linux (musl)
+-    # Warning: make won't treat nested ifs as makefile directives if you use tabs instead of spaces
+-    ifneq (,$(findstring musl,$(shell ldd --version))) # linux (musl)
 -		CC=gcc CXX=g++ TAGS=musl $(MAKE) cli-builder
--	else # linux (glibc)
+-    else # linux (glibc)
 -		CC=gcc CXX=g++ $(MAKE) cli-builder
--	endif
+-    endif
 -else # darwin
 -	$(MAKE) cli-builder
 -endif


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- PLACEHOLDER

New Features
- PLACEHOLDER

Bug Fixes
- PLACEHOLDER

Checklist
---------
<!-- 
Check each item below to ensure high-quality CLI development practices are followed. PR approval will not be granted until the checklist is fully reviewed.
For detailed instructions, please refer to this Confluence page: https://confluentinc.atlassian.net/wiki/spaces/AEGI/pages/3949592874/
-->
- [ ] I have successfully built and used a custom CLI binary, without linter issues from this PR.
- [ ] I have clearly specified in the `What` section below whether this PR applies to Confluent Cloud, Confluent Platform, or both. 
- [ ] I have verified this PR in Confluent Cloud pre-prod or production environment, if applicable.
- [ ] I have verified this PR in Confluent Platform on-premises environment, if applicable.
- [ ] I have attached manual CLI verification results or screenshots in the `Test & Review` section below.
- [ ] I have added appropriate CLI integration or unit tests for any new or updated commands and functionality.
- [ ] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [ ] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [ ] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [ ] Confluent Cloud prod
  - [ ] Confluent Cloud stag
  - [ ] Confluent Platform
  - [ ] Check this box if the feature is enabled for certain organizations only

What
----
It turns out that makefile doesn't like nested ifs using tabs instead of spaces, which was causing `make build` to not work on Linux.

Blast Radius
----
N/A, not a customer facing change.

References
----------
<!-- Include links to relevant resources for this PR, such as: 
- Related GitHub issues 
- Tickets (JIRA, etc.) 
- Internal documentation or design specs 
- Other related PRs 
Copy and paste the links below for easy reference.
-->

Test & Review
-------------
Tested in an Ubuntu 24.04 docker image.

Before:
```
make build
ifneq (,) # linux (musl)
/bin/bash: -c: line 1: syntax error near unexpected token `,'
/bin/bash: -c: line 1: `ifneq (,) # linux (musl)'
make: *** [Makefile:10: build] Error 2
```

After:
```
make build
CC=gcc CXX=g++ make cli-builder
make[1]: Entering directory '/cli'
GOOS="" GOARCH="" CC="" CXX="" CGO_LDFLAGS="" go install github.com/goreleaser/goreleaser@v1.21.2
TAGS= CC=gcc CXX=g++ CGO_LDFLAGS= goreleaser build --clean --single-target --snapshot
  • starting build...
  • loading                                          path=.goreleaser.yml
  • building only for linux/arm64                    reason=single target is enabled
  • skipping validate...
  • loading environment variables
  • getting and validating git state
    • accepting to run without a git repository because this is a snapshot
    • git state                                      commit=none branch=none current_tag=v0.0.0 previous_tag=<unknown> dirty=false
    • pipe skipped                                   reason=disabled during snapshot mode
  • parsing tag
  • setting defaults
  • snapshotting
    • building snapshot...                           version=0.0.0-SNAPSHOT-none
  • checking distribution directory
    • cleaning dist
  • loading go mod information
  • build prerequisites
  • writing effective config file
    • writing                                        config=dist/config.yaml
  • building binaries
    • building                                       binary=dist/confluent_linux_arm64/confluent
    • took: 2s
  • storing release metadata
    • writing                                        file=dist/artifacts.json
    • writing                                        file=dist/metadata.json
  • build succeeded after 1s
  • thanks for using goreleaser!
make[1]: Leaving directory '/cli'
```