### PR TITLE
CF-3666 : Block mutations on CFK-managed CMF resources in the CLI

### DIFF
--- a/internal/flink/cfk_guard.go
+++ b/internal/flink/cfk_guard.go
@@ -8,11 +8,7 @@ import (
 	"github.com/confluentinc/cli/v4/pkg/errors"
 )
 
-// CFK (Confluent for Kubernetes) stamps every CMF resource it creates with these
-// ownership annotations (RFC 68). Their presence is the read-side signal that a
-// resource must be managed through its Kubernetes custom resource rather than the
-// CLI. The CLI blocks mutations on these resources until out-of-band edit
-// detection ships; reads remain unrestricted.
+// CFK stamps these ownership annotations on every CMF resource it creates (RFC 68).
 const (
 	cfkManagedByAnnotation          = "cmf.platform.confluent.io/managed-by"
 	cfkManagedByValue               = "confluent-operator"
@@ -20,10 +16,7 @@ const (
 	cfkManagedByNameAnnotation      = "cmf.platform.confluent.io/managed-by-name"
 )
 
-// errIfCfkManaged returns a user-facing error when the given annotations mark the
-// resource as owned by CFK, and nil otherwise. resourceType is a display label
-// (e.g. resource.FlinkStatement) and name is the resource name; both appear in the
-// message so the user can act without guessing.
+// errIfCfkManaged returns an error naming the owning custom resource if the annotations mark it CFK-owned, else nil.
 func errIfCfkManaged(resourceType, name string, annotations map[string]string) error {
 	if annotations[cfkManagedByAnnotation] != cfkManagedByValue {
 		return nil
@@ -40,9 +33,7 @@ func errIfCfkManaged(resourceType, name string, annotations map[string]string) e
 	return errors.NewErrorWithSuggestions(errorMsg, suggestions)
 }
 
-// cfkOwnerReference renders the owning custom resource as `"namespace/name"` from
-// the CFK ownership annotations, falling back to `"name"` or "" as the annotations
-// allow.
+// cfkOwnerReference renders the owning custom resource as `"namespace/name"` (or `"name"`, or "").
 func cfkOwnerReference(annotations map[string]string) string {
 	namespace := annotations[cfkManagedByNamespaceAnnotation]
 	name := annotations[cfkManagedByNameAnnotation]
@@ -56,10 +47,7 @@ func cfkOwnerReference(annotations map[string]string) string {
 	}
 }
 
-// flinkApplicationAnnotations extracts metadata.annotations from a FlinkApplication.
-// Unlike the other CMF resources, FlinkApplication exposes its metadata as an
-// untyped map, so annotations are read with type assertions. Returns nil when no
-// string-valued annotations are present.
+// flinkApplicationAnnotations reads metadata.annotations from a FlinkApplication, whose metadata is untyped.
 func flinkApplicationAnnotations(application cmfsdk.FlinkApplication) map[string]string {
 	rawAnnotations, ok := application.GetMetadata()["annotations"].(map[string]interface{})
 	if !ok {

--- a/internal/flink/cfk_guard.go
+++ b/internal/flink/cfk_guard.go
@@ -1,0 +1,76 @@
+package flink
+
+import (
+	"fmt"
+
+	cmfsdk "github.com/confluentinc/cmf-sdk-go/v1"
+
+	"github.com/confluentinc/cli/v4/pkg/errors"
+)
+
+// CFK (Confluent for Kubernetes) stamps every CMF resource it creates with these
+// ownership annotations (RFC 68). Their presence is the read-side signal that a
+// resource must be managed through its Kubernetes custom resource rather than the
+// CLI. The CLI blocks mutations on these resources until out-of-band edit
+// detection ships; reads remain unrestricted.
+const (
+	cfkManagedByAnnotation          = "cmf.platform.confluent.io/managed-by"
+	cfkManagedByValue               = "confluent-operator"
+	cfkManagedByNamespaceAnnotation = "cmf.platform.confluent.io/managed-by-namespace"
+	cfkManagedByNameAnnotation      = "cmf.platform.confluent.io/managed-by-name"
+)
+
+// errIfCfkManaged returns a user-facing error when the given annotations mark the
+// resource as owned by CFK, and nil otherwise. resourceType is a display label
+// (e.g. resource.FlinkStatement) and name is the resource name; both appear in the
+// message so the user can act without guessing.
+func errIfCfkManaged(resourceType, name string, annotations map[string]string) error {
+	if annotations[cfkManagedByAnnotation] != cfkManagedByValue {
+		return nil
+	}
+
+	errorMsg := fmt.Sprintf(`%s "%s" is managed by Confluent for Kubernetes (CFK) and cannot be modified through the CLI`, resourceType, name)
+
+	suggestions := "This resource was created by CFK. Edit or delete it through the owning Kubernetes custom resource"
+	if owner := cfkOwnerReference(annotations); owner != "" {
+		suggestions += fmt.Sprintf(" %s", owner)
+	}
+	suggestions += ", for example with `kubectl edit` or `kubectl delete`."
+
+	return errors.NewErrorWithSuggestions(errorMsg, suggestions)
+}
+
+// cfkOwnerReference renders the owning custom resource as `"namespace/name"` from
+// the CFK ownership annotations, falling back to `"name"` or "" as the annotations
+// allow.
+func cfkOwnerReference(annotations map[string]string) string {
+	namespace := annotations[cfkManagedByNamespaceAnnotation]
+	name := annotations[cfkManagedByNameAnnotation]
+	switch {
+	case namespace != "" && name != "":
+		return fmt.Sprintf(`"%s/%s"`, namespace, name)
+	case name != "":
+		return fmt.Sprintf(`"%s"`, name)
+	default:
+		return ""
+	}
+}
+
+// flinkApplicationAnnotations extracts metadata.annotations from a FlinkApplication.
+// Unlike the other CMF resources, FlinkApplication exposes its metadata as an
+// untyped map, so annotations are read with type assertions. Returns nil when no
+// string-valued annotations are present.
+func flinkApplicationAnnotations(application cmfsdk.FlinkApplication) map[string]string {
+	rawAnnotations, ok := application.GetMetadata()["annotations"].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	annotations := make(map[string]string, len(rawAnnotations))
+	for key, value := range rawAnnotations {
+		if stringValue, ok := value.(string); ok {
+			annotations[key] = stringValue
+		}
+	}
+	return annotations
+}

--- a/internal/flink/cfk_guard.go
+++ b/internal/flink/cfk_guard.go
@@ -47,7 +47,8 @@ func cfkOwnerReference(annotations map[string]string) string {
 	}
 }
 
-// flinkApplicationAnnotations reads metadata.annotations from a FlinkApplication, whose metadata is untyped.
+// flinkApplicationAnnotations reads string-valued metadata.annotations from a FlinkApplication
+// (whose metadata is untyped), returning nil when none are present.
 func flinkApplicationAnnotations(application cmfsdk.FlinkApplication) map[string]string {
 	rawAnnotations, ok := application.GetMetadata()["annotations"].(map[string]interface{})
 	if !ok {
@@ -59,6 +60,9 @@ func flinkApplicationAnnotations(application cmfsdk.FlinkApplication) map[string
 		if stringValue, ok := value.(string); ok {
 			annotations[key] = stringValue
 		}
+	}
+	if len(annotations) == 0 {
+		return nil
 	}
 	return annotations
 }

--- a/internal/flink/cfk_guard.go
+++ b/internal/flink/cfk_guard.go
@@ -8,43 +8,22 @@ import (
 	"github.com/confluentinc/cli/v4/pkg/errors"
 )
 
-// CFK stamps these ownership annotations on every CMF resource it creates (RFC 68).
-const (
-	cfkManagedByAnnotation          = "cmf.platform.confluent.io/managed-by"
-	cfkManagedByValue               = "confluent-operator"
-	cfkManagedByNamespaceAnnotation = "cmf.platform.confluent.io/managed-by-namespace"
-	cfkManagedByNameAnnotation      = "cmf.platform.confluent.io/managed-by-name"
-)
+// cfkManagedByAnnotation marks a CMF resource as CFK-managed. CFK stamps it on every
+// resource it creates (RFC 68); its value is the owning CR identity "<namespace>/<name>".
+// Read-side clients block mutations based on the annotation's presence.
+const cfkManagedByAnnotation = "cmf.platform.confluent.io/managed-by"
 
-// errIfCfkManaged returns an error naming the owning custom resource if the annotations mark it CFK-owned, else nil.
+// errIfCfkManaged returns an error naming the owning custom resource if the resource is CFK-managed, else nil.
 func errIfCfkManaged(resourceType, name string, annotations map[string]string) error {
-	if annotations[cfkManagedByAnnotation] != cfkManagedByValue {
+	owner := annotations[cfkManagedByAnnotation]
+	if owner == "" {
 		return nil
 	}
 
 	errorMsg := fmt.Sprintf(`%s "%s" is managed by Confluent for Kubernetes (CFK) and cannot be modified through the CLI`, resourceType, name)
-
-	suggestions := "This resource was created by CFK. Edit or delete it through the owning Kubernetes custom resource"
-	if owner := cfkOwnerReference(annotations); owner != "" {
-		suggestions += fmt.Sprintf(" %s", owner)
-	}
-	suggestions += ", for example with `kubectl edit` or `kubectl delete`."
+	suggestions := fmt.Sprintf("This resource is owned by the Kubernetes custom resource %q. Edit or delete it there, for example with `kubectl edit` or `kubectl delete`.", owner)
 
 	return errors.NewErrorWithSuggestions(errorMsg, suggestions)
-}
-
-// cfkOwnerReference renders the owning custom resource as `"namespace/name"` (or `"name"`, or "").
-func cfkOwnerReference(annotations map[string]string) string {
-	namespace := annotations[cfkManagedByNamespaceAnnotation]
-	name := annotations[cfkManagedByNameAnnotation]
-	switch {
-	case namespace != "" && name != "":
-		return fmt.Sprintf(`"%s/%s"`, namespace, name)
-	case name != "":
-		return fmt.Sprintf(`"%s"`, name)
-	default:
-		return ""
-	}
 }
 
 // flinkApplicationAnnotations reads string-valued metadata.annotations from a FlinkApplication

--- a/internal/flink/cfk_guard.go
+++ b/internal/flink/cfk_guard.go
@@ -9,7 +9,7 @@ import (
 )
 
 // cfkManagedByAnnotation marks a CMF resource as CFK-managed. CFK stamps it on every
-// resource it creates (RFC 68); its value is the owning CR identity "<namespace>/<name>".
+// resource it creates; its value is the owning CR identity "<namespace>/<name>".
 // Read-side clients block mutations based on the annotation's presence.
 const cfkManagedByAnnotation = "cmf.platform.confluent.io/managed-by"
 

--- a/internal/flink/cfk_guard_test.go
+++ b/internal/flink/cfk_guard_test.go
@@ -1,0 +1,125 @@
+package flink
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	cmfsdk "github.com/confluentinc/cmf-sdk-go/v1"
+
+	"github.com/confluentinc/cli/v4/pkg/errors"
+	"github.com/confluentinc/cli/v4/pkg/resource"
+)
+
+func TestErrIfCfkManaged(t *testing.T) {
+	tests := []struct {
+		name                string
+		annotations         map[string]string
+		expectError         bool
+		errorContains       string
+		suggestionsContains string
+	}{
+		{
+			name:        "nil annotations are not CFK-managed",
+			annotations: nil,
+			expectError: false,
+		},
+		{
+			name:        "absent ownership annotation is not CFK-managed",
+			annotations: map[string]string{"some.other/annotation": "value"},
+			expectError: false,
+		},
+		{
+			name:        "wrong ownership value is not CFK-managed",
+			annotations: map[string]string{cfkManagedByAnnotation: "someone-else"},
+			expectError: false,
+		},
+		{
+			name: "CFK-managed with namespace and name names the owning custom resource",
+			annotations: map[string]string{
+				cfkManagedByAnnotation:          cfkManagedByValue,
+				cfkManagedByNamespaceAnnotation: "flink-system",
+				cfkManagedByNameAnnotation:      "my-statement-cr",
+			},
+			expectError:         true,
+			errorContains:       `Flink SQL statement "my-statement" is managed by Confluent for Kubernetes (CFK)`,
+			suggestionsContains: `"flink-system/my-statement-cr"`,
+		},
+		{
+			name: "CFK-managed with only name falls back to the bare custom resource name",
+			annotations: map[string]string{
+				cfkManagedByAnnotation:     cfkManagedByValue,
+				cfkManagedByNameAnnotation: "my-statement-cr",
+			},
+			expectError:         true,
+			suggestionsContains: `"my-statement-cr"`,
+		},
+		{
+			name:                "CFK-managed without owner annotations still blocks and points to kubectl",
+			annotations:         map[string]string{cfkManagedByAnnotation: cfkManagedByValue},
+			expectError:         true,
+			suggestionsContains: "`kubectl edit`",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := errIfCfkManaged(resource.FlinkStatement, "my-statement", tt.annotations)
+			if !tt.expectError {
+				require.NoError(t, err)
+				return
+			}
+
+			require.Error(t, err)
+			if tt.errorContains != "" {
+				require.ErrorContains(t, err, tt.errorContains)
+			}
+			if tt.suggestionsContains != "" {
+				errorWithSuggestions, ok := err.(errors.ErrorWithSuggestions)
+				require.True(t, ok)
+				require.Contains(t, errorWithSuggestions.GetSuggestionsMsg(), tt.suggestionsContains)
+			}
+		})
+	}
+}
+
+func TestFlinkApplicationAnnotations(t *testing.T) {
+	tests := []struct {
+		name     string
+		metadata map[string]interface{}
+		expected map[string]string
+	}{
+		{
+			name:     "metadata without annotations returns nil",
+			metadata: map[string]interface{}{"name": "my-app"},
+			expected: nil,
+		},
+		{
+			name: "string-valued annotations are extracted",
+			metadata: map[string]interface{}{
+				"name": "my-app",
+				"annotations": map[string]interface{}{
+					cfkManagedByAnnotation: cfkManagedByValue,
+				},
+			},
+			expected: map[string]string{cfkManagedByAnnotation: cfkManagedByValue},
+		},
+		{
+			name: "non-string annotation values are skipped",
+			metadata: map[string]interface{}{
+				"annotations": map[string]interface{}{
+					cfkManagedByAnnotation: cfkManagedByValue,
+					"replicas":             int64(3),
+				},
+			},
+			expected: map[string]string{cfkManagedByAnnotation: cfkManagedByValue},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			application := cmfsdk.FlinkApplication{Metadata: tt.metadata}
+			require.Equal(t, tt.expected, flinkApplicationAnnotations(application))
+		})
+	}
+}

--- a/internal/flink/cfk_guard_test.go
+++ b/internal/flink/cfk_guard_test.go
@@ -114,6 +114,13 @@ func TestFlinkApplicationAnnotations(t *testing.T) {
 			},
 			expected: map[string]string{cfkManagedByAnnotation: cfkManagedByValue},
 		},
+		{
+			name: "annotations object with only non-string values returns nil",
+			metadata: map[string]interface{}{
+				"annotations": map[string]interface{}{"replicas": int64(3)},
+			},
+			expected: nil,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/flink/cfk_guard_test.go
+++ b/internal/flink/cfk_guard_test.go
@@ -30,33 +30,20 @@ func TestErrIfCfkManaged(t *testing.T) {
 			expectError: false,
 		},
 		{
-			name:        "wrong ownership value is not CFK-managed",
-			annotations: map[string]string{cfkManagedByAnnotation: "someone-else"},
+			name:        "empty ownership annotation value is not CFK-managed",
+			annotations: map[string]string{cfkManagedByAnnotation: ""},
 			expectError: false,
 		},
 		{
-			name: "CFK-managed with namespace and name names the owning custom resource",
-			annotations: map[string]string{
-				cfkManagedByAnnotation:          cfkManagedByValue,
-				cfkManagedByNamespaceAnnotation: "flink-system",
-				cfkManagedByNameAnnotation:      "my-statement-cr",
-			},
+			name:                "CFK-managed: the annotation value names the owning custom resource",
+			annotations:         map[string]string{cfkManagedByAnnotation: "flink-system/my-statement-cr"},
 			expectError:         true,
 			errorContains:       `Flink SQL statement "my-statement" is managed by Confluent for Kubernetes (CFK)`,
 			suggestionsContains: `"flink-system/my-statement-cr"`,
 		},
 		{
-			name: "CFK-managed with only name falls back to the bare custom resource name",
-			annotations: map[string]string{
-				cfkManagedByAnnotation:     cfkManagedByValue,
-				cfkManagedByNameAnnotation: "my-statement-cr",
-			},
-			expectError:         true,
-			suggestionsContains: `"my-statement-cr"`,
-		},
-		{
-			name:                "CFK-managed without owner annotations still blocks and points to kubectl",
-			annotations:         map[string]string{cfkManagedByAnnotation: cfkManagedByValue},
+			name:                "CFK-managed: suggestion points to kubectl",
+			annotations:         map[string]string{cfkManagedByAnnotation: "flink-system/my-statement-cr"},
 			expectError:         true,
 			suggestionsContains: "`kubectl edit`",
 		},
@@ -99,20 +86,20 @@ func TestFlinkApplicationAnnotations(t *testing.T) {
 			metadata: map[string]interface{}{
 				"name": "my-app",
 				"annotations": map[string]interface{}{
-					cfkManagedByAnnotation: cfkManagedByValue,
+					cfkManagedByAnnotation: "flink-system/my-app-cr",
 				},
 			},
-			expected: map[string]string{cfkManagedByAnnotation: cfkManagedByValue},
+			expected: map[string]string{cfkManagedByAnnotation: "flink-system/my-app-cr"},
 		},
 		{
 			name: "non-string annotation values are skipped",
 			metadata: map[string]interface{}{
 				"annotations": map[string]interface{}{
-					cfkManagedByAnnotation: cfkManagedByValue,
+					cfkManagedByAnnotation: "flink-system/my-app-cr",
 					"replicas":             int64(3),
 				},
 			},
-			expected: map[string]string{cfkManagedByAnnotation: cfkManagedByValue},
+			expected: map[string]string{cfkManagedByAnnotation: "flink-system/my-app-cr"},
 		},
 		{
 			name: "annotations object with only non-string values returns nil",

--- a/internal/flink/command_application_delete.go
+++ b/internal/flink/command_application_delete.go
@@ -41,6 +41,19 @@ func (c *command) applicationDelete(cmd *cobra.Command, args []string) error {
 		return err == nil
 	}
 
+	// Block deletion of CFK-owned resources before prompting for confirmation. The
+	// whole batch fails if any resource is CFK-owned. Resources that cannot be
+	// fetched are skipped here and reported by ValidateAndConfirm below.
+	for _, name := range args {
+		application, describeErr := client.DescribeApplication(c.createContext(), environment, name)
+		if describeErr != nil {
+			continue
+		}
+		if err := errIfCfkManaged(resource.FlinkApplication, name, flinkApplicationAnnotations(application)); err != nil {
+			return err
+		}
+	}
+
 	if err := deletion.ValidateAndConfirm(cmd, args, existenceFunc, resource.FlinkApplication); err != nil {
 		// We are validating only the existence of the resources (there is no prefix validation).
 		// Thus we can add some extra context for the error.

--- a/internal/flink/command_application_delete.go
+++ b/internal/flink/command_application_delete.go
@@ -41,9 +41,7 @@ func (c *command) applicationDelete(cmd *cobra.Command, args []string) error {
 		return err == nil
 	}
 
-	// Block deletion of CFK-owned resources before prompting for confirmation. The
-	// whole batch fails if any resource is CFK-owned. Resources that cannot be
-	// fetched are skipped here and reported by ValidateAndConfirm below.
+	// Refuse the whole batch if any resource is CFK-owned; unreadable names fall to the check below.
 	for _, name := range args {
 		application, describeErr := client.DescribeApplication(c.createContext(), environment, name)
 		if describeErr != nil {

--- a/internal/flink/command_application_update.go
+++ b/internal/flink/command_application_update.go
@@ -5,6 +5,7 @@ import (
 
 	pcmd "github.com/confluentinc/cli/v4/pkg/cmd"
 	"github.com/confluentinc/cli/v4/pkg/output"
+	"github.com/confluentinc/cli/v4/pkg/resource"
 )
 
 func (c *command) newApplicationUpdateCommand() *cobra.Command {
@@ -38,6 +39,16 @@ func (c *command) applicationUpdate(cmd *cobra.Command, args []string) error {
 	sdkApplication, err := readApplicationResourceFile(args[0])
 	if err != nil {
 		return err
+	}
+
+	// Block mutations on CFK-owned resources. Best-effort: if the current resource
+	// cannot be fetched, fall through and let the update surface the real error.
+	if applicationName, ok := sdkApplication.GetMetadata()["name"].(string); ok && applicationName != "" {
+		if existingApplication, describeErr := client.DescribeApplication(c.createContext(), environment, applicationName); describeErr == nil {
+			if err := errIfCfkManaged(resource.FlinkApplication, applicationName, flinkApplicationAnnotations(existingApplication)); err != nil {
+				return err
+			}
+		}
 	}
 
 	sdkOutputApplication, err := client.UpdateApplication(c.createContext(), environment, sdkApplication)

--- a/internal/flink/command_application_update.go
+++ b/internal/flink/command_application_update.go
@@ -41,8 +41,7 @@ func (c *command) applicationUpdate(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	// Block mutations on CFK-owned resources. Best-effort: if the current resource
-	// cannot be fetched, fall through and let the update surface the real error.
+	// Block the update if the resource is CFK-owned; if unreadable, let the update report it.
 	if applicationName, ok := sdkApplication.GetMetadata()["name"].(string); ok && applicationName != "" {
 		if existingApplication, describeErr := client.DescribeApplication(c.createContext(), environment, applicationName); describeErr == nil {
 			if err := errIfCfkManaged(resource.FlinkApplication, applicationName, flinkApplicationAnnotations(existingApplication)); err != nil {

--- a/internal/flink/command_catalog_database_delete.go
+++ b/internal/flink/command_catalog_database_delete.go
@@ -41,6 +41,19 @@ func (c *command) catalogDatabaseDelete(cmd *cobra.Command, args []string) error
 		return err == nil
 	}
 
+	// Block deletion of CFK-owned resources before prompting for confirmation. The
+	// whole batch fails if any resource is CFK-owned. Resources that cannot be
+	// fetched are skipped here and reported by ValidateAndConfirm below.
+	for _, name := range args {
+		database, describeErr := client.DescribeDatabase(c.createContext(), catalogName, name)
+		if describeErr != nil {
+			continue
+		}
+		if err := errIfCfkManaged(resource.FlinkDatabase, name, database.Metadata.GetAnnotations()); err != nil {
+			return err
+		}
+	}
+
 	if err := deletion.ValidateAndConfirm(cmd, args, existenceFunc, resource.FlinkDatabase); err != nil {
 		// We are validating only the existence of the resources (there is no prefix validation).
 		// Thus, we can add some extra context for the error.

--- a/internal/flink/command_catalog_database_delete.go
+++ b/internal/flink/command_catalog_database_delete.go
@@ -41,9 +41,7 @@ func (c *command) catalogDatabaseDelete(cmd *cobra.Command, args []string) error
 		return err == nil
 	}
 
-	// Block deletion of CFK-owned resources before prompting for confirmation. The
-	// whole batch fails if any resource is CFK-owned. Resources that cannot be
-	// fetched are skipped here and reported by ValidateAndConfirm below.
+	// Refuse the whole batch if any resource is CFK-owned; unreadable names fall to the check below.
 	for _, name := range args {
 		database, describeErr := client.DescribeDatabase(c.createContext(), catalogName, name)
 		if describeErr != nil {

--- a/internal/flink/command_catalog_database_update.go
+++ b/internal/flink/command_catalog_database_update.go
@@ -46,8 +46,7 @@ func (c *command) catalogDatabaseUpdate(cmd *cobra.Command, args []string) error
 
 	databaseName := sdkDatabase.Metadata.Name
 
-	// Block mutations on CFK-owned resources. Best-effort: if the current resource
-	// cannot be fetched, fall through and let the update surface the real error.
+	// Block the update if the resource is CFK-owned; if unreadable, let the update report it.
 	if existingDatabase, describeErr := client.DescribeDatabase(c.createContext(), catalogName, databaseName); describeErr == nil {
 		if err := errIfCfkManaged(resource.FlinkDatabase, databaseName, existingDatabase.Metadata.GetAnnotations()); err != nil {
 			return err

--- a/internal/flink/command_catalog_database_update.go
+++ b/internal/flink/command_catalog_database_update.go
@@ -6,6 +6,7 @@ import (
 	"github.com/spf13/cobra"
 
 	pcmd "github.com/confluentinc/cli/v4/pkg/cmd"
+	"github.com/confluentinc/cli/v4/pkg/resource"
 )
 
 func (c *command) newCatalogDatabaseUpdateCommand() *cobra.Command {
@@ -44,6 +45,14 @@ func (c *command) catalogDatabaseUpdate(cmd *cobra.Command, args []string) error
 	}
 
 	databaseName := sdkDatabase.Metadata.Name
+
+	// Block mutations on CFK-owned resources. Best-effort: if the current resource
+	// cannot be fetched, fall through and let the update surface the real error.
+	if existingDatabase, describeErr := client.DescribeDatabase(c.createContext(), catalogName, databaseName); describeErr == nil {
+		if err := errIfCfkManaged(resource.FlinkDatabase, databaseName, existingDatabase.Metadata.GetAnnotations()); err != nil {
+			return err
+		}
+	}
 
 	if err := client.UpdateDatabase(c.createContext(), catalogName, databaseName, sdkDatabase); err != nil {
 		return err

--- a/internal/flink/command_catalog_delete.go
+++ b/internal/flink/command_catalog_delete.go
@@ -33,9 +33,7 @@ func (c *command) catalogDelete(cmd *cobra.Command, args []string) error {
 		return err == nil
 	}
 
-	// Block deletion of CFK-owned resources before prompting for confirmation. The
-	// whole batch fails if any resource is CFK-owned. Resources that cannot be
-	// fetched are skipped here and reported by ValidateAndConfirm below.
+	// Refuse the whole batch if any resource is CFK-owned; unreadable names fall to the check below.
 	for _, name := range args {
 		catalog, describeErr := client.DescribeCatalog(c.createContext(), name)
 		if describeErr != nil {

--- a/internal/flink/command_catalog_delete.go
+++ b/internal/flink/command_catalog_delete.go
@@ -33,6 +33,19 @@ func (c *command) catalogDelete(cmd *cobra.Command, args []string) error {
 		return err == nil
 	}
 
+	// Block deletion of CFK-owned resources before prompting for confirmation. The
+	// whole batch fails if any resource is CFK-owned. Resources that cannot be
+	// fetched are skipped here and reported by ValidateAndConfirm below.
+	for _, name := range args {
+		catalog, describeErr := client.DescribeCatalog(c.createContext(), name)
+		if describeErr != nil {
+			continue
+		}
+		if err := errIfCfkManaged(resource.FlinkCatalog, name, catalog.Metadata.GetAnnotations()); err != nil {
+			return err
+		}
+	}
+
 	if err := deletion.ValidateAndConfirm(cmd, args, existenceFunc, resource.FlinkCatalog); err != nil {
 		// We are validating only the existence of the resources (there is no prefix validation).
 		// Thus, we can add some extra context for the error.

--- a/internal/flink/command_catalog_update.go
+++ b/internal/flink/command_catalog_update.go
@@ -42,8 +42,7 @@ func (c *command) catalogUpdate(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("catalog name is required: ensure the resource file contains a non-empty \"metadata.name\" field")
 	}
 
-	// Block mutations on CFK-owned resources. Best-effort: if the current resource
-	// cannot be fetched, fall through and let the update surface the real error.
+	// Block the update if the resource is CFK-owned; if unreadable, let the update report it.
 	if existingCatalog, describeErr := client.DescribeCatalog(c.createContext(), catalogName); describeErr == nil {
 		if err := errIfCfkManaged(resource.FlinkCatalog, catalogName, existingCatalog.Metadata.GetAnnotations()); err != nil {
 			return err

--- a/internal/flink/command_catalog_update.go
+++ b/internal/flink/command_catalog_update.go
@@ -6,6 +6,7 @@ import (
 	"github.com/spf13/cobra"
 
 	pcmd "github.com/confluentinc/cli/v4/pkg/cmd"
+	"github.com/confluentinc/cli/v4/pkg/resource"
 )
 
 func (c *command) newCatalogUpdateCommand() *cobra.Command {
@@ -39,6 +40,14 @@ func (c *command) catalogUpdate(cmd *cobra.Command, args []string) error {
 	catalogName := sdkCatalog.Metadata.Name
 	if catalogName == "" {
 		return fmt.Errorf("catalog name is required: ensure the resource file contains a non-empty \"metadata.name\" field")
+	}
+
+	// Block mutations on CFK-owned resources. Best-effort: if the current resource
+	// cannot be fetched, fall through and let the update surface the real error.
+	if existingCatalog, describeErr := client.DescribeCatalog(c.createContext(), catalogName); describeErr == nil {
+		if err := errIfCfkManaged(resource.FlinkCatalog, catalogName, existingCatalog.Metadata.GetAnnotations()); err != nil {
+			return err
+		}
 	}
 
 	if err := client.UpdateCatalog(c.createContext(), catalogName, sdkCatalog); err != nil {

--- a/internal/flink/command_compute_pool_delete_onprem.go
+++ b/internal/flink/command_compute_pool_delete_onprem.go
@@ -44,6 +44,19 @@ func (c *command) computePoolDeleteOnPrem(cmd *cobra.Command, args []string) err
 		return err == nil
 	}
 
+	// Block deletion of CFK-owned resources before prompting for confirmation. The
+	// whole batch fails if any resource is CFK-owned. Resources that cannot be
+	// fetched are skipped here and reported by ValidateAndConfirm below.
+	for _, name := range args {
+		computePool, describeErr := client.DescribeComputePool(c.createContext(), environment, name)
+		if describeErr != nil {
+			continue
+		}
+		if err := errIfCfkManaged(resource.FlinkComputePool, name, computePool.Metadata.GetAnnotations()); err != nil {
+			return err
+		}
+	}
+
 	if err := deletion.ValidateAndConfirm(cmd, args, existenceFunc, resource.FlinkComputePool); err != nil {
 		// We are validating only the existence of the resources (there is no prefix validation).
 		// Thus, we can add some extra context for the error.

--- a/internal/flink/command_compute_pool_delete_onprem.go
+++ b/internal/flink/command_compute_pool_delete_onprem.go
@@ -44,9 +44,7 @@ func (c *command) computePoolDeleteOnPrem(cmd *cobra.Command, args []string) err
 		return err == nil
 	}
 
-	// Block deletion of CFK-owned resources before prompting for confirmation. The
-	// whole batch fails if any resource is CFK-owned. Resources that cannot be
-	// fetched are skipped here and reported by ValidateAndConfirm below.
+	// Refuse the whole batch if any resource is CFK-owned; unreadable names fall to the check below.
 	for _, name := range args {
 		computePool, describeErr := client.DescribeComputePool(c.createContext(), environment, name)
 		if describeErr != nil {

--- a/internal/flink/command_environment_delete.go
+++ b/internal/flink/command_environment_delete.go
@@ -35,6 +35,19 @@ func (c *command) environmentDelete(cmd *cobra.Command, args []string) error {
 		return err == nil
 	}
 
+	// Block deletion of CFK-owned resources before prompting for confirmation. The
+	// whole batch fails if any resource is CFK-owned. Resources that cannot be
+	// fetched are skipped here and reported by ValidateAndConfirm below.
+	for _, name := range args {
+		environment, describeErr := client.DescribeEnvironment(c.createContext(), name)
+		if describeErr != nil {
+			continue
+		}
+		if err := errIfCfkManaged(resource.FlinkEnvironment, name, environment.Metadata.GetAnnotations()); err != nil {
+			return err
+		}
+	}
+
 	if err := deletion.ValidateAndConfirm(cmd, args, existenceFunc, resource.FlinkEnvironment); err != nil {
 		// We are validating only the existence of the resources (there is no prefix validation). Thus we can
 		// add some extra context for the error.

--- a/internal/flink/command_environment_delete.go
+++ b/internal/flink/command_environment_delete.go
@@ -35,9 +35,7 @@ func (c *command) environmentDelete(cmd *cobra.Command, args []string) error {
 		return err == nil
 	}
 
-	// Block deletion of CFK-owned resources before prompting for confirmation. The
-	// whole batch fails if any resource is CFK-owned. Resources that cannot be
-	// fetched are skipped here and reported by ValidateAndConfirm below.
+	// Refuse the whole batch if any resource is CFK-owned; unreadable names fall to the check below.
 	for _, name := range args {
 		environment, describeErr := client.DescribeEnvironment(c.createContext(), name)
 		if describeErr != nil {

--- a/internal/flink/command_environment_update.go
+++ b/internal/flink/command_environment_update.go
@@ -9,6 +9,7 @@ import (
 
 	pcmd "github.com/confluentinc/cli/v4/pkg/cmd"
 	"github.com/confluentinc/cli/v4/pkg/output"
+	"github.com/confluentinc/cli/v4/pkg/resource"
 )
 
 func (c *command) newEnvironmentUpdateCommand() *cobra.Command {
@@ -38,6 +39,14 @@ func (c *command) environmentUpdate(cmd *cobra.Command, args []string) error {
 	}
 
 	environmentName := args[0]
+
+	// Block mutations on CFK-owned resources. Best-effort: if the current resource
+	// cannot be fetched, fall through and let the update surface the real error.
+	if existingEnvironment, describeErr := client.DescribeEnvironment(c.createContext(), environmentName); describeErr == nil {
+		if err := errIfCfkManaged(resource.FlinkEnvironment, environmentName, existingEnvironment.Metadata.GetAnnotations()); err != nil {
+			return err
+		}
+	}
 
 	// Read file contents or parse defaults if applicable
 	var defaultsApplicationParsed, defaultsComputePoolParsed map[string]interface{}

--- a/internal/flink/command_environment_update.go
+++ b/internal/flink/command_environment_update.go
@@ -40,8 +40,7 @@ func (c *command) environmentUpdate(cmd *cobra.Command, args []string) error {
 
 	environmentName := args[0]
 
-	// Block mutations on CFK-owned resources. Best-effort: if the current resource
-	// cannot be fetched, fall through and let the update surface the real error.
+	// Block the update if the resource is CFK-owned; if unreadable, let the update report it.
 	if existingEnvironment, describeErr := client.DescribeEnvironment(c.createContext(), environmentName); describeErr == nil {
 		if err := errIfCfkManaged(resource.FlinkEnvironment, environmentName, existingEnvironment.Metadata.GetAnnotations()); err != nil {
 			return err

--- a/internal/flink/command_secret_delete.go
+++ b/internal/flink/command_secret_delete.go
@@ -34,6 +34,19 @@ func (c *command) secretDelete(cmd *cobra.Command, args []string) error {
 		return err == nil
 	}
 
+	// Block deletion of CFK-owned resources before prompting for confirmation. The
+	// whole batch fails if any resource is CFK-owned. Resources that cannot be
+	// fetched are skipped here and reported by ValidateAndConfirm below.
+	for _, name := range args {
+		secret, describeErr := client.DescribeSecret(c.createContext(), name)
+		if describeErr != nil {
+			continue
+		}
+		if err := errIfCfkManaged(resource.FlinkSecret, name, secret.Metadata.GetAnnotations()); err != nil {
+			return err
+		}
+	}
+
 	if err := deletion.ValidateAndConfirm(cmd, args, existenceFunc, resource.FlinkSecret); err != nil {
 		suggestions := "List available Flink secrets with `confluent flink secret list`."
 		suggestions += "\nCheck that CMF is running and accessible."

--- a/internal/flink/command_secret_delete.go
+++ b/internal/flink/command_secret_delete.go
@@ -34,9 +34,7 @@ func (c *command) secretDelete(cmd *cobra.Command, args []string) error {
 		return err == nil
 	}
 
-	// Block deletion of CFK-owned resources before prompting for confirmation. The
-	// whole batch fails if any resource is CFK-owned. Resources that cannot be
-	// fetched are skipped here and reported by ValidateAndConfirm below.
+	// Refuse the whole batch if any resource is CFK-owned; unreadable names fall to the check below.
 	for _, name := range args {
 		secret, describeErr := client.DescribeSecret(c.createContext(), name)
 		if describeErr != nil {

--- a/internal/flink/command_secret_mapping_delete.go
+++ b/internal/flink/command_secret_mapping_delete.go
@@ -42,6 +42,19 @@ func (c *command) secretMappingDelete(cmd *cobra.Command, args []string) error {
 		return err == nil
 	}
 
+	// Block deletion of CFK-owned resources before prompting for confirmation. The
+	// whole batch fails if any resource is CFK-owned. Resources that cannot be
+	// fetched are skipped here and reported by ValidateAndConfirm below.
+	for _, name := range args {
+		mapping, describeErr := client.DescribeSecretMapping(c.createContext(), environment, name)
+		if describeErr != nil {
+			continue
+		}
+		if err := errIfCfkManaged(resource.FlinkSecretMapping, name, mapping.Metadata.GetAnnotations()); err != nil {
+			return err
+		}
+	}
+
 	if err := deletion.ValidateAndConfirm(cmd, args, existenceFunc, resource.FlinkSecretMapping); err != nil {
 		suggestions := "List available Flink secret mappings with `confluent flink secret-mapping list --environment <envName>`."
 		suggestions += "\nCheck that CMF is running and accessible."

--- a/internal/flink/command_secret_mapping_delete.go
+++ b/internal/flink/command_secret_mapping_delete.go
@@ -42,9 +42,7 @@ func (c *command) secretMappingDelete(cmd *cobra.Command, args []string) error {
 		return err == nil
 	}
 
-	// Block deletion of CFK-owned resources before prompting for confirmation. The
-	// whole batch fails if any resource is CFK-owned. Resources that cannot be
-	// fetched are skipped here and reported by ValidateAndConfirm below.
+	// Refuse the whole batch if any resource is CFK-owned; unreadable names fall to the check below.
 	for _, name := range args {
 		mapping, describeErr := client.DescribeSecretMapping(c.createContext(), environment, name)
 		if describeErr != nil {

--- a/internal/flink/command_secret_mapping_update.go
+++ b/internal/flink/command_secret_mapping_update.go
@@ -47,8 +47,7 @@ func (c *command) secretMappingUpdate(cmd *cobra.Command, args []string) error {
 		mappingName = *sdkMapping.Metadata.Name
 	}
 
-	// Block mutations on CFK-owned resources. Best-effort: if the current resource
-	// cannot be fetched, fall through and let the update surface the real error.
+	// Block the update if the resource is CFK-owned; if unreadable, let the update report it.
 	if existingMapping, describeErr := client.DescribeSecretMapping(c.createContext(), environment, mappingName); describeErr == nil {
 		if err := errIfCfkManaged(resource.FlinkSecretMapping, mappingName, existingMapping.Metadata.GetAnnotations()); err != nil {
 			return err

--- a/internal/flink/command_secret_mapping_update.go
+++ b/internal/flink/command_secret_mapping_update.go
@@ -4,6 +4,7 @@ import (
 	"github.com/spf13/cobra"
 
 	pcmd "github.com/confluentinc/cli/v4/pkg/cmd"
+	"github.com/confluentinc/cli/v4/pkg/resource"
 )
 
 func (c *command) newSecretMappingUpdateCommand() *cobra.Command {
@@ -44,6 +45,14 @@ func (c *command) secretMappingUpdate(cmd *cobra.Command, args []string) error {
 	var mappingName string
 	if sdkMapping.Metadata != nil && sdkMapping.Metadata.Name != nil {
 		mappingName = *sdkMapping.Metadata.Name
+	}
+
+	// Block mutations on CFK-owned resources. Best-effort: if the current resource
+	// cannot be fetched, fall through and let the update surface the real error.
+	if existingMapping, describeErr := client.DescribeSecretMapping(c.createContext(), environment, mappingName); describeErr == nil {
+		if err := errIfCfkManaged(resource.FlinkSecretMapping, mappingName, existingMapping.Metadata.GetAnnotations()); err != nil {
+			return err
+		}
 	}
 
 	sdkOutputMapping, err := client.UpdateSecretMapping(c.createContext(), environment, mappingName, sdkMapping)

--- a/internal/flink/command_secret_update.go
+++ b/internal/flink/command_secret_update.go
@@ -37,8 +37,7 @@ func (c *command) secretUpdate(cmd *cobra.Command, args []string) error {
 
 	secretName := sdkSecret.Metadata.Name
 
-	// Block mutations on CFK-owned resources. Best-effort: if the current resource
-	// cannot be fetched, fall through and let the update surface the real error.
+	// Block the update if the resource is CFK-owned; if unreadable, let the update report it.
 	if existingSecret, describeErr := client.DescribeSecret(c.createContext(), secretName); describeErr == nil {
 		if err := errIfCfkManaged(resource.FlinkSecret, secretName, existingSecret.Metadata.GetAnnotations()); err != nil {
 			return err

--- a/internal/flink/command_secret_update.go
+++ b/internal/flink/command_secret_update.go
@@ -4,6 +4,7 @@ import (
 	"github.com/spf13/cobra"
 
 	pcmd "github.com/confluentinc/cli/v4/pkg/cmd"
+	"github.com/confluentinc/cli/v4/pkg/resource"
 )
 
 func (c *command) newSecretUpdateCommand() *cobra.Command {
@@ -35,6 +36,15 @@ func (c *command) secretUpdate(cmd *cobra.Command, args []string) error {
 	}
 
 	secretName := sdkSecret.Metadata.Name
+
+	// Block mutations on CFK-owned resources. Best-effort: if the current resource
+	// cannot be fetched, fall through and let the update surface the real error.
+	if existingSecret, describeErr := client.DescribeSecret(c.createContext(), secretName); describeErr == nil {
+		if err := errIfCfkManaged(resource.FlinkSecret, secretName, existingSecret.Metadata.GetAnnotations()); err != nil {
+			return err
+		}
+	}
+
 	sdkOutputSecret, err := client.UpdateSecret(c.createContext(), secretName, sdkSecret)
 	if err != nil {
 		return err

--- a/internal/flink/command_statement_delete_onprem.go
+++ b/internal/flink/command_statement_delete_onprem.go
@@ -44,9 +44,7 @@ func (c *command) statementDeleteOnPrem(cmd *cobra.Command, args []string) error
 		return err == nil
 	}
 
-	// Block deletion of CFK-owned resources before prompting for confirmation. The
-	// whole batch fails if any resource is CFK-owned. Resources that cannot be
-	// fetched are skipped here and reported by ValidateAndConfirm below.
+	// Refuse the whole batch if any resource is CFK-owned; unreadable names fall to the check below.
 	for _, name := range args {
 		statement, describeErr := client.GetStatement(c.createContext(), environment, name)
 		if describeErr != nil {

--- a/internal/flink/command_statement_delete_onprem.go
+++ b/internal/flink/command_statement_delete_onprem.go
@@ -44,6 +44,19 @@ func (c *command) statementDeleteOnPrem(cmd *cobra.Command, args []string) error
 		return err == nil
 	}
 
+	// Block deletion of CFK-owned resources before prompting for confirmation. The
+	// whole batch fails if any resource is CFK-owned. Resources that cannot be
+	// fetched are skipped here and reported by ValidateAndConfirm below.
+	for _, name := range args {
+		statement, describeErr := client.GetStatement(c.createContext(), environment, name)
+		if describeErr != nil {
+			continue
+		}
+		if err := errIfCfkManaged(resource.FlinkStatement, name, statement.Metadata.GetAnnotations()); err != nil {
+			return err
+		}
+	}
+
 	if err := deletion.ValidateAndConfirm(cmd, args, existenceFunc, resource.FlinkStatement); err != nil {
 		suggestions := "List available Flink SQL statements with `confluent flink statement list`."
 		suggestions += "\nCheck that CMF is running and accessible."

--- a/internal/flink/command_statement_rescale_onprem.go
+++ b/internal/flink/command_statement_rescale_onprem.go
@@ -53,6 +53,10 @@ func (c *command) statementRescaleOnPrem(cmd *cobra.Command, args []string) erro
 		return err
 	}
 
+	if err := errIfCfkManaged(resource.FlinkStatement, name, statement.Metadata.GetAnnotations()); err != nil {
+		return err
+	}
+
 	// Construct the statement to rescale with different parallelism
 	statement = cmfsdk.Statement{
 		ApiVersion: statement.GetApiVersion(),

--- a/internal/flink/command_statement_resume_onprem.go
+++ b/internal/flink/command_statement_resume_onprem.go
@@ -46,6 +46,10 @@ func (c *command) statementResumeOnPrem(cmd *cobra.Command, args []string) error
 		return err
 	}
 
+	if err := errIfCfkManaged(resource.FlinkStatement, name, statement.Metadata.GetAnnotations()); err != nil {
+		return err
+	}
+
 	// Construct the statement to be stopped
 	statement = cmfsdk.Statement{
 		ApiVersion: statement.GetApiVersion(),

--- a/internal/flink/command_statement_resume_onprem.go
+++ b/internal/flink/command_statement_resume_onprem.go
@@ -50,7 +50,7 @@ func (c *command) statementResumeOnPrem(cmd *cobra.Command, args []string) error
 		return err
 	}
 
-	// Construct the statement to be stopped
+	// Construct the statement to be resumed
 	statement = cmfsdk.Statement{
 		ApiVersion: statement.GetApiVersion(),
 		Kind:       statement.GetKind(),

--- a/internal/flink/command_statement_stop_onprem.go
+++ b/internal/flink/command_statement_stop_onprem.go
@@ -46,6 +46,10 @@ func (c *command) statementStopOnPrem(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	if err := errIfCfkManaged(resource.FlinkStatement, name, statement.Metadata.GetAnnotations()); err != nil {
+		return err
+	}
+
 	// Construct the statement to be stopped
 	statement = cmfsdk.Statement{
 		ApiVersion: statement.GetApiVersion(),

--- a/test/fixtures/input/flink/application/update-cfk-managed.json
+++ b/test/fixtures/input/flink/application/update-cfk-managed.json
@@ -1,0 +1,34 @@
+{
+    "apiVersion": "cmf.confluent.io/v1",
+    "kind": "FlinkApplication",
+    "metadata": {
+        "name": "cfk-managed-app"
+    },
+    "spec": {
+        "image": "confluentinc/cp-flink:1.19.1-cp1",
+        "flinkVersion": "v1_19",
+        "flinkConfiguration": {
+            "taskmanager.numberOfTaskSlots": "2"
+        },
+        "serviceAccount": "flink",
+        "jobManager": {
+            "resource": {
+                "memory": "1048m",
+                "cpu": 1
+            }
+        },
+        "taskManager": {
+            "resource": {
+                "memory": "1048m",
+                "cpu": 1
+            }
+        },
+        "job": {
+            "jarURI": "local:///opt/flink/examples/streaming/StateMachineExample.jar",
+            "state": "running",
+            "parallelism": 3,
+            "upgradeMode": "stateless"
+        }
+    },
+    "status": null
+}

--- a/test/fixtures/output/flink/application/delete-cfk-managed.golden
+++ b/test/fixtures/output/flink/application/delete-cfk-managed.golden
@@ -1,0 +1,4 @@
+Error: Flink application "cfk-managed-app" is managed by Confluent for Kubernetes (CFK) and cannot be modified through the CLI
+
+Suggestions:
+    This resource was created by CFK. Edit or delete it through the owning Kubernetes custom resource "flink-system/cfk-managed-app-cr", for example with `kubectl edit` or `kubectl delete`.

--- a/test/fixtures/output/flink/application/delete-cfk-managed.golden
+++ b/test/fixtures/output/flink/application/delete-cfk-managed.golden
@@ -1,4 +1,4 @@
 Error: Flink application "cfk-managed-app" is managed by Confluent for Kubernetes (CFK) and cannot be modified through the CLI
 
 Suggestions:
-    This resource was created by CFK. Edit or delete it through the owning Kubernetes custom resource "flink-system/cfk-managed-app-cr", for example with `kubectl edit` or `kubectl delete`.
+    This resource is owned by the Kubernetes custom resource "flink-system/cfk-managed-app-cr". Edit or delete it there, for example with `kubectl edit` or `kubectl delete`.

--- a/test/fixtures/output/flink/application/update-cfk-managed.golden
+++ b/test/fixtures/output/flink/application/update-cfk-managed.golden
@@ -1,0 +1,4 @@
+Error: Flink application "cfk-managed-app" is managed by Confluent for Kubernetes (CFK) and cannot be modified through the CLI
+
+Suggestions:
+    This resource was created by CFK. Edit or delete it through the owning Kubernetes custom resource "flink-system/cfk-managed-app-cr", for example with `kubectl edit` or `kubectl delete`.

--- a/test/fixtures/output/flink/application/update-cfk-managed.golden
+++ b/test/fixtures/output/flink/application/update-cfk-managed.golden
@@ -1,4 +1,4 @@
 Error: Flink application "cfk-managed-app" is managed by Confluent for Kubernetes (CFK) and cannot be modified through the CLI
 
 Suggestions:
-    This resource was created by CFK. Edit or delete it through the owning Kubernetes custom resource "flink-system/cfk-managed-app-cr", for example with `kubectl edit` or `kubectl delete`.
+    This resource is owned by the Kubernetes custom resource "flink-system/cfk-managed-app-cr". Edit or delete it there, for example with `kubectl edit` or `kubectl delete`.

--- a/test/fixtures/output/flink/statement/delete-batch-cfk-managed.golden
+++ b/test/fixtures/output/flink/statement/delete-batch-cfk-managed.golden
@@ -1,4 +1,4 @@
 Error: Flink SQL statement "cfk-managed-stmt" is managed by Confluent for Kubernetes (CFK) and cannot be modified through the CLI
 
 Suggestions:
-    This resource was created by CFK. Edit or delete it through the owning Kubernetes custom resource "flink-system/cfk-managed-stmt-cr", for example with `kubectl edit` or `kubectl delete`.
+    This resource is owned by the Kubernetes custom resource "flink-system/cfk-managed-stmt-cr". Edit or delete it there, for example with `kubectl edit` or `kubectl delete`.

--- a/test/fixtures/output/flink/statement/delete-batch-cfk-managed.golden
+++ b/test/fixtures/output/flink/statement/delete-batch-cfk-managed.golden
@@ -1,0 +1,4 @@
+Error: Flink SQL statement "cfk-managed-stmt" is managed by Confluent for Kubernetes (CFK) and cannot be modified through the CLI
+
+Suggestions:
+    This resource was created by CFK. Edit or delete it through the owning Kubernetes custom resource "flink-system/cfk-managed-stmt-cr", for example with `kubectl edit` or `kubectl delete`.

--- a/test/fixtures/output/flink/statement/delete-cfk-managed.golden
+++ b/test/fixtures/output/flink/statement/delete-cfk-managed.golden
@@ -1,4 +1,4 @@
 Error: Flink SQL statement "cfk-managed-stmt" is managed by Confluent for Kubernetes (CFK) and cannot be modified through the CLI
 
 Suggestions:
-    This resource was created by CFK. Edit or delete it through the owning Kubernetes custom resource "flink-system/cfk-managed-stmt-cr", for example with `kubectl edit` or `kubectl delete`.
+    This resource is owned by the Kubernetes custom resource "flink-system/cfk-managed-stmt-cr". Edit or delete it there, for example with `kubectl edit` or `kubectl delete`.

--- a/test/fixtures/output/flink/statement/delete-cfk-managed.golden
+++ b/test/fixtures/output/flink/statement/delete-cfk-managed.golden
@@ -1,0 +1,4 @@
+Error: Flink SQL statement "cfk-managed-stmt" is managed by Confluent for Kubernetes (CFK) and cannot be modified through the CLI
+
+Suggestions:
+    This resource was created by CFK. Edit or delete it through the owning Kubernetes custom resource "flink-system/cfk-managed-stmt-cr", for example with `kubectl edit` or `kubectl delete`.

--- a/test/fixtures/output/flink/statement/rescale-cfk-managed.golden
+++ b/test/fixtures/output/flink/statement/rescale-cfk-managed.golden
@@ -1,4 +1,4 @@
 Error: Flink SQL statement "cfk-managed-stmt" is managed by Confluent for Kubernetes (CFK) and cannot be modified through the CLI
 
 Suggestions:
-    This resource was created by CFK. Edit or delete it through the owning Kubernetes custom resource "flink-system/cfk-managed-stmt-cr", for example with `kubectl edit` or `kubectl delete`.
+    This resource is owned by the Kubernetes custom resource "flink-system/cfk-managed-stmt-cr". Edit or delete it there, for example with `kubectl edit` or `kubectl delete`.

--- a/test/fixtures/output/flink/statement/rescale-cfk-managed.golden
+++ b/test/fixtures/output/flink/statement/rescale-cfk-managed.golden
@@ -1,0 +1,4 @@
+Error: Flink SQL statement "cfk-managed-stmt" is managed by Confluent for Kubernetes (CFK) and cannot be modified through the CLI
+
+Suggestions:
+    This resource was created by CFK. Edit or delete it through the owning Kubernetes custom resource "flink-system/cfk-managed-stmt-cr", for example with `kubectl edit` or `kubectl delete`.

--- a/test/fixtures/output/flink/statement/resume-cfk-managed.golden
+++ b/test/fixtures/output/flink/statement/resume-cfk-managed.golden
@@ -1,4 +1,4 @@
 Error: Flink SQL statement "cfk-managed-stmt" is managed by Confluent for Kubernetes (CFK) and cannot be modified through the CLI
 
 Suggestions:
-    This resource was created by CFK. Edit or delete it through the owning Kubernetes custom resource "flink-system/cfk-managed-stmt-cr", for example with `kubectl edit` or `kubectl delete`.
+    This resource is owned by the Kubernetes custom resource "flink-system/cfk-managed-stmt-cr". Edit or delete it there, for example with `kubectl edit` or `kubectl delete`.

--- a/test/fixtures/output/flink/statement/resume-cfk-managed.golden
+++ b/test/fixtures/output/flink/statement/resume-cfk-managed.golden
@@ -1,0 +1,4 @@
+Error: Flink SQL statement "cfk-managed-stmt" is managed by Confluent for Kubernetes (CFK) and cannot be modified through the CLI
+
+Suggestions:
+    This resource was created by CFK. Edit or delete it through the owning Kubernetes custom resource "flink-system/cfk-managed-stmt-cr", for example with `kubectl edit` or `kubectl delete`.

--- a/test/fixtures/output/flink/statement/stop-cfk-managed.golden
+++ b/test/fixtures/output/flink/statement/stop-cfk-managed.golden
@@ -1,4 +1,4 @@
 Error: Flink SQL statement "cfk-managed-stmt" is managed by Confluent for Kubernetes (CFK) and cannot be modified through the CLI
 
 Suggestions:
-    This resource was created by CFK. Edit or delete it through the owning Kubernetes custom resource "flink-system/cfk-managed-stmt-cr", for example with `kubectl edit` or `kubectl delete`.
+    This resource is owned by the Kubernetes custom resource "flink-system/cfk-managed-stmt-cr". Edit or delete it there, for example with `kubectl edit` or `kubectl delete`.

--- a/test/fixtures/output/flink/statement/stop-cfk-managed.golden
+++ b/test/fixtures/output/flink/statement/stop-cfk-managed.golden
@@ -1,0 +1,4 @@
+Error: Flink SQL statement "cfk-managed-stmt" is managed by Confluent for Kubernetes (CFK) and cannot be modified through the CLI
+
+Suggestions:
+    This resource was created by CFK. Edit or delete it through the owning Kubernetes custom resource "flink-system/cfk-managed-stmt-cr", for example with `kubectl edit` or `kubectl delete`.

--- a/test/flink_onprem_test.go
+++ b/test/flink_onprem_test.go
@@ -652,6 +652,26 @@ func (s *CLITestSuite) TestFlinkStatementUpdateOnPrem() {
 	runIntegrationTestsWithMultipleAuth(s, tests)
 }
 
+// Mutations on resources created by CFK are blocked; the user is pointed at the
+// owning Kubernetes custom resource. Reads stay unrestricted (covered elsewhere).
+func (s *CLITestSuite) TestFlinkOnPremCfkManagedResourcesAreBlocked() {
+	tests := []CLITest{
+		// Statement (typed metadata): state changes and delete are blocked.
+		{args: "flink statement stop cfk-managed-stmt --environment default", fixture: "flink/statement/stop-cfk-managed.golden", exitCode: 1},
+		{args: "flink statement resume cfk-managed-stmt --environment default", fixture: "flink/statement/resume-cfk-managed.golden", exitCode: 1},
+		{args: "flink statement rescale cfk-managed-stmt --parallelism 2 --environment default", fixture: "flink/statement/rescale-cfk-managed.golden", exitCode: 1},
+		{args: "flink statement delete cfk-managed-stmt --environment default --force", fixture: "flink/statement/delete-cfk-managed.golden", exitCode: 1},
+		// The whole batch is refused (nothing deleted) when any name is CFK-owned,
+		// regardless of its position in the argument list.
+		{args: "flink statement delete test-stmt1 cfk-managed-stmt --environment default --force", fixture: "flink/statement/delete-batch-cfk-managed.golden", exitCode: 1},
+		// Application (untyped metadata): update and delete are blocked.
+		{args: "flink application delete cfk-managed-app --environment default --force", fixture: "flink/application/delete-cfk-managed.golden", exitCode: 1},
+		{args: "flink application update --environment default test/fixtures/input/flink/application/update-cfk-managed.json", fixture: "flink/application/update-cfk-managed.golden", exitCode: 1},
+	}
+
+	runIntegrationTestsWithMultipleAuth(s, tests)
+}
+
 func (s *CLITestSuite) TestFlinkStatementExceptionListOnPrem() {
 	tests := []CLITest{
 		// success scenarios

--- a/test/flink_onprem_test.go
+++ b/test/flink_onprem_test.go
@@ -652,8 +652,7 @@ func (s *CLITestSuite) TestFlinkStatementUpdateOnPrem() {
 	runIntegrationTestsWithMultipleAuth(s, tests)
 }
 
-// Mutations on resources created by CFK are blocked; the user is pointed at the
-// owning Kubernetes custom resource. Reads stay unrestricted (covered elsewhere).
+// Mutations on CFK-created resources are blocked; reads stay unrestricted.
 func (s *CLITestSuite) TestFlinkOnPremCfkManagedResourcesAreBlocked() {
 	tests := []CLITest{
 		// Statement (typed metadata): state changes and delete are blocked.

--- a/test/test-server/flink_onprem_handler.go
+++ b/test/test-server/flink_onprem_handler.go
@@ -18,6 +18,24 @@ import (
 
 const invalidSecretMappingName = "invalid-secret-mapping"
 
+// Sentinel resource names the on-prem mock stamps with CFK ownership annotations,
+// so the CLI's blocking of mutations on CFK-created resources can be exercised
+// end-to-end.
+const (
+	cfkManagedStatement   = "cfk-managed-stmt"
+	cfkManagedApplication = "cfk-managed-app"
+)
+
+// cfkOwnershipAnnotations returns the ownership annotations CFK stamps on every CMF
+// resource it creates (RFC 68), naming the owning custom resource crName.
+func cfkOwnershipAnnotations(crName string) map[string]string {
+	return map[string]string{
+		"cmf.platform.confluent.io/managed-by":           "confluent-operator",
+		"cmf.platform.confluent.io/managed-by-namespace": "flink-system",
+		"cmf.platform.confluent.io/managed-by-name":      crName,
+	}
+}
+
 func createSecretMapping(name string) cmfsdk.EnvironmentSecretMapping {
 	timeStamp := time.Date(2025, time.August, 5, 12, 0, 0, 0, time.UTC).String()
 	mappingName := name
@@ -803,6 +821,14 @@ func handleCmfApplication(t *testing.T) http.HandlerFunc {
 				return
 			}
 
+			if application == cfkManagedApplication && environment == "default" {
+				outputApplication := createApplication(application)
+				outputApplication.Metadata["annotations"] = cfkOwnershipAnnotations(cfkManagedApplication + "-cr")
+				err := json.NewEncoder(w).Encode(outputApplication)
+				require.NoError(t, err)
+				return
+			}
+
 			if strings.Contains(application, "failure") {
 				http.Error(w, "", http.StatusUnprocessableEntity)
 				return
@@ -1409,6 +1435,12 @@ func handleCmfStatement(t *testing.T) http.HandlerFunc {
 				require.NoError(t, err)
 			} else if stmtName == "test-stmt-savepoint" {
 				stmt := createFlinkStatementSavepoint(stmtName, false, 1)
+				err := json.NewEncoder(w).Encode(stmt)
+				require.NoError(t, err)
+			} else if stmtName == cfkManagedStatement {
+				stmt := createFlinkStatement(stmtName, false, 1)
+				annotations := cfkOwnershipAnnotations(cfkManagedStatement + "-cr")
+				stmt.Metadata.Annotations = &annotations
 				err := json.NewEncoder(w).Encode(stmt)
 				require.NoError(t, err)
 			} else {

--- a/test/test-server/flink_onprem_handler.go
+++ b/test/test-server/flink_onprem_handler.go
@@ -18,16 +18,13 @@ import (
 
 const invalidSecretMappingName = "invalid-secret-mapping"
 
-// Sentinel resource names the on-prem mock stamps with CFK ownership annotations,
-// so the CLI's blocking of mutations on CFK-created resources can be exercised
-// end-to-end.
+// Sentinel names the mock stamps as CFK-owned, to exercise CLI mutation blocking.
 const (
 	cfkManagedStatement   = "cfk-managed-stmt"
 	cfkManagedApplication = "cfk-managed-app"
 )
 
-// cfkOwnershipAnnotations returns the ownership annotations CFK stamps on every CMF
-// resource it creates (RFC 68), naming the owning custom resource crName.
+// cfkOwnershipAnnotations returns the CFK ownership annotations naming custom resource crName.
 func cfkOwnershipAnnotations(crName string) map[string]string {
 	return map[string]string{
 		"cmf.platform.confluent.io/managed-by":           "confluent-operator",

--- a/test/test-server/flink_onprem_handler.go
+++ b/test/test-server/flink_onprem_handler.go
@@ -24,12 +24,11 @@ const (
 	cfkManagedApplication = "cfk-managed-app"
 )
 
-// cfkOwnershipAnnotations returns the CFK ownership annotations naming custom resource crName.
+// cfkOwnershipAnnotations returns the CFK ownership annotation, whose value is the
+// owning custom resource identity "<namespace>/<name>" (RFC 68 / CF-3914).
 func cfkOwnershipAnnotations(crName string) map[string]string {
 	return map[string]string{
-		"cmf.platform.confluent.io/managed-by":           "confluent-operator",
-		"cmf.platform.confluent.io/managed-by-namespace": "flink-system",
-		"cmf.platform.confluent.io/managed-by-name":      crName,
+		"cmf.platform.confluent.io/managed-by": "flink-system/" + crName,
 	}
 }
 


### PR DESCRIPTION
Release Notes
-------------
New Features
- The Confluent CLI now blocks mutating operations (`update`, `delete`, and statement `stop`/`resume`/`rescale`) on CMF resources created by Confluent for Kubernetes (CFK), pointing users to `kubectl` on the owning custom resource. Reads are unaffected.

Checklist
---------
- [x] I have successfully built and used a custom CLI binary, without linter issues from this PR.
- [x] I have clearly specified in the `What` section below whether this PR applies to Confluent Cloud, Confluent Platform, or both.
- [x] I have attached manual CLI verification results or screenshots in the `Test & Review` section below.
- [x] I have added appropriate CLI integration or unit tests for any new or updated commands and functionality.
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [x] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [ ] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [ ] Confluent Cloud prod
  - [ ] Confluent Cloud stag
  - [x] Confluent Platform
  - [ ] Check this box if the feature is enabled for certain organizations only

What
----
Implements **CF-3666** for the Confluent CLI, targeting **Confluent Platform / CP Flink (CMF on-prem)**.

CFK stamps a `cmf.platform.confluent.io/managed-by` annotation (value `<namespace>/<name>`) on every CMF resource it creates (RFC 68 / CF-3914). The CLI now refuses to mutate any resource carrying it and points the user to `kubectl`.

- Adds `internal/flink/cfk_guard.go` — blocks when the annotation is present and names the owning custom resource.
- Guards `update`, `delete`, and statement `stop`/`resume`/`rescale` across all eight on-prem CMF kinds: application, environment, compute pool, catalog, database, statement, secret, secret mapping.
- `delete` refuses the whole batch if any name is CFK-owned.
- `create` and reads (`describe`/`list`) are unaffected.

Blast Radius
----
- Limited to mutating `confluent flink` on-prem commands; cloud commands and all reads are unchanged.
- Fires only on resources carrying the annotation; worst case is over-blocking a legitimate mutation. No API, payload, or migration changes.
- No breaking changes; straightforward to revert.

References
----------
- Jira: [CF-3666](https://confluentinc.atlassian.net/browse/CF-3666)
- Producer of the annotation: [CF-3914](https://confluentinc.atlassian.net/browse/CF-3914) (confluent-operator#4565)
- Epic: [CF-3404](https://confluentinc.atlassian.net/browse/CF-3404); RFC 68 (API Considerations #6).

Test & Review
-------------
- Unit tests (`cfk_guard_test.go`) and integration golden tests (`TestFlinkOnPremCfkManagedResourcesAreBlocked`): blocked state-change, single + batch delete, and update for both typed and untyped metadata resources.
- Manual: verified live against a real CMF (`--cmf.k8s.enabled=false`) with the real CLI binary — `delete`/`update` blocked on a CFK-stamped environment; reads and non-owned mutations unaffected. Transcript in the comment below.


[CF-3666]: https://confluentinc.atlassian.net/browse/CF-3666?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ