### PR TITLE
Enable r2 code review for confluentinc/cli

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -88,6 +88,19 @@ blocks:
           commands:
             - test-results publish . -N "windows/amd64"
 
+  - name: "R2 Code Review"
+    dependencies: [ ]
+    run:
+      # run on all pull requests
+      when: "pull_request =~ '.+'"
+    task:
+      jobs:
+        - name: "R2 Code Review"
+          commands:
+            # || true: code review failures are unrelated to the codebase and should not block CI.
+            # Please report issues to Slack channel #r2.
+            - r2 code-review --verbose --timeout=15m || true
+
 after_pipeline:
   task:
     jobs:

--- a/service.yml
+++ b/service.yml
@@ -20,8 +20,6 @@ semaphore:
   pipeline_enable: false
 make:
   enable: false
-code_review:
-  enable: true
 sonarqube:
   enable: true
   languages: ["go"]

--- a/service.yml
+++ b/service.yml
@@ -20,6 +20,8 @@ semaphore:
   pipeline_enable: false
 make:
   enable: false
+code_review:
+  enable: true
 sonarqube:
   enable: true
   languages: ["go"]


### PR DESCRIPTION
Release Notes
-------------

Breaking Changes
- None

New Features
- Add an R2 Code Review CI step that runs r2 code-review on every pull request, posting AI-powered review comments back to GitHub.

Bug Fixes
- None

Checklist
---------
- [ ] I have successfully built and used a custom CLI binary, without linter issues from this PR.
- [x] I have clearly specified in the `What` section below whether this PR applies to Confluent Cloud, Confluent Platform, or both. 
- [ ] I have verified this PR in Confluent Cloud pre-prod or production environment, if applicable.
- [ ] I have verified this PR in Confluent Platform on-premises environment, if applicable.
- [ ] I have attached manual CLI verification results or screenshots in the `Test & Review` section below.
- [ ] I have added appropriate CLI integration or unit tests for any new or updated commands and functionality.
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [x] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [ ] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [ ] Confluent Cloud prod
  - [ ] Confluent Cloud stag
  - [ ] Confluent Platform
  - [ ] Check this box if the feature is enabled for certain organizations only

What
----
This PR enables R2 Code Review for the `confluentinc/cli` repository CI pipeline. 

* Adds a new “R2 Code Review” block to `.semaphore/semaphore.yml` that runs on all pull requests.
* Executes `r2 code-review --verbose --timeout=15m || true` so R2 feedback is non-blocking and will not fail CI if R2 itself has issues. 
* Uses the standard onboarding flow from `go/r2-code-review`, giving `confluentinc/cli` the same AI review coverage as other repos that have already adopted R2. 
* Applies to both Confluent Cloud and Confluent Platform code in the CLI, but is purely CI/PR tooling; there is no change to any user-facing command behavior.

Blast Radius
------------
Impact is limited to the CLI CI pipeline and PR experience:

* **Customer-facing impact:** None. No CLI commands, flags, or APIs change.
* **If something goes wrong:**
  * *Worst case:* the R2 block in Semaphore could be noisy or flaky, adding extra comments or timing out.
  * It is explicitly wrapped in `|| true`, so CI will still pass/fail based on existing jobs only.
  * Existing build / lint / test / release behavior is unchanged.
  * If needed, the R2 block can be quickly disabled or removed from `.semaphore/semaphore.yml` without affecting any runtime behavior of the CLI.

References
----------
* N/A

Test & Review
-------------
* Verified the new R2 Code Review block executes correctly in the Semaphore CI pipeline for this PR.