### PR TITLE
Fix a typo in service.yml.

### DIFF
--- a/service.yml
+++ b/service.yml
@@ -22,5 +22,5 @@ make:
   enable: false
 sonarqube:
   enable: true
-  languages: go
+  languages: ["go"]
   main_branch: main


### PR DESCRIPTION
Release Notes
-------------
This PR does not introduce any user-facing changes.

Checklist
---------
NA, as this PR only disables further automatic updates for the Makefile.

What
----
This PR fixes a typo in service.yml. To be more specific, we should be using:
```
sonarqube:
  enable: true
  languages: ["go"]
```
instead of a bare string here to resolve the unexpected comma.

Blast Radius
----
NA, as this PR only disables further automatic updates for the Makefile.

References
----------
* https://confluentinc.atlassian.net/browse/APIE-552
* https://confluent.slack.com/archives/C9Y6NAM6X/p1754954119343639?thread_ts=1754326052.344299&cid=C9Y6NAM6X

Test & Review
-------------
We will need to wait for the next service bot update.
