### PR TITLE
APIE-552: Disable service-bot-managed Makefile to allow manual management of the customized Makefile.

### DIFF
--- a/service.yml
+++ b/service.yml
@@ -19,7 +19,7 @@ semaphore:
   enable: true
   pipeline_enable: false
 make:
-  enable: true
+  enable: false
 sonarqube:
   enable: true
   languages: go


### PR DESCRIPTION
Release Notes
-------------
This PR does not introduce any user-facing changes.

Checklist
---------
NA, as this PR only disables further automatic updates for the Makefile.

What
----
This PR disables service-bot-managed Makefile to allow manual management of the customized Makefile per the DevProd's team recommendation to make sure CLI service bot updates won't edit Makefile that would trigger CLI tests failures and other errors like
```
make: *** No rule to make target 'mk-include/cc-begin.mk'.  Stop.
```

More specifically, further https://github.com/confluentinc/cli/pull/3089/files will not include changes to Makefile and will only impact Sonarqube integration.

Blast Radius
----
NA, as this PR only disables further automatic updates for the Makefile.

References
----------
* https://confluentinc.atlassian.net/browse/APIE-552
* https://confluent.slack.com/archives/C9Y6NAM6X/p1754954119343639?thread_ts=1754326052.344299&cid=C9Y6NAM6X

Test & Review
-------------
We will need to wait for the next update of https://github.com/confluentinc/cli/pull/3089/files after merging this PR to see whether it still includes Makefile changes.
