### PR TITLE
APIE-567: Remove the outdated note about AWS PrivateLink for the "confluent kafka cluster create" command.

### DIFF
--- a/internal/kafka/command_cluster_create.go
+++ b/internal/kafka/command_cluster_create.go
@@ -35,7 +35,7 @@ func (c *clusterCommand) newCreateCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:         "create <name>",
 		Short:       "Create a Kafka cluster.",
-		Long:        "Create a Kafka cluster.\n\nNote: You cannot use this command to create a cluster that is configured with AWS PrivateLink. You must use the UI to create a cluster of that configuration.",
+		Long:        "Create a Kafka cluster.",
 		Args:        cobra.ExactArgs(1),
 		RunE:        c.create,
 		Annotations: map[string]string{pcmd.RunRequirement: pcmd.RequireNonAPIKeyCloudLogin},

--- a/test/fixtures/output/kafka/cluster/create-help.golden
+++ b/test/fixtures/output/kafka/cluster/create-help.golden
@@ -1,7 +1,5 @@
 Create a Kafka cluster.
 
-Note: You cannot use this command to create a cluster that is configured with AWS PrivateLink. You must use the UI to create a cluster of that configuration.
-
 Usage:
   confluent kafka cluster create <name> [flags]
 


### PR DESCRIPTION
Release Notes
-------------
Bug Fixes
- Updated CLI documentation to remove the outdated note about AWS PrivateLink for the confluent kafka cluster create command.

Checklist
---------
<!-- 
Check each item below to ensure high-quality CLI development practices are followed. PR approval will not be granted until the checklist is fully reviewed.
For detailed instructions, please refer to this Confluence page: https://confluentinc.atlassian.net/wiki/spaces/AEGI/pages/3949592874/
-->
- [ ] I have successfully built and used a custom CLI binary, without linter issues from this PR.
- [ ] I have clearly specified in the `What` section below whether this PR applies to Confluent Cloud, Confluent Platform, or both. 
- [ ] I have verified this PR in Confluent Cloud pre-prod or production environment, if applicable.
- [ ] I have verified this PR in Confluent Platform on-premises environment, if applicable.
- [] I have attached manual CLI verification results or screenshots in the `Test & Review` section below.
- [x ] I have added appropriate CLI integration or unit tests for any new or updated commands and functionality.
- [ ] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [ ] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [ ] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [ ] Confluent Cloud prod
  - [ ] Confluent Cloud stag
  - [ ] Confluent Platform
  - [ ] Check this box if the feature is enabled for certain organizations only

What
----
This PR updates CLI documentation to remove the outdated note about AWS PrivateLink for the `confluent kafka cluster create` command.

Blast Radius
----
NA, this PR only updates the description of the attribute, which in turn updates the CLI documentation.

References
----------
* https://confluentinc.atlassian.net/browse/APIE-567

Test & Review
-------------
<!-- Has this PR been tested? If so, explain **how** it was tested. Include: 
- Steps taken to verify the changes. 
- Links to manual verification documents, logs, or screenshots to save reviewers' time. 
- Any additional notes on testing (e.g., environments used, edge cases tested). 
- Screenshot showing successful resource creation, updates etc.
Example: - [Manual Verification Document](https://docs.google.com/document/d/1GwXz9hNOkub_Br-2nssoYWCf6elZBvwo7TMhCNYinwE/edit?tab=t.0#heading=h.dvbi09ntxjw6)
-->
