### PR TITLE
[CLI-3374] Update confluent local kafka version from 7.6.0 to 8.0.0

### DIFF
--- a/internal/local/command_kafka.go
+++ b/internal/local/command_kafka.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	dockerImageName             = "confluentinc/confluent-local:7.6.0"
+	dockerImageName             = "confluentinc/confluent-local:8.0.0"
 	localhostPrefix             = "http://localhost:%s"
 	localhost                   = "0.0.0.0"
 	kafkaRestNotReadySuggestion = "Kafka REST connection is not ready. Re-running the command may solve the issue."


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- PLACEHOLDER

New Features
- Update `confluent local kafka start` to use the newer 8.0.0 version of the "confluent-local" Docker image

Bug Fixes
- PLACEHOLDER

Checklist
---------
<!-- 
Check each item below to ensure high-quality CLI development practices are followed. PR approval will not be granted until the checklist is fully reviewed.
For detailed instructions, please refer to this Confluence page: https://confluentinc.atlassian.net/wiki/spaces/AEGI/pages/3949592874/
-->
- [x] I have successfully built and used a custom CLI binary, without linter issues from this PR.
- [x] I have clearly specified in the `What` section below whether this PR applies to Confluent Cloud, Confluent Platform, or both. 
- [ ] I have verified this PR in Confluent Cloud pre-prod or production environment, if applicable.
- [ ] I have verified this PR in Confluent Platform on-premises environment, if applicable.
- [x] I have attached manual CLI verification results or screenshots in the `Test & Review` section below.
- [ ] I have added appropriate CLI integration or unit tests for any new or updated commands and functionality.
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [x] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [ ] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [ ] Confluent Cloud prod
  - [ ] Confluent Cloud stag
  - [ ] Confluent Platform
  - [ ] Check this box if the feature is enabled for certain organizations only

What
----
`confluent local kafka` currently uses a really old version of the docker image.

Blast Radius
----
Minimal: this command group includes a disclaimer that it is intended for development and testing, not production usage.

References
----------
<!-- Include links to relevant resources for this PR, such as: 
- Related GitHub issues 
- Tickets (JIRA, etc.) 
- Internal documentation or design specs 
- Other related PRs 
Copy and paste the links below for easy reference.
-->

Test & Review
-------------
Manual testing of some local Kafka commands after updating to the new image:
Start:
```
confluent local kafka start
The local commands are intended for a single-node development environment only, NOT for production usage. See more: https://docs.confluent.io/current/cli/index.html


Pulling from confluentinc/confluent-local
Digest: sha256:7f954fd083664f1de4687e42566f73c8b90d56166f877e79fac8640257661589
Status: Image is up to date for confluentinc/confluent-local:8.0.0
+-----------------+-------+
| Kafka REST Port | 8082  |
| Plaintext Ports | 51600 |
+-----------------+-------+
Started Confluent Local containers "107d5d609e".
To continue your Confluent Local experience, run `confluent local kafka topic create <topic>` and `confluent local kafka topic produce <topic>`.
```

Create a topic:
```
confluent local kafka topic create my-topic
Created topic "my-topic".
```

Produce:
```
confluent local kafka topic produce my-topic
Starting Kafka Producer. Use Ctrl-C or Ctrl-D to exit.
hello
world
^C%
```

Consume:
```
confluent local kafka topic consume my-topic -b
Starting Kafka Consumer. Use Ctrl-C to exit.
hello
world
^CStopping Consumer.
```

List brokers:
```
confluent local kafka broker list
         Cluster         | Broker ID |           Host           | Port   
-------------------------+-----------+--------------------------+--------
  4L6g3nShT-eMCtK--X86sw |         1 | confluent-local-broker-1 | 51601  
```

Stop:
```
confluent local kafka stop
Confluent Local has been stopped: removed container "107d5d609e".
```