### PR TITLE
[KGLOBAL-6770] Fix CLI LaunchDarkly flag name for cluster-link RBAC namespace

### DIFF
--- a/internal/iam/command_rbac_role_describe.go
+++ b/internal/iam/command_rbac_role_describe.go
@@ -70,7 +70,7 @@ func (c *roleCommand) ccloudDescribe(cmd *cobra.Command, role string) error {
 		namespacesList = append(namespacesList, flinkModelNamespace.Value())
 	}
 
-	if featureflags.Manager.BoolVariation("cluster.link.rbac.namespace.cli.enable", c.Context, ldClient, true, false) {
+	if featureflags.Manager.BoolVariation("kafka.config.cluster.link.rbac.namespace.cli.enable", c.Context, ldClient, true, false) {
 		namespacesList = append(namespacesList, clusterLinkNamespace.Value())
 	}
 

--- a/internal/iam/command_rbac_role_list.go
+++ b/internal/iam/command_rbac_role_list.go
@@ -49,7 +49,7 @@ func (c *roleCommand) ccloudList(cmd *cobra.Command) error {
 	roles = append(roles, usmRoles...)
 
 	ldClient := featureflags.GetCcloudLaunchDarklyClient(c.Context.PlatformName)
-	if featureflags.Manager.BoolVariation("cluster.link.rbac.namespace.cli.enable", c.Context, ldClient, true, false) {
+	if featureflags.Manager.BoolVariation("kafka.config.cluster.link.rbac.namespace.cli.enable", c.Context, ldClient, true, false) {
 		clusterLinkRoles, err := c.namespaceRoles(optional.NewString(clusterLinkNamespace.Value()))
 		if err != nil {
 			return err

--- a/test/test-server/ccloud_handlers.go
+++ b/test/test-server/ccloud_handlers.go
@@ -411,18 +411,18 @@ func handleLaunchDarkly(t *testing.T) http.HandlerFunc {
 		require.NoError(t, json.Unmarshal(ldUserData, &ldUser))
 
 		flags := map[string]any{
-			"testBool":                                  true,
-			"testString":                                "string",
-			"testInt":                                   1,
-			"testAnotherInt":                            99,
-			"testJson":                                  map[string]any{"key": "val"},
-			"cli.deprecation_notices":                   []map[string]any{},
-			"cli.client_quotas.enable":                  true,
-			"cli.stream_designer.source_code.enable":    true,
-			"flink.rbac.namespace.cli.enable":           true,
-			"cluster.link.rbac.namespace.cli.enable":    true,
-			"auth.rbac.identity_admin.enable":           true,
-			"flink.language_service.enable_diagnostics": true,
+			"testBool":                               true,
+			"testString":                             "string",
+			"testInt":                                1,
+			"testAnotherInt":                         99,
+			"testJson":                               map[string]any{"key": "val"},
+			"cli.deprecation_notices":                []map[string]any{},
+			"cli.client_quotas.enable":               true,
+			"cli.stream_designer.source_code.enable": true,
+			"flink.rbac.namespace.cli.enable":        true,
+			"kafka.config.cluster.link.rbac.namespace.cli.enable":              true,
+			"auth.rbac.identity_admin.enable":                                  true,
+			"flink.language_service.enable_diagnostics":                        true,
 			"cloud_growth.marketplace_linking_advertisement_experiment.enable": true,
 		}
 


### PR DESCRIPTION
Release Notes
-------------

Bug Fixes
- Fix the LaunchDarkly flag key used to gate the `cluster-link` RBAC namespace in `confluent iam rbac role list` and `confluent iam rbac role describe`, so the gate actually resolves and `ClusterLinkConnection` can be surfaced once the flag is enabled.

Checklist
---------
- [x] I have successfully built and used a custom CLI binary, without linter issues from this PR.
- [x] I have clearly specified in the `What` section below whether this PR applies to Confluent Cloud, Confluent Platform, or both.
- [x] I have verified this PR in Confluent Cloud pre-prod or production environment, if applicable.
- [ ] I have verified this PR in Confluent Platform on-premises environment, if applicable.
- [x] I have added appropriate CLI integration or unit tests for any new or updated commands and functionality.
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [x] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [x] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [ ] Confluent Cloud prod
  - [ ] Confluent Cloud stag
  - [ ] Confluent Platform
  - [ ] Check this box if the feature is enabled for certain organizations only

What
----
**Applies to:** Confluent Cloud only. Follow-up to #3359.

#3359 gated the `cluster-link` RBAC namespace behind the LaunchDarkly flag key `cluster.link.rbac.namespace.cli.enable`, but the flag that was actually created in the `default` LD project is **`kafka.config.cluster.link.rbac.namespace.cli.enable`** (the `kafka.config.` prefix routes approvals to the Kafka team, which owns cluster-link RBAC).

Because the key didn't match any existing flag, `BoolVariation(..., default=false)` always returned `false`, so the `cluster-link` namespace was never queried and `ClusterLinkConnection` never appeared — even in devel where the flag is enabled.

This PR aligns the flag key in the code with the real LD flag:
- `internal/iam/command_rbac_role_describe.go`
- `internal/iam/command_rbac_role_list.go`
- `test/test-server/ccloud_handlers.go` — mock LD response key

> Note: the flag `kafka.config.cluster.link.rbac.namespace.cli.enable` also needs **"Available on client-side SDKs"** toggled ON for the CLI's client-side LD client to receive it; that is an LD-UI change tracked separately.

Blast Radius
----
Minimal. The namespace remains gated behind the LaunchDarkly flag (default `false`), so there is no customer-visible change until the flag is enabled per environment. Before this fix the gate could never evaluate true (wrong key); after it, the gate works as intended — devel on, stag/prod off.

References
----------
- JIRA: [KGLOBAL-6770](https://confluentinc.atlassian.net/browse/KGLOBAL-6770)
- Follow-up to: #3359
- LaunchDarkly flag: `kafka.config.cluster.link.rbac.namespace.cli.enable` (project `default`)

Test & Review
-------------
### Automated
- `go build ./internal/iam/... ./test/test-server/...` — pass
- `go test ./internal/iam/...` — pass
- `TestCLI/TestIamRbacRole_Cloud` (list + describe) — pass

### Manual verification (custom binary from this branch, flag key `kafka.config.cluster.link.rbac.namespace.cli.enable`)

**Devel (`devel.cpdev.cloud`) — flag ON → role visible:**
```
$ confluent iam rbac role describe ClusterLinkConnection
+---------------+----------------------------------------+
| Name          | ClusterLinkConnection                  |
| Access Policy | [                                      |
|               |   {                                    |
|               |     "bindingScope": "cluster",         |
|               |     "bindWithResource": true,          |
|               |     "allowedOperations": [             |
|               |       {                                |
|               |         "resourceType": "ClusterLink", |
|               |         "operations": [                |
|               |           "Describe",                  |
|               |           "AcceptInboundConnection",   |
|               |           "StartOutboundConnection"    |
|               |         ]                              |
|               |       }                                |
|               |     ]                                  |
|               |   }                                    |
|               | ]                                      |
|               |                                        |
+---------------+----------------------------------------+

$ confluent iam rbac role list -o json | jq -r '.[] | select(.name=="ClusterLinkConnection") | .name'
ClusterLinkConnection
```

**Prod (`confluent.cloud`) — flag OFF → role NOT visible:**
```
$ confluent iam rbac role describe ClusterLinkConnection
Error: unknown role "ClusterLinkConnection"

Suggestions:
    The available roles are "AccountAdmin", "Assigner", "CloudClusterAdmin", "DataDiscovery", "DataSteward", "DeveloperManage", "DeveloperRead", "DeveloperWrite", "EnvironmentAdmin", "FlinkAdmin", "FlinkDeveloper", "FlinkFunctionDeveloper", "KsqlAdmin", "MetricsViewer", "Operator", "OrganizationAdmin", "ResourceKeyAdmin", "ResourceOwner", "UsmAgent", and "UsmOperator".

$ confluent iam rbac role list -o json | jq '[.[] | select(.name=="ClusterLinkConnection")]'
[]
```

Note that the prod role list still includes the Flink roles (whose namespace is gated by a separate flag that *is* enabled in prod), confirming feature-flag evaluation is working in prod and that `ClusterLinkConnection` is hidden specifically because `kafka.config.cluster.link.rbac.namespace.cli.enable` is off in prod.


[KGLOBAL-6770]: https://confluentinc.atlassian.net/browse/KGLOBAL-6770?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
