### PR TITLE
[APIE-1040] Default flink statement --wait-timeout to 1m (defer 6h to next major)

### DIFF
--- a/internal/flink/command_statement_create.go
+++ b/internal/flink/command_statement_create.go
@@ -28,10 +28,14 @@ var (
 	flinkStatementFailedPhases  = []string{"FAILED"}
 )
 
-// statementsAPICreateTimeout aligns with terraform-provider-confluent's
-// statementsAPICreateTimeout in internal/provider/constants.go. CLI users can
-// shorten it with --wait-timeout; TF has no equivalent override.
-const flinkStatementCreateWaitTimeout = 6 * time.Hour
+// flinkStatementCreateWaitTimeout is the default for --wait-timeout. It is kept
+// at 1 minute to match the pre-framework `--wait` behavior (a hardcoded
+// retry.Retry(time.Second, time.Minute, ...) poll), so customers who scripted
+// around that 1-minute timer are not affected by the --wait refactor. Bump to
+// 6h in the next major version (aligning with terraform-provider-confluent's
+// statementsAPICreateTimeout in internal/provider/constants.go); CLI users can
+// already lengthen it with --wait-timeout in the meantime. (APIE-1040)
+const flinkStatementCreateWaitTimeout = time.Minute
 
 func (c *command) newStatementCreateCommand() *cobra.Command {
 	cmd := &cobra.Command{

--- a/test/fixtures/output/flink/statement/create-help-onprem.golden
+++ b/test/fixtures/output/flink/statement/create-help-onprem.golden
@@ -12,7 +12,7 @@ Flags:
       --database string                     The name of the default database.
       --flink-configuration string          The file path to hold the Flink configuration for the statement.
       --wait                                Block until the statement reaches a terminal state.
-      --wait-timeout duration               Maximum time to wait when --wait is set. (default 6h0m0s)
+      --wait-timeout duration               Maximum time to wait when --wait is set. (default 1m0s)
       --url string                          Base URL of the Confluent Manager for Apache Flink (CMF). Environment variable "CONFLUENT_CMF_URL" may be set in place of this flag.
       --client-key-path string              Path to client private key for mTLS authentication. Environment variable "CONFLUENT_CMF_CLIENT_KEY_PATH" may be set in place of this flag.
       --client-cert-path string             Path to client cert to be verified by Confluent Manager for Apache Flink. Include for mTLS authentication. Environment variable "CONFLUENT_CMF_CLIENT_CERT_PATH" may be set in place of this flag.

--- a/test/fixtures/output/flink/statement/create-help.golden
+++ b/test/fixtures/output/flink/statement/create-help.golden
@@ -18,7 +18,7 @@ Flags:
       --service-account string   Service account ID.
       --database string          The database which will be used as the default database. When using Kafka, this is the cluster ID.
       --wait                     Block until the statement reaches a terminal state.
-      --wait-timeout duration    Maximum time to wait when --wait is set. (default 6h0m0s)
+      --wait-timeout duration    Maximum time to wait when --wait is set. (default 1m0s)
       --property strings         A mechanism to pass properties in the form key=value when creating a Flink statement.
       --environment string       Environment ID.
       --context string           CLI context name.

--- a/test/fixtures/output/flink/statement/create-missing-compute-pool-failure.golden
+++ b/test/fixtures/output/flink/statement/create-missing-compute-pool-failure.golden
@@ -11,7 +11,7 @@ Flags:
       --database string                     The name of the default database.
       --flink-configuration string          The file path to hold the Flink configuration for the statement.
       --wait                                Block until the statement reaches a terminal state.
-      --wait-timeout duration               Maximum time to wait when --wait is set. (default 6h0m0s)
+      --wait-timeout duration               Maximum time to wait when --wait is set. (default 1m0s)
       --url string                          Base URL of the Confluent Manager for Apache Flink (CMF). Environment variable "CONFLUENT_CMF_URL" may be set in place of this flag.
       --client-key-path string              Path to client private key for mTLS authentication. Environment variable "CONFLUENT_CMF_CLIENT_KEY_PATH" may be set in place of this flag.
       --client-cert-path string             Path to client cert to be verified by Confluent Manager for Apache Flink. Include for mTLS authentication. Environment variable "CONFLUENT_CMF_CLIENT_CERT_PATH" may be set in place of this flag.

--- a/test/fixtures/output/flink/statement/create-missing-sql-failure.golden
+++ b/test/fixtures/output/flink/statement/create-missing-sql-failure.golden
@@ -11,7 +11,7 @@ Flags:
       --database string                     The name of the default database.
       --flink-configuration string          The file path to hold the Flink configuration for the statement.
       --wait                                Block until the statement reaches a terminal state.
-      --wait-timeout duration               Maximum time to wait when --wait is set. (default 6h0m0s)
+      --wait-timeout duration               Maximum time to wait when --wait is set. (default 1m0s)
       --url string                          Base URL of the Confluent Manager for Apache Flink (CMF). Environment variable "CONFLUENT_CMF_URL" may be set in place of this flag.
       --client-key-path string              Path to client private key for mTLS authentication. Environment variable "CONFLUENT_CMF_CLIENT_KEY_PATH" may be set in place of this flag.
       --client-cert-path string             Path to client cert to be verified by Confluent Manager for Apache Flink. Include for mTLS authentication. Environment variable "CONFLUENT_CMF_CLIENT_CERT_PATH" may be set in place of this flag.


### PR DESCRIPTION
## Summary

Addresses review feedback on the `--wait` reapply (#3389): keep the `flink statement create` **`--wait-timeout` default at 1 minute** instead of jumping to 6h.

The pre-framework `--wait` used a hardcoded `retry.Retry(time.Second, time.Minute, …)` — a **1-minute** timeout. Customers may have scripted around that timer, so silently changing the default to 6h on the `--wait` refactor is a behavior change we'd rather not ship mid-cycle. This keeps the observable default identical to today and defers the 6h bump to the **next major version** (users who want longer can already pass `--wait-timeout`).

One-line change to the constant + the four `flink statement create` help goldens (`(default 6h0m0s)` → `(default 1m0s)`).

## Test plan

- [x] `gofmt` clean; `go test ./internal/flink/` passes
- [x] Built the binary and confirmed `confluent flink statement create --help` renders `--wait-timeout … (default 1m0s)` (matches the regenerated golden)
- [x] Updated all 4 affected goldens (`create-help`, `create-help-onprem`, `create-missing-compute-pool-failure`, `create-missing-sql-failure`); no other `6h0m0s` references remain

Stacked on #3389 (`re-apply-wait-pr`) — the `flinkStatementCreateWaitTimeout` constant only exists there, so this targets that branch; merging it folds the 1m default into the reapply before it lands on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
