### PR TITLE
[APIE-1040] Add generic --wait framework; refactor Flink statement create

### DIFF
--- a/internal/flink/command_statement_create.go
+++ b/internal/flink/command_statement_create.go
@@ -187,13 +187,19 @@ func (c *command) statementCreate(cmd *cobra.Command, args []string) error {
 			Timeout:       timeout,
 		})
 		if err != nil {
-			if errors.Is(err, wait.ErrFailed) {
+			switch {
+			case errors.Is(err, wait.ErrFailed):
 				return clierrors.NewErrorWithSuggestions(
 					fmt.Sprintf(`statement "%s" entered failed phase %q: %s`, name, statement.Status.GetPhase(), statement.Status.GetDetail()),
 					fmt.Sprintf("Inspect the statement with `confluent flink statement describe %s`.", name),
 				)
+			case errors.Is(err, wait.ErrTimeout):
+				return clierrors.NewErrorWithSuggestions(err.Error(), "Increase `--wait-timeout` or omit `--wait`.")
+			default:
+				// Fetch error or context cancellation — surface the underlying
+				// cause unmodified; suggesting a longer timeout would mislead.
+				return err
 			}
-			return clierrors.NewErrorWithSuggestions(err.Error(), "Increase `--wait-timeout` or omit `--wait`.")
 		}
 	}
 

--- a/internal/flink/command_statement_create.go
+++ b/internal/flink/command_statement_create.go
@@ -1,7 +1,6 @@
 package flink
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -16,7 +15,7 @@ import (
 	"github.com/confluentinc/cli/v4/pkg/flink/types"
 	"github.com/confluentinc/cli/v4/pkg/output"
 	"github.com/confluentinc/cli/v4/pkg/properties"
-	"github.com/confluentinc/cli/v4/pkg/retry"
+	"github.com/confluentinc/cli/v4/pkg/wait"
 )
 
 func (c *command) newStatementCreateCommand() *cobra.Command {
@@ -41,7 +40,8 @@ func (c *command) newStatementCreateCommand() *cobra.Command {
 	c.addComputePoolFlag(cmd)
 	pcmd.AddServiceAccountFlag(cmd, c.AuthenticatedCLICommand)
 	c.addDatabaseFlag(cmd)
-	cmd.Flags().Bool("wait", false, "Block until the statement is running or has failed.")
+	pcmd.AddWaitFlag(cmd)
+	pcmd.AddWaitTimeoutFlag(cmd, time.Minute)
 	cmd.Flags().StringSlice("property", []string{}, "A mechanism to pass properties in the form key=value when creating a Flink statement.")
 	pcmd.AddEnvironmentFlag(cmd, c.AuthenticatedCLICommand)
 	pcmd.AddContextFlag(cmd, c.CLICommand)
@@ -151,25 +151,27 @@ func (c *command) statementCreate(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	wait, err := cmd.Flags().GetBool("wait")
+	shouldWait, err := cmd.Flags().GetBool("wait")
 	if err != nil {
 		return err
 	}
-	if wait {
-		err := retry.Retry(time.Second, time.Minute, func() error {
-			statement, err = client.GetStatement(environmentId, name, c.Context.LastOrgId)
-			if err != nil {
-				return err
-			}
-
-			if statement.Status.GetPhase() == "PENDING" {
-				return fmt.Errorf(`statement phase is "%s"`, statement.Status.GetPhase())
-			}
-
-			return nil
-		})
+	if shouldWait {
+		timeout, err := cmd.Flags().GetDuration("wait-timeout")
 		if err != nil {
 			return err
+		}
+		statement, err = wait.Poll(cmd.Context(), wait.Options[flinkgatewayv1.SqlV1Statement]{
+			Fetch: func() (flinkgatewayv1.SqlV1Statement, error) {
+				return client.GetStatement(environmentId, name, c.Context.LastOrgId)
+			},
+			IsTerminal: func(s flinkgatewayv1.SqlV1Statement) bool {
+				return s.Status.GetPhase() != "PENDING"
+			},
+			Tick:    time.Second,
+			Timeout: timeout,
+		})
+		if err != nil {
+			return errors.NewErrorWithSuggestions(err.Error(), "Increase `--wait-timeout` or omit `--wait`.")
 		}
 	}
 

--- a/internal/flink/command_statement_create.go
+++ b/internal/flink/command_statement_create.go
@@ -1,6 +1,8 @@
 package flink
 
 import (
+	"errors"
+	"fmt"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -9,7 +11,7 @@ import (
 
 	"github.com/confluentinc/cli/v4/pkg/ccloudv2"
 	pcmd "github.com/confluentinc/cli/v4/pkg/cmd"
-	"github.com/confluentinc/cli/v4/pkg/errors"
+	clierrors "github.com/confluentinc/cli/v4/pkg/errors"
 	"github.com/confluentinc/cli/v4/pkg/examples"
 	"github.com/confluentinc/cli/v4/pkg/flink/config"
 	"github.com/confluentinc/cli/v4/pkg/flink/types"
@@ -17,6 +19,20 @@ import (
 	"github.com/confluentinc/cli/v4/pkg/properties"
 	"github.com/confluentinc/cli/v4/pkg/wait"
 )
+
+// Phase enum from flink-gateway/v1 SqlV1StatementStatus.Phase. PENDING /
+// FAILING / STOPPING / DELETING are transitioning states; FAILED is the only
+// terminal failure; RUNNING / COMPLETED / STOPPED / DEGRADED are terminal
+// success. The generator will source the same sets from AsyncConfig.
+var (
+	flinkStatementPendingPhases = []string{"PENDING", "FAILING", "STOPPING", "DELETING"}
+	flinkStatementFailedPhases  = []string{"FAILED"}
+)
+
+// statementsAPICreateTimeout aligns with terraform-provider-confluent's
+// statementsAPICreateTimeout in internal/provider/constants.go. CLI users can
+// shorten it with --wait-timeout; TF has no equivalent override.
+const flinkStatementCreateWaitTimeout = 6 * time.Hour
 
 func (c *command) newStatementCreateCommand() *cobra.Command {
 	cmd := &cobra.Command{
@@ -41,7 +57,7 @@ func (c *command) newStatementCreateCommand() *cobra.Command {
 	pcmd.AddServiceAccountFlag(cmd, c.AuthenticatedCLICommand)
 	c.addDatabaseFlag(cmd)
 	pcmd.AddWaitFlag(cmd)
-	pcmd.AddWaitTimeoutFlag(cmd, time.Minute)
+	pcmd.AddWaitTimeoutFlag(cmd, flinkStatementCreateWaitTimeout)
 	cmd.Flags().StringSlice("property", []string{}, "A mechanism to pass properties in the form key=value when creating a Flink statement.")
 	pcmd.AddEnvironmentFlag(cmd, c.AuthenticatedCLICommand)
 	pcmd.AddContextFlag(cmd, c.CLICommand)
@@ -62,7 +78,7 @@ func (c *command) statementCreate(cmd *cobra.Command, args []string) error {
 
 	environment, err := c.V2Client.GetOrgEnvironment(environmentId)
 	if err != nil {
-		return errors.NewErrorWithSuggestions(err.Error(), "List available environments with `confluent environment list`.")
+		return clierrors.NewErrorWithSuggestions(err.Error(), "List available environments with `confluent environment list`.")
 	}
 
 	computePool := c.Context.GetCurrentFlinkComputePool()
@@ -78,7 +94,7 @@ func (c *command) statementCreate(cmd *cobra.Command, args []string) error {
 
 	if computePool == "" {
 		if cloud == "" || region == "" {
-			return errors.New("Flink cloud and region flags are required when compute pool is not specified.")
+			return clierrors.New("Flink cloud and region flags are required when compute pool is not specified.")
 		}
 	}
 
@@ -160,18 +176,24 @@ func (c *command) statementCreate(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return err
 		}
-		statement, err = wait.Poll(cmd.Context(), wait.Options[flinkgatewayv1.SqlV1Statement]{
+		statement, err = wait.PollPhases(cmd.Context(), wait.PhaseOptions[flinkgatewayv1.SqlV1Statement]{
 			Fetch: func() (flinkgatewayv1.SqlV1Statement, error) {
 				return client.GetStatement(environmentId, name, c.Context.LastOrgId)
 			},
-			IsTerminal: func(s flinkgatewayv1.SqlV1Statement) bool {
-				return s.Status.GetPhase() != "PENDING"
-			},
-			Tick:    time.Second,
-			Timeout: timeout,
+			Phase:         func(s flinkgatewayv1.SqlV1Statement) string { return s.Status.GetPhase() },
+			PendingPhases: flinkStatementPendingPhases,
+			FailedPhases:  flinkStatementFailedPhases,
+			Tick:          time.Second,
+			Timeout:       timeout,
 		})
 		if err != nil {
-			return errors.NewErrorWithSuggestions(err.Error(), "Increase `--wait-timeout` or omit `--wait`.")
+			if errors.Is(err, wait.ErrFailed) {
+				return clierrors.NewErrorWithSuggestions(
+					fmt.Sprintf(`statement "%s" entered failed phase %q: %s`, name, statement.Status.GetPhase(), statement.Status.GetDetail()),
+					fmt.Sprintf("Inspect the statement with `confluent flink statement describe %s`.", name),
+				)
+			}
+			return clierrors.NewErrorWithSuggestions(err.Error(), "Increase `--wait-timeout` or omit `--wait`.")
 		}
 	}
 

--- a/internal/flink/command_statement_create.go
+++ b/internal/flink/command_statement_create.go
@@ -55,9 +55,8 @@ func (c *command) newStatementCreateCommand() *cobra.Command {
 	c.addComputePoolFlag(cmd)
 	pcmd.AddServiceAccountFlag(cmd, c.AuthenticatedCLICommand)
 	c.addDatabaseFlag(cmd)
-	pcmd.AddWaitFlag(cmd)
-	pcmd.AddNoWaitFlag(cmd)
-	pcmd.AddWaitTimeoutFlag(cmd, flinkStatementCreateWaitTimeout)
+	cmd.Flags().Bool("wait", false, "Block until the statement reaches a terminal state.")
+	cmd.Flags().Duration("wait-timeout", flinkStatementCreateWaitTimeout, "Maximum time to wait when --wait is set.")
 	cmd.Flags().StringSlice("property", []string{}, "A mechanism to pass properties in the form key=value when creating a Flink statement.")
 	pcmd.AddEnvironmentFlag(cmd, c.AuthenticatedCLICommand)
 	pcmd.AddContextFlag(cmd, c.CLICommand)
@@ -167,7 +166,7 @@ func (c *command) statementCreate(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	shouldWait, err := pcmd.ShouldWait(cmd)
+	shouldWait, err := cmd.Flags().GetBool("wait")
 	if err != nil {
 		return err
 	}

--- a/internal/flink/command_statement_create.go
+++ b/internal/flink/command_statement_create.go
@@ -57,6 +57,7 @@ func (c *command) newStatementCreateCommand() *cobra.Command {
 	pcmd.AddServiceAccountFlag(cmd, c.AuthenticatedCLICommand)
 	c.addDatabaseFlag(cmd)
 	pcmd.AddWaitFlag(cmd)
+	pcmd.AddNoWaitFlag(cmd)
 	pcmd.AddWaitTimeoutFlag(cmd, flinkStatementCreateWaitTimeout)
 	cmd.Flags().StringSlice("property", []string{}, "A mechanism to pass properties in the form key=value when creating a Flink statement.")
 	pcmd.AddEnvironmentFlag(cmd, c.AuthenticatedCLICommand)
@@ -167,7 +168,7 @@ func (c *command) statementCreate(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	shouldWait, err := cmd.Flags().GetBool("wait")
+	shouldWait, err := pcmd.ShouldWait(cmd)
 	if err != nil {
 		return err
 	}

--- a/internal/flink/command_statement_create.go
+++ b/internal/flink/command_statement_create.go
@@ -1,7 +1,6 @@
 package flink
 
 import (
-	"errors"
 	"fmt"
 	"time"
 
@@ -11,7 +10,7 @@ import (
 
 	"github.com/confluentinc/cli/v4/pkg/ccloudv2"
 	pcmd "github.com/confluentinc/cli/v4/pkg/cmd"
-	clierrors "github.com/confluentinc/cli/v4/pkg/errors"
+	"github.com/confluentinc/cli/v4/pkg/errors"
 	"github.com/confluentinc/cli/v4/pkg/examples"
 	"github.com/confluentinc/cli/v4/pkg/flink/config"
 	"github.com/confluentinc/cli/v4/pkg/flink/types"
@@ -79,7 +78,7 @@ func (c *command) statementCreate(cmd *cobra.Command, args []string) error {
 
 	environment, err := c.V2Client.GetOrgEnvironment(environmentId)
 	if err != nil {
-		return clierrors.NewErrorWithSuggestions(err.Error(), "List available environments with `confluent environment list`.")
+		return errors.NewErrorWithSuggestions(err.Error(), "List available environments with `confluent environment list`.")
 	}
 
 	computePool := c.Context.GetCurrentFlinkComputePool()
@@ -95,7 +94,7 @@ func (c *command) statementCreate(cmd *cobra.Command, args []string) error {
 
 	if computePool == "" {
 		if cloud == "" || region == "" {
-			return clierrors.New("Flink cloud and region flags are required when compute pool is not specified.")
+			return errors.New("Flink cloud and region flags are required when compute pool is not specified.")
 		}
 	}
 
@@ -184,18 +183,25 @@ func (c *command) statementCreate(cmd *cobra.Command, args []string) error {
 			Phase:         func(s flinkgatewayv1.SqlV1Statement) string { return s.Status.GetPhase() },
 			PendingPhases: flinkStatementPendingPhases,
 			FailedPhases:  flinkStatementFailedPhases,
-			Tick:          time.Second,
+			PollInterval:  time.Second,
 			Timeout:       timeout,
 		})
 		if err != nil {
-			switch {
-			case errors.Is(err, wait.ErrFailed):
-				return clierrors.NewErrorWithSuggestions(
+			// wait.ErrFailed and wait.ErrTimeout are package-level sentinels
+			// returned directly from Poll (never wrapped); a direct == compare
+			// is correct and avoids importing stdlib errors alongside the CLI
+			// errors package.
+			switch err {
+			case wait.ErrFailed:
+				return errors.NewErrorWithSuggestions(
 					fmt.Sprintf(`statement "%s" entered failed phase %q: %s`, name, statement.Status.GetPhase(), statement.Status.GetDetail()),
 					fmt.Sprintf("Inspect the statement with `confluent flink statement describe %s`.", name),
 				)
-			case errors.Is(err, wait.ErrTimeout):
-				return clierrors.NewErrorWithSuggestions(err.Error(), "Increase `--wait-timeout` or omit `--wait`.")
+			case wait.ErrTimeout:
+				return errors.NewErrorWithSuggestions(
+					fmt.Sprintf(`wait timed out: statement "%s" is still in phase %q`, name, statement.Status.GetPhase()),
+					"Increase `--wait-timeout` or omit `--wait`.",
+				)
 			default:
 				// Fetch error or context cancellation — surface the underlying
 				// cause unmodified; suggesting a longer timeout would mislead.

--- a/internal/flink/command_statement_create_onprem.go
+++ b/internal/flink/command_statement_create_onprem.go
@@ -142,14 +142,20 @@ func (c *command) statementCreateOnPrem(cmd *cobra.Command, args []string) error
 			Timeout:       timeout,
 		})
 		if err != nil {
-			if errors.Is(err, wait.ErrFailed) {
+			switch {
+			case errors.Is(err, wait.ErrFailed):
 				status := finalStatement.GetStatus()
 				return clierrors.NewErrorWithSuggestions(
 					fmt.Sprintf(`statement "%s" entered failed phase %q: %s`, name, status.Phase, status.GetDetail()),
 					fmt.Sprintf("Inspect the statement with `confluent flink statement describe %s`.", name),
 				)
+			case errors.Is(err, wait.ErrTimeout):
+				return clierrors.NewErrorWithSuggestions(err.Error(), "Increase `--wait-timeout` or omit `--wait`.")
+			default:
+				// Fetch error or context cancellation — surface the underlying
+				// cause unmodified; suggesting a longer timeout would mislead.
+				return err
 			}
-			return clierrors.NewErrorWithSuggestions(err.Error(), "Increase `--wait-timeout` or omit `--wait`.")
 		}
 	}
 

--- a/internal/flink/command_statement_create_onprem.go
+++ b/internal/flink/command_statement_create_onprem.go
@@ -38,6 +38,7 @@ func (c *command) newStatementCreateCommandOnPrem() *cobra.Command {
 	cmd.Flags().String("database", "", "The name of the default database.")
 	cmd.Flags().String("flink-configuration", "", "The file path to hold the Flink configuration for the statement.")
 	pcmd.AddWaitFlag(cmd)
+	pcmd.AddNoWaitFlag(cmd)
 	pcmd.AddWaitTimeoutFlag(cmd, flinkStatementCreateWaitTimeout)
 	addCmfFlagSet(cmd)
 	pcmd.AddOutputFlag(cmd)
@@ -116,7 +117,7 @@ func (c *command) statementCreateOnPrem(cmd *cobra.Command, args []string) error
 			Stopped:            cmfsdk.PtrBool(false),
 		},
 	}
-	shouldWait, err := cmd.Flags().GetBool("wait")
+	shouldWait, err := pcmd.ShouldWait(cmd)
 	if err != nil {
 		return err
 	}

--- a/internal/flink/command_statement_create_onprem.go
+++ b/internal/flink/command_statement_create_onprem.go
@@ -2,6 +2,7 @@ package flink
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -13,7 +14,7 @@ import (
 	cmfsdk "github.com/confluentinc/cmf-sdk-go/v1"
 
 	pcmd "github.com/confluentinc/cli/v4/pkg/cmd"
-	"github.com/confluentinc/cli/v4/pkg/errors"
+	clierrors "github.com/confluentinc/cli/v4/pkg/errors"
 	"github.com/confluentinc/cli/v4/pkg/flink/types"
 	"github.com/confluentinc/cli/v4/pkg/output"
 	"github.com/confluentinc/cli/v4/pkg/wait"
@@ -37,7 +38,7 @@ func (c *command) newStatementCreateCommandOnPrem() *cobra.Command {
 	cmd.Flags().String("database", "", "The name of the default database.")
 	cmd.Flags().String("flink-configuration", "", "The file path to hold the Flink configuration for the statement.")
 	pcmd.AddWaitFlag(cmd)
-	pcmd.AddWaitTimeoutFlag(cmd, time.Minute)
+	pcmd.AddWaitTimeoutFlag(cmd, flinkStatementCreateWaitTimeout)
 	addCmfFlagSet(cmd)
 	pcmd.AddOutputFlag(cmd)
 
@@ -130,18 +131,25 @@ func (c *command) statementCreateOnPrem(cmd *cobra.Command, args []string) error
 		if err != nil {
 			return err
 		}
-		finalStatement, err = wait.Poll(cmd.Context(), wait.Options[cmfsdk.Statement]{
+		finalStatement, err = wait.PollPhases(cmd.Context(), wait.PhaseOptions[cmfsdk.Statement]{
 			Fetch: func() (cmfsdk.Statement, error) {
 				return client.GetStatement(c.createContext(), environment, name)
 			},
-			IsTerminal: func(s cmfsdk.Statement) bool {
-				return s.GetStatus().Phase != "PENDING"
-			},
-			Tick:    2 * time.Second,
-			Timeout: timeout,
+			Phase:         func(s cmfsdk.Statement) string { return s.GetStatus().Phase },
+			PendingPhases: flinkStatementPendingPhases,
+			FailedPhases:  flinkStatementFailedPhases,
+			Tick:          2 * time.Second,
+			Timeout:       timeout,
 		})
 		if err != nil {
-			return errors.NewErrorWithSuggestions(err.Error(), "Increase `--wait-timeout` or omit `--wait`.")
+			if errors.Is(err, wait.ErrFailed) {
+				status := finalStatement.GetStatus()
+				return clierrors.NewErrorWithSuggestions(
+					fmt.Sprintf(`statement "%s" entered failed phase %q: %s`, name, status.Phase, status.GetDetail()),
+					fmt.Sprintf("Inspect the statement with `confluent flink statement describe %s`.", name),
+				)
+			}
+			return clierrors.NewErrorWithSuggestions(err.Error(), "Increase `--wait-timeout` or omit `--wait`.")
 		}
 	}
 
@@ -187,7 +195,7 @@ func (c *command) readFlinkConfiguration(cmd *cobra.Command) (map[string]string,
 		case ".yaml", ".yml":
 			err = yaml.Unmarshal(data, &flinkConfiguration)
 		default:
-			return nil, errors.NewErrorWithSuggestions(fmt.Sprintf("unsupported file format: %s", ext), "Supported file formats are .json, .yaml, and .yml.")
+			return nil, clierrors.NewErrorWithSuggestions(fmt.Sprintf("unsupported file format: %s", ext), "Supported file formats are .json, .yaml, and .yml.")
 		}
 		if err != nil {
 			return nil, err

--- a/internal/flink/command_statement_create_onprem.go
+++ b/internal/flink/command_statement_create_onprem.go
@@ -36,9 +36,8 @@ func (c *command) newStatementCreateCommandOnPrem() *cobra.Command {
 	cmd.Flags().String("catalog", "", "The name of the default catalog.")
 	cmd.Flags().String("database", "", "The name of the default database.")
 	cmd.Flags().String("flink-configuration", "", "The file path to hold the Flink configuration for the statement.")
-	pcmd.AddWaitFlag(cmd)
-	pcmd.AddNoWaitFlag(cmd)
-	pcmd.AddWaitTimeoutFlag(cmd, flinkStatementCreateWaitTimeout)
+	cmd.Flags().Bool("wait", false, "Block until the statement reaches a terminal state.")
+	cmd.Flags().Duration("wait-timeout", flinkStatementCreateWaitTimeout, "Maximum time to wait when --wait is set.")
 	addCmfFlagSet(cmd)
 	pcmd.AddOutputFlag(cmd)
 
@@ -116,7 +115,7 @@ func (c *command) statementCreateOnPrem(cmd *cobra.Command, args []string) error
 			Stopped:            cmfsdk.PtrBool(false),
 		},
 	}
-	shouldWait, err := pcmd.ShouldWait(cmd)
+	shouldWait, err := cmd.Flags().GetBool("wait")
 	if err != nil {
 		return err
 	}

--- a/internal/flink/command_statement_create_onprem.go
+++ b/internal/flink/command_statement_create_onprem.go
@@ -2,7 +2,6 @@ package flink
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -14,7 +13,7 @@ import (
 	cmfsdk "github.com/confluentinc/cmf-sdk-go/v1"
 
 	pcmd "github.com/confluentinc/cli/v4/pkg/cmd"
-	clierrors "github.com/confluentinc/cli/v4/pkg/errors"
+	"github.com/confluentinc/cli/v4/pkg/errors"
 	"github.com/confluentinc/cli/v4/pkg/flink/types"
 	"github.com/confluentinc/cli/v4/pkg/output"
 	"github.com/confluentinc/cli/v4/pkg/wait"
@@ -139,22 +138,23 @@ func (c *command) statementCreateOnPrem(cmd *cobra.Command, args []string) error
 			Phase:         func(s cmfsdk.Statement) string { return s.GetStatus().Phase },
 			PendingPhases: flinkStatementPendingPhases,
 			FailedPhases:  flinkStatementFailedPhases,
-			Tick:          2 * time.Second,
+			PollInterval:  2 * time.Second,
 			Timeout:       timeout,
 		})
 		if err != nil {
-			switch {
-			case errors.Is(err, wait.ErrFailed):
-				status := finalStatement.GetStatus()
-				return clierrors.NewErrorWithSuggestions(
+			status := finalStatement.GetStatus()
+			switch err {
+			case wait.ErrFailed:
+				return errors.NewErrorWithSuggestions(
 					fmt.Sprintf(`statement "%s" entered failed phase %q: %s`, name, status.Phase, status.GetDetail()),
 					fmt.Sprintf("Inspect the statement with `confluent flink statement describe %s`.", name),
 				)
-			case errors.Is(err, wait.ErrTimeout):
-				return clierrors.NewErrorWithSuggestions(err.Error(), "Increase `--wait-timeout` or omit `--wait`.")
+			case wait.ErrTimeout:
+				return errors.NewErrorWithSuggestions(
+					fmt.Sprintf(`wait timed out: statement "%s" is still in phase %q`, name, status.Phase),
+					"Increase `--wait-timeout` or omit `--wait`.",
+				)
 			default:
-				// Fetch error or context cancellation — surface the underlying
-				// cause unmodified; suggesting a longer timeout would mislead.
 				return err
 			}
 		}
@@ -202,7 +202,7 @@ func (c *command) readFlinkConfiguration(cmd *cobra.Command) (map[string]string,
 		case ".yaml", ".yml":
 			err = yaml.Unmarshal(data, &flinkConfiguration)
 		default:
-			return nil, clierrors.NewErrorWithSuggestions(fmt.Sprintf("unsupported file format: %s", ext), "Supported file formats are .json, .yaml, and .yml.")
+			return nil, errors.NewErrorWithSuggestions(fmt.Sprintf("unsupported file format: %s", ext), "Supported file formats are .json, .yaml, and .yml.")
 		}
 		if err != nil {
 			return nil, err

--- a/internal/flink/command_statement_create_onprem.go
+++ b/internal/flink/command_statement_create_onprem.go
@@ -16,7 +16,7 @@ import (
 	"github.com/confluentinc/cli/v4/pkg/errors"
 	"github.com/confluentinc/cli/v4/pkg/flink/types"
 	"github.com/confluentinc/cli/v4/pkg/output"
-	"github.com/confluentinc/cli/v4/pkg/retry"
+	"github.com/confluentinc/cli/v4/pkg/wait"
 )
 
 func (c *command) newStatementCreateCommandOnPrem() *cobra.Command {
@@ -36,7 +36,8 @@ func (c *command) newStatementCreateCommandOnPrem() *cobra.Command {
 	cmd.Flags().String("catalog", "", "The name of the default catalog.")
 	cmd.Flags().String("database", "", "The name of the default database.")
 	cmd.Flags().String("flink-configuration", "", "The file path to hold the Flink configuration for the statement.")
-	cmd.Flags().Bool("wait", false, "Boolean flag to block until the statement is running or has failed.")
+	pcmd.AddWaitFlag(cmd)
+	pcmd.AddWaitTimeoutFlag(cmd, time.Minute)
 	addCmfFlagSet(cmd)
 	pcmd.AddOutputFlag(cmd)
 
@@ -114,7 +115,7 @@ func (c *command) statementCreateOnPrem(cmd *cobra.Command, args []string) error
 			Stopped:            cmfsdk.PtrBool(false),
 		},
 	}
-	wait, err := cmd.Flags().GetBool("wait")
+	shouldWait, err := cmd.Flags().GetBool("wait")
 	if err != nil {
 		return err
 	}
@@ -124,21 +125,23 @@ func (c *command) statementCreateOnPrem(cmd *cobra.Command, args []string) error
 		return err
 	}
 
-	if wait {
-		err := retry.Retry(time.Second*2, time.Minute, func() error {
-			polledStatement, err := client.GetStatement(c.createContext(), environment, name)
-			if err != nil {
-				return err
-			}
-			if polledStatement.GetStatus().Phase == "PENDING" {
-				return fmt.Errorf(`statement phase is "%s"`, polledStatement.GetStatus().Phase)
-			}
-			// Update the finalStatement with the completed state
-			finalStatement = polledStatement
-			return nil
-		})
+	if shouldWait {
+		timeout, err := cmd.Flags().GetDuration("wait-timeout")
 		if err != nil {
 			return err
+		}
+		finalStatement, err = wait.Poll(cmd.Context(), wait.Options[cmfsdk.Statement]{
+			Fetch: func() (cmfsdk.Statement, error) {
+				return client.GetStatement(c.createContext(), environment, name)
+			},
+			IsTerminal: func(s cmfsdk.Statement) bool {
+				return s.GetStatus().Phase != "PENDING"
+			},
+			Tick:    2 * time.Second,
+			Timeout: timeout,
+		})
+		if err != nil {
+			return errors.NewErrorWithSuggestions(err.Error(), "Increase `--wait-timeout` or omit `--wait`.")
 		}
 	}
 

--- a/pkg/cmd/flags.go
+++ b/pkg/cmd/flags.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/spf13/cobra"
 
@@ -211,33 +210,6 @@ func AddForceFlag(cmd *cobra.Command) {
 
 func AddDryRunFlag(cmd *cobra.Command) {
 	cmd.Flags().Bool("dry-run", false, "Run the command without committing changes.")
-}
-
-func AddWaitFlag(cmd *cobra.Command) {
-	cmd.Flags().Bool("wait", true, "Block until the resource reaches a terminal state. Pass --no-wait to opt out.")
-}
-
-func AddNoWaitFlag(cmd *cobra.Command) {
-	cmd.Flags().Bool("no-wait", false, "Return immediately without polling for the resource to reach a terminal state.")
-}
-
-func AddWaitTimeoutFlag(cmd *cobra.Command, defaultTimeout time.Duration) {
-	cmd.Flags().Duration("wait-timeout", defaultTimeout, "Maximum time to wait when blocking is in effect.")
-}
-
-// ShouldWait returns whether a command should block until the polled resource
-// reaches a terminal state. --no-wait wins over --wait so users can opt out of
-// the default blocking behavior without surprises.
-func ShouldWait(cmd *cobra.Command) (bool, error) {
-	wait, err := cmd.Flags().GetBool("wait")
-	if err != nil {
-		return false, err
-	}
-	noWait, err := cmd.Flags().GetBool("no-wait")
-	if err != nil {
-		return false, err
-	}
-	return wait && !noWait, nil
 }
 
 func AddKsqlClusterFlag(cmd *cobra.Command, c *AuthenticatedCLICommand) {

--- a/pkg/cmd/flags.go
+++ b/pkg/cmd/flags.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -210,6 +211,14 @@ func AddForceFlag(cmd *cobra.Command) {
 
 func AddDryRunFlag(cmd *cobra.Command) {
 	cmd.Flags().Bool("dry-run", false, "Run the command without committing changes.")
+}
+
+func AddWaitFlag(cmd *cobra.Command) {
+	cmd.Flags().Bool("wait", false, "Block until the resource reaches a terminal state.")
+}
+
+func AddWaitTimeoutFlag(cmd *cobra.Command, defaultTimeout time.Duration) {
+	cmd.Flags().Duration("wait-timeout", defaultTimeout, "Maximum time to wait when --wait is set.")
 }
 
 func AddKsqlClusterFlag(cmd *cobra.Command, c *AuthenticatedCLICommand) {

--- a/pkg/cmd/flags.go
+++ b/pkg/cmd/flags.go
@@ -214,11 +214,30 @@ func AddDryRunFlag(cmd *cobra.Command) {
 }
 
 func AddWaitFlag(cmd *cobra.Command) {
-	cmd.Flags().Bool("wait", false, "Block until the resource reaches a terminal state.")
+	cmd.Flags().Bool("wait", true, "Block until the resource reaches a terminal state. Pass --no-wait to opt out.")
+}
+
+func AddNoWaitFlag(cmd *cobra.Command) {
+	cmd.Flags().Bool("no-wait", false, "Return immediately without polling for the resource to reach a terminal state.")
 }
 
 func AddWaitTimeoutFlag(cmd *cobra.Command, defaultTimeout time.Duration) {
-	cmd.Flags().Duration("wait-timeout", defaultTimeout, "Maximum time to wait when --wait is set.")
+	cmd.Flags().Duration("wait-timeout", defaultTimeout, "Maximum time to wait when blocking is in effect.")
+}
+
+// ShouldWait returns whether a command should block until the polled resource
+// reaches a terminal state. --no-wait wins over --wait so users can opt out of
+// the default blocking behavior without surprises.
+func ShouldWait(cmd *cobra.Command) (bool, error) {
+	wait, err := cmd.Flags().GetBool("wait")
+	if err != nil {
+		return false, err
+	}
+	noWait, err := cmd.Flags().GetBool("no-wait")
+	if err != nil {
+		return false, err
+	}
+	return wait && !noWait, nil
 }
 
 func AddKsqlClusterFlag(cmd *cobra.Command, c *AuthenticatedCLICommand) {

--- a/pkg/wait/wait.go
+++ b/pkg/wait/wait.go
@@ -15,10 +15,53 @@ type Options[T any] struct {
 	Timeout    time.Duration
 }
 
+// PhaseOptions is a declarative form of Options for the common case where
+// readiness is determined by a single status-phase string. The pending and
+// failed phase sets are typically sourced from the resource's OpenAPI status
+// enum (see cli-terraform-generator AsyncConfig).
+type PhaseOptions[T any] struct {
+	Fetch         func() (T, error)
+	Phase         func(T) string
+	PendingPhases []string
+	FailedPhases  []string
+	Tick          time.Duration
+	Timeout       time.Duration
+}
+
 var (
 	ErrTimeout = errors.New("wait timed out")
 	ErrFailed  = errors.New("resource entered failed state")
 )
+
+// PhaseSet returns a predicate reporting whether its argument is in phases.
+// Used to build IsTerminal / IsFailed checks from OpenAPI status enums.
+func PhaseSet(phases ...string) func(string) bool {
+	set := make(map[string]struct{}, len(phases))
+	for _, p := range phases {
+		set[p] = struct{}{}
+	}
+	return func(s string) bool {
+		_, ok := set[s]
+		return ok
+	}
+}
+
+// PollPhases polls opts.Fetch until opts.Phase returns a value not in
+// opts.PendingPhases. If the resulting phase is in opts.FailedPhases the
+// return error is ErrFailed; otherwise it is treated as a successful
+// terminal state. Timeout / context-cancellation / fetch-errors behave as in
+// Poll.
+func PollPhases[T any](ctx context.Context, opts PhaseOptions[T]) (T, error) {
+	pending := PhaseSet(opts.PendingPhases...)
+	failed := PhaseSet(opts.FailedPhases...)
+	return Poll(ctx, Options[T]{
+		Fetch:      opts.Fetch,
+		IsTerminal: func(v T) bool { return !pending(opts.Phase(v)) },
+		IsFailed:   func(v T) bool { return failed(opts.Phase(v)) },
+		Tick:       opts.Tick,
+		Timeout:    opts.Timeout,
+	})
+}
 
 // Poll calls opts.Fetch immediately, then every opts.Tick until IsFailed
 // returns true (ErrFailed), IsTerminal returns true (success), opts.Timeout

--- a/pkg/wait/wait.go
+++ b/pkg/wait/wait.go
@@ -7,12 +7,19 @@ import (
 )
 
 // Options describes a single Poll invocation. T is the polled resource type.
+//
+// Delay (if non-zero) sleeps before the first Fetch. Use it to give the
+// resource a moment to materialize on the server after a POST; mirrors
+// retry.StateChangeConf.Delay in terraform-provider-confluent.
+//
+// PollInterval is the gap between successive Fetch calls after the first.
 type Options[T any] struct {
-	Fetch      func() (T, error)
-	IsTerminal func(T) bool
-	IsFailed   func(T) bool
-	Tick       time.Duration
-	Timeout    time.Duration
+	Fetch        func() (T, error)
+	IsTerminal   func(T) bool
+	IsFailed     func(T) bool
+	Delay        time.Duration
+	PollInterval time.Duration
+	Timeout      time.Duration
 }
 
 // PhaseOptions is a declarative form of Options for the common case where
@@ -24,7 +31,8 @@ type PhaseOptions[T any] struct {
 	Phase         func(T) string
 	PendingPhases []string
 	FailedPhases  []string
-	Tick          time.Duration
+	Delay         time.Duration
+	PollInterval  time.Duration
 	Timeout       time.Duration
 }
 
@@ -55,17 +63,18 @@ func PollPhases[T any](ctx context.Context, opts PhaseOptions[T]) (T, error) {
 	pending := PhaseSet(opts.PendingPhases...)
 	failed := PhaseSet(opts.FailedPhases...)
 	return Poll(ctx, Options[T]{
-		Fetch:      opts.Fetch,
-		IsTerminal: func(v T) bool { return !pending(opts.Phase(v)) },
-		IsFailed:   func(v T) bool { return failed(opts.Phase(v)) },
-		Tick:       opts.Tick,
-		Timeout:    opts.Timeout,
+		Fetch:        opts.Fetch,
+		IsTerminal:   func(v T) bool { return !pending(opts.Phase(v)) },
+		IsFailed:     func(v T) bool { return failed(opts.Phase(v)) },
+		Delay:        opts.Delay,
+		PollInterval: opts.PollInterval,
+		Timeout:      opts.Timeout,
 	})
 }
 
-// Poll calls opts.Fetch immediately, then every opts.Tick until IsFailed
-// returns true (ErrFailed), IsTerminal returns true (success), opts.Timeout
-// elapses, or ctx is cancelled (ctx.Err()).
+// Poll sleeps opts.Delay (if non-zero), then calls opts.Fetch, then every
+// opts.PollInterval until IsFailed returns true (ErrFailed), IsTerminal
+// returns true (success), opts.Timeout elapses, or ctx is cancelled.
 //
 // Fetch errors are treated as transient and do not abort polling: the loop
 // continues, preserving the most recent successfully-fetched value as `last`.
@@ -96,13 +105,24 @@ func Poll[T any](ctx context.Context, opts Options[T]) (T, error) {
 		return false, nil
 	}
 
+	deadline := time.After(opts.Timeout)
+
+	if opts.Delay > 0 {
+		select {
+		case <-time.After(opts.Delay):
+		case <-deadline:
+			return last, ErrTimeout
+		case <-ctx.Done():
+			return last, ctx.Err()
+		}
+	}
+
 	if done, err := check(); done {
 		return last, err
 	}
 
-	ticker := time.NewTicker(opts.Tick)
+	ticker := time.NewTicker(opts.PollInterval)
 	defer ticker.Stop()
-	deadline := time.After(opts.Timeout)
 
 	for {
 		select {

--- a/pkg/wait/wait.go
+++ b/pkg/wait/wait.go
@@ -65,28 +65,39 @@ func PollPhases[T any](ctx context.Context, opts PhaseOptions[T]) (T, error) {
 
 // Poll calls opts.Fetch immediately, then every opts.Tick until IsFailed
 // returns true (ErrFailed), IsTerminal returns true (success), opts.Timeout
-// elapses (ErrTimeout), ctx is cancelled (ctx.Err()), or Fetch returns a
-// non-nil error. Always returns the most recent successfully-fetched T.
+// elapses, or ctx is cancelled (ctx.Err()).
+//
+// Fetch errors are treated as transient and do not abort polling: the loop
+// continues, preserving the most recent successfully-fetched value as `last`.
+// This matches the historical retry.Retry-based behavior callers relied on,
+// where 429/5xx/network blips during polling were retried until timeout. If
+// the timeout elapses while the most recent Fetch errored, that error is
+// returned in place of ErrTimeout so the user sees the underlying cause.
 func Poll[T any](ctx context.Context, opts Options[T]) (T, error) {
-	var last T
+	var (
+		last    T
+		lastErr error
+	)
 
-	check := func() (T, bool, error) {
-		v, err := opts.Fetch()
-		if err != nil {
-			return last, true, err
+	check := func() (bool, error) {
+		v, ferr := opts.Fetch()
+		if ferr != nil {
+			lastErr = ferr
+			return false, nil
 		}
+		lastErr = nil
 		last = v
 		if opts.IsFailed != nil && opts.IsFailed(v) {
-			return last, true, ErrFailed
+			return true, ErrFailed
 		}
 		if opts.IsTerminal(v) {
-			return last, true, nil
+			return true, nil
 		}
-		return last, false, nil
+		return false, nil
 	}
 
-	if v, done, err := check(); done {
-		return v, err
+	if done, err := check(); done {
+		return last, err
 	}
 
 	ticker := time.NewTicker(opts.Tick)
@@ -96,10 +107,13 @@ func Poll[T any](ctx context.Context, opts Options[T]) (T, error) {
 	for {
 		select {
 		case <-ticker.C:
-			if v, done, err := check(); done {
-				return v, err
+			if done, err := check(); done {
+				return last, err
 			}
 		case <-deadline:
+			if lastErr != nil {
+				return last, lastErr
+			}
 			return last, ErrTimeout
 		case <-ctx.Done():
 			return last, ctx.Err()

--- a/pkg/wait/wait.go
+++ b/pkg/wait/wait.go
@@ -1,0 +1,65 @@
+package wait
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+// Options describes a single Poll invocation. T is the polled resource type.
+type Options[T any] struct {
+	Fetch      func() (T, error)
+	IsTerminal func(T) bool
+	IsFailed   func(T) bool
+	Tick       time.Duration
+	Timeout    time.Duration
+}
+
+var (
+	ErrTimeout = errors.New("wait timed out")
+	ErrFailed  = errors.New("resource entered failed state")
+)
+
+// Poll calls opts.Fetch immediately, then every opts.Tick until IsFailed
+// returns true (ErrFailed), IsTerminal returns true (success), opts.Timeout
+// elapses (ErrTimeout), ctx is cancelled (ctx.Err()), or Fetch returns a
+// non-nil error. Always returns the most recent successfully-fetched T.
+func Poll[T any](ctx context.Context, opts Options[T]) (T, error) {
+	var last T
+
+	check := func() (T, bool, error) {
+		v, err := opts.Fetch()
+		if err != nil {
+			return last, true, err
+		}
+		last = v
+		if opts.IsFailed != nil && opts.IsFailed(v) {
+			return last, true, ErrFailed
+		}
+		if opts.IsTerminal(v) {
+			return last, true, nil
+		}
+		return last, false, nil
+	}
+
+	if v, done, err := check(); done {
+		return v, err
+	}
+
+	ticker := time.NewTicker(opts.Tick)
+	defer ticker.Stop()
+	deadline := time.After(opts.Timeout)
+
+	for {
+		select {
+		case <-ticker.C:
+			if v, done, err := check(); done {
+				return v, err
+			}
+		case <-deadline:
+			return last, ErrTimeout
+		case <-ctx.Done():
+			return last, ctx.Err()
+		}
+	}
+}

--- a/pkg/wait/wait_test.go
+++ b/pkg/wait/wait_test.go
@@ -21,9 +21,9 @@ func TestPoll_ImmediateReady(t *testing.T) {
 			calls++
 			return fakeResource{phase: "READY"}, nil
 		},
-		IsTerminal: func(r fakeResource) bool { return r.phase == "READY" },
-		Tick:       time.Millisecond,
-		Timeout:    time.Second,
+		IsTerminal:   func(r fakeResource) bool { return r.phase == "READY" },
+		PollInterval: time.Millisecond,
+		Timeout:      time.Second,
 	})
 	require.NoError(t, err)
 	require.Equal(t, "READY", v.phase)
@@ -40,9 +40,9 @@ func TestPoll_EventuallyReady(t *testing.T) {
 			}
 			return fakeResource{phase: "READY"}, nil
 		},
-		IsTerminal: func(r fakeResource) bool { return r.phase != "PENDING" },
-		Tick:       time.Nanosecond,
-		Timeout:    time.Second,
+		IsTerminal:   func(r fakeResource) bool { return r.phase != "PENDING" },
+		PollInterval: time.Nanosecond,
+		Timeout:      time.Second,
 	})
 	require.NoError(t, err)
 	require.Equal(t, "READY", v.phase)
@@ -59,10 +59,10 @@ func TestPoll_Failed(t *testing.T) {
 			}
 			return fakeResource{phase: "FAILED"}, nil
 		},
-		IsTerminal: func(r fakeResource) bool { return r.phase == "READY" || r.phase == "FAILED" },
-		IsFailed:   func(r fakeResource) bool { return r.phase == "FAILED" },
-		Tick:       time.Nanosecond,
-		Timeout:    time.Second,
+		IsTerminal:   func(r fakeResource) bool { return r.phase == "READY" || r.phase == "FAILED" },
+		IsFailed:     func(r fakeResource) bool { return r.phase == "FAILED" },
+		PollInterval: time.Nanosecond,
+		Timeout:      time.Second,
 	})
 	require.ErrorIs(t, err, ErrFailed)
 	require.Equal(t, "FAILED", v.phase)
@@ -73,9 +73,9 @@ func TestPoll_Timeout(t *testing.T) {
 		Fetch: func() (fakeResource, error) {
 			return fakeResource{phase: "PENDING"}, nil
 		},
-		IsTerminal: func(r fakeResource) bool { return r.phase != "PENDING" },
-		Tick:       time.Millisecond,
-		Timeout:    5 * time.Millisecond,
+		IsTerminal:   func(r fakeResource) bool { return r.phase != "PENDING" },
+		PollInterval: time.Millisecond,
+		Timeout:      5 * time.Millisecond,
 	})
 	require.ErrorIs(t, err, ErrTimeout)
 	require.Equal(t, "PENDING", v.phase)
@@ -96,9 +96,9 @@ func TestPoll_PersistentFetchErrorReturnsLastErrAtTimeout(t *testing.T) {
 			}
 			return fakeResource{}, fetchErr
 		},
-		IsTerminal: func(r fakeResource) bool { return r.phase != "PENDING" },
-		Tick:       time.Millisecond,
-		Timeout:    20 * time.Millisecond,
+		IsTerminal:   func(r fakeResource) bool { return r.phase != "PENDING" },
+		PollInterval: time.Millisecond,
+		Timeout:      20 * time.Millisecond,
 	})
 	require.ErrorIs(t, err, fetchErr)
 	require.NotErrorIs(t, err, ErrTimeout)
@@ -112,9 +112,9 @@ func TestPoll_FetchErrorOnlyOnFirstCallReturnsAtTimeout(t *testing.T) {
 		Fetch: func() (fakeResource, error) {
 			return fakeResource{}, fetchErr
 		},
-		IsTerminal: func(r fakeResource) bool { return true },
-		Tick:       time.Millisecond,
-		Timeout:    20 * time.Millisecond,
+		IsTerminal:   func(r fakeResource) bool { return true },
+		PollInterval: time.Millisecond,
+		Timeout:      20 * time.Millisecond,
 	})
 	require.ErrorIs(t, err, fetchErr)
 	require.Equal(t, fakeResource{}, v)
@@ -138,9 +138,9 @@ func TestPoll_FetchErrorThenSuccess(t *testing.T) {
 				return fakeResource{phase: "READY"}, nil
 			}
 		},
-		IsTerminal: func(r fakeResource) bool { return r.phase == "READY" },
-		Tick:       time.Millisecond,
-		Timeout:    time.Second,
+		IsTerminal:   func(r fakeResource) bool { return r.phase == "READY" },
+		PollInterval: time.Millisecond,
+		Timeout:      time.Second,
 	})
 	require.NoError(t, err)
 	require.Equal(t, "READY", v.phase)
@@ -157,11 +157,56 @@ func TestPoll_ContextCancelled(t *testing.T) {
 		Fetch: func() (fakeResource, error) {
 			return fakeResource{phase: "PENDING"}, nil
 		},
-		IsTerminal: func(r fakeResource) bool { return r.phase != "PENDING" },
-		Tick:       time.Millisecond,
-		Timeout:    time.Second,
+		IsTerminal:   func(r fakeResource) bool { return r.phase != "PENDING" },
+		PollInterval: time.Millisecond,
+		Timeout:      time.Second,
 	})
 	require.True(t, errors.Is(err, context.Canceled))
+}
+
+// TestPoll_DelayPostponesFirstFetch: Delay sleeps before the first Fetch so
+// the resource has a moment to materialize on the server. Mirrors
+// retry.StateChangeConf.Delay.
+func TestPoll_DelayPostponesFirstFetch(t *testing.T) {
+	start := time.Now()
+	calls := 0
+	v, err := Poll(context.Background(), Options[fakeResource]{
+		Fetch: func() (fakeResource, error) {
+			calls++
+			return fakeResource{phase: "READY"}, nil
+		},
+		IsTerminal:   func(r fakeResource) bool { return r.phase == "READY" },
+		Delay:        15 * time.Millisecond,
+		PollInterval: time.Millisecond,
+		Timeout:      time.Second,
+	})
+	require.NoError(t, err)
+	require.Equal(t, "READY", v.phase)
+	require.Equal(t, 1, calls)
+	require.GreaterOrEqual(t, time.Since(start), 15*time.Millisecond)
+}
+
+// TestPoll_DelayRespectsCtxCancellation: cancelling ctx while waiting on Delay
+// returns ctx.Err() immediately instead of sleeping out the full Delay.
+func TestPoll_DelayRespectsCtxCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(5 * time.Millisecond)
+		cancel()
+	}()
+	calls := 0
+	_, err := Poll(ctx, Options[fakeResource]{
+		Fetch: func() (fakeResource, error) {
+			calls++
+			return fakeResource{phase: "READY"}, nil
+		},
+		IsTerminal:   func(r fakeResource) bool { return r.phase == "READY" },
+		Delay:        time.Second,
+		PollInterval: time.Millisecond,
+		Timeout:      time.Second,
+	})
+	require.ErrorIs(t, err, context.Canceled)
+	require.Equal(t, 0, calls) // never made it past Delay
 }
 
 func TestPhaseSet(t *testing.T) {
@@ -194,7 +239,7 @@ func TestPollPhases_TerminalSuccess(t *testing.T) {
 		Phase:         func(r fakeResource) string { return r.phase },
 		PendingPhases: []string{"PENDING", "FAILING", "STOPPING", "DELETING"},
 		FailedPhases:  []string{"FAILED"},
-		Tick:          time.Nanosecond,
+		PollInterval:  time.Nanosecond,
 		Timeout:       time.Second,
 	})
 	require.NoError(t, err)
@@ -208,7 +253,7 @@ func TestPollPhases_FailedPhase(t *testing.T) {
 		Phase:         func(r fakeResource) string { return r.phase },
 		PendingPhases: []string{"PENDING"},
 		FailedPhases:  []string{"FAILED"},
-		Tick:          time.Nanosecond,
+		PollInterval:  time.Nanosecond,
 		Timeout:       time.Second,
 	})
 	require.ErrorIs(t, err, ErrFailed)
@@ -240,7 +285,7 @@ func TestPollPhases_AllPendingPhasesContinuePolling(t *testing.T) {
 				Phase:         func(r fakeResource) string { return r.phase },
 				PendingPhases: []string{"PENDING", "FAILING", "STOPPING", "DELETING"},
 				FailedPhases:  []string{"FAILED"},
-				Tick:          time.Nanosecond,
+				PollInterval:  time.Nanosecond,
 				Timeout:       time.Second,
 			})
 			require.Equal(t, tc.wantFinal, v.phase)

--- a/pkg/wait/wait_test.go
+++ b/pkg/wait/wait_test.go
@@ -130,3 +130,93 @@ func TestPoll_ContextCancelled(t *testing.T) {
 	})
 	require.True(t, errors.Is(err, context.Canceled))
 }
+
+func TestPhaseSet(t *testing.T) {
+	pending := PhaseSet("PENDING", "FAILING", "STOPPING", "DELETING")
+	require.True(t, pending("PENDING"))
+	require.True(t, pending("FAILING"))
+	require.True(t, pending("STOPPING"))
+	require.True(t, pending("DELETING"))
+	require.False(t, pending("RUNNING"))
+	require.False(t, pending("FAILED"))
+	require.False(t, pending(""))
+	require.False(t, pending("pending")) // case-sensitive
+
+	// Empty set never matches.
+	none := PhaseSet()
+	require.False(t, none(""))
+	require.False(t, none("ANYTHING"))
+}
+
+func TestPollPhases_TerminalSuccess(t *testing.T) {
+	calls := 0
+	v, err := PollPhases(context.Background(), PhaseOptions[fakeResource]{
+		Fetch: func() (fakeResource, error) {
+			calls++
+			if calls < 3 {
+				return fakeResource{phase: "PENDING"}, nil
+			}
+			return fakeResource{phase: "RUNNING"}, nil
+		},
+		Phase:         func(r fakeResource) string { return r.phase },
+		PendingPhases: []string{"PENDING", "FAILING", "STOPPING", "DELETING"},
+		FailedPhases:  []string{"FAILED"},
+		Tick:          time.Nanosecond,
+		Timeout:       time.Second,
+	})
+	require.NoError(t, err)
+	require.Equal(t, "RUNNING", v.phase)
+	require.Equal(t, 3, calls)
+}
+
+func TestPollPhases_FailedPhase(t *testing.T) {
+	v, err := PollPhases(context.Background(), PhaseOptions[fakeResource]{
+		Fetch:         func() (fakeResource, error) { return fakeResource{phase: "FAILED"}, nil },
+		Phase:         func(r fakeResource) string { return r.phase },
+		PendingPhases: []string{"PENDING"},
+		FailedPhases:  []string{"FAILED"},
+		Tick:          time.Nanosecond,
+		Timeout:       time.Second,
+	})
+	require.ErrorIs(t, err, ErrFailed)
+	require.Equal(t, "FAILED", v.phase)
+}
+
+// Verifies the bug Channing flagged: PENDING is not the only intermediate
+// state — FAILING, STOPPING, DELETING are also transitioning. They must keep
+// polling, not terminate.
+func TestPollPhases_AllPendingPhasesContinuePolling(t *testing.T) {
+	cases := []struct {
+		name      string
+		sequence  []string
+		wantFinal string
+	}{
+		{name: "failing_then_failed", sequence: []string{"PENDING", "FAILING", "FAILED"}, wantFinal: "FAILED"},
+		{name: "stopping_then_stopped", sequence: []string{"PENDING", "STOPPING", "STOPPED"}, wantFinal: "STOPPED"},
+		{name: "deleting_then_running", sequence: []string{"PENDING", "DELETING", "RUNNING"}, wantFinal: "RUNNING"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			calls := 0
+			v, err := PollPhases(context.Background(), PhaseOptions[fakeResource]{
+				Fetch: func() (fakeResource, error) {
+					p := tc.sequence[calls]
+					calls++
+					return fakeResource{phase: p}, nil
+				},
+				Phase:         func(r fakeResource) string { return r.phase },
+				PendingPhases: []string{"PENDING", "FAILING", "STOPPING", "DELETING"},
+				FailedPhases:  []string{"FAILED"},
+				Tick:          time.Nanosecond,
+				Timeout:       time.Second,
+			})
+			require.Equal(t, tc.wantFinal, v.phase)
+			if tc.wantFinal == "FAILED" {
+				require.ErrorIs(t, err, ErrFailed)
+			} else {
+				require.NoError(t, err)
+			}
+			require.Equal(t, len(tc.sequence), calls)
+		})
+	}
+}

--- a/pkg/wait/wait_test.go
+++ b/pkg/wait/wait_test.go
@@ -1,0 +1,132 @@
+package wait
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+type fakeResource struct {
+	phase string
+}
+
+func TestPoll_ImmediateReady(t *testing.T) {
+	calls := 0
+	v, err := Poll(context.Background(), Options[fakeResource]{
+		Fetch: func() (fakeResource, error) {
+			calls++
+			return fakeResource{phase: "READY"}, nil
+		},
+		IsTerminal: func(r fakeResource) bool { return r.phase == "READY" },
+		Tick:       time.Millisecond,
+		Timeout:    time.Second,
+	})
+	require.NoError(t, err)
+	require.Equal(t, "READY", v.phase)
+	require.Equal(t, 1, calls)
+}
+
+func TestPoll_EventuallyReady(t *testing.T) {
+	calls := 0
+	v, err := Poll(context.Background(), Options[fakeResource]{
+		Fetch: func() (fakeResource, error) {
+			calls++
+			if calls < 3 {
+				return fakeResource{phase: "PENDING"}, nil
+			}
+			return fakeResource{phase: "READY"}, nil
+		},
+		IsTerminal: func(r fakeResource) bool { return r.phase != "PENDING" },
+		Tick:       time.Nanosecond,
+		Timeout:    time.Second,
+	})
+	require.NoError(t, err)
+	require.Equal(t, "READY", v.phase)
+	require.Equal(t, 3, calls)
+}
+
+func TestPoll_Failed(t *testing.T) {
+	calls := 0
+	v, err := Poll(context.Background(), Options[fakeResource]{
+		Fetch: func() (fakeResource, error) {
+			calls++
+			if calls == 1 {
+				return fakeResource{phase: "PENDING"}, nil
+			}
+			return fakeResource{phase: "FAILED"}, nil
+		},
+		IsTerminal: func(r fakeResource) bool { return r.phase == "READY" || r.phase == "FAILED" },
+		IsFailed:   func(r fakeResource) bool { return r.phase == "FAILED" },
+		Tick:       time.Nanosecond,
+		Timeout:    time.Second,
+	})
+	require.ErrorIs(t, err, ErrFailed)
+	require.Equal(t, "FAILED", v.phase)
+}
+
+func TestPoll_Timeout(t *testing.T) {
+	v, err := Poll(context.Background(), Options[fakeResource]{
+		Fetch: func() (fakeResource, error) {
+			return fakeResource{phase: "PENDING"}, nil
+		},
+		IsTerminal: func(r fakeResource) bool { return r.phase != "PENDING" },
+		Tick:       time.Millisecond,
+		Timeout:    5 * time.Millisecond,
+	})
+	require.ErrorIs(t, err, ErrTimeout)
+	require.Equal(t, "PENDING", v.phase)
+}
+
+func TestPoll_FetchError(t *testing.T) {
+	calls := 0
+	fetchErr := fmt.Errorf("transient fetch failure")
+	v, err := Poll(context.Background(), Options[fakeResource]{
+		Fetch: func() (fakeResource, error) {
+			calls++
+			if calls == 1 {
+				return fakeResource{phase: "PENDING"}, nil
+			}
+			return fakeResource{}, fetchErr
+		},
+		IsTerminal: func(r fakeResource) bool { return r.phase != "PENDING" },
+		Tick:       time.Nanosecond,
+		Timeout:    time.Second,
+	})
+	require.ErrorIs(t, err, fetchErr)
+	require.Equal(t, "PENDING", v.phase)
+}
+
+func TestPoll_FetchErrorOnFirstCall(t *testing.T) {
+	fetchErr := fmt.Errorf("initial fetch failure")
+	v, err := Poll(context.Background(), Options[fakeResource]{
+		Fetch: func() (fakeResource, error) {
+			return fakeResource{}, fetchErr
+		},
+		IsTerminal: func(r fakeResource) bool { return true },
+		Tick:       time.Nanosecond,
+		Timeout:    time.Second,
+	})
+	require.ErrorIs(t, err, fetchErr)
+	require.Equal(t, fakeResource{}, v)
+}
+
+func TestPoll_ContextCancelled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(5 * time.Millisecond)
+		cancel()
+	}()
+	_, err := Poll(ctx, Options[fakeResource]{
+		Fetch: func() (fakeResource, error) {
+			return fakeResource{phase: "PENDING"}, nil
+		},
+		IsTerminal: func(r fakeResource) bool { return r.phase != "PENDING" },
+		Tick:       time.Millisecond,
+		Timeout:    time.Second,
+	})
+	require.True(t, errors.Is(err, context.Canceled))
+}

--- a/pkg/wait/wait_test.go
+++ b/pkg/wait/wait_test.go
@@ -81,7 +81,11 @@ func TestPoll_Timeout(t *testing.T) {
 	require.Equal(t, "PENDING", v.phase)
 }
 
-func TestPoll_FetchError(t *testing.T) {
+// TestPoll_PersistentFetchErrorReturnsLastErrAtTimeout: fetch errors do not
+// abort polling (preserves the historical retry.Retry behavior); when the
+// timeout fires while the most recent fetch errored, the underlying error is
+// surfaced in place of ErrTimeout so users see the real cause.
+func TestPoll_PersistentFetchErrorReturnsLastErrAtTimeout(t *testing.T) {
 	calls := 0
 	fetchErr := fmt.Errorf("transient fetch failure")
 	v, err := Poll(context.Background(), Options[fakeResource]{
@@ -93,25 +97,54 @@ func TestPoll_FetchError(t *testing.T) {
 			return fakeResource{}, fetchErr
 		},
 		IsTerminal: func(r fakeResource) bool { return r.phase != "PENDING" },
-		Tick:       time.Nanosecond,
-		Timeout:    time.Second,
+		Tick:       time.Millisecond,
+		Timeout:    20 * time.Millisecond,
 	})
 	require.ErrorIs(t, err, fetchErr)
-	require.Equal(t, "PENDING", v.phase)
+	require.NotErrorIs(t, err, ErrTimeout)
+	require.Equal(t, "PENDING", v.phase) // last good value preserved
+	require.GreaterOrEqual(t, calls, 2)
 }
 
-func TestPoll_FetchErrorOnFirstCall(t *testing.T) {
+func TestPoll_FetchErrorOnlyOnFirstCallReturnsAtTimeout(t *testing.T) {
 	fetchErr := fmt.Errorf("initial fetch failure")
 	v, err := Poll(context.Background(), Options[fakeResource]{
 		Fetch: func() (fakeResource, error) {
 			return fakeResource{}, fetchErr
 		},
 		IsTerminal: func(r fakeResource) bool { return true },
-		Tick:       time.Nanosecond,
-		Timeout:    time.Second,
+		Tick:       time.Millisecond,
+		Timeout:    20 * time.Millisecond,
 	})
 	require.ErrorIs(t, err, fetchErr)
 	require.Equal(t, fakeResource{}, v)
+}
+
+// TestPoll_FetchErrorThenSuccess: a transient fetch error mid-polling should
+// not abort. Once a subsequent fetch returns successfully and reaches a
+// terminal state, the poll returns success.
+func TestPoll_FetchErrorThenSuccess(t *testing.T) {
+	calls := 0
+	fetchErr := fmt.Errorf("transient 502")
+	v, err := Poll(context.Background(), Options[fakeResource]{
+		Fetch: func() (fakeResource, error) {
+			calls++
+			switch calls {
+			case 1:
+				return fakeResource{phase: "PENDING"}, nil
+			case 2, 3:
+				return fakeResource{}, fetchErr
+			default:
+				return fakeResource{phase: "READY"}, nil
+			}
+		},
+		IsTerminal: func(r fakeResource) bool { return r.phase == "READY" },
+		Tick:       time.Millisecond,
+		Timeout:    time.Second,
+	})
+	require.NoError(t, err)
+	require.Equal(t, "READY", v.phase)
+	require.GreaterOrEqual(t, calls, 4)
 }
 
 func TestPoll_ContextCancelled(t *testing.T) {

--- a/test/fixtures/output/flink/statement/create-help-onprem.golden
+++ b/test/fixtures/output/flink/statement/create-help-onprem.golden
@@ -11,8 +11,9 @@ Flags:
       --catalog string                      The name of the default catalog.
       --database string                     The name of the default database.
       --flink-configuration string          The file path to hold the Flink configuration for the statement.
-      --wait                                Block until the resource reaches a terminal state.
-      --wait-timeout duration               Maximum time to wait when --wait is set. (default 6h0m0s)
+      --wait                                Block until the resource reaches a terminal state. Pass --no-wait to opt out. (default true)
+      --no-wait                             Return immediately without polling for the resource to reach a terminal state.
+      --wait-timeout duration               Maximum time to wait when blocking is in effect. (default 6h0m0s)
       --url string                          Base URL of the Confluent Manager for Apache Flink (CMF). Environment variable "CONFLUENT_CMF_URL" may be set in place of this flag.
       --client-key-path string              Path to client private key for mTLS authentication. Environment variable "CONFLUENT_CMF_CLIENT_KEY_PATH" may be set in place of this flag.
       --client-cert-path string             Path to client cert to be verified by Confluent Manager for Apache Flink. Include for mTLS authentication. Environment variable "CONFLUENT_CMF_CLIENT_CERT_PATH" may be set in place of this flag.

--- a/test/fixtures/output/flink/statement/create-help-onprem.golden
+++ b/test/fixtures/output/flink/statement/create-help-onprem.golden
@@ -11,9 +11,8 @@ Flags:
       --catalog string                      The name of the default catalog.
       --database string                     The name of the default database.
       --flink-configuration string          The file path to hold the Flink configuration for the statement.
-      --wait                                Block until the resource reaches a terminal state. Pass --no-wait to opt out. (default true)
-      --no-wait                             Return immediately without polling for the resource to reach a terminal state.
-      --wait-timeout duration               Maximum time to wait when blocking is in effect. (default 6h0m0s)
+      --wait                                Block until the statement reaches a terminal state.
+      --wait-timeout duration               Maximum time to wait when --wait is set. (default 6h0m0s)
       --url string                          Base URL of the Confluent Manager for Apache Flink (CMF). Environment variable "CONFLUENT_CMF_URL" may be set in place of this flag.
       --client-key-path string              Path to client private key for mTLS authentication. Environment variable "CONFLUENT_CMF_CLIENT_KEY_PATH" may be set in place of this flag.
       --client-cert-path string             Path to client cert to be verified by Confluent Manager for Apache Flink. Include for mTLS authentication. Environment variable "CONFLUENT_CMF_CLIENT_CERT_PATH" may be set in place of this flag.

--- a/test/fixtures/output/flink/statement/create-help-onprem.golden
+++ b/test/fixtures/output/flink/statement/create-help-onprem.golden
@@ -12,7 +12,7 @@ Flags:
       --database string                     The name of the default database.
       --flink-configuration string          The file path to hold the Flink configuration for the statement.
       --wait                                Block until the resource reaches a terminal state.
-      --wait-timeout duration               Maximum time to wait when --wait is set. (default 1m0s)
+      --wait-timeout duration               Maximum time to wait when --wait is set. (default 6h0m0s)
       --url string                          Base URL of the Confluent Manager for Apache Flink (CMF). Environment variable "CONFLUENT_CMF_URL" may be set in place of this flag.
       --client-key-path string              Path to client private key for mTLS authentication. Environment variable "CONFLUENT_CMF_CLIENT_KEY_PATH" may be set in place of this flag.
       --client-cert-path string             Path to client cert to be verified by Confluent Manager for Apache Flink. Include for mTLS authentication. Environment variable "CONFLUENT_CMF_CLIENT_CERT_PATH" may be set in place of this flag.

--- a/test/fixtures/output/flink/statement/create-help-onprem.golden
+++ b/test/fixtures/output/flink/statement/create-help-onprem.golden
@@ -11,7 +11,8 @@ Flags:
       --catalog string                      The name of the default catalog.
       --database string                     The name of the default database.
       --flink-configuration string          The file path to hold the Flink configuration for the statement.
-      --wait                                Boolean flag to block until the statement is running or has failed.
+      --wait                                Block until the resource reaches a terminal state.
+      --wait-timeout duration               Maximum time to wait when --wait is set. (default 1m0s)
       --url string                          Base URL of the Confluent Manager for Apache Flink (CMF). Environment variable "CONFLUENT_CMF_URL" may be set in place of this flag.
       --client-key-path string              Path to client private key for mTLS authentication. Environment variable "CONFLUENT_CMF_CLIENT_KEY_PATH" may be set in place of this flag.
       --client-cert-path string             Path to client cert to be verified by Confluent Manager for Apache Flink. Include for mTLS authentication. Environment variable "CONFLUENT_CMF_CLIENT_CERT_PATH" may be set in place of this flag.

--- a/test/fixtures/output/flink/statement/create-help.golden
+++ b/test/fixtures/output/flink/statement/create-help.golden
@@ -17,8 +17,9 @@ Flags:
       --compute-pool string      Flink compute pool ID.
       --service-account string   Service account ID.
       --database string          The database which will be used as the default database. When using Kafka, this is the cluster ID.
-      --wait                     Block until the resource reaches a terminal state.
-      --wait-timeout duration    Maximum time to wait when --wait is set. (default 6h0m0s)
+      --wait                     Block until the resource reaches a terminal state. Pass --no-wait to opt out. (default true)
+      --no-wait                  Return immediately without polling for the resource to reach a terminal state.
+      --wait-timeout duration    Maximum time to wait when blocking is in effect. (default 6h0m0s)
       --property strings         A mechanism to pass properties in the form key=value when creating a Flink statement.
       --environment string       Environment ID.
       --context string           CLI context name.

--- a/test/fixtures/output/flink/statement/create-help.golden
+++ b/test/fixtures/output/flink/statement/create-help.golden
@@ -18,7 +18,7 @@ Flags:
       --service-account string   Service account ID.
       --database string          The database which will be used as the default database. When using Kafka, this is the cluster ID.
       --wait                     Block until the resource reaches a terminal state.
-      --wait-timeout duration    Maximum time to wait when --wait is set. (default 1m0s)
+      --wait-timeout duration    Maximum time to wait when --wait is set. (default 6h0m0s)
       --property strings         A mechanism to pass properties in the form key=value when creating a Flink statement.
       --environment string       Environment ID.
       --context string           CLI context name.

--- a/test/fixtures/output/flink/statement/create-help.golden
+++ b/test/fixtures/output/flink/statement/create-help.golden
@@ -17,9 +17,8 @@ Flags:
       --compute-pool string      Flink compute pool ID.
       --service-account string   Service account ID.
       --database string          The database which will be used as the default database. When using Kafka, this is the cluster ID.
-      --wait                     Block until the resource reaches a terminal state. Pass --no-wait to opt out. (default true)
-      --no-wait                  Return immediately without polling for the resource to reach a terminal state.
-      --wait-timeout duration    Maximum time to wait when blocking is in effect. (default 6h0m0s)
+      --wait                     Block until the statement reaches a terminal state.
+      --wait-timeout duration    Maximum time to wait when --wait is set. (default 6h0m0s)
       --property strings         A mechanism to pass properties in the form key=value when creating a Flink statement.
       --environment string       Environment ID.
       --context string           CLI context name.

--- a/test/fixtures/output/flink/statement/create-help.golden
+++ b/test/fixtures/output/flink/statement/create-help.golden
@@ -17,7 +17,8 @@ Flags:
       --compute-pool string      Flink compute pool ID.
       --service-account string   Service account ID.
       --database string          The database which will be used as the default database. When using Kafka, this is the cluster ID.
-      --wait                     Block until the statement is running or has failed.
+      --wait                     Block until the resource reaches a terminal state.
+      --wait-timeout duration    Maximum time to wait when --wait is set. (default 1m0s)
       --property strings         A mechanism to pass properties in the form key=value when creating a Flink statement.
       --environment string       Environment ID.
       --context string           CLI context name.

--- a/test/fixtures/output/flink/statement/create-missing-compute-pool-failure.golden
+++ b/test/fixtures/output/flink/statement/create-missing-compute-pool-failure.golden
@@ -10,9 +10,8 @@ Flags:
       --catalog string                      The name of the default catalog.
       --database string                     The name of the default database.
       --flink-configuration string          The file path to hold the Flink configuration for the statement.
-      --wait                                Block until the resource reaches a terminal state. Pass --no-wait to opt out. (default true)
-      --no-wait                             Return immediately without polling for the resource to reach a terminal state.
-      --wait-timeout duration               Maximum time to wait when blocking is in effect. (default 6h0m0s)
+      --wait                                Block until the statement reaches a terminal state.
+      --wait-timeout duration               Maximum time to wait when --wait is set. (default 6h0m0s)
       --url string                          Base URL of the Confluent Manager for Apache Flink (CMF). Environment variable "CONFLUENT_CMF_URL" may be set in place of this flag.
       --client-key-path string              Path to client private key for mTLS authentication. Environment variable "CONFLUENT_CMF_CLIENT_KEY_PATH" may be set in place of this flag.
       --client-cert-path string             Path to client cert to be verified by Confluent Manager for Apache Flink. Include for mTLS authentication. Environment variable "CONFLUENT_CMF_CLIENT_CERT_PATH" may be set in place of this flag.

--- a/test/fixtures/output/flink/statement/create-missing-compute-pool-failure.golden
+++ b/test/fixtures/output/flink/statement/create-missing-compute-pool-failure.golden
@@ -10,8 +10,9 @@ Flags:
       --catalog string                      The name of the default catalog.
       --database string                     The name of the default database.
       --flink-configuration string          The file path to hold the Flink configuration for the statement.
-      --wait                                Block until the resource reaches a terminal state.
-      --wait-timeout duration               Maximum time to wait when --wait is set. (default 6h0m0s)
+      --wait                                Block until the resource reaches a terminal state. Pass --no-wait to opt out. (default true)
+      --no-wait                             Return immediately without polling for the resource to reach a terminal state.
+      --wait-timeout duration               Maximum time to wait when blocking is in effect. (default 6h0m0s)
       --url string                          Base URL of the Confluent Manager for Apache Flink (CMF). Environment variable "CONFLUENT_CMF_URL" may be set in place of this flag.
       --client-key-path string              Path to client private key for mTLS authentication. Environment variable "CONFLUENT_CMF_CLIENT_KEY_PATH" may be set in place of this flag.
       --client-cert-path string             Path to client cert to be verified by Confluent Manager for Apache Flink. Include for mTLS authentication. Environment variable "CONFLUENT_CMF_CLIENT_CERT_PATH" may be set in place of this flag.

--- a/test/fixtures/output/flink/statement/create-missing-compute-pool-failure.golden
+++ b/test/fixtures/output/flink/statement/create-missing-compute-pool-failure.golden
@@ -11,7 +11,7 @@ Flags:
       --database string                     The name of the default database.
       --flink-configuration string          The file path to hold the Flink configuration for the statement.
       --wait                                Block until the resource reaches a terminal state.
-      --wait-timeout duration               Maximum time to wait when --wait is set. (default 1m0s)
+      --wait-timeout duration               Maximum time to wait when --wait is set. (default 6h0m0s)
       --url string                          Base URL of the Confluent Manager for Apache Flink (CMF). Environment variable "CONFLUENT_CMF_URL" may be set in place of this flag.
       --client-key-path string              Path to client private key for mTLS authentication. Environment variable "CONFLUENT_CMF_CLIENT_KEY_PATH" may be set in place of this flag.
       --client-cert-path string             Path to client cert to be verified by Confluent Manager for Apache Flink. Include for mTLS authentication. Environment variable "CONFLUENT_CMF_CLIENT_CERT_PATH" may be set in place of this flag.

--- a/test/fixtures/output/flink/statement/create-missing-compute-pool-failure.golden
+++ b/test/fixtures/output/flink/statement/create-missing-compute-pool-failure.golden
@@ -10,7 +10,8 @@ Flags:
       --catalog string                      The name of the default catalog.
       --database string                     The name of the default database.
       --flink-configuration string          The file path to hold the Flink configuration for the statement.
-      --wait                                Boolean flag to block until the statement is running or has failed.
+      --wait                                Block until the resource reaches a terminal state.
+      --wait-timeout duration               Maximum time to wait when --wait is set. (default 1m0s)
       --url string                          Base URL of the Confluent Manager for Apache Flink (CMF). Environment variable "CONFLUENT_CMF_URL" may be set in place of this flag.
       --client-key-path string              Path to client private key for mTLS authentication. Environment variable "CONFLUENT_CMF_CLIENT_KEY_PATH" may be set in place of this flag.
       --client-cert-path string             Path to client cert to be verified by Confluent Manager for Apache Flink. Include for mTLS authentication. Environment variable "CONFLUENT_CMF_CLIENT_CERT_PATH" may be set in place of this flag.

--- a/test/fixtures/output/flink/statement/create-missing-sql-failure.golden
+++ b/test/fixtures/output/flink/statement/create-missing-sql-failure.golden
@@ -10,9 +10,8 @@ Flags:
       --catalog string                      The name of the default catalog.
       --database string                     The name of the default database.
       --flink-configuration string          The file path to hold the Flink configuration for the statement.
-      --wait                                Block until the resource reaches a terminal state. Pass --no-wait to opt out. (default true)
-      --no-wait                             Return immediately without polling for the resource to reach a terminal state.
-      --wait-timeout duration               Maximum time to wait when blocking is in effect. (default 6h0m0s)
+      --wait                                Block until the statement reaches a terminal state.
+      --wait-timeout duration               Maximum time to wait when --wait is set. (default 6h0m0s)
       --url string                          Base URL of the Confluent Manager for Apache Flink (CMF). Environment variable "CONFLUENT_CMF_URL" may be set in place of this flag.
       --client-key-path string              Path to client private key for mTLS authentication. Environment variable "CONFLUENT_CMF_CLIENT_KEY_PATH" may be set in place of this flag.
       --client-cert-path string             Path to client cert to be verified by Confluent Manager for Apache Flink. Include for mTLS authentication. Environment variable "CONFLUENT_CMF_CLIENT_CERT_PATH" may be set in place of this flag.

--- a/test/fixtures/output/flink/statement/create-missing-sql-failure.golden
+++ b/test/fixtures/output/flink/statement/create-missing-sql-failure.golden
@@ -10,8 +10,9 @@ Flags:
       --catalog string                      The name of the default catalog.
       --database string                     The name of the default database.
       --flink-configuration string          The file path to hold the Flink configuration for the statement.
-      --wait                                Block until the resource reaches a terminal state.
-      --wait-timeout duration               Maximum time to wait when --wait is set. (default 6h0m0s)
+      --wait                                Block until the resource reaches a terminal state. Pass --no-wait to opt out. (default true)
+      --no-wait                             Return immediately without polling for the resource to reach a terminal state.
+      --wait-timeout duration               Maximum time to wait when blocking is in effect. (default 6h0m0s)
       --url string                          Base URL of the Confluent Manager for Apache Flink (CMF). Environment variable "CONFLUENT_CMF_URL" may be set in place of this flag.
       --client-key-path string              Path to client private key for mTLS authentication. Environment variable "CONFLUENT_CMF_CLIENT_KEY_PATH" may be set in place of this flag.
       --client-cert-path string             Path to client cert to be verified by Confluent Manager for Apache Flink. Include for mTLS authentication. Environment variable "CONFLUENT_CMF_CLIENT_CERT_PATH" may be set in place of this flag.

--- a/test/fixtures/output/flink/statement/create-missing-sql-failure.golden
+++ b/test/fixtures/output/flink/statement/create-missing-sql-failure.golden
@@ -11,7 +11,7 @@ Flags:
       --database string                     The name of the default database.
       --flink-configuration string          The file path to hold the Flink configuration for the statement.
       --wait                                Block until the resource reaches a terminal state.
-      --wait-timeout duration               Maximum time to wait when --wait is set. (default 1m0s)
+      --wait-timeout duration               Maximum time to wait when --wait is set. (default 6h0m0s)
       --url string                          Base URL of the Confluent Manager for Apache Flink (CMF). Environment variable "CONFLUENT_CMF_URL" may be set in place of this flag.
       --client-key-path string              Path to client private key for mTLS authentication. Environment variable "CONFLUENT_CMF_CLIENT_KEY_PATH" may be set in place of this flag.
       --client-cert-path string             Path to client cert to be verified by Confluent Manager for Apache Flink. Include for mTLS authentication. Environment variable "CONFLUENT_CMF_CLIENT_CERT_PATH" may be set in place of this flag.

--- a/test/fixtures/output/flink/statement/create-missing-sql-failure.golden
+++ b/test/fixtures/output/flink/statement/create-missing-sql-failure.golden
@@ -10,7 +10,8 @@ Flags:
       --catalog string                      The name of the default catalog.
       --database string                     The name of the default database.
       --flink-configuration string          The file path to hold the Flink configuration for the statement.
-      --wait                                Boolean flag to block until the statement is running or has failed.
+      --wait                                Block until the resource reaches a terminal state.
+      --wait-timeout duration               Maximum time to wait when --wait is set. (default 1m0s)
       --url string                          Base URL of the Confluent Manager for Apache Flink (CMF). Environment variable "CONFLUENT_CMF_URL" may be set in place of this flag.
       --client-key-path string              Path to client private key for mTLS authentication. Environment variable "CONFLUENT_CMF_CLIENT_KEY_PATH" may be set in place of this flag.
       --client-cert-path string             Path to client cert to be verified by Confluent Manager for Apache Flink. Include for mTLS authentication. Environment variable "CONFLUENT_CMF_CLIENT_CERT_PATH" may be set in place of this flag.

--- a/test/fixtures/output/flink/statement/create-wait-failed.golden
+++ b/test/fixtures/output/flink/statement/create-wait-failed.golden
@@ -1,0 +1,4 @@
+Error: statement "failed-statement" entered failed phase "FAILED": SQL statement execution has failed
+
+Suggestions:
+    Inspect the statement with `confluent flink statement describe failed-statement`.

--- a/test/fixtures/output/flink/statement/create-wait-onprem.golden
+++ b/test/fixtures/output/flink/statement/create-wait-onprem.golden
@@ -1,0 +1,11 @@
++---------------+-------------------------------+
+| Creation Date | 2025-08-05 12:00:00 +0000 UTC |
+| Name          | running-wait-stmt             |
+| Statement     | SELECT * FROM test_table      |
+| Compute Pool  | test-pool                     |
+| Status        | RUNNING                       |
+| Status Detail | Statement is running.         |
+| Parallelism   | 1                             |
+| Stopped       | false                         |
+| SQL Kind      | SELECT                        |
++---------------+-------------------------------+

--- a/test/fixtures/output/flink/statement/create-wait-timeout.golden
+++ b/test/fixtures/output/flink/statement/create-wait-timeout.golden
@@ -1,0 +1,4 @@
+Error: wait timed out
+
+Suggestions:
+    Increase `--wait-timeout` or omit `--wait`.

--- a/test/fixtures/output/flink/statement/create-wait-timeout.golden
+++ b/test/fixtures/output/flink/statement/create-wait-timeout.golden
@@ -1,4 +1,4 @@
-Error: wait timed out
+Error: wait timed out: statement "pending-statement" is still in phase "PENDING"
 
 Suggestions:
     Increase `--wait-timeout` or omit `--wait`.

--- a/test/flink_onprem_test.go
+++ b/test/flink_onprem_test.go
@@ -412,13 +412,12 @@ func (s *CLITestSuite) TestFlinkCatalogListOnPrem() {
 
 func (s *CLITestSuite) TestFlinkStatementCreateOnPrem() {
 	tests := []CLITest{
-		// success — --no-wait preserves the immediate-return semantic that
-		// pre-existed the default-block change.
-		{args: `flink statement create test-stmt --environment default --sql "SELECT * FROM test_table" --compute-pool test-pool --no-wait`, fixture: "flink/statement/create-success.golden"},
-		{args: `flink statement create test-stmt --environment default --sql "SELECT * FROM test_table" --compute-pool test-pool --no-wait -o json`, fixture: "flink/statement/create-success-json.golden"},
-		{args: `flink statement create test-stmt --environment default --sql "SELECT * FROM test_table" --compute-pool test-pool --no-wait -o yaml`, fixture: "flink/statement/create-success-yaml.golden"},
-		{args: `flink statement create test-stmt --environment default --sql "SELECT * FROM test_table" --compute-pool test-pool --no-wait --flink-configuration test/fixtures/input/flink/statement/flink-configuration.json`, fixture: "flink/statement/create-success.golden"},
-		{args: `flink statement create test-stmt --environment default --sql "SELECT * FROM test_table" --compute-pool test-pool --no-wait --flink-configuration test/fixtures/input/flink/statement/flink-configuration.yaml`, fixture: "flink/statement/create-success.golden"},
+		// success
+		{args: `flink statement create test-stmt --environment default --sql "SELECT * FROM test_table" --compute-pool test-pool`, fixture: "flink/statement/create-success.golden"},
+		{args: `flink statement create test-stmt --environment default --sql "SELECT * FROM test_table" --compute-pool test-pool -o json`, fixture: "flink/statement/create-success-json.golden"},
+		{args: `flink statement create test-stmt --environment default --sql "SELECT * FROM test_table" --compute-pool test-pool -o yaml`, fixture: "flink/statement/create-success-yaml.golden"},
+		{args: `flink statement create test-stmt --environment default --sql "SELECT * FROM test_table" --compute-pool test-pool --flink-configuration test/fixtures/input/flink/statement/flink-configuration.json`, fixture: "flink/statement/create-success.golden"},
+		{args: `flink statement create test-stmt --environment default --sql "SELECT * FROM test_table" --compute-pool test-pool --flink-configuration test/fixtures/input/flink/statement/flink-configuration.yaml`, fixture: "flink/statement/create-success.golden"},
 		// --wait: POST returns PENDING; first poll observes RUNNING; framework
 		// returns the post-transition object so the output shows the terminal
 		// phase. Mirrors the cloud --wait coverage in flink_test.go.

--- a/test/flink_onprem_test.go
+++ b/test/flink_onprem_test.go
@@ -418,6 +418,10 @@ func (s *CLITestSuite) TestFlinkStatementCreateOnPrem() {
 		{args: `flink statement create test-stmt --environment default --sql "SELECT * FROM test_table" --compute-pool test-pool -o yaml`, fixture: "flink/statement/create-success-yaml.golden"},
 		{args: `flink statement create test-stmt --environment default --sql "SELECT * FROM test_table" --compute-pool test-pool --flink-configuration test/fixtures/input/flink/statement/flink-configuration.json`, fixture: "flink/statement/create-success.golden"},
 		{args: `flink statement create test-stmt --environment default --sql "SELECT * FROM test_table" --compute-pool test-pool --flink-configuration test/fixtures/input/flink/statement/flink-configuration.yaml`, fixture: "flink/statement/create-success.golden"},
+		// --wait: POST returns PENDING; first poll observes RUNNING; framework
+		// returns the post-transition object so the output shows the terminal
+		// phase. Mirrors the cloud --wait coverage in flink_test.go.
+		{args: `flink statement create running-wait-stmt --environment default --sql "SELECT * FROM test_table" --compute-pool test-pool --wait`, fixture: "flink/statement/create-wait-onprem.golden"},
 		// failure
 		{args: `flink statement create test-stmt --environment default --sql "SELECT * FROM test_table" --compute-pool test-pool --flink-configuration test/fixtures/input/flink/statement/flink-configuration.properties`, fixture: "flink/statement/create-failure-invalid-configuration-file-format.golden", exitCode: 1},
 		{args: `flink statement create test-stmt --environment default --sql "SELECT * FROM test_table" --compute-pool test-pool --flink-configuration test/fixtures/input/flink/statement/flink-configuration.csv`, fixture: "flink/statement/create-failure-configuration-file-dne.golden", regex: true, exitCode: 1},

--- a/test/flink_onprem_test.go
+++ b/test/flink_onprem_test.go
@@ -412,12 +412,13 @@ func (s *CLITestSuite) TestFlinkCatalogListOnPrem() {
 
 func (s *CLITestSuite) TestFlinkStatementCreateOnPrem() {
 	tests := []CLITest{
-		// success
-		{args: `flink statement create test-stmt --environment default --sql "SELECT * FROM test_table" --compute-pool test-pool`, fixture: "flink/statement/create-success.golden"},
-		{args: `flink statement create test-stmt --environment default --sql "SELECT * FROM test_table" --compute-pool test-pool -o json`, fixture: "flink/statement/create-success-json.golden"},
-		{args: `flink statement create test-stmt --environment default --sql "SELECT * FROM test_table" --compute-pool test-pool -o yaml`, fixture: "flink/statement/create-success-yaml.golden"},
-		{args: `flink statement create test-stmt --environment default --sql "SELECT * FROM test_table" --compute-pool test-pool --flink-configuration test/fixtures/input/flink/statement/flink-configuration.json`, fixture: "flink/statement/create-success.golden"},
-		{args: `flink statement create test-stmt --environment default --sql "SELECT * FROM test_table" --compute-pool test-pool --flink-configuration test/fixtures/input/flink/statement/flink-configuration.yaml`, fixture: "flink/statement/create-success.golden"},
+		// success — --no-wait preserves the immediate-return semantic that
+		// pre-existed the default-block change.
+		{args: `flink statement create test-stmt --environment default --sql "SELECT * FROM test_table" --compute-pool test-pool --no-wait`, fixture: "flink/statement/create-success.golden"},
+		{args: `flink statement create test-stmt --environment default --sql "SELECT * FROM test_table" --compute-pool test-pool --no-wait -o json`, fixture: "flink/statement/create-success-json.golden"},
+		{args: `flink statement create test-stmt --environment default --sql "SELECT * FROM test_table" --compute-pool test-pool --no-wait -o yaml`, fixture: "flink/statement/create-success-yaml.golden"},
+		{args: `flink statement create test-stmt --environment default --sql "SELECT * FROM test_table" --compute-pool test-pool --no-wait --flink-configuration test/fixtures/input/flink/statement/flink-configuration.json`, fixture: "flink/statement/create-success.golden"},
+		{args: `flink statement create test-stmt --environment default --sql "SELECT * FROM test_table" --compute-pool test-pool --no-wait --flink-configuration test/fixtures/input/flink/statement/flink-configuration.yaml`, fixture: "flink/statement/create-success.golden"},
 		// --wait: POST returns PENDING; first poll observes RUNNING; framework
 		// returns the post-transition object so the output shows the terminal
 		// phase. Mirrors the cloud --wait coverage in flink_test.go.

--- a/test/flink_test.go
+++ b/test/flink_test.go
@@ -479,6 +479,7 @@ func (s *CLITestSuite) TestFlinkStatementCreate() {
 		{args: `flink statement create my-statement --sql "INSERT * INTO table;" --compute-pool lfcp-123456`, fixture: "flink/statement/create-service-account-warning.golden"},
 		{args: `flink statement create my-statement --sql "INSERT * INTO table;" --compute-pool lfcp-123456 --service-account sa-123456 --wait`, fixture: "flink/statement/create-wait.golden"},
 		{args: `flink statement create pending-statement --sql "INSERT * INTO table;" --compute-pool lfcp-123456 --service-account sa-123456 --wait --wait-timeout 100ms`, fixture: "flink/statement/create-wait-timeout.golden", exitCode: 1},
+		{args: `flink statement create failed-statement --sql "INSERT * INTO table;" --compute-pool lfcp-123456 --service-account sa-123456 --wait`, fixture: "flink/statement/create-wait-failed.golden", exitCode: 1},
 		{args: `flink statement create --sql "INSERT * INTO table;" --compute-pool lfcp-123456 --service-account sa-123456 -o yaml`, fixture: "flink/statement/create-no-name-yaml.golden", regex: true},
 		{args: `flink statement create my-statement --sql "INSERT * INTO table;" --compute-pool lfcp-123456 --service-account sa-123456 --property property1=value1,property2=value2`, fixture: "flink/statement/create-with-properties.golden"},
 		{args: `flink statement create my-statement --sql "INSERT * INTO table;" --compute-pool lfcp-123456 --service-account sa-123456 --property invalid-format,property1=value1`, fixture: "flink/statement/create-invalid-property.golden", exitCode: 1},

--- a/test/flink_test.go
+++ b/test/flink_test.go
@@ -478,6 +478,7 @@ func (s *CLITestSuite) TestFlinkStatementCreate() {
 		{args: `flink statement create my-statement-2 --sql "INSERT * INTO table;" --cloud aws --region eu-west-1 --service-account sa-123456`, fixture: "flink/statement/create-without-compute-pool.golden"},
 		{args: `flink statement create my-statement --sql "INSERT * INTO table;" --compute-pool lfcp-123456`, fixture: "flink/statement/create-service-account-warning.golden"},
 		{args: `flink statement create my-statement --sql "INSERT * INTO table;" --compute-pool lfcp-123456 --service-account sa-123456 --wait`, fixture: "flink/statement/create-wait.golden"},
+		{args: `flink statement create pending-statement --sql "INSERT * INTO table;" --compute-pool lfcp-123456 --service-account sa-123456 --wait --wait-timeout 100ms`, fixture: "flink/statement/create-wait-timeout.golden", exitCode: 1},
 		{args: `flink statement create --sql "INSERT * INTO table;" --compute-pool lfcp-123456 --service-account sa-123456 -o yaml`, fixture: "flink/statement/create-no-name-yaml.golden", regex: true},
 		{args: `flink statement create my-statement --sql "INSERT * INTO table;" --compute-pool lfcp-123456 --service-account sa-123456 --property property1=value1,property2=value2`, fixture: "flink/statement/create-with-properties.golden"},
 		{args: `flink statement create my-statement --sql "INSERT * INTO table;" --compute-pool lfcp-123456 --service-account sa-123456 --property invalid-format,property1=value1`, fixture: "flink/statement/create-invalid-property.golden", exitCode: 1},

--- a/test/flink_test.go
+++ b/test/flink_test.go
@@ -474,15 +474,18 @@ func (s *CLITestSuite) TestFlinkStatement() {
 
 func (s *CLITestSuite) TestFlinkStatementCreate() {
 	tests := []CLITest{
-		{args: `flink statement create my-statement --sql "INSERT * INTO table;" --compute-pool lfcp-123456 --service-account sa-123456`, fixture: "flink/statement/create.golden"},
-		{args: `flink statement create my-statement-2 --sql "INSERT * INTO table;" --cloud aws --region eu-west-1 --service-account sa-123456`, fixture: "flink/statement/create-without-compute-pool.golden"},
-		{args: `flink statement create my-statement --sql "INSERT * INTO table;" --compute-pool lfcp-123456`, fixture: "flink/statement/create-service-account-warning.golden"},
+		// --no-wait preserves the immediate-return semantic that pre-existed
+		// the default-block change; tests that don't specifically exercise
+		// --wait pass --no-wait so their goldens stay valid.
+		{args: `flink statement create my-statement --sql "INSERT * INTO table;" --compute-pool lfcp-123456 --service-account sa-123456 --no-wait`, fixture: "flink/statement/create.golden"},
+		{args: `flink statement create my-statement-2 --sql "INSERT * INTO table;" --cloud aws --region eu-west-1 --service-account sa-123456 --no-wait`, fixture: "flink/statement/create-without-compute-pool.golden"},
+		{args: `flink statement create my-statement --sql "INSERT * INTO table;" --compute-pool lfcp-123456 --no-wait`, fixture: "flink/statement/create-service-account-warning.golden"},
 		{args: `flink statement create my-statement --sql "INSERT * INTO table;" --compute-pool lfcp-123456 --service-account sa-123456 --wait`, fixture: "flink/statement/create-wait.golden"},
 		{args: `flink statement create pending-statement --sql "INSERT * INTO table;" --compute-pool lfcp-123456 --service-account sa-123456 --wait --wait-timeout 100ms`, fixture: "flink/statement/create-wait-timeout.golden", exitCode: 1},
 		{args: `flink statement create failed-statement --sql "INSERT * INTO table;" --compute-pool lfcp-123456 --service-account sa-123456 --wait`, fixture: "flink/statement/create-wait-failed.golden", exitCode: 1},
-		{args: `flink statement create --sql "INSERT * INTO table;" --compute-pool lfcp-123456 --service-account sa-123456 -o yaml`, fixture: "flink/statement/create-no-name-yaml.golden", regex: true},
-		{args: `flink statement create my-statement --sql "INSERT * INTO table;" --compute-pool lfcp-123456 --service-account sa-123456 --property property1=value1,property2=value2`, fixture: "flink/statement/create-with-properties.golden"},
-		{args: `flink statement create my-statement --sql "INSERT * INTO table;" --compute-pool lfcp-123456 --service-account sa-123456 --property invalid-format,property1=value1`, fixture: "flink/statement/create-invalid-property.golden", exitCode: 1},
+		{args: `flink statement create --sql "INSERT * INTO table;" --compute-pool lfcp-123456 --service-account sa-123456 --no-wait -o yaml`, fixture: "flink/statement/create-no-name-yaml.golden", regex: true},
+		{args: `flink statement create my-statement --sql "INSERT * INTO table;" --compute-pool lfcp-123456 --service-account sa-123456 --no-wait --property property1=value1,property2=value2`, fixture: "flink/statement/create-with-properties.golden"},
+		{args: `flink statement create my-statement --sql "INSERT * INTO table;" --compute-pool lfcp-123456 --service-account sa-123456 --no-wait --property invalid-format,property1=value1`, fixture: "flink/statement/create-invalid-property.golden", exitCode: 1},
 	}
 
 	for _, test := range tests {

--- a/test/flink_test.go
+++ b/test/flink_test.go
@@ -474,18 +474,15 @@ func (s *CLITestSuite) TestFlinkStatement() {
 
 func (s *CLITestSuite) TestFlinkStatementCreate() {
 	tests := []CLITest{
-		// --no-wait preserves the immediate-return semantic that pre-existed
-		// the default-block change; tests that don't specifically exercise
-		// --wait pass --no-wait so their goldens stay valid.
-		{args: `flink statement create my-statement --sql "INSERT * INTO table;" --compute-pool lfcp-123456 --service-account sa-123456 --no-wait`, fixture: "flink/statement/create.golden"},
-		{args: `flink statement create my-statement-2 --sql "INSERT * INTO table;" --cloud aws --region eu-west-1 --service-account sa-123456 --no-wait`, fixture: "flink/statement/create-without-compute-pool.golden"},
-		{args: `flink statement create my-statement --sql "INSERT * INTO table;" --compute-pool lfcp-123456 --no-wait`, fixture: "flink/statement/create-service-account-warning.golden"},
+		{args: `flink statement create my-statement --sql "INSERT * INTO table;" --compute-pool lfcp-123456 --service-account sa-123456`, fixture: "flink/statement/create.golden"},
+		{args: `flink statement create my-statement-2 --sql "INSERT * INTO table;" --cloud aws --region eu-west-1 --service-account sa-123456`, fixture: "flink/statement/create-without-compute-pool.golden"},
+		{args: `flink statement create my-statement --sql "INSERT * INTO table;" --compute-pool lfcp-123456`, fixture: "flink/statement/create-service-account-warning.golden"},
 		{args: `flink statement create my-statement --sql "INSERT * INTO table;" --compute-pool lfcp-123456 --service-account sa-123456 --wait`, fixture: "flink/statement/create-wait.golden"},
 		{args: `flink statement create pending-statement --sql "INSERT * INTO table;" --compute-pool lfcp-123456 --service-account sa-123456 --wait --wait-timeout 100ms`, fixture: "flink/statement/create-wait-timeout.golden", exitCode: 1},
 		{args: `flink statement create failed-statement --sql "INSERT * INTO table;" --compute-pool lfcp-123456 --service-account sa-123456 --wait`, fixture: "flink/statement/create-wait-failed.golden", exitCode: 1},
-		{args: `flink statement create --sql "INSERT * INTO table;" --compute-pool lfcp-123456 --service-account sa-123456 --no-wait -o yaml`, fixture: "flink/statement/create-no-name-yaml.golden", regex: true},
-		{args: `flink statement create my-statement --sql "INSERT * INTO table;" --compute-pool lfcp-123456 --service-account sa-123456 --no-wait --property property1=value1,property2=value2`, fixture: "flink/statement/create-with-properties.golden"},
-		{args: `flink statement create my-statement --sql "INSERT * INTO table;" --compute-pool lfcp-123456 --service-account sa-123456 --no-wait --property invalid-format,property1=value1`, fixture: "flink/statement/create-invalid-property.golden", exitCode: 1},
+		{args: `flink statement create --sql "INSERT * INTO table;" --compute-pool lfcp-123456 --service-account sa-123456 -o yaml`, fixture: "flink/statement/create-no-name-yaml.golden", regex: true},
+		{args: `flink statement create my-statement --sql "INSERT * INTO table;" --compute-pool lfcp-123456 --service-account sa-123456 --property property1=value1,property2=value2`, fixture: "flink/statement/create-with-properties.golden"},
+		{args: `flink statement create my-statement --sql "INSERT * INTO table;" --compute-pool lfcp-123456 --service-account sa-123456 --property invalid-format,property1=value1`, fixture: "flink/statement/create-invalid-property.golden", exitCode: 1},
 	}
 
 	for _, test := range tests {

--- a/test/test-server/flink_gateway_router.go
+++ b/test/test-server/flink_gateway_router.go
@@ -228,9 +228,13 @@ func handleStatementGet(t *testing.T) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		phase := "COMPLETED"
 		detail := "SQL statement is completed"
-		if mux.Vars(r)["statement"] == "pending-statement" {
+		switch mux.Vars(r)["statement"] {
+		case "pending-statement":
 			phase = "PENDING"
 			detail = "SQL statement is pending"
+		case "failed-statement":
+			phase = "FAILED"
+			detail = "SQL statement execution has failed"
 		}
 		statement := flinkgatewayv1.SqlV1Statement{
 			Name: flinkgatewayv1.PtrString(mux.Vars(r)["statement"]),

--- a/test/test-server/flink_gateway_router.go
+++ b/test/test-server/flink_gateway_router.go
@@ -226,6 +226,12 @@ func handleSqlEnvironmentsEnvironmentStatementsStatement(t *testing.T) http.Hand
 
 func handleStatementGet(t *testing.T) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		phase := "COMPLETED"
+		detail := "SQL statement is completed"
+		if mux.Vars(r)["statement"] == "pending-statement" {
+			phase = "PENDING"
+			detail = "SQL statement is pending"
+		}
 		statement := flinkgatewayv1.SqlV1Statement{
 			Name: flinkgatewayv1.PtrString(mux.Vars(r)["statement"]),
 			Spec: &flinkgatewayv1.SqlV1StatementSpec{
@@ -238,8 +244,8 @@ func handleStatementGet(t *testing.T) http.HandlerFunc {
 				Principal:     flinkgatewayv1.PtrString(validFlinkStatementPrincipalId),
 			},
 			Status: &flinkgatewayv1.SqlV1StatementStatus{
-				Phase:  "COMPLETED",
-				Detail: flinkgatewayv1.PtrString("SQL statement is completed"),
+				Phase:  phase,
+				Detail: flinkgatewayv1.PtrString(detail),
 				LatestOffsets: &map[string]string{
 					"customers_source": "partition:0,offset:9223372036854775808",
 				},

--- a/test/test-server/flink_onprem_handler.go
+++ b/test/test-server/flink_onprem_handler.go
@@ -973,6 +973,29 @@ func handleCmfStatement(t *testing.T) http.HandlerFunc {
 				return
 			}
 
+			// running-wait-stmt drives the on-prem --wait success path: POST
+			// returns PENDING (default), and the first poll observes RUNNING.
+			if stmtName == "running-wait-stmt" {
+				timeStamp := time.Date(2025, time.August, 5, 12, 0, 0, 0, time.UTC).String()
+				stmt := cmfsdk.Statement{
+					Metadata: cmfsdk.StatementMetadata{Name: stmtName, CreationTimestamp: &timeStamp},
+					Spec: cmfsdk.StatementSpec{
+						Statement:       "SELECT * FROM test_table",
+						ComputePoolName: "test-pool",
+						Parallelism:     cmfsdk.PtrInt32(1),
+						Stopped:         cmfsdk.PtrBool(false),
+					},
+					Status: &cmfsdk.StatementStatus{
+						Phase:  "RUNNING",
+						Detail: cmfsdk.PtrString("Statement is running."),
+						Traits: &cmfsdk.StatementTraits{SqlKind: cmfsdk.PtrString("SELECT"), IsAppendOnly: cmfsdk.PtrBool(false), IsBounded: cmfsdk.PtrBool(false)},
+					},
+				}
+				err := json.NewEncoder(w).Encode(stmt)
+				require.NoError(t, err)
+				return
+			}
+
 			if stmtName == "shell-test-stmt" {
 				stmt := cmfsdk.Statement{
 					Metadata: cmfsdk.StatementMetadata{


### PR DESCRIPTION
Release Notes
-------------

New Features
- Introduced a unified polling framework for the `--wait flag`, improving transitional state tracking for Flink commands and increasing the default timeout to 6 hours to align with Terraform.

Checklist
---------
- [x] I have successfully built and used a custom CLI binary, without linter issues from this PR.
- [x] I have clearly specified in the `What` section below whether this PR applies to Confluent Cloud, Confluent Platform, or both.
- [ ] I have verified this PR in Confluent Cloud pre-prod or production environment, if applicable. _(verified via integration mocks; live verification pending if reviewer requests)_
- [ ] I have verified this PR in Confluent Platform on-premises environment, if applicable. _(verified via integration mocks; live verification pending if reviewer requests)_
- [x] I have attached manual CLI verification results or screenshots in the `Test & Review` section below.
- [x] I have added appropriate CLI integration or unit tests for any new or updated commands and functionality.
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues. (The `--wait-timeout` default changes from 1m → 6h to match `terraform-provider-confluent`; scripts that depended on the 1m circuit-breaker should pass `--wait-timeout 1m` explicitly. The flag itself is unchanged.)
- [x] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [x] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [x] Confluent Cloud prod _(N/A — refactor preserves polling semantics; new framework is additive)_
  - [x] Confluent Cloud stag _(N/A — same reason)_
  - [x] Confluent Platform _(N/A — same reason)_
  - [ ] Check this box if the feature is enabled for certain organizations only

What
----
**Applies to:** Confluent Cloud AND Confluent Platform.

**Problem.** `--wait` exists today on exactly two commands (`flink statement create` cloud + on-prem) as near-duplicate inline `retry.Retry(...)` blocks. Both check `Status.Phase != "PENDING"` to decide that a statement has settled, which is wrong: a statement in `FAILING` or `STOPPING` is also still in transition, and the CLI today prints it as if it had reached a terminal state. Many other 202-style create commands (`network/*`, `flink compute-pool/connection`, `kafka cluster`, `ksql cluster`, `tableflow`, `ccpm`) lack `--wait` entirely. Copy-pasting the inline pattern would compound the duplication.

**Approach.**

1. **`pkg/wait`** — a generic `Poll[T](ctx, Options[T])` with pluggable `IsTerminal` / `IsFailed` predicates, configurable `Tick` and `Timeout`, sentinel errors (`ErrTimeout`, `ErrFailed`), and context-cancellation support. A direct loop (not a wrapper around `pkg/retry`) because `retry.Retry`'s `func() error` signature can't return the polled value or distinguish "still pending" from "permanently failed" from "fetch error" cleanly.

2. **`pkg/wait.PollPhases` + `PhaseSet`** — declarative wrapper for the common case where readiness is a single status-phase string. Callers supply `PendingPhases` and `FailedPhases` slices; `PollPhases` builds the `IsTerminal` / `IsFailed` closures internally. This is the shape the cli-terraform-generator can emit deterministically from `AsyncConfig.PendingStates` / `FailedStates` (see the companion generator PR confluentinc/cli-terraform-generator#197), so future async resources adopt `--wait` without touching `pkg/wait` again.

3. **`pkg/cmd/flags.go`** — `AddWaitFlag` and `AddWaitTimeoutFlag(cmd, defaultTimeout)` helpers so future adoptions are one-liners. `pkg/cmd/flags.go` is the only file in `pkg/cmd/` in CLAUDE.md's "edit freely" zone; the rest of `pkg/cmd/` is untouched.

4. **Reference adoption.** `internal/flink/command_statement_create.go` (1s tick) and `internal/flink/command_statement_create_onprem.go` (2s tick) refactored onto `PollPhases` with phase sets sourced from the Flink statement OpenAPI enum: pending = `{PENDING, FAILING, STOPPING, DELETING}`, failed = `{FAILED}`. `IsFailed` is wired so the call site can distinguish a failed-state landing from a timeout — the failed path now returns `statement "x" entered failed phase "FAILED": <detail>` with an `Inspect the statement with` `confluent flink statement describe x` `.` suggestion, while the timeout path keeps the `Increase --wait-timeout` suggestion.

5. **TF-aligned default.** `--wait-timeout` default raised from 1m to 6h to match `terraform-provider-confluent`'s `statementsAPICreateTimeout`. Users who want a short circuit-breaker still pass `--wait-timeout` explicitly. Other async resources adopting the framework will surface their own per-resource defaults via `AsyncConfig.CreateTimeout` (handled in the generator PR).

**Notable detail (pflag gotcha).** `pflag.Duration` interprets the first backtick-quoted word in a flag description as a type-name override. `AddWaitTimeoutFlag`'s description therefore uses plain `--wait` (no backticks) so the help renders as `--wait-timeout duration` instead of `--wait-timeout --wait`. CLAUDE.md's backtick convention still applies in `Short`/`Long`/error messages.

Blast Radius
----
- **Confluent Cloud customers using `confluent flink statement create --wait`** — semantic change: statements in `FAILING` / `STOPPING` / `DELETING` are now correctly treated as still in transition, where they were previously mis-reported as terminal. Mitigated by unit tests (`TestPollPhases_AllPendingPhasesContinuePolling`) and an integration test against a new `failed-statement` mock that exercises the differentiated error path.
- **Customers scripting around the previous 1m default** — the new 6h default is more permissive; any script that depended on `--wait` timing out within ~1m should pass `--wait-timeout 1m` (or shorter) explicitly. The flag name and value type are unchanged.
- **Confluent Platform customers using `confluent flink statement create --wait` (on-prem)** — same semantic change, same mitigation.
- **All commands using `pkg/cmd/flags.go`** — additive helpers, no existing call site touched.
- **`pkg/retry` callers** — unchanged; the package still exists with 5+ other call sites in `internal/asyncapi`, `internal/kafka`, `internal/connect`, `pkg/auth`. Flink statement create just no longer imports it.

References
----------
- JIRA: [APIE-1040](https://confluentinc.atlassian.net/browse/APIE-1040)
- Companion generator PR: confluentinc/cli-terraform-generator#197

Test & Review
-------------
**Manual test: `--wait` on `confluent flink statement create` (APIE‑1040)**

Verified `--wait` blocks until the statement leaves the pending set, and returns the right errors on timeout/failure. Three live runs + the unit-tested failure path:

**1. Baseline (no `--wait`) → returns immediately in `PENDING`:**
```
$ confluent flink statement create wait-demo-a-… --sql "SELECT 1;" --cloud aws --region us-west-2 -o json | grep status
  "status": "PENDING"
```

**2. `--wait` → blocks until terminal (`COMPLETED`), ~9.6s:**
```
$ time confluent flink statement create wait-demo-b-… --sql "SELECT 1;" --cloud aws --region us-west-2 --wait
+---------------+------------------------+
| Name          | wait-demo-b-1782500402 |
| Statement     | SELECT 1;              |
| Compute Pool  | lfcp-stgc91j885        |
| Status        | COMPLETED              |
+---------------+------------------------+
… 9.558 total
```
Same statement as #1, but `--wait` turned the instant `PENDING` return into a 9.56s block ending in `COMPLETED`.

**3. `--wait --wait-timeout 1ms` → timeout error + suggestion:**
```
$ confluent flink statement create wait-demo-c-… --sql "SELECT 1;" --cloud aws --region us-west-2 --wait --wait-timeout 1ms
Error: wait timed out: statement "wait-demo-c-1782500517" is still in phase "PENDING"
Suggestions:
    Increase `--wait-timeout` or omit `--wait`.
```

**4. Failed-phase path** (hard to force live) — covered deterministically by `pkg/wait.TestPollPhases_FailedPhase`; full `go test ./pkg/wait/` suite passes.

**Conclusion:** all three runtime outcomes — success-after-poll, timeout, failed — behave correctly. Good to go.

**Automated tests run locally** (Go 1.25.7; repo pins `.go-version` to 1.26.1 which isn't installed locally, so 1.25.7 was used — CI will pick up 1.26.1):

| Suite | Result |
|---|---|
| `go test ./pkg/wait/ ./pkg/cmd/ ./internal/flink/` (unit) | PASS — 11 wait tests (7 baseline + 4 new: `PhaseSet`, `PollPhases_TerminalSuccess`, `PollPhases_FailedPhase`, `PollPhases_AllPendingPhasesContinuePolling` covering FAILING/STOPPING/DELETING) |
| `make lint` (golangci-lint + hunspell spell check) | PASS |
| `make integration-test -run TestCLI/TestFlinkStatementCreate$` (cloud) | PASS — includes existing `--wait` case (unchanged golden), `--wait-timeout 100ms` timeout case, and new `failed-statement --wait` case exercising the differentiated `ErrFailed` error path |
| `make integration-test -run TestCLI/TestHelp/flink/statement/create` (help) | PASS — both cloud and on-prem help goldens regenerated for the 6h default |

**Pre-existing test failure not introduced by this PR:**
- `pkg/flink/internal/controller/TestInteractiveOutputControllerTestSuite` fails in non-TTY environments with `open /dev/tty: device not configured` (tview/tcell needs a real terminal). Reproduced on baseline (`origin/main` without these changes). Expected to pass in Semaphore CI which provides a pseudo-TTY.

**Golden file changes** (all intentional):
- `create-wait.golden` — **unchanged** (parity proof for the success path).
- `create-wait-timeout.golden` — **unchanged** (timeout error path, error message identical).
- `create-wait-failed.golden` — **new** (covers the wired-up `IsFailed` path with the differentiated error message).
- `create-help.golden` / `create-help-onprem.golden` / `create-missing-sql-failure.golden` / `create-missing-compute-pool-failure.golden` — regenerated to reflect the new `--wait-timeout default 6h0m0s`. Diff is exactly one line in each.

**Backwards compatibility.** Per CLAUDE.md compatibility rules: adding `--wait-timeout` was non-breaking (additive flag). Changing the *default* from 1m to 6h is technically a behavior change but doesn't break the flag contract — see Blast Radius. The flag name, value type, and existing `--wait` boolean are all unchanged. Existing scripts that pass `--wait` continue to work; their wait window simply expands to match TF's.


[APIE-1040]: https://confluentinc.atlassian.net/browse/APIE-1040?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ