### PR TITLE
CF-3932 : Stop HTML-escaping <, >, & in -o json output

### DIFF
--- a/pkg/output/serialized_output.go
+++ b/pkg/output/serialized_output.go
@@ -37,6 +37,6 @@ func marshalJSON(v any) ([]byte, error) {
 	if err := encoder.Encode(v); err != nil {
 		return nil, err
 	}
-	// Encode appends a trailing newline; trim it to match json.Marshal.
-	return bytes.TrimRight(buffer.Bytes(), "\n"), nil
+	// Encode appends a single trailing newline; drop just it to match json.Marshal.
+	return bytes.TrimSuffix(buffer.Bytes(), []byte("\n")), nil
 }

--- a/pkg/output/serialized_output.go
+++ b/pkg/output/serialized_output.go
@@ -1,6 +1,7 @@
 package output
 
 import (
+	"bytes"
 	"encoding/json"
 
 	"github.com/spf13/cobra"
@@ -12,7 +13,7 @@ import (
 func SerializedOutput(cmd *cobra.Command, v any) error {
 	switch GetFormat(cmd) {
 	default:
-		out, err := json.Marshal(v)
+		out, err := marshalJSON(v)
 		if err != nil {
 			return err
 		}
@@ -25,4 +26,17 @@ func SerializedOutput(cmd *cobra.Command, v any) error {
 		Print(false, string(out))
 	}
 	return nil
+}
+
+// marshalJSON marshals v to JSON without HTML-escaping <, >, and & (which
+// encoding/json does by default), keeping text like SQL statements readable.
+func marshalJSON(v any) ([]byte, error) {
+	buffer := new(bytes.Buffer)
+	encoder := json.NewEncoder(buffer)
+	encoder.SetEscapeHTML(false)
+	if err := encoder.Encode(v); err != nil {
+		return nil, err
+	}
+	// Encode appends a trailing newline; trim it to match json.Marshal.
+	return bytes.TrimRight(buffer.Bytes(), "\n"), nil
 }

--- a/pkg/output/table.go
+++ b/pkg/output/table.go
@@ -1,7 +1,6 @@
 package output
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 	"reflect"
@@ -126,7 +125,7 @@ func (t *Table) printCore(writer io.Writer, auto bool) error {
 
 		switch t.format {
 		default:
-			out, err := json.Marshal(v)
+			out, err := marshalJSON(v)
 			if err != nil {
 				return err
 			}

--- a/pkg/output/table_test.go
+++ b/pkg/output/table_test.go
@@ -128,6 +128,41 @@ func TestTable_NoAutoWrap(t *testing.T) {
 	}
 }
 
+func TestTable_NoHTMLEscape(t *testing.T) {
+	// <, >, and & must appear verbatim in -o json output, not HTML-escaped.
+	buf := new(bytes.Buffer)
+	cmd := &cobra.Command{}
+	cmd.Flags().String("output", JSON.String(), "")
+	cmd.SetOut(buf)
+
+	table := NewTable(cmd)
+	table.Add(&out{
+		Id:          1,
+		Name:        "lkc-123456",
+		Description: "SELECT 1 WHERE 1 < 2 AND 3 > 2 & true",
+	})
+
+	err := table.Print()
+	require.NoError(t, err)
+
+	expected := strings.Join([]string{
+		"{",
+		`  "is_current": false,`,
+		`  "id": 1,`,
+		`  "name": "lkc-123456",`,
+		`  "description": "SELECT 1 WHERE 1 < 2 AND 3 > 2 & true"`,
+		"}",
+	}, "\n") + "\n"
+	require.Equal(t, expected, buf.String())
+}
+
+func TestMarshalJSON_NoHTMLEscape(t *testing.T) {
+	// marshalJSON backs both the Table and SerializedOutput JSON paths.
+	out, err := marshalJSON(map[string]string{"statement": "SELECT 1 WHERE 1 < 2 AND 3 > 2 & true"})
+	require.NoError(t, err)
+	require.Equal(t, `{"statement":"SELECT 1 WHERE 1 < 2 AND 3 > 2 & true"}`, string(out))
+}
+
 func TestTable_Filter(t *testing.T) {
 	tests := map[string][]string{
 		Human.String(): {

--- a/test/fixtures/output/api-key/7.golden
+++ b/test/fixtures/output/api-key/7.golden
@@ -3,7 +3,7 @@
     "key": "DEACTIVATEDUSERKEY",
     "description": "",
     "owner": "sa-6666",
-    "owner_email": "\u003cdeactivated user\u003e",
+    "owner_email": "<deactivated user>",
     "resource_type": "kafka",
     "resource": "lkc-bob",
     "created": "1999-02-24T00:00:00Z"
@@ -30,7 +30,7 @@
     "key": "MULTICLUSTERKEY3",
     "description": "works for two clusters and owned by service account",
     "owner": "sa-12345",
-    "owner_email": "\u003cservice account\u003e",
+    "owner_email": "<service account>",
     "resource_type": "kafka",
     "resource": "lkc-abc",
     "created": "1999-02-24T00:00:00Z"
@@ -66,7 +66,7 @@
     "key": "SERVICEACCOUNTKEY1",
     "description": "",
     "owner": "sa-12345",
-    "owner_email": "\u003cservice account\u003e",
+    "owner_email": "<service account>",
     "resource_type": "kafka",
     "resource": "lkc-bob",
     "created": "1999-02-24T00:00:00Z"


### PR DESCRIPTION
Release Notes
-------------
Breaking Changes
- NONE

New Features
- NONE

Bug Fixes
- `-o json` output no longer HTML-escapes `<`, `>`, and `&`, keeping readable text such as SQL statements intact.

Checklist
---------
- [x] I have successfully built and used a custom CLI binary, without linter issues from this PR.
- [x] I have clearly specified in the `What` section below whether this PR applies to Confluent Cloud, Confluent Platform, or both.
- [x] I have attached manual CLI verification results or screenshots in the `Test & Review` section below.
- [x] I have added appropriate CLI integration or unit tests for any new or updated commands and functionality.
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [x] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [ ] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [ ] Confluent Cloud prod
  - [ ] Confluent Cloud stag
  - [ ] Confluent Platform
  - [ ] Check this box if the feature is enabled for certain organizations only

What
----
**Both Confluent Cloud and Confluent Platform** (shared output package used by every command).
- Go's `encoding/json` HTML-escapes `<`, `>`, and `&` by default. Both `-o json` serializers (`pkg/output/serialized_output.go`, `pkg/output/table.go`) used `json.Marshal`, mangling any JSON output with those characters (most visibly Flink SQL statements).
- Fix: a shared `marshalJSON` helper (`json.Encoder` with `SetEscapeHTML(false)`) that both serializers use. Drop-in for `json.Marshal`; YAML path untouched.

Blast Radius
----
- `-o json` for every command now emits `<`, `>`, `&` verbatim instead of their escaped Unicode sequences. Both forms are valid JSON and decode identically, so parsers are unaffected; exact-string matching against the old escaped form would need to match the raw characters.
- `-o yaml` and human/table output unchanged.

References
----------
- https://confluentinc.atlassian.net/browse/CF-3932

Test & Review
-------------
Environment: local CMF `cmf-app 2.4-SNAPSHOT` (HTTP, `--cmf.k8s.enabled=false`); CLI built from this branch vs released `confluent v4.54.0`.

Manual CLI validation: attached in the comment below.
