### PR TITLE
APIE-1043: Fix RTCE topic live test compile and missing --cloud flag.

### DIFF
--- a/test/live/rtce_topic_live_test.go
+++ b/test/live/rtce_topic_live_test.go
@@ -15,6 +15,9 @@ func (s *CLILiveTestSuite) TestRtceTopicCRUDLive() {
 
 	// Variables
 	rtceTopicName := uniqueName("rtceto")
+	topicName := uniqueName("topic")
+	cloud := liveTestCloud()
+	region := liveTestRegion()
 	description := "Live test description"
 	updatedDescription := "Updated live test description"
 
@@ -37,7 +40,7 @@ func (s *CLILiveTestSuite) TestRtceTopicCRUDLive() {
 		},
 		{
 			Name:            "Create RTCE topic",
-			Args:            "rtce rtce-topic create " + rtceTopicName + " --description \"" + description + "\" --region \"" + region + "\" --topic-name \"" + topicName + "\" --environment {{.env_id}} -o json",
+			Args:            "rtce rtce-topic create " + rtceTopicName + " --cloud " + cloud + " --description \"" + description + "\" --region \"" + region + "\" --topic-name \"" + topicName + "\" --environment {{.env_id}} -o json",
 			UseStateVars:    true,
 			CaptureID:       "rtce_topic_id",
 			JSONFields:      map[string]string{},


### PR DESCRIPTION
Release Notes
  -------------
 
  Checklist
  ---------
  - [x] I have successfully built and used a custom CLI binary, without linter issues from this PR.
  - [x] I have clearly specified in the `What` section below whether this PR applies to Confluent Cloud, Confluent Platform, or both.
  - [ ] I have verified this PR in Confluent Cloud pre-prod or production environment, if applicable.
  - [ ] I have verified this PR in Confluent Platform on-premises environment, if applicable.
  - [x] I have attached manual CLI verification results or screenshots in the `Test & Review` section below.
  - [x] I have added appropriate CLI integration or unit tests for any new or updated commands and functionality.
  - [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
  - [x] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
  - [ ] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
    - [ ] Confluent Cloud prod
    - [ ] Confluent Cloud stag
    - [ ] Confluent Platform
    - [x] Check this box if the feature is enabled for certain organizations only

  What
  ----
  Applies to: **Confluent Cloud**.

  Fixes the RTCE topic live test (`test/live/rtce_topic_live_test.go`), which was added in #3331 (APIE-989) and did not compile:

  test/live/rtce_topic_live_test.go:40:120: undefined: region
  test/live/rtce_topic_live_test.go:40:152: undefined: topicName

  Changes:
  - Declare the missing `region` and `topicName` locals using existing live-test idioms — `liveTestRegion()` (reads `CLI_LIVE_TEST_REGION`, defaults to `us-east-1`) and `uniqueName("topic")`, matching the pattern in
  `kafka_topic_live_test.go`.
  - Pass the required `--cloud` flag to `rtce rtce-topic create` (sourced from `liveTestCloud()`); the command marks `--cloud` as required in `internal/rtce/command_rtce_topic_create.go`, so the test would have failed at
  runtime even after the compile fix.

  No production code paths are touched — only `test/live/rtce_topic_live_test.go`.

  Blast Radius
  ----
  None for customers. This is a test-only change behind the `live_test` build tag; it only affects the `make live-test-*` targets run internally against Confluent Cloud. If the test itself regresses, the only impact is a
  failing live-test run for the RTCE topic CRUD flow.

  References
  ----------

  Test & Review
  -------------
  Verified the package now compiles under the relevant build tags:

  $ go test -tags 'live_test all' -run NoMatchXYZ ./test/live/
  ok    github.com/confluentinc/cli/v4/test/live        0.356s [no tests to run]

  Full live run (`make live-test-*`) requires Confluent Cloud credentials and was not executed locally — please run in CI / a prod-credentialed environment before merge.
