### PR TITLE
[IDENTITY-7450] Support Global Key - Store & Use

### DIFF
--- a/internal/api-key/command.go
+++ b/internal/api-key/command.go
@@ -32,7 +32,7 @@ const (
 	apiKeyNotValidForClusterSuggestions = "Specify the cluster this API key belongs to using the `--resource` flag. Alternatively, first execute the `confluent kafka cluster use` command to set the context to the proper cluster for this key and retry the `confluent api-key store` command."
 	apiKeyUseFailedErrorMsg             = "unable to set active API key"
 	apiKeyUseFailedSuggestions          = "If you did not create this API key with the CLI or created it on another computer, you must first store the API key and secret locally with `confluent api-key store %s <secret>`."
-	nonKafkaNotImplementedErrorMsg      = "functionality not yet available for non-Kafka cluster resources"
+	nonKafkaNotImplementedErrorMsg      = "functionality not yet available for resources other than Kafka clusters and Global API keys"
 	refuseToOverrideSecretSuggestions   = "If you would like to override the existing secret stored for API key \"%s\", use the `--force` flag."
 	unableToStoreApiKeyErrorMsg         = "unable to store API key locally: %w"
 )

--- a/internal/api-key/command_create.go
+++ b/internal/api-key/command_create.go
@@ -171,8 +171,15 @@ func (c *command) create(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	if resourceType == resource.KafkaCluster {
+	switch resourceType {
+	case resource.KafkaCluster:
 		if err := c.keystore.StoreAPIKey(c.V2Client, userKey, resourceId); err != nil {
+			return fmt.Errorf(unableToStoreApiKeyErrorMsg, err)
+		}
+	case resource.Global:
+		// Global keys' secrets are irretrievable after creation, so always store them locally — same
+		// rationale as Kafka cluster keys. The user can still copy the printed secret if they want.
+		if err := c.keystore.StoreGlobalAPIKey(userKey); err != nil {
 			return fmt.Errorf(unableToStoreApiKeyErrorMsg, err)
 		}
 	}
@@ -182,13 +189,23 @@ func (c *command) create(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 	if use {
-		if resourceType != resource.KafkaCluster {
+		switch resourceType {
+		case resource.KafkaCluster:
+			if err := c.useAPIKey(userKey.Key, resourceId); err != nil {
+				return errors.NewWrapErrorWithSuggestions(err, apiKeyUseFailedErrorMsg, fmt.Sprintf(apiKeyUseFailedSuggestions, userKey.Key))
+			}
+			output.Printf(c.Config.EnableColor, useAPIKeyMsg, userKey.Key)
+		case resource.Global:
+			if err := c.Context.SetActiveGlobalAPIKey(userKey.Key); err != nil {
+				return errors.NewWrapErrorWithSuggestions(err, apiKeyUseFailedErrorMsg, fmt.Sprintf(apiKeyUseFailedSuggestions, userKey.Key))
+			}
+			if err := c.Config.Save(); err != nil {
+				return err
+			}
+			output.Printf(c.Config.EnableColor, useGlobalAPIKeyMsg, userKey.Key)
+		default:
 			return fmt.Errorf("`--use` set but ineffective: %s", nonKafkaNotImplementedErrorMsg)
 		}
-		if err := c.useAPIKey(userKey.Key, resourceId); err != nil {
-			return errors.NewWrapErrorWithSuggestions(err, apiKeyUseFailedErrorMsg, fmt.Sprintf(apiKeyUseFailedSuggestions, userKey.Key))
-		}
-		output.Printf(c.Config.EnableColor, useAPIKeyMsg, userKey.Key)
 	}
 
 	return nil

--- a/internal/api-key/command_store.go
+++ b/internal/api-key/command_store.go
@@ -50,12 +50,48 @@ func (c *command) newStoreCommand() *cobra.Command {
 func (c *command) store(cmd *cobra.Command, args []string) error {
 	c.setKeyStoreIfNil()
 
+	key := args[0]
+	secret := args[1]
+
+	force, err := cmd.Flags().GetBool("force")
+	if err != nil {
+		return err
+	}
+
+	// Check if API key exists server-side
+	apiKey, httpResp, err := c.V2Client.GetApiKey(key)
+	if err != nil {
+		return errors.CatchApiKeyForbiddenAccessError(err, getOperation, httpResp)
+	}
+
+	resourceType, clusterId, _, resolveErr := c.resolveResourceId(cmd, c.V2Client)
+	isGlobalKey := apiKey.GetSpec().Resource.GetKind() == "Global"
+
+	// Detect Global API keys by either the explicit --resource global flag or the server-side resource Kind.
+	// Global keys are org-scoped and stored separately from cluster-scoped keys.
+	if resourceType == resource.Global || isGlobalKey {
+		if resourceType == resource.Global && !isGlobalKey {
+			return errors.NewErrorWithSuggestions(
+				fmt.Sprintf("API key %q is not a Global API key", key),
+				"Omit `--resource global`, or pass the correct resource ID.",
+			)
+		}
+		if isGlobalKey && resourceType != "" && resourceType != resource.Global {
+			return errors.NewErrorWithSuggestions(
+				fmt.Sprintf("API key %q is a Global API key, but --resource was set to %q", key, resourceType),
+				"Re-run with `--resource global`, or omit `--resource` to auto-detect.",
+			)
+		}
+		return c.storeGlobal(key, secret, force)
+	}
+
 	var cluster *config.KafkaClusterConfig
 
 	// Attempt to get cluster from --resource flag if set; if that doesn't work,
-	// attempt to fall back to the currently active Kafka cluster
-	resourceType, clusterId, _, err := c.resolveResourceId(cmd, c.V2Client)
-	if err == nil && clusterId != "" {
+	// attempt to fall back to the currently active Kafka cluster.
+	// Preserve historical behavior: if --resource resolution failed, silently fall through to the
+	// active cluster (the cluster/key-mismatch check below will surface real problems).
+	if resolveErr == nil && clusterId != "" {
 		if resourceType != resource.KafkaCluster {
 			return errors.New(nonKafkaNotImplementedErrorMsg)
 		}
@@ -72,20 +108,6 @@ func (c *command) store(cmd *cobra.Command, args []string) error {
 				apiKeyNotValidForClusterSuggestions,
 			)
 		}
-	}
-
-	key := args[0]
-	secret := args[1]
-
-	force, err := cmd.Flags().GetBool("force")
-	if err != nil {
-		return err
-	}
-
-	// Check if API key exists server-side
-	apiKey, httpResp, err := c.V2Client.GetApiKey(key)
-	if err != nil {
-		return errors.CatchApiKeyForbiddenAccessError(err, getOperation, httpResp)
 	}
 
 	apiKeyIsValidForTargetCluster := cluster.GetId() != "" && cluster.GetId() == apiKey.GetSpec().Resource.GetId()
@@ -112,5 +134,19 @@ func (c *command) store(cmd *cobra.Command, args []string) error {
 	}
 
 	output.ErrPrintf(c.Config.EnableColor, "Stored secret for API key \"%s\".\n", key)
+	return nil
+}
+
+func (c *command) storeGlobal(key, secret string, force bool) error {
+	if c.keystore.HasGlobalAPIKey(key) && !force {
+		return errors.NewErrorWithSuggestions(
+			fmt.Sprintf(`refusing to overwrite existing secret for API Key "%s"`, key),
+			fmt.Sprintf(refuseToOverrideSecretSuggestions, key),
+		)
+	}
+	if err := c.keystore.StoreGlobalAPIKey(&config.APIKeyPair{Key: key, Secret: secret}); err != nil {
+		return fmt.Errorf(unableToStoreApiKeyErrorMsg, err)
+	}
+	output.ErrPrintf(c.Config.EnableColor, "Stored secret for Global API key \"%s\".\n", key)
 	return nil
 }

--- a/internal/api-key/command_use.go
+++ b/internal/api-key/command_use.go
@@ -12,7 +12,10 @@ import (
 	"github.com/confluentinc/cli/v4/pkg/resource"
 )
 
-const useAPIKeyMsg = "Using API Key \"%s\".\n"
+const (
+	useAPIKeyMsg       = "Using API Key \"%s\".\n"
+	useGlobalAPIKeyMsg = "Using Global API Key \"%s\".\n"
+)
 
 func (c *command) newUseCommand() *cobra.Command {
 	cmd := &cobra.Command{
@@ -34,6 +37,21 @@ func (c *command) newUseCommand() *cobra.Command {
 func (c *command) use(cmd *cobra.Command, args []string) error {
 	c.setKeyStoreIfNil()
 
+	apiKey := args[0]
+
+	// Global keys are stored on the Context, not on a specific Kafka cluster. Check there first so
+	// `confluent api-key use <global-key>` without --resource works seamlessly.
+	if !cmd.Flags().Changed("resource") && c.Context.HasGlobalAPIKey(apiKey) {
+		if err := c.Context.SetActiveGlobalAPIKey(apiKey); err != nil {
+			return errors.NewWrapErrorWithSuggestions(err, apiKeyUseFailedErrorMsg, fmt.Sprintf(apiKeyUseFailedSuggestions, apiKey))
+		}
+		if err := c.Config.Save(); err != nil {
+			return err
+		}
+		output.Printf(c.Config.EnableColor, useGlobalAPIKeyMsg, apiKey)
+		return nil
+	}
+
 	var clusterId string
 
 	if cmd.Flags().Changed("resource") {
@@ -46,20 +64,20 @@ func (c *command) use(cmd *cobra.Command, args []string) error {
 		}
 		clusterId = resourceId
 	} else {
-		clusterId = c.Context.KafkaClusterContext.FindApiKeyClusterId(args[0])
+		clusterId = c.Context.KafkaClusterContext.FindApiKeyClusterId(apiKey)
 		if clusterId == "" {
 			return errors.NewErrorWithSuggestions(
-				fmt.Sprintf(`API key "%s" and associated Kafka cluster are not stored in local CLI state`, args[0]),
-				fmt.Sprintf(apiKeyUseFailedSuggestions, args[0]),
+				fmt.Sprintf(`API key "%s" and associated Kafka cluster are not stored in local CLI state`, apiKey),
+				fmt.Sprintf(apiKeyUseFailedSuggestions, apiKey),
 			)
 		}
 	}
 
-	if err := c.useAPIKey(args[0], clusterId); err != nil {
-		return errors.NewWrapErrorWithSuggestions(err, apiKeyUseFailedErrorMsg, fmt.Sprintf(apiKeyUseFailedSuggestions, args[0]))
+	if err := c.useAPIKey(apiKey, clusterId); err != nil {
+		return errors.NewWrapErrorWithSuggestions(err, apiKeyUseFailedErrorMsg, fmt.Sprintf(apiKeyUseFailedSuggestions, apiKey))
 	}
 
-	output.Printf(c.Config.EnableColor, useAPIKeyMsg, args[0])
+	output.Printf(c.Config.EnableColor, useAPIKeyMsg, apiKey)
 	return nil
 }
 

--- a/internal/asyncapi/command_export.go
+++ b/internal/asyncapi/command_export.go
@@ -491,12 +491,20 @@ func (c *command) getClusterDetails(details *accountDetails, flags *flags, cmd *
 		}
 		clusterCreds = cluster.APIKeys[flags.kafkaApiKey]
 	} else {
-		clusterCreds = cluster.APIKeys[cluster.APIKey]
+		// No explicit --kafka-api-key: resolve the cluster-scoped active key, falling back to the
+		// active Global API key (see Context.ResolveKafkaAPIKey).
+		apiKey, apiSecret, err := c.Context.ResolveKafkaAPIKey(cluster)
+		if err != nil {
+			return err
+		}
+		if apiKey != "" {
+			clusterCreds = &config.APIKeyPair{Key: apiKey, Secret: apiSecret}
+		}
 	}
 	if clusterCreds == nil {
 		return errors.NewErrorWithSuggestions(
 			"API key not set for the Kafka cluster",
-			"Set an API key pair for the Kafka cluster using `confluent api-key create --resource <cluster-id>` and then use it with `--kafka-api-key`.",
+			"Set an API key pair for the Kafka cluster using `confluent api-key create --resource <cluster-id>` and then use it with `--kafka-api-key`, or set an active Global API key with `confluent api-key use`.",
 		)
 	}
 

--- a/internal/kafka/command_clientconfig_create.go
+++ b/internal/kafka/command_clientconfig_create.go
@@ -179,7 +179,7 @@ func (c *clientConfigCommand) setKafkaCluster(cmd *cobra.Command, configFile str
 		return "", err
 	}
 
-	if err := addApiKeyToCluster(cmd, kafkaCluster); err != nil {
+	if err := addApiKeyToCluster(cmd, c.Context, kafkaCluster); err != nil {
 		return "", err
 	}
 
@@ -200,11 +200,16 @@ func (c *clientConfigCommand) setKafkaCluster(cmd *cobra.Command, configFile str
 		}
 	}
 
+	apiKey, apiSecret, err := c.Context.ResolveKafkaAPIKey(kafkaCluster)
+	if err != nil {
+		return "", err
+	}
+
 	// replace BROKER_ENDPOINT, CLUSTER_API_KEY, and CLUSTER_API_SECRET templates
 	configFile = replaceTemplates(configFile, map[string]string{
 		brokerEndpointTemplate:   kafkaCluster.Bootstrap,
-		clusterApiKeyTemplate:    kafkaCluster.APIKey,
-		clusterApiSecretTemplate: kafkaCluster.GetApiSecret(),
+		clusterApiKeyTemplate:    apiKey,
+		clusterApiSecretTemplate: apiSecret,
 	})
 	return configFile, nil
 }
@@ -283,7 +288,7 @@ func (c *clientConfigCommand) getSchemaRegistryCluster() (*srcmv3.SrcmV3Cluster,
 }
 
 func (c *clientConfigCommand) validateKafkaCredentials(kafkaCluster *config.KafkaClusterConfig) error {
-	configMap, err := getCommonConfig(kafkaCluster, c.clientId)
+	configMap, err := getCommonConfig(c.Context, kafkaCluster, c.clientId)
 	if err != nil {
 		return err
 	}

--- a/internal/kafka/command_topic.go
+++ b/internal/kafka/command_topic.go
@@ -173,7 +173,7 @@ func (c *command) prepareAnonymousContext(cmd *cobra.Command) error {
 	return nil
 }
 
-func addApiKeyToCluster(cmd *cobra.Command, cluster *config.KafkaClusterConfig) error {
+func addApiKeyToCluster(cmd *cobra.Command, ctx *config.Context, cluster *config.KafkaClusterConfig) error {
 	apiKey, err := cmd.Flags().GetString("api-key")
 	if err != nil {
 		return err
@@ -190,6 +190,12 @@ func addApiKeyToCluster(cmd *cobra.Command, cluster *config.KafkaClusterConfig) 
 			Key:    apiKey,
 			Secret: apiSecret,
 		}
+	}
+
+	// If the cluster has no scoped API key, accept an active Global API key as a fallback. The Kafka
+	// REST/admin path will resolve credentials via Context.ResolveKafkaAPIKey() downstream.
+	if cluster.APIKey == "" && ctx.GetActiveGlobalAPIKey() != "" {
+		return nil
 	}
 
 	if cluster.APIKey == "" {

--- a/internal/kafka/command_topic_consume.go
+++ b/internal/kafka/command_topic_consume.go
@@ -127,7 +127,7 @@ func (c *command) consumeCloud(cmd *cobra.Command, args []string) error {
 		cluster.Bootstrap = bootstrap
 	}
 
-	if err := addApiKeyToCluster(cmd, cluster); err != nil {
+	if err := addApiKeyToCluster(cmd, c.Context, cluster); err != nil {
 		return err
 	}
 
@@ -193,7 +193,7 @@ func (c *command) consumeCloud(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	consumer, err := newConsumer(group, cluster, c.clientID, configFile, config)
+	consumer, err := newConsumer(group, c.Context, cluster, c.clientID, configFile, config)
 	if err != nil {
 		return fmt.Errorf(errors.FailedToCreateConsumerErrorMsg, err)
 	}

--- a/internal/kafka/command_topic_produce.go
+++ b/internal/kafka/command_topic_produce.go
@@ -143,7 +143,7 @@ func (c *command) produceCloud(cmd *cobra.Command, args []string) error {
 		cluster.Bootstrap = bootstrap
 	}
 
-	if err := addApiKeyToCluster(cmd, cluster); err != nil {
+	if err := addApiKeyToCluster(cmd, c.Context, cluster); err != nil {
 		return err
 	}
 
@@ -184,7 +184,7 @@ func (c *command) produceCloud(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	producer, err := newProducer(cluster, c.clientID, configFile, config)
+	producer, err := newProducer(c.Context, cluster, c.clientID, configFile, config)
 	if err != nil {
 		return fmt.Errorf(errors.FailedToCreateProducerErrorMsg, err)
 	}

--- a/internal/kafka/confluent_kafka.go
+++ b/internal/kafka/confluent_kafka.go
@@ -161,8 +161,8 @@ func (c *command) retrieveUnsecuredToken(e ckgo.OAuthBearerTokenRefresh) (ckgo.O
 	return oauthBearerToken, nil
 }
 
-func newProducer(kafka *config.KafkaClusterConfig, clientID, configPath string, configStrings []string) (*ckgo.Producer, error) {
-	configMap, err := getProducerConfigMap(kafka, clientID)
+func newProducer(ctx *config.Context, kafka *config.KafkaClusterConfig, clientID, configPath string, configStrings []string) (*ckgo.Producer, error) {
+	configMap, err := getProducerConfigMap(ctx, kafka, clientID)
 	if err != nil {
 		return nil, fmt.Errorf(errors.FailedToGetConfigurationErrorMsg, err)
 	}
@@ -170,8 +170,8 @@ func newProducer(kafka *config.KafkaClusterConfig, clientID, configPath string, 
 	return newProducerWithOverwrittenConfigs(configMap, configPath, configStrings)
 }
 
-func newConsumer(group string, kafka *config.KafkaClusterConfig, clientID, configPath string, configStrings []string) (*ckgo.Consumer, error) {
-	configMap, err := getConsumerConfigMap(group, kafka, clientID)
+func newConsumer(group string, ctx *config.Context, kafka *config.KafkaClusterConfig, clientID, configPath string, configStrings []string) (*ckgo.Consumer, error) {
+	configMap, err := getConsumerConfigMap(group, ctx, kafka, clientID)
 	if err != nil {
 		return nil, fmt.Errorf(errors.FailedToGetConfigurationErrorMsg, err)
 	}

--- a/internal/kafka/confluent_kafka_configs.go
+++ b/internal/kafka/confluent_kafka_configs.go
@@ -27,8 +27,13 @@ type PartitionFilter struct {
 	Index   int32
 }
 
-func getCommonConfig(kafka *config.KafkaClusterConfig, clientId string) (*ckgo.ConfigMap, error) {
+func getCommonConfig(ctx *config.Context, kafka *config.KafkaClusterConfig, clientId string) (*ckgo.ConfigMap, error) {
 	if err := kafka.DecryptAPIKeys(); err != nil {
+		return nil, err
+	}
+
+	apiKey, apiSecret, err := ctx.ResolveKafkaAPIKey(kafka)
+	if err != nil {
 		return nil, err
 	}
 
@@ -38,15 +43,15 @@ func getCommonConfig(kafka *config.KafkaClusterConfig, clientId string) (*ckgo.C
 		"ssl.endpoint.identification.algorithm": "https",
 		"client.id":                             clientId,
 		"bootstrap.servers":                     kafka.Bootstrap,
-		"sasl.username":                         kafka.APIKey,
-		"sasl.password":                         kafka.GetApiSecret(),
+		"sasl.username":                         apiKey,
+		"sasl.password":                         apiSecret,
 	}
 
 	return configMap, nil
 }
 
-func getProducerConfigMap(kafka *config.KafkaClusterConfig, clientID string) (*ckgo.ConfigMap, error) {
-	configMap, err := getCommonConfig(kafka, clientID)
+func getProducerConfigMap(ctx *config.Context, kafka *config.KafkaClusterConfig, clientID string) (*ckgo.ConfigMap, error) {
+	configMap, err := getCommonConfig(ctx, kafka, clientID)
 	if err != nil {
 		return nil, err
 	}
@@ -62,8 +67,8 @@ func getProducerConfigMap(kafka *config.KafkaClusterConfig, clientID string) (*c
 	return configMap, nil
 }
 
-func getConsumerConfigMap(group string, kafka *config.KafkaClusterConfig, clientID string) (*ckgo.ConfigMap, error) {
-	configMap, err := getCommonConfig(kafka, clientID)
+func getConsumerConfigMap(group string, ctx *config.Context, kafka *config.KafkaClusterConfig, clientID string) (*ckgo.ConfigMap, error) {
+	configMap, err := getCommonConfig(ctx, kafka, clientID)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -119,6 +119,7 @@ func SetupTestInputs(isCloud bool) *TestInputs {
 		CurrentEnvironment: environmentId,
 		Environments:       map[string]*EnvironmentContext{environmentId: {}},
 		State:              regularOrgContextState,
+		GlobalAPIKeys:      map[string]*APIKeyPair{},
 	}
 	statelessContext := &Context{
 		Name:           contextName,
@@ -129,6 +130,7 @@ func SetupTestInputs(isCloud bool) *TestInputs {
 		Environments:   map[string]*EnvironmentContext{},
 		State:          &ContextState{},
 		Config:         &Config{SavedCredentials: savedCredentials},
+		GlobalAPIKeys:  map[string]*APIKeyPair{},
 	}
 	twoEnvStatefulContext := &Context{
 		Name:               contextName,
@@ -141,7 +143,8 @@ func SetupTestInputs(isCloud bool) *TestInputs {
 			"env-123456": {},
 			"env-flag":   {},
 		},
-		State: regularOrgContextState,
+		State:         regularOrgContextState,
+		GlobalAPIKeys: map[string]*APIKeyPair{},
 	}
 	context := "onprem"
 	if isCloud {

--- a/pkg/config/context.go
+++ b/pkg/config/context.go
@@ -591,6 +591,9 @@ func (c *Context) HasGlobalAPIKey(key string) bool {
 // StoreGlobalAPIKey inserts a Global API key pair into the org-level keystore and encrypts it.
 // Callers must persist the Context (Config.Save) after this returns.
 func (c *Context) StoreGlobalAPIKey(pair *APIKeyPair) error {
+	if pair == nil || pair.Key == "" || pair.Secret == "" {
+		return fmt.Errorf("Global API key pair must include both key and secret")
+	}
 	if c.GlobalAPIKeys == nil {
 		c.GlobalAPIKeys = map[string]*APIKeyPair{}
 	}
@@ -634,16 +637,20 @@ func (c *Context) GetActiveGlobalAPIKeyPair() *APIKeyPair {
 }
 
 // ResolveKafkaAPIKey returns the API key/secret to use against the given Kafka cluster: prefer the
-// cluster-scoped active key, falling back to the active Global key. Returned secret is decrypted.
-// Returns ("", "", nil) if neither is set.
+// cluster-scoped active key, falling back to the active Global key only when no cluster-scoped key is
+// set. Returned secret is decrypted. Returns ("", "", nil) if neither is set, and an error if the
+// cluster's active key is set but its secret is missing locally (a broken cluster-scoped config that
+// must not be silently masked by the Global fallback).
 func (c *Context) ResolveKafkaAPIKey(kcc *KafkaClusterConfig) (string, string, error) {
 	if kcc != nil && kcc.APIKey != "" {
-		if pair, ok := kcc.APIKeys[kcc.APIKey]; ok {
-			if err := pair.DecryptSecret(); err != nil {
-				return "", "", err
-			}
-			return pair.Key, pair.Secret, nil
+		pair, ok := kcc.APIKeys[kcc.APIKey]
+		if !ok {
+			return "", "", fmt.Errorf("current Kafka API key %q is set for cluster %q but no secret is stored locally", kcc.APIKey, kcc.ID)
 		}
+		if err := pair.DecryptSecret(); err != nil {
+			return "", "", err
+		}
+		return pair.Key, pair.Secret, nil
 	}
 	if pair := c.GetActiveGlobalAPIKeyPair(); pair != nil {
 		if err := pair.DecryptSecret(); err != nil {

--- a/pkg/config/context.go
+++ b/pkg/config/context.go
@@ -26,6 +26,11 @@ type Context struct {
 	LastOrgId           string                         `json:"last_org_id,omitempty"`
 	FeatureFlags        *FeatureFlags                  `json:"feature_flags,omitempty"`
 	IsMFA               bool                           `json:"is_mfa,omitempty"`
+	// GlobalAPIKeys stores org-scoped (Global) API key pairs that are not tied to a single resource.
+	GlobalAPIKeys map[string]*APIKeyPair `json:"global_api_keys,omitempty"`
+	// ActiveGlobalAPIKey is the Global API key chosen via `confluent api-key use`; used as a fallback when no
+	// resource-scoped API key is set on the active cluster.
+	ActiveGlobalAPIKey string `json:"active_global_api_key,omitempty"`
 
 	// Deprecated
 	NetrcMachineName       string                            `json:"netrc_machine_name,omitempty"`
@@ -78,8 +83,53 @@ func (c *Context) validate() error {
 	if c.State == nil {
 		c.State = new(ContextState)
 	}
+	if c.GlobalAPIKeys == nil {
+		c.GlobalAPIKeys = map[string]*APIKeyPair{}
+	}
+	c.validateGlobalAPIKeys()
 	c.KafkaClusterContext.Validate()
 	return nil
+}
+
+func (c *Context) validateGlobalAPIKeys() {
+	missingKey := false
+	mismatchKey := false
+	missingSecret := false
+	for key, pair := range c.GlobalAPIKeys {
+		if pair == nil || pair.Key == "" {
+			delete(c.GlobalAPIKeys, key)
+			missingKey = true
+			continue
+		}
+		if key != pair.Key {
+			delete(c.GlobalAPIKeys, key)
+			mismatchKey = true
+			continue
+		}
+		if pair.Secret == "" {
+			delete(c.GlobalAPIKeys, key)
+			missingSecret = true
+		}
+	}
+	if missingKey || mismatchKey || missingSecret {
+		var problems []string
+		if missingKey {
+			problems = append(problems, "API key missing")
+		}
+		if mismatchKey {
+			problems = append(problems, "key of the dictionary does not match API key of the pair")
+		}
+		if missingSecret {
+			problems = append(problems, "API secret missing")
+		}
+		output.ErrPrintf(false, "There are malformed Global API key pair entries under context \"%s\". Issues: %s. Deleting the malformed entries.\n", c.Name, strings.Join(problems, ", "))
+	}
+	if c.ActiveGlobalAPIKey != "" {
+		if _, ok := c.GlobalAPIKeys[c.ActiveGlobalAPIKey]; !ok {
+			output.ErrPrintf(false, "Active Global API key \"%s\" has no info stored for context \"%s\". Removing active setting.\n", c.ActiveGlobalAPIKey, c.Name)
+			c.ActiveGlobalAPIKey = ""
+		}
+	}
 }
 
 func (c *Context) Save() error {
@@ -507,6 +557,101 @@ func printApiKeysDictErrorMessage(missingKey, mismatchKey, missingSecret bool, c
 	output.ErrPrintf(false, "The issues are the following: %s.\n", strings.Join(problems, ", "))
 	output.ErrPrintln(false, "Deleting the malformed entries.")
 	output.ErrPrintf(false, "You can re-add the API key pair with `confluent api-key store --resource %s`\n", cluster.ID)
+}
+
+// EncryptGlobalAPIKeys encrypts every stored Global API key secret in place. Idempotent: pairs that are
+// already encrypted are skipped (matching APIKeyPair.EncryptSecret semantics).
+func (c *Context) EncryptGlobalAPIKeys() error {
+	for _, pair := range c.GlobalAPIKeys {
+		if err := pair.EncryptSecret(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// DecryptGlobalAPIKeys decrypts every stored Global API key secret in place.
+func (c *Context) DecryptGlobalAPIKeys() error {
+	for _, pair := range c.GlobalAPIKeys {
+		if err := pair.DecryptSecret(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *Context) HasGlobalAPIKey(key string) bool {
+	if c == nil || c.GlobalAPIKeys == nil {
+		return false
+	}
+	_, ok := c.GlobalAPIKeys[key]
+	return ok
+}
+
+// StoreGlobalAPIKey inserts a Global API key pair into the org-level keystore and encrypts it.
+// Callers must persist the Context (Config.Save) after this returns.
+func (c *Context) StoreGlobalAPIKey(pair *APIKeyPair) error {
+	if c.GlobalAPIKeys == nil {
+		c.GlobalAPIKeys = map[string]*APIKeyPair{}
+	}
+	c.GlobalAPIKeys[pair.Key] = pair
+	return c.EncryptGlobalAPIKeys()
+}
+
+func (c *Context) DeleteGlobalAPIKey(key string) {
+	if c == nil || c.GlobalAPIKeys == nil {
+		return
+	}
+	delete(c.GlobalAPIKeys, key)
+	if c.ActiveGlobalAPIKey == key {
+		c.ActiveGlobalAPIKey = ""
+	}
+}
+
+func (c *Context) GetActiveGlobalAPIKey() string {
+	if c == nil {
+		return ""
+	}
+	return c.ActiveGlobalAPIKey
+}
+
+// SetActiveGlobalAPIKey selects the given key as the active Global key. Returns an error if the key
+// is not stored locally.
+func (c *Context) SetActiveGlobalAPIKey(key string) error {
+	if !c.HasGlobalAPIKey(key) {
+		return fmt.Errorf("Global API key %q is not stored in local CLI state", key)
+	}
+	c.ActiveGlobalAPIKey = key
+	return nil
+}
+
+// GetActiveGlobalAPIKeyPair returns the active Global API key pair, or nil if none is set.
+func (c *Context) GetActiveGlobalAPIKeyPair() *APIKeyPair {
+	if c == nil || c.ActiveGlobalAPIKey == "" {
+		return nil
+	}
+	return c.GlobalAPIKeys[c.ActiveGlobalAPIKey]
+}
+
+// ResolveKafkaAPIKey returns the API key/secret to use against the given Kafka cluster: prefer the
+// cluster-scoped active key, falling back to the active Global key. Returned secret is decrypted.
+// Returns ("", "", nil) if neither is set.
+func (c *Context) ResolveKafkaAPIKey(kcc *KafkaClusterConfig) (string, string, error) {
+	if kcc != nil && kcc.APIKey != "" {
+		if pair, ok := kcc.APIKeys[kcc.APIKey]; ok {
+			if err := pair.DecryptSecret(); err != nil {
+				return "", "", err
+			}
+			return pair.Key, pair.Secret, nil
+		}
+	}
+	if pair := c.GetActiveGlobalAPIKeyPair(); pair != nil {
+		if err := pair.DecryptSecret(); err != nil {
+			return "", "", err
+		}
+		return pair.Key, pair.Secret, nil
+	}
+	return "", "", nil
 }
 
 func (c *Context) ParseFlagsIntoContext(cmd *cobra.Command) error {

--- a/pkg/config/context_test.go
+++ b/pkg/config/context_test.go
@@ -202,3 +202,32 @@ func TestContext_ValidateGlobalAPIKeys_RemovesOrphanedActive(t *testing.T) {
 	ctx.validateGlobalAPIKeys()
 	require.Empty(t, ctx.ActiveGlobalAPIKey, "validate should clear active key when not present in map")
 }
+
+func TestContext_StoreGlobalAPIKey_RejectsIncompletePair(t *testing.T) {
+	ctx := getBaseContext()
+
+	require.Error(t, ctx.StoreGlobalAPIKey(nil), "nil pair should be rejected")
+	require.Error(t, ctx.StoreGlobalAPIKey(&APIKeyPair{Secret: "secret-only"}), "missing key should be rejected")
+	require.Error(t, ctx.StoreGlobalAPIKey(&APIKeyPair{Key: "key-only"}), "missing secret should be rejected")
+
+	// A malformed pair must not be persisted.
+	require.False(t, ctx.HasGlobalAPIKey("key-only"))
+	require.Empty(t, ctx.GlobalAPIKeys)
+}
+
+func TestContext_ResolveKafkaAPIKey_ErrorsWhenClusterSecretMissing(t *testing.T) {
+	ctx := getBaseContext()
+
+	// Cluster has an active key set, but its secret is not stored locally.
+	kcc := ctx.KafkaClusterContext.GetActiveKafkaClusterConfig()
+	require.NotNil(t, kcc)
+	kcc.APIKey = "CLUSTER-KEY"
+	kcc.APIKeys = map[string]*APIKeyPair{}
+
+	// A usable Global key exists, but it must NOT be silently used to mask the broken cluster config.
+	require.NoError(t, ctx.StoreGlobalAPIKey(&APIKeyPair{Key: "GLOBAL-KEY", Secret: "global-secret"}))
+	require.NoError(t, ctx.SetActiveGlobalAPIKey("GLOBAL-KEY"))
+
+	_, _, err := ctx.ResolveKafkaAPIKey(kcc)
+	require.Error(t, err, "should surface the broken cluster-scoped config rather than fall back to Global")
+}

--- a/pkg/config/context_test.go
+++ b/pkg/config/context_test.go
@@ -215,6 +215,58 @@ func TestContext_StoreGlobalAPIKey_RejectsIncompletePair(t *testing.T) {
 	require.Empty(t, ctx.GlobalAPIKeys)
 }
 
+func TestContext_ValidateGlobalAPIKeys_DeletesMalformedEntries(t *testing.T) {
+	ctx := getBaseContext()
+	ctx.GlobalAPIKeys = map[string]*APIKeyPair{
+		"nil-pair":  nil,                            // missing key (nil pair)
+		"empty-key": {Key: "", Secret: "s"},         // missing key (empty Key)
+		"MISMATCH":  {Key: "OTHER", Secret: "s"},    // key/pair mismatch
+		"NO-SECRET": {Key: "NO-SECRET", Secret: ""}, // missing secret
+		"GOOD":      {Key: "GOOD", Secret: "s"},     // valid, must survive
+	}
+
+	ctx.validateGlobalAPIKeys()
+
+	require.Len(t, ctx.GlobalAPIKeys, 1)
+	require.True(t, ctx.HasGlobalAPIKey("GOOD"))
+	require.False(t, ctx.HasGlobalAPIKey("nil-pair"))
+	require.False(t, ctx.HasGlobalAPIKey("empty-key"))
+	require.False(t, ctx.HasGlobalAPIKey("MISMATCH"))
+	require.False(t, ctx.HasGlobalAPIKey("NO-SECRET"))
+}
+
+func TestContext_EncryptDecryptGlobalAPIKeys(t *testing.T) {
+	ctx := getBaseContext()
+	ctx.GlobalAPIKeys = map[string]*APIKeyPair{"K": {Key: "K", Secret: "plain-secret"}}
+
+	require.NoError(t, ctx.EncryptGlobalAPIKeys())
+	require.NotEqual(t, "plain-secret", ctx.GlobalAPIKeys["K"].Secret, "secret should be encrypted in place")
+
+	require.NoError(t, ctx.DecryptGlobalAPIKeys())
+	require.Equal(t, "plain-secret", ctx.GlobalAPIKeys["K"].Secret, "secret should round-trip back to plaintext")
+}
+
+func TestContext_GlobalAPIKey_NilAndEmptyReceiverSafety(t *testing.T) {
+	var nilCtx *Context
+	require.False(t, nilCtx.HasGlobalAPIKey("x"))
+	require.Empty(t, nilCtx.GetActiveGlobalAPIKey())
+	require.Nil(t, nilCtx.GetActiveGlobalAPIKeyPair())
+	require.NotPanics(t, func() { nilCtx.DeleteGlobalAPIKey("x") })
+
+	// Non-nil context with no active key set: GetActiveGlobalAPIKeyPair returns nil.
+	ctx := getBaseContext()
+	require.Empty(t, ctx.GetActiveGlobalAPIKey())
+	require.Nil(t, ctx.GetActiveGlobalAPIKeyPair())
+
+	// Deleting a key that isn't present is a no-op and does not panic.
+	require.NotPanics(t, func() { ctx.DeleteGlobalAPIKey("not-stored") })
+
+	// StoreGlobalAPIKey lazily initializes a nil map.
+	ctx.GlobalAPIKeys = nil
+	require.NoError(t, ctx.StoreGlobalAPIKey(&APIKeyPair{Key: "K", Secret: "s"}))
+	require.True(t, ctx.HasGlobalAPIKey("K"))
+}
+
 func TestContext_ResolveKafkaAPIKey_ErrorsWhenClusterSecretMissing(t *testing.T) {
 	ctx := getBaseContext()
 

--- a/pkg/config/context_test.go
+++ b/pkg/config/context_test.go
@@ -111,3 +111,94 @@ func getEnvAndClusterFlagContext() *Context {
 
 	return ctx
 }
+
+func TestContext_GlobalAPIKeyStorage(t *testing.T) {
+	ctx := getBaseContext()
+	require.NotNil(t, ctx.GlobalAPIKeys, "validate() should initialize GlobalAPIKeys")
+
+	pair := &APIKeyPair{Key: "GLOBAL-KEY-1", Secret: "plain-secret"}
+	require.NoError(t, ctx.StoreGlobalAPIKey(pair))
+
+	require.True(t, ctx.HasGlobalAPIKey("GLOBAL-KEY-1"))
+	require.False(t, ctx.HasGlobalAPIKey("missing"))
+
+	// After Store, the secret is encrypted in place. Resolve must decrypt it.
+	stored := ctx.GlobalAPIKeys["GLOBAL-KEY-1"]
+	require.NotEqual(t, "plain-secret", stored.Secret, "secret should be encrypted at rest")
+
+	require.NoError(t, ctx.SetActiveGlobalAPIKey("GLOBAL-KEY-1"))
+	require.Equal(t, "GLOBAL-KEY-1", ctx.GetActiveGlobalAPIKey())
+
+	// SetActiveGlobalAPIKey must reject keys that aren't stored.
+	require.Error(t, ctx.SetActiveGlobalAPIKey("unknown-key"))
+}
+
+func TestContext_ResolveKafkaAPIKey_PrefersClusterScoped(t *testing.T) {
+	ctx := getBaseContext()
+
+	// Pre-populate a cluster-scoped key on the active cluster.
+	kcc := ctx.KafkaClusterContext.GetActiveKafkaClusterConfig()
+	require.NotNil(t, kcc)
+	clusterKey := &APIKeyPair{Key: "CLUSTER-KEY", Secret: "cluster-secret"}
+	require.NoError(t, clusterKey.EncryptSecret())
+	kcc.APIKeys = map[string]*APIKeyPair{"CLUSTER-KEY": clusterKey}
+	kcc.APIKey = "CLUSTER-KEY"
+
+	// Also set up a global key + active marker.
+	require.NoError(t, ctx.StoreGlobalAPIKey(&APIKeyPair{Key: "GLOBAL-KEY", Secret: "global-secret"}))
+	require.NoError(t, ctx.SetActiveGlobalAPIKey("GLOBAL-KEY"))
+
+	key, secret, err := ctx.ResolveKafkaAPIKey(kcc)
+	require.NoError(t, err)
+	require.Equal(t, "CLUSTER-KEY", key)
+	require.Equal(t, "cluster-secret", secret)
+}
+
+func TestContext_ResolveKafkaAPIKey_FallsBackToGlobal(t *testing.T) {
+	ctx := getBaseContext()
+
+	kcc := ctx.KafkaClusterContext.GetActiveKafkaClusterConfig()
+	require.NotNil(t, kcc)
+	kcc.APIKey = ""
+	kcc.APIKeys = map[string]*APIKeyPair{}
+
+	require.NoError(t, ctx.StoreGlobalAPIKey(&APIKeyPair{Key: "GLOBAL-KEY", Secret: "global-secret"}))
+	require.NoError(t, ctx.SetActiveGlobalAPIKey("GLOBAL-KEY"))
+
+	key, secret, err := ctx.ResolveKafkaAPIKey(kcc)
+	require.NoError(t, err)
+	require.Equal(t, "GLOBAL-KEY", key)
+	require.Equal(t, "global-secret", secret)
+}
+
+func TestContext_ResolveKafkaAPIKey_NoCredentialsConfigured(t *testing.T) {
+	ctx := getBaseContext()
+	kcc := ctx.KafkaClusterContext.GetActiveKafkaClusterConfig()
+	require.NotNil(t, kcc)
+	kcc.APIKey = ""
+	kcc.APIKeys = map[string]*APIKeyPair{}
+
+	key, secret, err := ctx.ResolveKafkaAPIKey(kcc)
+	require.NoError(t, err)
+	require.Empty(t, key)
+	require.Empty(t, secret)
+}
+
+func TestContext_DeleteGlobalAPIKey_ClearsActive(t *testing.T) {
+	ctx := getBaseContext()
+	require.NoError(t, ctx.StoreGlobalAPIKey(&APIKeyPair{Key: "GLOBAL-KEY", Secret: "global-secret"}))
+	require.NoError(t, ctx.SetActiveGlobalAPIKey("GLOBAL-KEY"))
+
+	ctx.DeleteGlobalAPIKey("GLOBAL-KEY")
+
+	require.False(t, ctx.HasGlobalAPIKey("GLOBAL-KEY"))
+	require.Empty(t, ctx.GetActiveGlobalAPIKey(), "deleting active key should clear ActiveGlobalAPIKey")
+}
+
+func TestContext_ValidateGlobalAPIKeys_RemovesOrphanedActive(t *testing.T) {
+	ctx := getBaseContext()
+	// Active key references a pair that doesn't exist in the map.
+	ctx.ActiveGlobalAPIKey = "ghost-key"
+	ctx.validateGlobalAPIKeys()
+	require.Empty(t, ctx.ActiveGlobalAPIKey, "validate should clear active key when not present in map")
+}

--- a/pkg/keystore/keystore.go
+++ b/pkg/keystore/keystore.go
@@ -36,6 +36,22 @@ func (c *ConfigKeyStore) StoreAPIKey(client *ccloudv2.Client, key *config.APIKey
 }
 
 func (c *ConfigKeyStore) DeleteAPIKey(key string) error {
-	c.Config.Context().KafkaClusterContext.DeleteApiKey(key)
+	ctx := c.Config.Context()
+	ctx.KafkaClusterContext.DeleteApiKey(key)
+	ctx.DeleteGlobalAPIKey(key)
+	return c.Config.Save()
+}
+
+// HasGlobalAPIKey reports whether a Global API key with the given id is stored locally.
+func (c *ConfigKeyStore) HasGlobalAPIKey(key string) bool {
+	return c.Config.Context().HasGlobalAPIKey(key)
+}
+
+// StoreGlobalAPIKey persists a Global API key pair on the active context. The secret is encrypted
+// at rest, matching the behavior of StoreAPIKey for cluster-scoped keys.
+func (c *ConfigKeyStore) StoreGlobalAPIKey(pair *config.APIKeyPair) error {
+	if err := c.Config.Context().StoreGlobalAPIKey(pair); err != nil {
+		return err
+	}
 	return c.Config.Save()
 }

--- a/test/api_key_test.go
+++ b/test/api_key_test.go
@@ -196,6 +196,18 @@ func (s *CLITestSuite) TestApiKeyGlobal() {
 
 		// guard: a cluster --resource on a Global key is rejected
 		{args: "api-key store UIGLOBALKEY100 NEWSECRET --resource lkc-cool1", fixture: "api-key/global/store-resource-mismatch-error.golden", exitCode: 1},
+
+		// create a Global key with --use: stores it locally and sets it as the active Global key
+		{
+			args: "api-key create --description created-and-used --resource global --use", fixture: "api-key/global/create-use.golden",
+			wantFunc: func(t *testing.T) {
+				cfg := config.New()
+				require.NoError(t, cfg.Load())
+				ctx := cfg.Context()
+				require.NotNil(t, ctx)
+				require.NotEmpty(t, ctx.GetActiveGlobalAPIKey(), "create --use should set an active Global key")
+			},
+		},
 	}
 
 	resetConfiguration(s.T(), false)

--- a/test/api_key_test.go
+++ b/test/api_key_test.go
@@ -156,6 +156,56 @@ func (s *CLITestSuite) TestApiKey() {
 	}
 }
 
+func (s *CLITestSuite) TestApiKeyGlobal() {
+	tests := []CLITest{
+		// store a Global API key: auto-detected from the server-side resource Kind (no --resource needed)
+		{args: "api-key store UIGLOBALKEY100 UIGLOBALSECRET100", login: "cloud", fixture: "api-key/global/store.golden"},
+
+		// storing again without --force is refused
+		{args: "api-key store UIGLOBALKEY100 NEWSECRET", fixture: "api-key/global/store-override-error.golden", exitCode: 1},
+
+		// --force overwrites the stored secret
+		{
+			args: "api-key store UIGLOBALKEY100 NEWSECRET --force", fixture: "api-key/global/store-force.golden",
+			wantFunc: func(t *testing.T) {
+				cfg := config.New()
+				require.NoError(t, cfg.Load())
+				ctx := cfg.Context()
+				require.NotNil(t, ctx)
+				require.NoError(t, ctx.DecryptGlobalAPIKeys())
+				pair := ctx.GlobalAPIKeys["UIGLOBALKEY100"]
+				require.NotNil(t, pair)
+				require.Equal(t, "NEWSECRET", pair.Secret)
+			},
+		},
+
+		// use the stored Global key as the active Global key
+		{
+			args: "api-key use UIGLOBALKEY100", fixture: "api-key/global/use.golden",
+			wantFunc: func(t *testing.T) {
+				cfg := config.New()
+				require.NoError(t, cfg.Load())
+				ctx := cfg.Context()
+				require.NotNil(t, ctx)
+				require.Equal(t, "UIGLOBALKEY100", ctx.GetActiveGlobalAPIKey())
+			},
+		},
+
+		// guard: --resource global on a non-Global (cluster) key is rejected
+		{args: "api-key store UIAPIKEY100 UIAPISECRET100 --resource global", fixture: "api-key/global/store-not-global-error.golden", exitCode: 1},
+
+		// guard: a cluster --resource on a Global key is rejected
+		{args: "api-key store UIGLOBALKEY100 NEWSECRET --resource lkc-cool1", fixture: "api-key/global/store-resource-mismatch-error.golden", exitCode: 1},
+	}
+
+	resetConfiguration(s.T(), false)
+
+	for _, test := range tests {
+		test.workflow = true
+		s.runIntegrationTest(test)
+	}
+}
+
 func (s *CLITestSuite) TestApiKeyCreate() {
 	tests := []CLITest{
 		{args: "api-key create --resource flink --cloud aws --region us-east-1", fixture: "api-key/create-flink.golden"},

--- a/test/asyncapi_test.go
+++ b/test/asyncapi_test.go
@@ -13,6 +13,10 @@ func (s *CLITestSuite) TestAsyncapiExport() {
 	tests := []CLITest{
 		{args: "asyncapi export", exitCode: 1, fixture: "asyncapi/no-kafka.golden"},
 		{args: "environment use " + testserver.SRApiEnvId},
+		// Global API key fallback: with only an active Global key and no cluster-scoped key, export succeeds.
+		{args: "api-key store UIGLOBALKEY100 UIGLOBALSECRET100"},
+		{args: "api-key use UIGLOBALKEY100"},
+		{args: "asyncapi export", fixture: "asyncapi/export-success.golden", useKafka: "lkc-asyncapi"},
 		// Spec Generated
 		{args: "asyncapi export", fixture: "asyncapi/export-success.golden", useKafka: "lkc-asyncapi", authKafka: true},
 		{args: "asyncapi export --schema-context dev --file asyncapi-with-context.yaml", useKafka: "lkc-asyncapi", authKafka: true},

--- a/test/fixtures/output/api-key/30.golden
+++ b/test/fixtures/output/api-key/30.golden
@@ -18,3 +18,4 @@
           | UIAPIKEY101        |                                | u-22bbb  | u-22bbb@confluent.io  | kafka           | lkc-other1   | 1999-02-24T00:00:00Z  
           | UIAPIKEY102        |                                | u-22bbb  | u-22bbb@confluent.io  | ksql            | lksqlc-ksql1 | 1999-02-24T00:00:00Z  
           | UIAPIKEY103        |                                | u-22bbb  | u-22bbb@confluent.io  | kafka           | lkc-cool1    | 1999-02-24T00:00:00Z  
+          | UIGLOBALKEY100     |                                | u-22bbb  | u-22bbb@confluent.io  | global          |              | 1999-02-24T00:00:00Z  

--- a/test/fixtures/output/api-key/33.golden
+++ b/test/fixtures/output/api-key/33.golden
@@ -19,3 +19,4 @@
           | UIAPIKEY101        |                                | u-22bbb  | u-22bbb@confluent.io  | kafka           | lkc-other1   | 1999-02-24T00:00:00Z  
           | UIAPIKEY102        |                                | u-22bbb  | u-22bbb@confluent.io  | ksql            | lksqlc-ksql1 | 1999-02-24T00:00:00Z  
           | UIAPIKEY103        |                                | u-22bbb  | u-22bbb@confluent.io  | kafka           | lkc-cool1    | 1999-02-24T00:00:00Z  
+          | UIGLOBALKEY100     |                                | u-22bbb  | u-22bbb@confluent.io  | global          |              | 1999-02-24T00:00:00Z  

--- a/test/fixtures/output/api-key/41.golden
+++ b/test/fixtures/output/api-key/41.golden
@@ -21,3 +21,4 @@
           | UIAPIKEY101        |                                | u-22bbb  | u-22bbb@confluent.io       | kafka           | lkc-other1   | 1999-02-24T00:00:00Z  
           | UIAPIKEY102        |                                | u-22bbb  | u-22bbb@confluent.io       | ksql            | lksqlc-ksql1 | 1999-02-24T00:00:00Z  
           | UIAPIKEY103        |                                | u-22bbb  | u-22bbb@confluent.io       | kafka           | lkc-cool1    | 1999-02-24T00:00:00Z  
+          | UIGLOBALKEY100     |                                | u-22bbb  | u-22bbb@confluent.io       | global          |              | 1999-02-24T00:00:00Z  

--- a/test/fixtures/output/api-key/43.golden
+++ b/test/fixtures/output/api-key/43.golden
@@ -22,3 +22,4 @@
           | UIAPIKEY101        |                                | u-22bbb  | u-22bbb@confluent.io  | kafka           | lkc-other1   | 1999-02-24T00:00:00Z  
           | UIAPIKEY102        |                                | u-22bbb  | u-22bbb@confluent.io  | ksql            | lksqlc-ksql1 | 1999-02-24T00:00:00Z  
           | UIAPIKEY103        |                                | u-22bbb  | u-22bbb@confluent.io  | kafka           | lkc-cool1    | 1999-02-24T00:00:00Z  
+          | UIGLOBALKEY100     |                                | u-22bbb  | u-22bbb@confluent.io  | global          |              | 1999-02-24T00:00:00Z  

--- a/test/fixtures/output/api-key/56.golden
+++ b/test/fixtures/output/api-key/56.golden
@@ -32,3 +32,4 @@
           | UIAPIKEY101        |                                | u-22bbb  | u-22bbb@confluent.io       | kafka           | lkc-other1   | 1999-02-24T00:00:00Z  
           | UIAPIKEY102        |                                | u-22bbb  | u-22bbb@confluent.io       | ksql            | lksqlc-ksql1 | 1999-02-24T00:00:00Z  
           | UIAPIKEY103        |                                | u-22bbb  | u-22bbb@confluent.io       | kafka           | lkc-cool1    | 1999-02-24T00:00:00Z  
+          | UIGLOBALKEY100     |                                | u-22bbb  | u-22bbb@confluent.io       | global          |              | 1999-02-24T00:00:00Z  

--- a/test/fixtures/output/api-key/6.golden
+++ b/test/fixtures/output/api-key/6.golden
@@ -14,3 +14,4 @@
           | UIAPIKEY101        |                                | u-22bbb  | u-22bbb@confluent.io  | kafka         | lkc-other1   | 1999-02-24T00:00:00Z  
           | UIAPIKEY102        |                                | u-22bbb  | u-22bbb@confluent.io  | ksql          | lksqlc-ksql1 | 1999-02-24T00:00:00Z  
           | UIAPIKEY103        |                                | u-22bbb  | u-22bbb@confluent.io  | kafka         | lkc-cool1    | 1999-02-24T00:00:00Z  
+          | UIGLOBALKEY100     |                                | u-22bbb  | u-22bbb@confluent.io  | global        |              | 1999-02-24T00:00:00Z  

--- a/test/fixtures/output/api-key/61.golden
+++ b/test/fixtures/output/api-key/61.golden
@@ -1,1 +1,1 @@
-Error: functionality not yet available for non-Kafka cluster resources
+Error: functionality not yet available for resources other than Kafka clusters and Global API keys

--- a/test/fixtures/output/api-key/7.golden
+++ b/test/fixtures/output/api-key/7.golden
@@ -106,5 +106,14 @@
     "resource_type": "kafka",
     "resource": "lkc-cool1",
     "created": "1999-02-24T00:00:00Z"
+  },
+  {
+    "key": "UIGLOBALKEY100",
+    "description": "",
+    "owner": "u-22bbb",
+    "owner_email": "u-22bbb@confluent.io",
+    "resource_type": "global",
+    "resource": "",
+    "created": "1999-02-24T00:00:00Z"
   }
 ]

--- a/test/fixtures/output/api-key/8.golden
+++ b/test/fixtures/output/api-key/8.golden
@@ -82,3 +82,10 @@
   resource_type: kafka
   resource: lkc-cool1
   created: "1999-02-24T00:00:00Z"
+- key: UIGLOBALKEY100
+  description: ""
+  owner: u-22bbb
+  owner_email: u-22bbb@confluent.io
+  resource_type: global
+  resource: ""
+  created: "1999-02-24T00:00:00Z"

--- a/test/fixtures/output/api-key/describe-autocomplete.golden
+++ b/test/fixtures/output/api-key/describe-autocomplete.golden
@@ -14,6 +14,7 @@ MYKEY17
 MYKEY18
 MYKEY19	human-output
 MYKEY2
+MYKEY20	created-and-used
 MYKEY3
 MYKEY4	my-cool-app
 MYKEY6	my-ksql-app

--- a/test/fixtures/output/api-key/describe-autocomplete.golden
+++ b/test/fixtures/output/api-key/describe-autocomplete.golden
@@ -23,5 +23,6 @@ UIAPIKEY100
 UIAPIKEY101
 UIAPIKEY102
 UIAPIKEY103
+UIGLOBALKEY100
 :4
 Completion ended with directive: ShellCompDirectiveNoFileComp

--- a/test/fixtures/output/api-key/global/create-use.golden
+++ b/test/fixtures/output/api-key/global/create-use.golden
@@ -1,0 +1,7 @@
+It may take a couple of minutes for the API key to be ready.
+Save the API key and secret. The secret is not retrievable later.
++------------+------------+
+| API Key    | MYKEY20    |
+| API Secret | MYSECRET20 |
++------------+------------+
+Using Global API Key "MYKEY20".

--- a/test/fixtures/output/api-key/global/store-force.golden
+++ b/test/fixtures/output/api-key/global/store-force.golden
@@ -1,0 +1,1 @@
+Stored secret for Global API key "UIGLOBALKEY100".

--- a/test/fixtures/output/api-key/global/store-not-global-error.golden
+++ b/test/fixtures/output/api-key/global/store-not-global-error.golden
@@ -1,0 +1,4 @@
+Error: API key "UIAPIKEY100" is not a Global API key
+
+Suggestions:
+    Omit `--resource global`, or pass the correct resource ID.

--- a/test/fixtures/output/api-key/global/store-override-error.golden
+++ b/test/fixtures/output/api-key/global/store-override-error.golden
@@ -1,0 +1,4 @@
+Error: refusing to overwrite existing secret for API Key "UIGLOBALKEY100"
+
+Suggestions:
+    If you would like to override the existing secret stored for API key "UIGLOBALKEY100", use the `--force` flag.

--- a/test/fixtures/output/api-key/global/store-resource-mismatch-error.golden
+++ b/test/fixtures/output/api-key/global/store-resource-mismatch-error.golden
@@ -1,0 +1,4 @@
+Error: API key "UIGLOBALKEY100" is a Global API key, but --resource was set to "Kafka cluster"
+
+Suggestions:
+    Re-run with `--resource global`, or omit `--resource` to auto-detect.

--- a/test/fixtures/output/api-key/global/store.golden
+++ b/test/fixtures/output/api-key/global/store.golden
@@ -1,0 +1,1 @@
+Stored secret for Global API key "UIGLOBALKEY100".

--- a/test/fixtures/output/api-key/global/use.golden
+++ b/test/fixtures/output/api-key/global/use.golden
@@ -1,0 +1,1 @@
+Using Global API Key "UIGLOBALKEY100".

--- a/test/fixtures/output/kafka/client-config/csharp-global-key.golden
+++ b/test/fixtures/output/kafka/client-config/csharp-global-key.golden
@@ -1,0 +1,10 @@
+# Required connection configs for Kafka producer, consumer, and admin
+bootstrap.servers=kafka-endpoint
+security.protocol=SASL_SSL
+sasl.mechanisms=PLAIN
+sasl.username=UIGLOBALKEY100
+sasl.password=UIGLOBALSECRET100
+
+# Best practice for higher availability in librdkafka clients prior to 1.7
+session.timeout.ms=45000
+

--- a/test/kafka_test.go
+++ b/test/kafka_test.go
@@ -313,6 +313,25 @@ func (s *CLITestSuite) TestKafkaClientConfig() {
 	}
 }
 
+func (s *CLITestSuite) TestKafkaClientConfigGlobalKey() {
+	tests := []CLITest{
+		// Store and activate a Global key, with no cluster-scoped key set.
+		{args: "api-key store UIGLOBALKEY100 UIGLOBALSECRET100"},
+		{args: "api-key use UIGLOBALKEY100"},
+		// client-config create falls back to the active Global key: the rendered config embeds it as
+		// sasl.username/sasl.password (csharp template needs no Schema Registry key-secret pair).
+		{args: "kafka client-config create csharp", useKafka: "lkc-cool1", fixture: "kafka/client-config/csharp-global-key.golden"},
+	}
+
+	resetConfiguration(s.T(), false)
+
+	for _, test := range tests {
+		test.login = "cloud"
+		test.workflow = true
+		s.runIntegrationTest(test)
+	}
+}
+
 func getCreateLinkConfigFile() string {
 	file, _ := os.CreateTemp(os.TempDir(), "test")
 	_, _ = file.Write([]byte("key=val\n key2=val2 \n key3=val password=pass"))

--- a/test/test-server/utils.go
+++ b/test/test-server/utils.go
@@ -189,6 +189,18 @@ func fillKeyStoreV2() {
 			Description: apikeysv2.PtrString(""),
 		},
 	}
+	keyStoreV2["UIGLOBALKEY100"] = &apikeysv2.IamV2ApiKey{
+		Id: apikeysv2.PtrString("UIGLOBALKEY100"),
+		Spec: &apikeysv2.IamV2ApiKeySpec{
+			Resource: &apikeysv2.ObjectReference{
+				Id:         "global",
+				ApiVersion: apikeysv2.PtrString("iam/v2"),
+				Kind:       apikeysv2.PtrString("Global"),
+			},
+			Owner:       &apikeysv2.ObjectReference{Id: "u-22bbb"},
+			Description: apikeysv2.PtrString(""),
+		},
+	}
 	keyStoreV2["SERVICEACCOUNTKEY1"] = &apikeysv2.IamV2ApiKey{
 		Id: apikeysv2.PtrString("SERVICEACCOUNTKEY1"),
 		Spec: &apikeysv2.IamV2ApiKeySpec{


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

New Features
- The `confluent api-key [store | use]` commands now support Global API keys; note that an active cluster-scoped key will take precedence over an active global key

Checklist
---------
<!-- 
Check each item below to ensure high-quality CLI development practices are followed. PR approval will not be granted until the checklist is fully reviewed.
For detailed instructions, please refer to this Confluence page: https://confluentinc.atlassian.net/wiki/spaces/AEGI/pages/3949592874/
-->
- [x] I have successfully built and used a custom CLI binary, without linter issues from this PR.
- [x] I have clearly specified in the `What` section below whether this PR applies to Confluent Cloud, Confluent Platform, or both. 
- [x] I have verified this PR in Confluent Cloud pre-prod or production environment, if applicable.
- [ ] I have verified this PR in Confluent Platform on-premises environment, if applicable.
- [x] I have attached manual CLI verification results or screenshots in the `Test & Review` section below.
- [x] I have added appropriate CLI integration or unit tests for any new or updated commands and functionality.
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [x] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [ ] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [ ] Confluent Cloud prod
  - [ ] Confluent Cloud stag
  - [ ] Confluent Platform
  - [ ] Check this box if the feature is enabled for certain organizations only

What
----
<!--
Briefly describe **what** you have changed and **why** these changes are necessary.
Optionally include: 
- The problem being solved or the feature being added. 
- The implementation strategy or approach taken. 
- Key technical details, design decisions, or any additional context reviewers should be aware of.
-->

**Applies to:** Confluent Cloud only — spanning both the **Control Plane** and the **Data Plane**.
  
This PR adds CLI support for **Global API keys Store & Use**

On the **control plane**, the `confluent api-key` commands now understand Global keys: `create --resource global` (optionally `--use`), `store` (auto detecting a Global key from its server-side resource kind), `use`. Global keys are persisted locally at the context level (separate from cluster-scoped keys), with their secrets encrypted at rest.

On the **data plane**, credential resolution for Kafka commands is centralized in a new `Context.ResolveKafkaAPIKey` helper: `kafka topic produce`, `kafka topic consume`, `kafka client-config create`, and `asyncapi export` now use the active Global API key as a fallback when the target cluster has no cluster-scoped API key. A cluster-scoped key always takes precedence when one exists, so existing behavior is unchanged.


Blast Radius
----
<!--
The Blast Radius section should include information on what will be the customer(s) impact if something goes wrong or unexpectedly, 
adding this section will trigger the PR author to think about the impact from product perspective, examples can be:
- Confluent Cloud customers who are using confluent kafka topic any subcommand will be blocked.
- Confluent Cloud customers who are using confluent kafka topic list commands will be blocked.
- Confluent Platform customers who are using --schema flag will be impacted.
- All customers who are using SSO to login will be impacted.
-->

Additive Global API key support; users not using Global keys are unaffected. The shared change reroutes API-key credential resolution for `kafka topic produce`/`consume`, `kafka client-config create`, and `asyncapi export` through `ResolveKafkaAPIKey`. A regression there could block those four commands, but cluster-scoped keys always take precedence (fallback only applies when no cluster key is set), so existing workflows are unchanged — verified by unit tests and manual stag validation. New config fields are optional/omitempty and backward compatible.


References
----------
<!-- Include links to relevant resources for this PR, such as: 
- Related GitHub issues 
- Tickets (JIRA, etc.) 
- Internal documentation or design specs 
- Other related PRs 
Copy and paste the links below for easy reference.
-->

https://confluentinc.atlassian.net/browse/IDENTITY-7450

Test & Review
-------------
<!-- Has this PR been tested? If so, explain **how** it was tested. Include: 
- Steps taken to verify the changes. 
- Links to manual verification documents, logs, or screenshots to save reviewers' time. 
- Any additional notes on testing (e.g., environments used, edge cases tested). 
- Screenshot showing successful resource creation, updates etc.
Example: - [Manual Verification Document](https://docs.google.com/document/d/1GwXz9hNOkub_Br-2nssoYWCf6elZBvwo7TMhCNYinwE/edit?tab=t.0#heading=h.dvbi09ntxjw6)
-->

Test steps & results: https://confluentinc.atlassian.net/wiki/spaces/~712020ba3ea6a8cdb24e61b11d46bc2b8c41b6/pages/5688525169/IDENTITY-7450+Manual+CLI+Validation+Global+API+Key+Store+Use
