### PR TITLE
Added RBAC example with Assigner role

### DIFF
--- a/internal/iam/command_rbac_role_binding_create.go
+++ b/internal/iam/command_rbac_role_binding_create.go
@@ -29,7 +29,7 @@ func (c *roleBindingCommand) newCreateCommand() *cobra.Command {
 			},
 			examples.Example{
 				Text: `Grant the role "ResourceOwner" to the principal "User:u-123456", in the environment "env-123456" for the Kafka cluster "lkc-123456" on the resource "Topic:my-topic":`,
-				Code: "confluent iam rbac role-binding create --principal User:u-123456 --role ResourceOwner --resource Topic:my-topic --environment env-123456 --cloud-cluster lkc-123456 --kafka-cluster lkc-123456"
+				Code: "confluent iam rbac role-binding create --principal User:u-123456 --role ResourceOwner --resource Topic:my-topic --environment env-123456 --cloud-cluster lkc-123456 --kafka-cluster lkc-123456",
 			},
 			examples.Example{
 				Text: `Grant the role "Assigner" to identity pool "User:pool-123456" for a service account resource "ServiceAccount:sa-123456":`,

--- a/internal/iam/command_rbac_role_binding_create.go
+++ b/internal/iam/command_rbac_role_binding_create.go
@@ -25,19 +25,19 @@ func (c *roleBindingCommand) newCreateCommand() *cobra.Command {
 		exs = append(exs,
 			examples.Example{
 				Text: `Grant the role "CloudClusterAdmin" to the principal "User:u-123456" in the environment "env-123456" for the cloud cluster "lkc-123456":`,
-				Code: `confluent iam rbac role-binding create --principal User:u-123456 --role CloudClusterAdmin --environment env-123456 --cloud-cluster lkc-123456`,
+				Code: "confluent iam rbac role-binding create --principal User:u-123456 --role CloudClusterAdmin --environment env-123456 --cloud-cluster lkc-123456",
 			},
 			examples.Example{
 				Text: `Grant the role "ResourceOwner" to the principal "User:u-123456", in the environment "env-123456" for the Kafka cluster "lkc-123456" on the resource "Topic:my-topic":`,
-				Code: `confluent iam rbac role-binding create --principal User:u-123456 --role ResourceOwner --resource Topic:my-topic --environment env-123456 --cloud-cluster lkc-123456 --kafka-cluster lkc-123456`,
+				Code: "confluent iam rbac role-binding create --principal User:u-123456 --role ResourceOwner --resource Topic:my-topic --environment env-123456 --cloud-cluster lkc-123456 --kafka-cluster lkc-123456"
 			},
 			examples.Example{
 				Text: `Grant the role "Assigner" to identity pool "User:pool-123456" for a service account resource "ServiceAccount:sa-123456":`,
-				Code: `confluent iam rbac role-binding create --principal User:pool-123456 --role Assigner --resource "ServiceAccount:sa-123456`,
+				Code: `confluent iam rbac role-binding create --principal User:pool-123456 --role Assigner --resource "ServiceAccount:sa-123456"`,
 			},
 			examples.Example{
 				Text: `Grant the role "MetricsViewer" to service account "sa-123456":`,
-				Code: `confluent iam rbac role-binding create --principal User:sa-123456 --role MetricsViewer`,
+				Code: "confluent iam rbac role-binding create --principal User:sa-123456 --role MetricsViewer",
 			},
 			examples.Example{
 				Text: `Grant the "ResourceOwner" role to principal "User:u-123456" and all subjects for Schema Registry cluster "lsrc-123456" in environment "env-123456":`,

--- a/internal/iam/command_rbac_role_binding_create.go
+++ b/internal/iam/command_rbac_role_binding_create.go
@@ -25,15 +25,19 @@ func (c *roleBindingCommand) newCreateCommand() *cobra.Command {
 		exs = append(exs,
 			examples.Example{
 				Text: `Grant the role "CloudClusterAdmin" to the principal "User:u-123456" in the environment "env-123456" for the cloud cluster "lkc-123456":`,
-				Code: "confluent iam rbac role-binding create --principal User:u-123456 --role CloudClusterAdmin --environment env-123456 --cloud-cluster lkc-123456",
+				Code: `confluent iam rbac role-binding create --principal User:u-123456 --role CloudClusterAdmin --environment env-123456 --cloud-cluster lkc-123456`,
 			},
 			examples.Example{
 				Text: `Grant the role "ResourceOwner" to the principal "User:u-123456", in the environment "env-123456" for the Kafka cluster "lkc-123456" on the resource "Topic:my-topic":`,
-				Code: "confluent iam rbac role-binding create --principal User:u-123456 --role ResourceOwner --resource Topic:my-topic --environment env-123456 --cloud-cluster lkc-123456 --kafka-cluster lkc-123456",
+				Code: `confluent iam rbac role-binding create --principal User:u-123456 --role ResourceOwner --resource Topic:my-topic --environment env-123456 --cloud-cluster lkc-123456 --kafka-cluster lkc-123456`,
+			},
+			examples.Example{
+				Text: `Grant the role "Assigner" to identity pool "User:pool-123456" for a service account resource "ServiceAccount:sa-123456":`,
+				Code: `confluent iam rbac role-binding create --principal User:pool-123456 --role Assigner --resource "ServiceAccount:sa-123456`,
 			},
 			examples.Example{
 				Text: `Grant the role "MetricsViewer" to service account "sa-123456":`,
-				Code: "confluent iam rbac role-binding create --principal User:sa-123456 --role MetricsViewer",
+				Code: `confluent iam rbac role-binding create --principal User:sa-123456 --role MetricsViewer`,
 			},
 			examples.Example{
 				Text: `Grant the "ResourceOwner" role to principal "User:u-123456" and all subjects for Schema Registry cluster "lsrc-123456" in environment "env-123456":`,

--- a/test/fixtures/output/iam/rbac/role-binding/create-help.golden
+++ b/test/fixtures/output/iam/rbac/role-binding/create-help.golden
@@ -12,6 +12,10 @@ Grant the role "ResourceOwner" to the principal "User:u-123456", in the environm
 
   $ confluent iam rbac role-binding create --principal User:u-123456 --role ResourceOwner --resource Topic:my-topic --environment env-123456 --cloud-cluster lkc-123456 --kafka-cluster lkc-123456
 
+Grant the role "Assigner" to identity pool "User:pool-123456" for a service account resource "ServiceAccount:sa-123456":
+
+  $ confluent iam rbac role-binding create --principal User:pool-123456 --role Assigner --resource "ServiceAccount:sa-123456"
+
 Grant the role "MetricsViewer" to service account "sa-123456":
 
   $ confluent iam rbac role-binding create --principal User:sa-123456 --role MetricsViewer


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- PLACEHOLDER

New Features
- Added an example for `confluent iam rbac role-binding create` showing how to create a role binding for the Assigner role on a service account

Bug Fixes
- PLACEHOLDER

Checklist
---------
- [ ] I have successfully built and used a custom CLI binary, without linter issues from this PR.
- [ ] I have clearly specified in the `What` section below whether this PR applies to Confluent Cloud, Confluent Platform, or both. 
- [x] I have verified this PR in Confluent Cloud pre-prod or production environment, if applicable.
- [ ] I have verified this PR in Confluent Platform on-premises environment, if applicable.
- [x] I have attached manual CLI verification results or screenshots in the `Test & Review` section below.
- [ ] I have added appropriate CLI integration or unit tests for any new or updated commands and functionality.
- [ ] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [ ] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [ ] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [x] Confluent Cloud prod
  - [ ] Confluent Cloud stag
  - [ ] Confluent Platform
  - [ ] Check this box if the feature is enabled for certain organizations only

What
----
Added example of CLI command for creating a rolebinding for Assigner role on a service account due to nuance of referencing service account as a resource (`ServiceAccount:sa-123` as opposed to `User:sa-123`)

Test & Review
-------------
This is the output following the example added. Resource identifiers have been modified.
`confluent iam rbac role-binding create --role Assigner --principal "User:pool-123" --resource "ServiceAccount:sa-123"`
```
+---------------+-----------------+
| Principal     | User:pool-123 |
| Role          | Assigner        |
| Resource Type | ServiceAccount  |
| Name          | sa-123      |
| Pattern Type  | LITERAL         |
+---------------+-----------------+

```