### PR TITLE
fix(deps): bump cmf-sdk-go v0.0.7 to v0.0.8

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -53,7 +53,7 @@ require (
 	github.com/confluentinc/ccloud-sdk-go-v2/sso v0.0.1
 	github.com/confluentinc/ccloud-sdk-go-v2/tableflow v0.6.0
 	github.com/confluentinc/ccloud-sdk-go-v2/usm v0.1.0
-	github.com/confluentinc/cmf-sdk-go v0.0.7
+	github.com/confluentinc/cmf-sdk-go v0.0.8
 	github.com/confluentinc/confluent-kafka-go/v2 v2.14.2
 	github.com/confluentinc/go-editor v0.11.0
 	github.com/confluentinc/go-prompt v0.2.40

--- a/go.sum
+++ b/go.sum
@@ -248,8 +248,8 @@ github.com/confluentinc/ccloud-sdk-go-v2/tableflow v0.6.0 h1:wrmpI4UJgWZ4rX1EYqU
 github.com/confluentinc/ccloud-sdk-go-v2/tableflow v0.6.0/go.mod h1:myRmhUEWzpwGqWvdsNk79QH41pkre1G21vmySyGQiWA=
 github.com/confluentinc/ccloud-sdk-go-v2/usm v0.1.0 h1:rF9cKecDCowq+oDWjf8rSpXXZHAnVXowIsT/OXF4MOI=
 github.com/confluentinc/ccloud-sdk-go-v2/usm v0.1.0/go.mod h1:umhEDvQp/5h0ALKBpYTQOmFwaWrvilnbE8Rkzh6oJ4Q=
-github.com/confluentinc/cmf-sdk-go v0.0.7 h1:+BS3A0v3K4VvzDjo1WwJMKWvlkmK7KK6hZSEzGaYRF4=
-github.com/confluentinc/cmf-sdk-go v0.0.7/go.mod h1:xY6OWDUc4UtKMgmade99v1C8/YovgWTl8tzeZ23LrEg=
+github.com/confluentinc/cmf-sdk-go v0.0.8 h1:ziiV4/lNKh49m7RxwPCDL04OFV54lA3SkeynsQ2SDC8=
+github.com/confluentinc/cmf-sdk-go v0.0.8/go.mod h1:xY6OWDUc4UtKMgmade99v1C8/YovgWTl8tzeZ23LrEg=
 github.com/confluentinc/confluent-avro-go/v2 v2.32.0 h1:PQjdGEaxCGrvdNtXsoMJsfY39WQyfrekEdOsh0e6bT0=
 github.com/confluentinc/confluent-avro-go/v2 v2.32.0/go.mod h1:WfNwYNykGDKOM3WrEqhHDNokB+PBRno5DJqS/cTtAko=
 github.com/confluentinc/confluent-kafka-go/v2 v2.14.2 h1:EYOGezeuuHtzXElXsAjalIyL9Qm5wBVNdy1m8fJElyM=


### PR DESCRIPTION
Release Notes
-------------
No user-facing changes.

Checklist
---------
- [x] I have successfully built and used a custom CLI binary, without linter issues from this PR.
- [x] I have clearly specified in the `What` section below whether this PR applies to Confluent Cloud, Confluent Platform, or both.
- [ ] I have attached manual CLI verification results or screenshots in the `Test & Review` section below.
- [x] I have added appropriate CLI integration or unit tests for any new or updated commands and functionality.
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [x] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [ ] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [ ] Confluent Cloud prod
  - [ ] Confluent Cloud stag
  - [x] Confluent Platform
  - [ ] Check this box if the feature is enabled for certain organizations only

What
----
This PR bumps `github.com/confluentinc/cmf-sdk-go` from **v0.0.7 → v0.0.8**. The new release regenerates the SDK for **CMF 2.4.0**. Targets **Confluent Platform / CP Flink (CMF on-prem)**.

- **No breaking changes and no CLI code changes.** The regenerated SDK is source-compatible with the current CLI — `go build ./...` compiles against v0.0.8 with zero code changes. Only `go.mod` / `go.sum` are touched.
- Keeps the CLI's CMF client current with the latest CMF API surface (CMF 2.4.0).

Blast Radius
----
- Scope is limited to the **CMF SDK dependency** consumed by on-prem Flink commands (`confluent flink compute-pool`, `environment`, `application`, `statement`, `catalog`, ...). No CLI code paths changed.
- If something goes wrong: risk is confined to any CMF request/response type whose generated shape changed between v0.0.7 and v0.0.8. Such an incompatibility would surface either at compile time (none — build is clean) or as a decode mismatch at runtime against a CMF 2.4.0 server.
- No changes to Confluent Cloud commands; no changes to any other command surface.
- Rollback is a single-commit revert (re-pin to v0.0.7).


Test & Review
-------------
**Environment**

- Repo: `confluentinc/cli`
- Branch: `bump-cmf-sdk-go-v0.0.8`
- SDK: `github.com/confluentinc/cmf-sdk-go v0.0.8`

**Automated**

- `go build ./...` clean
- `go test ./internal/flink/... ./pkg/cmd/... ./pkg/flink/...` passes 

**Manual CLI validation**

- N/A — dependency-only bump with no code changes to exercise.
