### PR TITLE
[APIE-510] Refactor the function normalizeExpected() to reduce the cognitive complexity complained by SonarQube 

### DIFF
--- a/pkg/flink/internal/results/result_converter_test.go
+++ b/pkg/flink/internal/results/result_converter_test.go
@@ -48,107 +48,126 @@ func (s *ResultConverterTestSuite) TestConvertField() {
 
 // normalizeExpected converts a raw generated value `result` into the exact
 // SDK shape produced by the StatementResultField.ToSDKType() implementations.
-// - STRUCTURED_TYPE -> map[string]any
-// - ROW            -> []any (positional)
-// - ARRAY          -> []any (elements normalized)
-// - MAP            -> []any of [key, value] pairs
-// - MULTISET       -> []any of [value, count] pairs
-// - atomic         -> as-is (note your Atomic ToSDKType returns string values)
 func normalizeExpected(result any, dataType flinkgatewayv1.DataType) any {
 	switch dataType.GetType() {
 	case "STRUCTURED_TYPE":
-		rawResults, ok := result.([]any)
-		fields := dataType.GetFields()
-		if !ok || fields == nil || len(rawResults) != len(fields) {
-			return result
-		}
-		normalized := make(map[string]any, len(rawResults))
-		for i, field := range fields {
-			normalized[field.GetName()] = normalizeExpected(rawResults[i], field.GetFieldType())
-		}
-		return normalized
+		return normalizeStructuredType(result, dataType)
 	case "ROW":
-		rawResults, ok := result.([]any)
-		fields := dataType.GetFields()
-		if !ok || fields == nil || len(rawResults) != len(fields) {
-			return result
-		}
-		normalized := make([]any, len(rawResults))
-		for i, field := range fields {
-			normalized[i] = normalizeExpected(rawResults[i], field.GetFieldType())
-		}
-		return normalized
+		return normalizeRow(result, dataType)
 	case "ARRAY":
-		elems, ok := result.([]any)
-		if !ok {
-			return result
-		}
-		elemType := dataType.GetElementType()
-		normalized := make([]any, len(elems))
-		for i := range elems {
-			if elemType.GetType() != "" {
-				normalized[i] = normalizeExpected(elems[i], elemType)
-			} else {
-				normalized[i] = elems[i]
-			}
-		}
-		return normalized
+		return normalizeArray(result, dataType)
 	case "MAP":
-		entries, ok := result.([]any)
-		if !ok {
-			return result
-		}
-		keyType := dataType.GetKeyType()
-		valType := dataType.GetValueType()
-		normalized := make([]any, 0, len(entries))
-		for _, entry := range entries {
-			pair, ok := entry.([]any)
-			// best-effort: keep as-is
-			if !ok || len(pair) != 2 {
-				normalized = append(normalized, entry)
-				continue
-			}
-			var key, value = pair[0], pair[1]
-			if keyType.GetType() != "" {
-				key = normalizeExpected(pair[0], keyType)
-			}
-			if valType.GetType() != "" {
-				value = normalizeExpected(pair[1], valType)
-			}
-			normalized = append(normalized, []any{key, value})
-		}
-		return normalized
+		return normalizeMap(result, dataType)
 	case "MULTISET":
-		// In our model, MULTISET is converted via MapStatementResultField with
-		// keyType = elementType, valueType = INTEGER; and ToSDKType() returns []any of pairs.
-		entries, ok := result.([]any)
-		if !ok {
-			return result
-		}
-		// logical "key" type
-		elemType := dataType.GetElementType()
-		// value/count type is INTEGER in our converter, but Atomic returns strings, so keep as-is.
-		normalized := make([]any, 0, len(entries))
-		for _, entry := range entries {
-			pair, ok := entry.([]any)
-			// best-effort: keep as-is
-			if !ok || len(pair) != 2 {
-				normalized = append(normalized, entry)
-				continue
-			}
-			value := pair[0]
-			if elemType.GetType() != "" {
-				value = normalizeExpected(pair[0], elemType)
-			}
-			// keep count as-is (often string "0"/"2" in your atomic model)
-			count := pair[1]
-			normalized = append(normalized, []any{value, count})
-		}
-		return normalized
+		return normalizeMultiSet(result, dataType)
 	default:
 		// atomic or unhandled: return as-is (our Atomic ToSDKType returns string for numbers)
 		return result
 	}
+}
+
+// ROW -> []any (positional)
+func normalizeRow(result any, dataType flinkgatewayv1.DataType) any {
+	rawResults, ok := result.([]any)
+	fields := dataType.GetFields()
+	if !ok || fields == nil || len(rawResults) != len(fields) {
+		return result
+	}
+	normalized := make([]any, len(rawResults))
+	for i, field := range fields {
+		normalized[i] = normalizeExpected(rawResults[i], field.GetFieldType())
+	}
+	return normalized
+}
+
+// STRUCTURED_TYPE -> map[string]any
+func normalizeStructuredType(result any, dataType flinkgatewayv1.DataType) any {
+	rawResults, ok := result.([]any)
+	fields := dataType.GetFields()
+	if !ok || fields == nil || len(rawResults) != len(fields) {
+		return result
+	}
+	normalized := make(map[string]any, len(rawResults))
+	for i, field := range fields {
+		normalized[field.GetName()] = normalizeExpected(rawResults[i], field.GetFieldType())
+	}
+	return normalized
+}
+
+// MAP -> []any of [key, value] pairs
+func normalizeMap(field any, dt flinkgatewayv1.DataType) any {
+	rawEntries, ok := field.([]any)
+	if !ok {
+		return field
+	}
+	keyT := dt.GetKeyType()
+	valT := dt.GetValueType()
+
+	normalized := make([]any, 0, len(rawEntries))
+	for _, rawEntry := range rawEntries {
+		pair, ok := rawEntry.([]any)
+		if !ok || len(pair) != 2 {
+			normalized = append(normalized, rawEntry)
+			continue
+		}
+		key, value := pair[0], pair[1]
+		if keyT.GetType() != "" {
+			key = normalizeExpected(key, keyT)
+		}
+		if valT.GetType() != "" {
+			value = normalizeExpected(value, valT)
+		}
+		normalized = append(normalized, []any{key, value})
+	}
+	return normalized
+}
+
+// ARRAY -> []any (elements normalized)
+func normalizeArray(result any, dataType flinkgatewayv1.DataType) any {
+	elems, ok := result.([]any)
+	if !ok {
+		return result
+	}
+	elemType := dataType.GetElementType()
+	normalized := make([]any, len(elems))
+	for i := range elems {
+		if elemType.GetType() != "" {
+			normalized[i] = normalizeExpected(elems[i], elemType)
+		} else {
+			normalized[i] = elems[i]
+		}
+	}
+	return normalized
+}
+
+// MULTISET -> []any of [value, count] pairs
+func normalizeMultiSet(result any, dataType flinkgatewayv1.DataType) any {
+	// In our model, MULTISET is converted via MapStatementResultField with
+	// keyType = elementType, valueType = INTEGER; and ToSDKType() returns []any of pairs.
+	entries, ok := result.([]any)
+	if !ok {
+		return result
+	}
+	// logical "key" type
+	elemType := dataType.GetElementType()
+	// value/count type is INTEGER in our converter, but Atomic returns strings, so keep as-is.
+	normalized := make([]any, 0, len(entries))
+	for _, entry := range entries {
+		pair, ok := entry.([]any)
+		// best-effort: keep as-is
+		if !ok || len(pair) != 2 {
+			normalized = append(normalized, entry)
+			continue
+		}
+		value := pair[0]
+		if elemType.GetType() != "" {
+			value = normalizeExpected(pair[0], elemType)
+		}
+		// keep count as-is (often string "0"/"2" in your atomic model)
+		count := pair[1]
+		normalized = append(normalized, []any{value, count})
+	}
+	return normalized
 }
 
 func (s *ResultConverterTestSuite) TestConvertFieldOnPrem() {


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->
Not applicable.

Breaking Changes
- PLACEHOLDER

New Features
- PLACEHOLDER

Bug Fixes
- PLACEHOLDER

Checklist
---------
<!-- 
Check each item below to ensure high-quality CLI development practices are followed. PR approval will not be granted until the checklist is fully reviewed.
For detailed instructions, please refer to this Confluence page: https://confluentinc.atlassian.net/wiki/spaces/AEGI/pages/3949592874/
-->
- [x] I have successfully built and used a custom CLI binary, without linter issues from this PR.
- [x] I have clearly specified in the `What` section below whether this PR applies to Confluent Cloud, Confluent Platform, or both. 
- [x] I have verified this PR in Confluent Cloud pre-prod or production environment, if applicable.
- [ ] I have verified this PR in Confluent Platform on-premises environment, if applicable.
- [x] I have attached manual CLI verification results or screenshots in the `Test & Review` section below.
- [x] I have added appropriate CLI integration or unit tests for any new or updated commands and functionality.
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [x] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [x] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [x] Confluent Cloud prod
  - [ ] Confluent Cloud stag
  - [ ] Confluent Platform
  - [ ] Check this box if the feature is enabled for certain organizations only

What
----
<!--
Briefly describe **what** you have changed and **why** these changes are necessary.
Optionally include: 
- The problem being solved or the feature being added. 
- The implementation strategy or approach taken. 
- Key technical details, design decisions, or any additional context reviewers should be aware of.
-->
Refactor the function normalizeExpected() to reduce the cognitive complexity complained by SonarQube.

Blast Radius
----
<!--
The Blast Radius section should include information on what will be the customer(s) impact if something goes wrong or unexpectedly, 
adding this section will trigger the PR author to think about the impact from product perspective, examples can be:
- Confluent Cloud customers who are using confluent kafka topic any subcommand will be blocked.
- Confluent Cloud customers who are using confluent kafka topic list commands will be blocked.
- Confluent Platform customers who are using --schema flag will be impacted.
- All customers who are using SSO to login will be impacted.
-->
No customer impact, the code changes from this PR only impact the result converter unit tests.

References
----------
<!-- Include links to relevant resources for this PR, such as: 
- Related GitHub issues 
- Tickets (JIRA, etc.) 
- Internal documentation or design specs 
- Other related PRs 
Copy and paste the links below for easy reference.
-->
https://confluentinc.atlassian.net/browse/APIE-510

Test & Review
-------------
<!-- Has this PR been tested? If so, explain **how** it was tested. Include: 
- Steps taken to verify the changes. 
- Links to manual verification documents, logs, or screenshots to save reviewers' time. 
- Any additional notes on testing (e.g., environments used, edge cases tested). 
- Screenshot showing successful resource creation, updates etc.
Example: - [Manual Verification Document](https://docs.google.com/document/d/1GwXz9hNOkub_Br-2nssoYWCf6elZBvwo7TMhCNYinwE/edit?tab=t.0#heading=h.dvbi09ntxjw6)
-->
The impacted test cases `TestConvertResults()` and `TestConvertFields()` pass from local unit test run.