### PR TITLE
Fix panic in api-key delete

### DIFF
--- a/internal/api-key/command_delete.go
+++ b/internal/api-key/command_delete.go
@@ -47,7 +47,7 @@ func (c *command) delete(cmd *cobra.Command, args []string) error {
 
 	errs := multierror.Append(err, c.deleteKeysFromKeyStore(deletedIds))
 	if errs.ErrorOrNil() != nil {
-		return errors.NewErrorWithSuggestions(err.Error(), errors.ApiKeyNotFoundSuggestions)
+		return errors.NewErrorWithSuggestions(errs.Error(), errors.ApiKeyNotFoundSuggestions)
 	}
 
 	return nil


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- PLACEHOLDER

New Features
- PLACEHOLDER

Bug Fixes
- Fix a bug causing `confluent api-key delete` to crash if it encounters an error saving while updating the config file

Checklist
---------
<!-- 
Check each item below to ensure high-quality CLI development practices are followed. PR approval will not be granted until the checklist is fully reviewed.
For detailed instructions, please refer to this Confluence page: https://confluentinc.atlassian.net/wiki/spaces/AEGI/pages/3949592874/
-->
- [x] I have successfully built and used a custom CLI binary, without linter issues from this PR.
- [x] I have clearly specified in the `What` section below whether this PR applies to Confluent Cloud, Confluent Platform, or both. 
- [x] I have verified this PR in Confluent Cloud pre-prod or production environment, if applicable.
- [ ] I have verified this PR in Confluent Platform on-premises environment, if applicable.
- [x] I have attached manual CLI verification results or screenshots in the `Test & Review` section below.
- [ ] I have added appropriate CLI integration or unit tests for any new or updated commands and functionality.
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [x] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [x] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [x] Confluent Cloud prod
  - [x] Confluent Cloud stag
  - [ ] Confluent Platform
  - [ ] Check this box if the feature is enabled for certain organizations only

What
----
The delete command displays a multierror. But there are multiple error variables, and the code was incorrectly calling the `.Error()` method on a nil error instead of the multierror, causing it to panic.

Blast Radius
----
Zero. The only change is in the output logic for an error.

References
----------
<!-- Include links to relevant resources for this PR, such as: 
- Related GitHub issues 
- Tickets (JIRA, etc.) 
- Internal documentation or design specs 
- Other related PRs 
Copy and paste the links below for easy reference.
-->

Test & Review
-------------
https://docs.google.com/document/d/1RN9nCxfpDSCTSZILBIn4pDOUS-GyEJ1gjt5_waxi1Q4/edit?usp=sharing