### PR TITLE
fix: use --normalize flag value when registering schemas

### DIFF
--- a/internal/kafka/command_topic_produce.go
+++ b/internal/kafka/command_topic_produce.go
@@ -65,6 +65,7 @@ func (c *command) newProduceCommand() *cobra.Command {
 	cmd.Flags().String("schema-registry-endpoint", "", "Endpoint for Schema Registry cluster.")
 	cmd.Flags().StringSlice("headers", nil, `A comma-separated list of headers formatted as "key:value".`)
 	cmd.Flags().Bool("schema-id-header", false, "Serialize schema ID in the header instead of the message prefix.")
+	cmd.Flags().Bool("normalize", false, "Alphabetize the list of schema fields when registering a new schema.")
 
 	// cloud-only flags
 	cmd.Flags().String("key-references", "", "The path to the message key schema references file.")
@@ -530,6 +531,11 @@ func (c *command) initSchemaAndGetInfo(cmd *cobra.Command, topic, mode string) (
 	}
 
 	if schema != "" && !schemaId.IsSet() {
+		normalize, err := cmd.Flags().GetBool("normalize")
+		if err != nil {
+			return nil, nil, err
+		}
+
 		// read schema info from local file and register schema
 		schemaCfg := &schemaregistry.RegisterSchemaConfigs{
 			SchemaDir:  schemaDir,
@@ -537,7 +543,7 @@ func (c *command) initSchemaAndGetInfo(cmd *cobra.Command, topic, mode string) (
 			Subject:    subject,
 			Format:     format,
 			SchemaType: serializationProvider.GetSchemaName(),
-			Normalize:  false,
+			Normalize:  normalize,
 		}
 
 		flag := "references"
@@ -675,6 +681,11 @@ func (c *command) initSchemaAndGetInfoOnPrem(cmd *cobra.Command, topic, mode str
 	}
 
 	if schema != "" && !schemaId.IsSet() {
+		normalize, err := cmd.Flags().GetBool("normalize")
+		if err != nil {
+			return nil, nil, err
+		}
+
 		// read schema info from local file and register schema
 		schemaCfg := &schemaregistry.RegisterSchemaConfigs{
 			SchemaDir:  schemaDir,
@@ -682,7 +693,7 @@ func (c *command) initSchemaAndGetInfoOnPrem(cmd *cobra.Command, topic, mode str
 			Subject:    subject,
 			Format:     format,
 			SchemaType: serializationProvider.GetSchemaName(),
-			Normalize:  false,
+			Normalize:  normalize,
 		}
 
 		flag := "references"

--- a/internal/kafka/command_topic_produce.go
+++ b/internal/kafka/command_topic_produce.go
@@ -537,6 +537,7 @@ func (c *command) initSchemaAndGetInfo(cmd *cobra.Command, topic, mode string) (
 			Subject:    subject,
 			Format:     format,
 			SchemaType: serializationProvider.GetSchemaName(),
+			Normalize:  false,
 		}
 
 		flag := "references"
@@ -681,6 +682,7 @@ func (c *command) initSchemaAndGetInfoOnPrem(cmd *cobra.Command, topic, mode str
 			Subject:    subject,
 			Format:     format,
 			SchemaType: serializationProvider.GetSchemaName(),
+			Normalize:  false,
 		}
 
 		flag := "references"

--- a/internal/kafka/command_topic_produce_test.go
+++ b/internal/kafka/command_topic_produce_test.go
@@ -4,10 +4,14 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	ckgo "github.com/confluentinc/confluent-kafka-go/v2/kafka"
+
+	pcmd "github.com/confluentinc/cli/v4/pkg/cmd"
+	"github.com/confluentinc/cli/v4/pkg/config"
 )
 
 type splitTest struct {
@@ -102,6 +106,31 @@ func TestGetKeyAndValue_Fail(t *testing.T) {
 func TestGetMetaInfoFromSchemaId(t *testing.T) {
 	metaInfo := getMetaInfoFromSchemaId(100004)
 	require.Equal(t, []byte{0x0, 0x0, 0x1, 0x86, 0xa4}, metaInfo)
+}
+
+func TestProduceCommand_NormalizeFlag(t *testing.T) {
+	cfg := config.AuthenticatedCloudConfigMock()
+	prerunner := &pcmd.PreRun{Config: cfg}
+	c := &command{
+		AuthenticatedCLICommand: pcmd.NewAuthenticatedCLICommand(new(cobra.Command), prerunner),
+		clientID:                "test-client-id",
+	}
+
+	cmd := c.newProduceCommand()
+
+	flag := cmd.Flags().Lookup("normalize")
+	require.NotNil(t, flag, "--normalize flag should be registered on `kafka topic produce`")
+	assert.Equal(t, "false", flag.DefValue, "--normalize flag should default to false")
+	assert.Equal(t, "Alphabetize the list of schema fields when registering a new schema.", flag.Usage)
+
+	normalize, err := cmd.Flags().GetBool("normalize")
+	require.NoError(t, err)
+	assert.False(t, normalize, "reading --normalize without setting it should return false")
+
+	require.NoError(t, cmd.Flags().Set("normalize", "true"))
+	normalize, err = cmd.Flags().GetBool("normalize")
+	require.NoError(t, err)
+	assert.True(t, normalize, "reading --normalize after setting it to true should return true")
 }
 
 func TestHeaders(t *testing.T) {

--- a/pkg/schemaregistry/schema.go
+++ b/pkg/schemaregistry/schema.go
@@ -80,7 +80,7 @@ func RegisterSchemaWithAuth(schemaCfg *RegisterSchemaConfigs, client *Client) (i
 		RuleSet:    schemaCfg.Ruleset,
 	}
 
-	response, err := client.Register(schemaCfg.Subject, request, true)
+	response, err := client.Register(schemaCfg.Subject, request, schemaCfg.Normalize)
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/schemaregistry/schema_test.go
+++ b/pkg/schemaregistry/schema_test.go
@@ -1,0 +1,67 @@
+package schemaregistry
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"testing"
+
+	srsdk "github.com/confluentinc/schema-registry-sdk-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRegisterSchemaWithAuth_ForwardsNormalizeFlag(t *testing.T) {
+	tests := []struct {
+		name          string
+		normalize     bool
+		expectedQuery string
+	}{
+		{
+			name:          "normalize false",
+			normalize:     false,
+			expectedQuery: "false",
+		},
+		{
+			name:          "normalize true",
+			normalize:     true,
+			expectedQuery: "true",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var captured url.Values
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				captured = r.URL.Query()
+				w.Header().Set("Content-Type", "application/vnd.schemaregistry.v1+json")
+				w.WriteHeader(http.StatusOK)
+				_, err := w.Write([]byte(`{"id": 1}`))
+				require.NoError(t, err)
+			}))
+			defer server.Close()
+
+			schemaPath := filepath.Join(t.TempDir(), "employee.avsc")
+			require.NoError(t, os.WriteFile(schemaPath, []byte(`{"type":"string"}`), 0644))
+
+			srConfig := srsdk.NewConfiguration()
+			srConfig.Servers = srsdk.ServerConfigurations{{URL: server.URL}}
+			client := NewClientWithApiKey(srConfig, srsdk.BasicAuth{UserName: "u", Password: "p"})
+
+			cfg := &RegisterSchemaConfigs{
+				Subject:    "employee-value",
+				SchemaType: "AVRO",
+				SchemaPath: schemaPath,
+				Normalize:  tt.normalize,
+			}
+
+			id, err := RegisterSchemaWithAuth(cfg, client)
+			require.NoError(t, err)
+			assert.Equal(t, int32(1), id)
+			assert.Equal(t, tt.expectedQuery, captured.Get("normalize"))
+		})
+	}
+}

--- a/test/fixtures/output/kafka/topic/produce-help-onprem.golden
+++ b/test/fixtures/output/kafka/topic/produce-help-onprem.golden
@@ -24,6 +24,7 @@ Flags:
       --schema-registry-endpoint string     Endpoint for Schema Registry cluster.
       --headers strings                     A comma-separated list of headers formatted as "key:value".
       --schema-id-header                    Serialize schema ID in the header instead of the message prefix.
+      --normalize                           Alphabetize the list of schema fields when registering a new schema.
       --key-references string               The path to the message key schema references file.
       --api-key string                      API key.
       --api-secret string                   API secret.

--- a/test/fixtures/output/kafka/topic/produce-help.golden
+++ b/test/fixtures/output/kafka/topic/produce-help.golden
@@ -24,6 +24,7 @@ Flags:
       --schema-registry-endpoint string     Endpoint for Schema Registry cluster.
       --headers strings                     A comma-separated list of headers formatted as "key:value".
       --schema-id-header                    Serialize schema ID in the header instead of the message prefix.
+      --normalize                           Alphabetize the list of schema fields when registering a new schema.
       --key-references string               The path to the message key schema references file.
       --api-key string                      API key.
       --api-secret string                   API secret.


### PR DESCRIPTION
Checklist
---------
- [x] I have successfully built and used a custom CLI binary, without linter issues from this PR.
- [x] I have clearly specified in the `What` section below whether this PR applies to Confluent Cloud, Confluent Platform, or both.
- [ ] I have verified this PR in Confluent Cloud pre-prod or production environment, if applicable.
- [ ] I have verified this PR in Confluent Platform on-premises environment, if applicable.
- [ ] I have attached manual CLI verification results or screenshots in the `Test & Review` section below.
- [x] I have added appropriate CLI integration or unit tests for any new or updated commands and functionality.
- [ ] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [x] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [ ] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [ ] Confluent Cloud prod
  - [ ] Confluent Cloud stag
  - [ ] Confluent Platform
  - [ ] Check this box if the feature is enabled for certain organizations only

> **Note on "no breaking changes":** This is a bug fix that restores the documented default behavior of `--normalize` (`false`). However, any client that was implicitly relying on the previous (undocumented) always-normalize behavior without passing `--normalize` will observe a change. This is described in detail in the *Default behavior after this fix* and *Blast Radius* sections below.

What
----
Applies to **both Confluent Cloud and Confluent Platform**.

### Bug fix
`pkg/schemaregistry.RegisterSchemaWithAuth` was passing a hard-coded `true` as the `normalize` argument to `client.Register`, so every schema registration went through the Schema Registry normalization path regardless of what the user set for `--normalize`. Callers populate `RegisterSchemaConfigs.Normalize` from the flag (or zero value), but that value was being dropped at the call site.

```go
-response, err := client.Register(schemaCfg.Subject, request, true)
+response, err := client.Register(schemaCfg.Subject, request, schemaCfg.Normalize)
```

The `Normalize` field is also now set explicitly at the `internal/kafka/command_topic_produce.go` call sites per review feedback, so no caller silently relies on the struct zero value.

### New flag: `confluent kafka topic produce --normalize`
To keep `kafka topic produce` symmetrical with `schema-registry schema create`, a `--normalize` flag is now available on the produce command. Before this PR, the produce command had no user-facing way to control normalization — registration during produce was implicitly forced on by the bug above, and would have been implicitly off after the bug fix. Exposing the flag directly is both clearer and preserves user control. Flag default is `false`, matching `schema create`.

### Default behavior after this fix

The `--normalize` flag is declared with a default of `false` on both commands, so after this PR:

- `confluent schema-registry schema create` **without** `--normalize` sends `normalize=false` — schemas are registered **without** normalization by default.
- `confluent schema-registry schema create --normalize` sends `normalize=true`.
- `confluent kafka topic produce` **without** `--normalize` likewise sends `normalize=false`.
- `confluent kafka topic produce --normalize` sends `normalize=true`.

This is a visible change from the previous (buggy) behavior, which always sent `normalize=true` regardless of the flag (on `schema create`) or ignored normalization entirely from user control (on `topic produce`).

Blast Radius
----
- Customers using `confluent schema-registry schema create` (Cloud and on-prem) will now get the un-normalized registration behavior by default, matching the flag's documented default of `false`.
- Customers who were relying on the (undocumented) always-normalize behavior to register schemas without passing `--normalize` will see a behavior change. They can restore the prior behavior by passing `--normalize`.
- `confluent kafka topic produce` schema-registration paths are likewise affected: they now send `normalize=false` by default instead of the previous forced `true`. Users who want normalization on produce can now opt in via the new `--normalize` flag.
- No impact on read paths, listing, or any other schema-registry subcommand.

References
----------
- JIRA: [CLI-3689](https://confluentinc.atlassian.net/browse/CLI-3689)

Test & Review
-------------

**Unit tests added (two):**

1. `pkg/schemaregistry/schema_test.go` — `TestRegisterSchemaWithAuth_ForwardsNormalizeFlag`. Stands up an `httptest` Schema Registry and asserts that the outbound `normalize` query parameter matches `RegisterSchemaConfigs.Normalize` for both `true` and `false`. Verified this test **fails** on the pre-fix code (hard-coded `true`) and **passes** on the fixed code — a genuine regression test for the bug.
2. `internal/kafka/command_topic_produce_test.go` — `TestProduceCommand_NormalizeFlag`. Constructs the produce command via `newProduceCommand` and asserts the `--normalize` flag is registered with the expected name, default (`false`), description, and round-trips correctly via `cmd.Flags().GetBool`. Verified this test **fails** when the flag declaration is removed from the command — also a genuine regression test.

**Help-output golden fixtures updated:**

- `test/fixtures/output/kafka/topic/produce-help.golden`
- `test/fixtures/output/kafka/topic/produce-help-onprem.golden`

These are consumed by `test/help_test.go`'s `TestHelp`, which auto-walks the command tree and diffs `--help` output against the goldens. The new `--normalize` line is inserted right after `--schema-id-header` to match cobra's output order.

**Other verification:**

- Built a local CLI binary with `go build -o confluent ./cmd/confluent` — build clean. Confirmed `./confluent schema-registry schema create --help` and `./confluent kafka topic produce --help` both render the `--normalize` flag correctly.
- Ran the full unit-test target locally (`go test -timeout 0 -count=1 $(go list ./... | grep -v .../test)`). All packages touched by this PR (`pkg/schemaregistry`, `internal/kafka`, `internal/schema-registry`) pass, including both new tests. The only failure is a pre-existing, unrelated flake in `pkg/flink/internal/controller` (details below).
- Ran `go vet` on the changed packages (`pkg/schemaregistry/...`, `internal/kafka/...`, `cmd/confluent/...`) — no issues. (Did not run the full `golangci-lint` suite locally; that will run in CI.)
- Not yet executed against Cloud or on-prem clusters — would like a reviewer's guidance on whether Schema Registry cluster verification is required for this size of fix, or whether the unit tests + CI are sufficient.

### Known pre-existing CI failure (unrelated to this PR)

Semaphore CI (`ci/semaphoreci/pr: Confluent CLI`) is reporting a failure on this PR. I reproduced the failure locally by running the full unit-test target (`$(go list ./... | grep -v .../test)`) and traced it to a **single pre-existing, unrelated test**:

- **Failing test:** `pkg/flink/internal/controller.TestInteractiveOutputControllerTestSuite/TestCloseTableViewOnUserInput`
- **Failure:** `panic: close of nil channel` originating in `github.com/gdamore/tcell/v2/tscreen.go:586` → `tview.(*Application).Stop` when the test goroutine sends an `Escape`/`CtrlQ` key event. Looks like a Go 1.26 / tcell 2.7.4 / tview interaction when no real TTY is attached.

Evidence it is pre-existing and not caused by this PR:

1. **Reproduces identically on `origin/main`** — I checked out the `main` version of `pkg/flink/internal/controller/` and re-ran the test in isolation; same panic, same stack, same line.
2. **This PR does not touch any Flink / TUI / `tcell` / `tview` code** — only `pkg/schemaregistry/schema.go`, `pkg/schemaregistry/schema_test.go`, `internal/kafka/command_topic_produce.go`, `internal/kafka/command_topic_produce_test.go`, and the two `kafka/topic/produce-help*.golden` fixtures.
3. **Recently merged PRs on `main` show the same CI failure** — e.g. PR #3327 was merged with `ci/semaphoreci/pr: FAILURE`, so the team has been merging past this flake.
4. All packages actually touched by this PR (`pkg/schemaregistry`, `internal/kafka`, `internal/schema-registry`) pass unit tests locally.

Proposed path: merge this PR through the same route other recent merges took (the flake is not a regression from this change), and track the flink controller test separately. Happy to file that ticket if one doesn't already exist.

[CLI-3689]: https://confluentinc.atlassian.net/browse/CLI-3689?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ