### PR TITLE
[INC-11256] Increase timeout for calls to `/api/access_tokens`

### DIFF
--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"runtime"
 	"strings"
+	"time"
 
 	"github.com/dghubble/sling"
 
@@ -230,7 +231,10 @@ func GetDataplaneToken(ctx *config.Context) (string, error) {
 		Error string `json:"error"`
 	}{}
 
-	s := sling.New().Add("Content-Type", "application/json").Add("Authorization", "Bearer "+ctx.GetAuthToken()).Post(endpoint).BodyJSON(map[string]any{})
+	client := utils.DefaultClient() // Declare a new client so that sling doesn't use the global default
+	client.Timeout = 30 * time.Second
+
+	s := sling.New().Client(client).Add("Content-Type", "application/json").Add("Authorization", "Bearer "+ctx.GetAuthToken()).Post(endpoint).BodyJSON(map[string]any{})
 
 	req, err := s.Request()
 	if err != nil {

--- a/pkg/ccloudv2/cli.go
+++ b/pkg/ccloudv2/cli.go
@@ -17,8 +17,7 @@ func newCliClient(url, userAgent string, unsafeTrace bool) *cliv1.APIClient {
 	cfg.UserAgent = userAgent
 
 	// We do not use a retryable HTTP client so the CLI does not hang if there is a problem with the usage service.
-	cfg.HTTPClient = http.DefaultClient
-	cfg.HTTPClient.Timeout = 5 * time.Second
+	cfg.HTTPClient = &http.Client{Timeout: 5 * time.Second}
 
 	return cliv1.NewAPIClient(cfg)
 }


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- PLACEHOLDER

New Features
- PLACEHOLDER

Bug Fixes
- PLACEHOLDER

Checklist
---------
<!-- 
Check each item below to ensure high-quality CLI development practices are followed. PR approval will not be granted until the checklist is fully reviewed.
For detailed instructions, please refer to this Confluence page: https://confluentinc.atlassian.net/wiki/spaces/AEGI/pages/3949592874/
-->
- [x] I have successfully built and used a custom CLI binary, without linter issues from this PR.
- [x] I have clearly specified in the `What` section below whether this PR applies to Confluent Cloud, Confluent Platform, or both. 
- [x] I have verified this PR in Confluent Cloud pre-prod or production environment, if applicable.
- [ ] I have verified this PR in Confluent Platform on-premises environment, if applicable.
- [x] I have attached manual CLI verification results or screenshots in the `Test & Review` section below.
- [ ] I have added appropriate CLI integration or unit tests for any new or updated commands and functionality.
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [x] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [x] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [x] Confluent Cloud prod
  - [x] Confluent Cloud stag
  - [ ] Confluent Platform
  - [ ] Check this box if the feature is enabled for certain organizations only

What
----
Two changes:
- Fix a bug where the api client setup for the cli service endpoints was modifying the global default client's timeout to 5 seconds.
- Update the client used for `POST /api/access_tokens` to have a 30 second timeout (it was previously using the global client w/ the 5 second timeout caused by the bug above.

Cloud only.

Blast Radius
----
Minimal. This change only increases the timeout from 5 to 30 seconds for one endpoint.

References
----------
<!-- Include links to relevant resources for this PR, such as: 
- Related GitHub issues 
- Tickets (JIRA, etc.) 
- Internal documentation or design specs 
- Other related PRs 
Copy and paste the links below for easy reference.
-->

Test & Review
-------------
Manual testing: https://docs.google.com/document/d/1pe-bTP_KJSJr-9LYzbX_J1RIJAm70TU3d_m4jImaHGE/edit?usp=sharing
