### PR TITLE
APIE-893: Skip linux/arm64 and windows/amd64 CI builds on PRs to save CI time

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -44,6 +44,8 @@ blocks:
             - test-results publish . -N "linux/amd64"
 
   - name: linux/arm64
+    run:
+      when: "branch = 'main'"
     dependencies: []
     task:
       agent:
@@ -61,6 +63,8 @@ blocks:
             - docker build . --file docker/Dockerfile_alpine_arm64 --tag test-build
 
   - name: windows/amd64
+    run:
+      when: "branch = 'main'"
     dependencies: []
     task:
       agent:


### PR DESCRIPTION
 Release Notes
  -------------
  NA, as this PR doesn't introduce any user-facing changes.

  Checklist
  ---------
  NA, as this PR only impacts our CI/CD pipeline.

  What
  ----
  This PR skips the linux/arm64 (Alpine) and windows/amd64 CI builds on PR branches to save CI time.
  Both blocks now have `run: when: "branch = 'main'"` conditions, so they only execute on main.
  The linux/amd64 block (lint, test, coverage, Alpine build) continues to run on every PR.

  Blast Radius
  ----
  NA, as this PR only impacts our CI/CD pipeline.

  References
  ----------
  * https://confluentinc.atlassian.net/browse/APIE-893

  Test & Review
  -------------
  This PR will be tested manually after merging by looking at Semaphore build.

  Follow Ups
  -------------
  NA
