### PR TITLE
DOCS-37625 Add confluent iam rbac rolebinding on-prem example for schema registry (Docs and Help)

### DIFF
--- a/internal/iam/command_rbac_role_binding_create.go
+++ b/internal/iam/command_rbac_role_binding_create.go
@@ -70,6 +70,10 @@ func (c *roleBindingCommand) newCreateCommand() *cobra.Command {
 				Text: `Create a role binding for the principal permitting it produce to topic "my-topic":`,
 				Code: "confluent iam rbac role-binding create --principal User:appSA --role DeveloperWrite --resource Topic:my-topic --kafka-cluster 0000000000000000000000",
 			},
+			examples.Example{
+				Text: `Create a role binding for the principal permitting it to manage all Schema Registry subjects:`,
+				Code: `confluent iam rbac role-binding create --principal User:test --role ResourceOwner --resource "Subject:*" --kafka-cluster 0000000000000000000000 --schema-registry-cluster sr-123456`,
+			},
 		)
 	}
 

--- a/internal/iam/command_rbac_role_binding_create.go
+++ b/internal/iam/command_rbac_role_binding_create.go
@@ -72,7 +72,7 @@ func (c *roleBindingCommand) newCreateCommand() *cobra.Command {
 			},
 			examples.Example{
 				Text: `Create a role binding for the principal permitting it to manage all Schema Registry subjects:`,
-				Code: `confluent iam rbac role-binding create --principal User:test --role ResourceOwner --resource "Subject:*" --kafka-cluster 0000000000000000000000 --schema-registry-cluster sr-123456`,
+				Code: `confluent iam rbac role-binding create --principal User:appSA --role ResourceOwner --resource "Subject:*" --kafka-cluster 0000000000000000000000 --schema-registry-cluster sr-123456`,
 			},
 		)
 	}

--- a/internal/iam/command_rbac_role_binding_create.go
+++ b/internal/iam/command_rbac_role_binding_create.go
@@ -72,7 +72,7 @@ func (c *roleBindingCommand) newCreateCommand() *cobra.Command {
 			},
 			examples.Example{
 				Text: `Create a role binding for the principal permitting it to manage all Schema Registry subjects:`,
-				Code: `confluent iam rbac role-binding create --principal User:appSA --role ResourceOwner --resource "Subject:*" --kafka-cluster 0000000000000000000000 --schema-registry-cluster sr-123456`,
+				Code: `confluent iam rbac role-binding create --principal User:appSA --role ResourceOwner --resource "Subject:*" --environment environment-12345 --schema-registry-cluster sr-123456`,
 			},
 		)
 	}

--- a/internal/iam/command_rbac_role_binding_create.go
+++ b/internal/iam/command_rbac_role_binding_create.go
@@ -72,7 +72,7 @@ func (c *roleBindingCommand) newCreateCommand() *cobra.Command {
 			},
 			examples.Example{
 				Text: `Create a role binding for the principal permitting it to manage all Schema Registry subjects:`,
-				Code: `confluent iam rbac role-binding create --principal User:appSA --role ResourceOwner --resource "Subject:*" --environment environment-12345 --schema-registry-cluster sr-123456`,
+				Code: `confluent iam rbac role-binding create --principal User:appSA --role ResourceOwner --resource "Subject:*" --kafka-cluster 0000000000000000000000 --schema-registry-cluster sr-123456`,
 			},
 		)
 	}

--- a/test/fixtures/output/iam/rbac/role-binding/create-help-onprem.golden
+++ b/test/fixtures/output/iam/rbac/role-binding/create-help-onprem.golden
@@ -10,7 +10,7 @@ Create a role binding for the principal permitting it produce to topic "my-topic
 
 Create a role binding for the principal permitting it to manage all Schema Registry subjects:
 
-  $ confluent iam rbac role-binding create --principal User:appSA --role ResourceOwner --resource "Subject:*" --environment environment-12345 --schema-registry-cluster sr-123456
+  $ confluent iam rbac role-binding create --principal User:appSA --role ResourceOwner --resource "Subject:*" --kafka-cluster 0000000000000000000000 --schema-registry-cluster sr-123456
 
 Flags:
       --role string                      REQUIRED: Role name of the new role binding.

--- a/test/fixtures/output/iam/rbac/role-binding/create-help-onprem.golden
+++ b/test/fixtures/output/iam/rbac/role-binding/create-help-onprem.golden
@@ -10,7 +10,7 @@ Create a role binding for the principal permitting it produce to topic "my-topic
 
 Create a role binding for the principal permitting it to manage all Schema Registry subjects:
 
-  $ confluent iam rbac role-binding create --principal User:appSA --role ResourceOwner --resource "Subject:*" --kafka-cluster 0000000000000000000000 --schema-registry-cluster sr-123456
+  $ confluent iam rbac role-binding create --principal User:appSA --role ResourceOwner --resource "Subject:*" --environment environment-12345 --schema-registry-cluster sr-123456
 
 Flags:
       --role string                      REQUIRED: Role name of the new role binding.

--- a/test/fixtures/output/iam/rbac/role-binding/create-help-onprem.golden
+++ b/test/fixtures/output/iam/rbac/role-binding/create-help-onprem.golden
@@ -8,6 +8,10 @@ Create a role binding for the principal permitting it produce to topic "my-topic
 
   $ confluent iam rbac role-binding create --principal User:appSA --role DeveloperWrite --resource Topic:my-topic --kafka-cluster 0000000000000000000000
 
+Create a role binding for the principal permitting it to manage all Schema Registry subjects:
+
+  $ confluent iam rbac role-binding create --principal User:test --role ResourceOwner --resource "Subject:*" --kafka-cluster 0000000000000000000000 --schema-registry-cluster sr-123456
+
 Flags:
       --role string                      REQUIRED: Role name of the new role binding.
       --principal string                 REQUIRED: Principal type and identifier using "Prefix:ID" format.

--- a/test/fixtures/output/iam/rbac/role-binding/create-help-onprem.golden
+++ b/test/fixtures/output/iam/rbac/role-binding/create-help-onprem.golden
@@ -10,7 +10,7 @@ Create a role binding for the principal permitting it produce to topic "my-topic
 
 Create a role binding for the principal permitting it to manage all Schema Registry subjects:
 
-  $ confluent iam rbac role-binding create --principal User:test --role ResourceOwner --resource "Subject:*" --kafka-cluster 0000000000000000000000 --schema-registry-cluster sr-123456
+  $ confluent iam rbac role-binding create --principal User:appSA --role ResourceOwner --resource "Subject:*" --kafka-cluster 0000000000000000000000 --schema-registry-cluster sr-123456
 
 Flags:
       --role string                      REQUIRED: Role name of the new role binding.


### PR DESCRIPTION

What
----
- Added a Schema Registry example to the on-prem examples for [confluent iam rolebinding create](https://docs.confluent.io/confluent-cli/current/command-reference/iam/rbac/role-binding/confluent_iam_rbac_role-binding_create.html)
- Added the **example** to the golden file 

Questions for reviewers
------------------------
@sgagniere I thought maybe I also needed to add something to `main/test/iam_test.go` but I don't think so. What I added to the golden file seems to be enough.


References
----------
- Ticket: https://confluentinc.atlassian.net/browse/DOCS-37625 
- List of semi related Docs tickets: [Docs CLI tickets](https://confluentinc.atlassian.net/issues/?filter=29227)

Test & Review
-------------
- `GOCOVERDIR=$(mktemp -d) go test -v ./test -run TestCLI/TestIamRbacRoleBinding_OnPrem` resulted in 100% PASS across the entire on-premises suite
