### PR TITLE
chore: make Windows smoke block resilient to vault + setup failures

### DIFF
--- a/.semaphore/smoke-tests.yml
+++ b/.semaphore/smoke-tests.yml
@@ -60,14 +60,6 @@ blocks:
             - $Env:PATH += ";C:\Program Files\Git\bin"
             - checkout
 
-            # Vault auth (vault-sem-get-secret is Linux-only; use native vault CLI on Windows,
-            # following the pattern from cli-release/.semaphore/4-release-cli.yml).
-            - $Env:VAULT_ADDR = "https://vault.cireops.gcp.internal.confluent.cloud"
-            - vault login -no-print token=$(vault write -field=token "auth/semaphore_self_hosted/login" role="default" jwt="$Env:SEMAPHORE_OIDC_TOKEN")
-            - $Env:CONFLUENT_CLOUD_EMAIL = (vault kv get -field=CONFLUENT_CLOUD_EMAIL v1/ci/kv/apif/cli/live-testing-data)
-            - $Env:CONFLUENT_CLOUD_PASSWORD = (vault kv get -field=CONFLUENT_CLOUD_PASSWORD v1/ci/kv/apif/cli/live-testing-data)
-            - $Env:SLACK_WEBHOOK_URL = (vault kv get -field=SLACK_WEBHOOK_URL v1/ci/kv/apif/cli/slack-notifications-live-testing)
-
             # Install Go (matches the pattern in semaphore.yml; chocolatey is community-maintained)
             - $ProgressPreference = 'SilentlyContinue'; Invoke-WebRequest -OutFile Go.zip -Uri https://go.dev/dl/go$(Get-Content .go-version).windows-amd64.zip -UseBasicParsing
             - 7z x Go.zip -oC:\
@@ -86,30 +78,78 @@ blocks:
             - $Env:SMOKE_ARCH = "amd64"
             - $Env:SMOKE_COMMAND = "environment_list"
 
-            # Build emitter + CLI directly (no `make` available without bash; mirrors Makefile targets)
+            # Build the emitter FIRST so it's available even if vault/test setup fails later.
             - go build -o bin\otel-smoke-metric.exe .\cmd\otel-smoke-metric
-            - go build -ldflags="-s -w -X main.disableUpdates=true" -o test\live\bin\confluent.exe .\cmd\confluent
 
-            - $Env:CLI_LIVE_TEST = "1"
-
-            # Run smoke + emit metric + Slack on failure as a single block so a non-zero
-            # `go test` exit code does NOT abort the job before metric emission.
+            # Single block runs vault auth, smoke test, Slack, and metric emission with a
+            # try/catch/finally so the metric is ALWAYS reported with a 0 on any failure.
             - |
-              go test ./test/live/ -v -run='.*Live$' -tags='live_test,smoke' -timeout 30m -parallel 4
-              if ($LASTEXITCODE -eq 0) {
-                $RESULT = "1"
-              } else {
-                $RESULT = "0"
-                Write-Host "Smoke tests failed on windows/amd64, sending Slack notification..."
-                try {
-                  Invoke-RestMethod -Method Post -Uri $Env:SLACK_WEBHOOK_URL -ContentType "application/json" -Body "{}"
-                } catch {
-                  Write-Host "Slack notification failed: $_"
+              $RESULT = "0"
+              try {
+                # Vault auth — vault-sem-get-secret is Linux-only, so use native vault CLI.
+                $Env:VAULT_ADDR = "https://vault.cireops.gcp.internal.confluent.cloud"
+                $vaultToken = vault write -field=token "auth/semaphore_self_hosted/login" role="default" jwt="$Env:SEMAPHORE_OIDC_TOKEN"
+                if ($LASTEXITCODE -ne 0) { throw "vault login failed" }
+                vault login -no-print token=$vaultToken
+                if ($LASTEXITCODE -ne 0) { throw "vault login token failed" }
+
+                # Pull every field from each secret as JSON and export them as env vars under
+                # both the original name AND an UPPER_SNAKE_CASE variant — this mirrors what
+                # vault-sem-get-secret does on Linux without us having to hard-code field names.
+                function Set-VaultFields {
+                  param([string]$Path)
+                  $json = vault kv get -format=json $Path
+                  if ($LASTEXITCODE -ne 0) { throw "vault kv get failed for $Path" }
+                  $secret = $json | ConvertFrom-Json
+                  $fields = if ($secret.data.PSObject.Properties.Name -contains 'data' -and $secret.data.data) {
+                    $secret.data.data
+                  } else {
+                    $secret.data
+                  }
+                  $names = @($fields.PSObject.Properties.Name)
+                  Write-Host "Fields in ${Path}: $($names -join ', ')"
+                  foreach ($prop in $fields.PSObject.Properties) {
+                    [Environment]::SetEnvironmentVariable($prop.Name, $prop.Value, 'Process')
+                    $upper = $prop.Name.ToUpper().Replace('-', '_')
+                    if ($upper -ne $prop.Name) {
+                      [Environment]::SetEnvironmentVariable($upper, $prop.Value, 'Process')
+                    }
+                  }
                 }
+                Set-VaultFields -Path "v1/ci/kv/apif/cli/live-testing-data"
+                Set-VaultFields -Path "v1/ci/kv/apif/cli/slack-notifications-live-testing"
+
+                # Build the CLI under test.
+                go build -ldflags="-s -w -X main.disableUpdates=true" -o test\live\bin\confluent.exe .\cmd\confluent
+                if ($LASTEXITCODE -ne 0) { throw "go build of confluent CLI failed" }
+
+                # Run the smoke test.
+                $Env:CLI_LIVE_TEST = "1"
+                go test ./test/live/ -v -run='.*Live$' -tags='live_test,smoke' -timeout 30m -parallel 4
+                if ($LASTEXITCODE -eq 0) {
+                  $RESULT = "1"
+                } else {
+                  Write-Host "Smoke test command exited non-zero on windows/amd64"
+                }
+              } catch {
+                Write-Host "Smoke pipeline failed before/during test on windows/amd64: $_"
+              } finally {
+                if ($RESULT -ne "1") {
+                  Write-Host "Smoke tests failed on windows/amd64, sending Slack notification..."
+                  if ($Env:SLACK_WEBHOOK_URL) {
+                    try {
+                      Invoke-RestMethod -Method Post -Uri $Env:SLACK_WEBHOOK_URL -ContentType "application/json" -Body "{}"
+                    } catch {
+                      Write-Host "Slack notification failed: $_"
+                    }
+                  } else {
+                    Write-Host "SLACK_WEBHOOK_URL not set — skipping Slack notification"
+                  }
+                }
+
+                # Always emit the metric so the windows/amd64 panel never goes to "No data" on infra failure.
+                & .\bin\otel-smoke-metric.exe $RESULT
               }
 
-              # Report pass/fail metric (never fails the pipeline; emitter always exits 0)
-              & .\bin\otel-smoke-metric.exe $RESULT
-
-              # Surface failure to Semaphore at the very end
+              # Surface failure to Semaphore at the very end.
               if ($RESULT -ne "1") { exit 1 }


### PR DESCRIPTION
## Summary

Follow-up to #3342. The first scheduled run of the smoke pipeline against `main` had:

- ✅ **linux/arm64** — passed cleanly, metric emitted
- ❌ **windows/amd64** — failed at `vault kv get -field=CONFLUENT_CLOUD_EMAIL …` with `Field "CONFLUENT_CLOUD_EMAIL" not present in secret`. Because the failure was on a regular YAML command line, the job aborted before reaching the metric emitter, so the windows panel showed "No data" instead of `0`.

This PR fixes both issues.

## Changes (all in `.semaphore/smoke-tests.yml`, windows/amd64 block only)

### 1. Dynamic vault field handling

Replaced 3 hardcoded `vault kv get -field=…` calls with a `Set-VaultFields` PowerShell helper that:

- Pulls each secret with `vault kv get -format=json`
- **Logs every field name it finds** — so the next run will print e.g. `Fields in v1/ci/kv/apif/cli/live-testing-data: email, password` and we'll know exactly what's there
- Exports each field under **both** its original name AND an `UPPER_SNAKE_CASE` variant, covering every common Vault → env-var convention (`email` / `EMAIL`, `confluent-cloud-email` / `CONFLUENT_CLOUD_EMAIL`, `confluent_cloud_email`, etc.) at once

This mirrors what `vault-sem-get-secret` does on Linux, which is why Linux works without specifying field names. `vault-sem-get-secret` ships with the Semaphore Linux agent toolbox and is not available on Windows agents.

### 2. Always emit the metric

The emitter binary is now built **before** the failable section. The vault auth + CLI build + smoke test are wrapped in one PowerShell `try / catch / finally`, and the `finally` clause **always** calls `otel-smoke-metric.exe` with the captured `$RESULT`:

- `$RESULT = "0"` is the default
- Only set to `"1"` after a clean test pass

So vault failures, build failures, test failures, or any thrown exception all report `cli_smoke_test_result{os="windows",arch="amd64"} = 0` to Heracles. The windows panel in [cc-terraform-monitoring#9639](https://github.com/confluentinc/cc-terraform-monitoring/pull/9639) will now go red on infra failures instead of going silent.

## Test plan

- [ ] Manually promote the smoke pipeline once after merge
- [ ] Look at the windows job log — confirm the `Fields in v1/ci/kv/apif/cli/live-testing-data: …` line lists field names that include something matching `CONFLUENT_CLOUD_EMAIL` / `CONFLUENT_CLOUD_PASSWORD` (after upper-snake-case normalization)
- [ ] If the test runs and passes: confirm `cli_smoke_test_result{os="windows",arch="amd64"} = 1` shows up in Heracles
- [ ] If the test still fails (e.g. fields really aren't there): confirm `cli_smoke_test_result{os="windows",arch="amd64"} = 0` shows up — the new always-emit guarantee makes the failure visible

## Out of scope

- Linux block is unchanged.
- Two-set-of-graphs in Grafana is already handled by the merged dashboard PR ([cc-terraform-monitoring#9639](https://github.com/confluentinc/cc-terraform-monitoring/pull/9639)) — separate panels per `{os, arch}` label, which is the standard Prometheus per-platform pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)