### PR TITLE
[CLI-3435] Update login requirement for cluster list 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@
 # Local agent/tooling artifacts
 /.planning/
 
+# Editor/IDE
+/.idea/
+
 # RPM/DEB
 /rpm/
 /deb/

--- a/internal/kafka/command_cluster.go
+++ b/internal/kafka/command_cluster.go
@@ -52,7 +52,11 @@ func newClusterCommand(cfg *config.Config, prerunner pcmd.PreRunner) *cobra.Comm
 		cmd.AddCommand(c.newListCommand())
 		cmd.AddCommand(c.newEndpointCommand(cfg))
 	} else {
-		cmd.AddCommand(c.newListCommandOnPrem())
+		listCmd := c.newListCommandOnPrem()
+		if !cfg.IsOnPremLogin() {
+			listCmd.Annotations = map[string]string{pcmd.RunRequirement: pcmd.RequireNonAPIKeyCloudLoginOrOnPremLogin}
+		}
+		cmd.AddCommand(listCmd)
 	}
 
 	return cmd

--- a/test/fixtures/output/kafka/list-without-login.golden
+++ b/test/fixtures/output/kafka/list-without-login.golden
@@ -1,0 +1,5 @@
+Error: you must log in to Confluent Cloud with a username and password or log in to Confluent Platform to use this command
+
+Suggestions:
+    Log in with `confluent login` or `confluent login --url <mds-url>`.
+    If you need a Confluent Cloud account, sign up with `confluent cloud-signup`.

--- a/test/kafka_test.go
+++ b/test/kafka_test.go
@@ -197,6 +197,16 @@ func (s *CLITestSuite) TestKafka() {
 	}
 }
 
+func (s *CLITestSuite) TestKafkaClusterListWithoutLogin() {
+	test := CLITest{
+		args:     "kafka cluster list",
+		fixture:  "kafka/list-without-login.golden",
+		exitCode: 1,
+	}
+
+	s.runIntegrationTest(test)
+}
+
 func (s *CLITestSuite) TestKafkaClusterCreate_Byok() {
 	test := CLITest{
 		login:   "cloud",


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- PLACEHOLDER

New Features
- PLACEHOLDER

Bug Fixes
- Fix the error message for the `confluent kafka cluster list` command when user is not logged in

Checklist
---------
<!-- 
Check each item below to ensure high-quality CLI development practices are followed. PR approval will not be granted until the checklist is fully reviewed.
For detailed instructions, please refer to this Confluence page: https://confluentinc.atlassian.net/wiki/spaces/AEGI/pages/3949592874/
-->
- [x] I have successfully built and used a custom CLI binary, without linter issues from this PR.
- [x] I have clearly specified in the `What` section below whether this PR applies to Confluent Cloud, Confluent Platform, or both. 
- [ ] I have verified this PR in Confluent Cloud pre-prod or production environment, if applicable.
- [ ] I have verified this PR in Confluent Platform on-premises environment, if applicable.
- [ ] I have attached manual CLI verification results or screenshots in the `Test & Review` section below.
- [x] I have added appropriate CLI integration or unit tests for any new or updated commands and functionality.
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [x] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [ ] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [ ] Confluent Cloud prod
  - [ ] Confluent Cloud stag
  - [ ] Confluent Platform
  - [ ] Check this box if the feature is enabled for certain organizations only

What
----
<!--
Briefly describe **what** you have changed and **why** these changes are necessary.
Optionally include: 
- The problem being solved or the feature being added. 
- The implementation strategy or approach taken. 
- Key technical details, design decisions, or any additional context reviewers should be aware of.
-->
Changes run requirement to require Cloud or OnPrem login

Blast Radius
----
<!--
The Blast Radius section should include information on what will be the customer(s) impact if something goes wrong or unexpectedly, 
adding this section will trigger the PR author to think about the impact from product perspective, examples can be:
- Confluent Cloud customers who are using confluent kafka topic any subcommand will be blocked.
- Confluent Cloud customers who are using confluent kafka topic list commands will be blocked.
- Confluent Platform customers who are using --schema flag will be impacted.
- All customers who are using SSO to login will be impacted.
-->
Low to none: this is a bug fix for an error message and should not impact any existing user workflows. 

References
----------
<!-- Include links to relevant resources for this PR, such as: 
- Related GitHub issues 
- Tickets (JIRA, etc.) 
- Internal documentation or design specs 
- Other related PRs 
Copy and paste the links below for easy reference.
-->
Resolves [#CLI-3435](https://confluentinc.atlassian.net/browse/CLI-3435)

Test & Review
-------------
<!-- Has this PR been tested? If so, explain **how** it was tested. Include: 
- Steps taken to verify the changes. 
- Links to manual verification documents, logs, or screenshots to save reviewers' time. 
- Any additional notes on testing (e.g., environments used, edge cases tested). 
- Screenshot showing successful resource creation, updates etc.
Example: - [Manual Verification Document](https://docs.google.com/document/d/1GwXz9hNOkub_Br-2nssoYWCf6elZBvwo7TMhCNYinwE/edit?tab=t.0#heading=h.dvbi09ntxjw6)
-->
Golden test when user not logged in for kafka added and updated.

User running command when logged out **before fix**:
```
% confluent kafka cluster list
Error: you must log in to Confluent Platform to use this command

Suggestions:
    Log in to Confluent Platform with `confluent login --url <mds-url>`.
```
**after fix**:
```
% confluent kafka cluster list
Error: you must log in to Confluent Cloud with a username and password or log in to Confluent Platform to use this command

Suggestions:
    Log in with `confluent login` or `confluent login --url <mds-url>`.
    If you need a Confluent Cloud account, sign up with `confluent cloud-signup`.
```

