### PR TITLE
[APIE-1288] Fix `network gateway create` example

### DIFF
--- a/internal/network/command_gateway_create.go
+++ b/internal/network/command_gateway_create.go
@@ -30,7 +30,7 @@ func (c *command) newGatewayCreateCommand() *cobra.Command {
 			},
 			examples.Example{
 				Text: `Create AWS private network interface gateway "my-pni-gateway".`,
-				Code: "confluent network gateway create my-pni-gateway --cloud aws --region us-east-1 --type private-network-interface",
+				Code: "confluent network gateway create my-pni-gateway --cloud aws --region us-east-1 --zones use1-az1,use1-az2,use1-az4 --type private-network-interface",
 			},
 			examples.Example{
 				Text: `Create Azure ingress private link gateway "my-azure-ingress-gateway".`,

--- a/test/fixtures/output/network/gateway/create-help.golden
+++ b/test/fixtures/output/network/gateway/create-help.golden
@@ -14,7 +14,7 @@ Create AWS egress private link gateway "my-egress-gateway".
 
 Create AWS private network interface gateway "my-pni-gateway".
 
-  $ confluent network gateway create my-pni-gateway --cloud aws --region us-east-1 --type private-network-interface
+  $ confluent network gateway create my-pni-gateway --cloud aws --region us-east-1 --zones use1-az1,use1-az2,use1-az4 --type private-network-interface
 
 Create Azure ingress private link gateway "my-azure-ingress-gateway".
 


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- PLACEHOLDER

New Features
- PLACEHOLDER

Bug Fixes
- Fix a typo in one of the examples for the `confluent network gateway create` command

Checklist
---------
<!-- 
Check each item below to ensure high-quality CLI development practices are followed. PR approval will not be granted until the checklist is fully reviewed.
For detailed instructions, please refer to this Confluence page: https://confluentinc.atlassian.net/wiki/spaces/AEGI/pages/3949592874/
-->
- [x] I have successfully built and used a custom CLI binary, without linter issues from this PR.
- [x] I have clearly specified in the `What` section below whether this PR applies to Confluent Cloud, Confluent Platform, or both. 
- [x] I have verified this PR in Confluent Cloud pre-prod or production environment, if applicable.
- [ ] I have verified this PR in Confluent Platform on-premises environment, if applicable.
- [x] I have attached manual CLI verification results or screenshots in the `Test & Review` section below.
- [ ] I have added appropriate CLI integration or unit tests for any new or updated commands and functionality.
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [x] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [x] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [x] Confluent Cloud prod
  - [x] Confluent Cloud stag
  - [ ] Confluent Platform
  - [ ] Check this box if the feature is enabled for certain organizations only

What
----
This PR fixes a typo in the example for creating a PNI gateway. The `zones` flag is required, but the example omitted it.

This is for a Cloud command.

Blast Radius
----
None; docs & help menu fix only.

References
----------
<!-- Include links to relevant resources for this PR, such as: 
- Related GitHub issues 
- Tickets (JIRA, etc.) 
- Internal documentation or design specs 
- Other related PRs 
Copy and paste the links below for easy reference.
-->

Test & Review
-------------
Results of running the example verbatim.

Before:
```
confluent network gateway create my-pni-gateway --cloud aws --region us-east-1  --type private-network-interface
Error: invalid zones count: 0
```
After:
```
confluent network gateway create my-pni-gateway --cloud aws --region us-east-1 --zones use1-az1,use1-az2,use1-az4 --type private-network-interface
+-------------+------------------------------+
| ID          | gw-<redacted>                |
| Name        | my-pni-gateway               |
| Environment | env-<redacted>               |
| Region      | us-east-1                    |
| Type        | AwsPrivateNetworkInterface   |
| Phase       | CREATED                      |
| Zones       | use1-az1, use1-az2, use1-az4 |
| Account     | <redacted>                   |
+-------------+------------------------------+
```
