### PR TITLE
Add error_message to connect artifact describe/list output

### DIFF
--- a/internal/connect/command_artifact.go
+++ b/internal/connect/command_artifact.go
@@ -21,6 +21,7 @@ type artifactOut struct {
 	Environment   string `human:"Environment" serialized:"environment"`
 	ContentFormat string `human:"Content Format" serialized:"content_format"`
 	Status        string `human:"Status" serialized:"status"`
+	ErrorMessage  string `human:"Error Message" serialized:"error_message"`
 }
 
 func newArtifactCommand(prerunner pcmd.PreRunner) *cobra.Command {
@@ -49,6 +50,7 @@ func convertToArtifactOut(artifact camv1.CamV1ConnectArtifact) *artifactOut {
 		Environment:   artifact.Spec.GetEnvironment(),
 		ContentFormat: artifact.Spec.GetContentFormat(),
 		Status:        artifact.Status.GetPhase(),
+		ErrorMessage:  artifact.Status.GetErrorMessage(),
 	}
 }
 


### PR DESCRIPTION
## Summary
Surfaces the new `error_message` field from `CamV1ConnectArtifactStatus` (Connect Artifact) so users see why artifact inspection failed instead of just `status: FAILED`.

## Note
Draft: this depends on a `ccloud-sdk-go-v2/cam` bump that hasn't been released yet, so it won't build until that lands. Opening early for review of the CLI-side change itself.

Jira: CC-40048

## Test plan
- [ ] Update golden fixtures under `test/fixtures/output/connect/artifact/` once the SDK bump lands and a FAILED-state scenario can be added to the fake test server