### PR TITLE
Revert "[APIE-1106] Update `kafka topic create/update` to support configs file with JSON values (#3394)"

### DIFF
--- a/internal/kafka/command_topic_create.go
+++ b/internal/kafka/command_topic_create.go
@@ -19,10 +19,6 @@ import (
 	"github.com/confluentinc/cli/v4/pkg/utils"
 )
 
-// confluent.*.association values are JSON strings. They must be stored verbatim,
-// so keys are passed as rawValueKeys to skip special-character un-escaping.
-var rawValueTopicConfigs = []string{"confluent.key.association", "confluent.value.association"}
-
 func (c *command) newCreateCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create <topic>",
@@ -39,7 +35,7 @@ func (c *command) newCreateCommand() *cobra.Command {
 	}
 
 	cmd.Flags().Uint32("partitions", 0, "Number of topic partitions.")
-	pcmd.AddConfigFlag(cmd)
+	cmd.Flags().StringSlice("config", nil, `A comma-separated list of configuration overrides ("key=value") for the topic being created.`)
 	pcmd.AddEndpointFlag(cmd, c.AuthenticatedCLICommand)
 	pcmd.AddDryRunFlag(cmd)
 	cmd.Flags().Bool("if-not-exists", false, "Exit gracefully if topic already exists.")
@@ -62,7 +58,8 @@ func (c *command) create(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	configMap, err := properties.GetMap(configs, rawValueTopicConfigs...)
+
+	configMap, err := properties.ConfigFlagToMap(configs)
 	if err != nil {
 		return err
 	}

--- a/internal/kafka/command_topic_update.go
+++ b/internal/kafka/command_topic_update.go
@@ -64,7 +64,7 @@ func (c *command) update(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	configMap, err := properties.GetMap(configs, rawValueTopicConfigs...)
+	configMap, err := properties.GetMap(configs)
 	if err != nil {
 		return err
 	}

--- a/pkg/properties/properties.go
+++ b/pkg/properties/properties.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"os"
-	"slices"
 	"sort"
 	"strings"
 
@@ -12,27 +11,26 @@ import (
 )
 
 // GetMap reads newline-separated configuration files or comma-separated lists of key=value pairs, and supports configuration values containing commas.
-// Values whose keys are listed in rawValueKeys are stored verbatim, skipping special characters un-escaping, to preserve values such as JSON strings unchanged.
-func GetMap(config []string, rawValueKeys ...string) (map[string]string, error) {
+func GetMap(config []string) (map[string]string, error) {
 	if len(config) == 1 && utils.FileExists(config[0]) {
-		return fileToMap(config[0], rawValueKeys...)
+		return fileToMap(config[0])
 	}
 
-	return ConfigFlagToMap(config, rawValueKeys...)
+	return ConfigFlagToMap(config)
 }
 
 // fileToMap reads key=value pairs from a properties file, ignoring comments and empty lines.
-func fileToMap(filename string, rawValueKeys ...string) (map[string]string, error) {
+func fileToMap(filename string) (map[string]string, error) {
 	buf, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, err
 	}
 
-	return ConfigSliceToMap(ParseLines(string(buf)), rawValueKeys...)
+	return ConfigSliceToMap(ParseLines(string(buf)))
 }
 
 // ConfigSliceToMap converts a list of key=value strings into a map.
-func ConfigSliceToMap(configs []string, rawValueKeys ...string) (map[string]string, error) {
+func ConfigSliceToMap(configs []string) (map[string]string, error) {
 	m := make(map[string]string)
 
 	for _, config := range configs {
@@ -41,12 +39,7 @@ func ConfigSliceToMap(configs []string, rawValueKeys ...string) (map[string]stri
 			return nil, fmt.Errorf(`failed to parse "key=value" pattern from configuration: %s`, config)
 		}
 
-		// rawValueKeys are stored as-is, all other values get un-escaped.
-		if slices.Contains(rawValueKeys, x[0]) {
-			m[x[0]] = x[1]
-		} else {
-			m[x[0]] = replaceSpecialCharacters(x[1])
-		}
+		m[x[0]] = replaceSpecialCharacters(x[1])
 	}
 
 	return m, nil
@@ -69,18 +62,14 @@ func ParseLines(content string) []string {
 }
 
 // ConfigFlagToMap reads key=values pairs from the --config flag and supports configuration values containing commas.
-func ConfigFlagToMap(configs []string, rawValueKeys ...string) (map[string]string, error) {
+func ConfigFlagToMap(configs []string) (map[string]string, error) {
 	m := make(map[string]string)
 
 	for i := len(configs) - 1; i >= 0; i-- {
 		if strings.Contains(configs[i], "=") {
 			x := strings.SplitN(configs[i], "=", 2)
 			if _, ok := m[x[0]]; !ok {
-				if slices.Contains(rawValueKeys, x[0]) {
-					m[x[0]] = x[1]
-				} else {
-					m[x[0]] = replaceSpecialCharacters(x[1])
-				}
+				m[x[0]] = replaceSpecialCharacters(x[1])
 			}
 		} else {
 			if i-1 >= 0 {

--- a/pkg/properties/properties_test.go
+++ b/pkg/properties/properties_test.go
@@ -1,8 +1,6 @@
 package properties
 
 import (
-	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -125,16 +123,4 @@ func TestCreateKeyValuePairsKeysWithDotsAndSorts(t *testing.T) {
 	m["link.mode"] = "BIDIRECTIONAL"
 	m["connection.mode"] = "OUTBOUND"
 	require.Equal(t, "\"connection.mode\"=\"OUTBOUND\"\n\"link.mode\"=\"BIDIRECTIONAL\"\n", CreateKeyValuePairs(m))
-}
-
-func TestGetMap_FileWithRawValueKeyPreservesJSON(t *testing.T) {
-	dir := t.TempDir()
-	path := filepath.Join(dir, "topic.properties")
-	// confluent.value.association is stored verbatim, so its JSON value must be preserved.
-	json := `{"schema":"{\"type\":\"record\",\"name\":\"TestRecord\",\"doc\":\"Basic test.\\na=b.\",\"fields\":[{\"name\":\"field1\",\"type\":[\"null\",\"string\"]}]}"}`
-	require.NoError(t, os.WriteFile(path, []byte("confluent.value.association="+json+"\n"), 0o600))
-
-	m, err := GetMap([]string{path}, "confluent.value.association")
-	require.NoError(t, err)
-	require.Equal(t, json, m["confluent.value.association"])
 }

--- a/test/fixtures/input/kafka/topic/topic-config-json.properties
+++ b/test/fixtures/input/kafka/topic/topic-config-json.properties
@@ -1,2 +1,0 @@
-confluent.key.association={"subject":"kafkaCLISubject"}
-confluent.value.association={"schema":"{\"type\":\"record\",\"name\":\"TestRecord\",\"doc\":\"Basic test.\\na=b.\",\"fields\":[{\"name\":\"field1\",\"type\":[\"null\",\"string\"]}]}"}

--- a/test/fixtures/input/kafka/topic/topic-config.properties
+++ b/test/fixtures/input/kafka/topic/topic-config.properties
@@ -1,2 +1,0 @@
-retention.ms=259200000
-compression.type=gzip

--- a/test/fixtures/output/kafka/topic/create-help.golden
+++ b/test/fixtures/output/kafka/topic/create-help.golden
@@ -10,7 +10,7 @@ Create a topic named "my_topic" with default options.
 
 Flags:
       --partitions uint32       Number of topic partitions.
-      --config strings          A comma-separated list of "key=value" pairs, or path to a configuration file containing a newline-separated list of "key=value" pairs.
+      --config strings          A comma-separated list of configuration overrides ("key=value") for the topic being created.
       --kafka-endpoint string   Endpoint to be used for this Kafka cluster.
       --dry-run                 Run the command without committing changes.
       --if-not-exists           Exit gracefully if topic already exists.

--- a/test/fixtures/output/kafka/topic/create.golden
+++ b/test/fixtures/output/kafka/topic/create.golden
@@ -9,7 +9,7 @@ Create a topic named "my_topic" with default options.
 
 Flags:
       --partitions uint32       Number of topic partitions.
-      --config strings          A comma-separated list of "key=value" pairs, or path to a configuration file containing a newline-separated list of "key=value" pairs.
+      --config strings          A comma-separated list of configuration overrides ("key=value") for the topic being created.
       --kafka-endpoint string   Endpoint to be used for this Kafka cluster.
       --dry-run                 Run the command without committing changes.
       --if-not-exists           Exit gracefully if topic already exists.

--- a/test/fixtures/output/kafka/topic/update-json-config.golden
+++ b/test/fixtures/output/kafka/topic/update-json-config.golden
@@ -1,6 +1,0 @@
-Updated the following configuration values for topic "topic-exist-rest":
-             Name             |                                        Value                                        | Read-Only  
-------------------------------+-------------------------------------------------------------------------------------+------------
-  confluent.key.association   | {"subject":"kafkaCLISubject"}                                                       | false      
-  confluent.value.association | {"schema":"{\"type\":\"record\",\"name\":\"TestRecord\",\"doc\":\"Basic             | false      
-                              | test.\\na=b.\",\"fields\":[{\"name\":\"field1\",\"type\":[\"null\",\"string\"]}]}"} |            

--- a/test/kafka_test.go
+++ b/test/kafka_test.go
@@ -152,8 +152,6 @@ func (s *CLITestSuite) TestKafka() {
 		{args: "kafka topic create", login: "cloud", useKafka: "lkc-create-topic", fixture: "kafka/topic/create.golden", exitCode: 1},
 		{args: "kafka topic create topic1", useKafka: "lkc-create-topic", fixture: "kafka/topic/create-success.golden"},
 		{args: "kafka topic create topic1 --dry-run", useKafka: "lkc-create-topic", fixture: "kafka/topic/create-success.golden"},
-		{args: "kafka topic create topic1 --config test/fixtures/input/kafka/topic/topic-config.properties", useKafka: "lkc-create-topic", fixture: "kafka/topic/create-success.golden"},
-		{args: "kafka topic create topic1 --config test/fixtures/input/kafka/topic/topic-config-json.properties", useKafka: "lkc-create-topic", fixture: "kafka/topic/create-success.golden"},
 		{args: "kafka topic create topic-exist", login: "cloud", useKafka: "lkc-create-topic", fixture: "kafka/topic/create-dup-topic.golden", exitCode: 1},
 		{args: "kafka topic create topic-exceed-limit --partitions 9001", login: "cloud", useKafka: "lkc-create-topic", fixture: "kafka/topic/create-limit-topic.golden", exitCode: 1},
 
@@ -180,8 +178,6 @@ func (s *CLITestSuite) TestKafka() {
 		{args: "kafka topic update topic-exist-rest --config retention.ms=1,compression.type=gzip -o json", useKafka: "lkc-describe-topic", fixture: "kafka/topic/update-success-rest-json.golden"},
 		{args: "kafka topic update topic-exist-rest --config retention.ms=1,compression.type=gzip -o yaml", useKafka: "lkc-describe-topic", fixture: "kafka/topic/update-success-rest-yaml.golden"},
 		{args: "kafka topic update topic-exist-rest --config num.partitions=6", useKafka: "lkc-describe-topic", fixture: "kafka/topic/update-success-rest-partitions-count.golden"},
-		{args: "kafka topic update topic-exist-rest --config test/fixtures/input/kafka/topic/topic-config.properties", useKafka: "lkc-describe-topic", fixture: "kafka/topic/update-success-rest.golden"},
-		{args: "kafka topic update topic-exist-rest --config test/fixtures/input/kafka/topic/topic-config-json.properties", useKafka: "lkc-describe-topic", fixture: "kafka/topic/update-json-config.golden"},
 	}
 
 	if runtime.GOOS != "windows" {

--- a/test/test-server/kafka_rest_router.go
+++ b/test/test-server/kafka_rest_router.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"slices"
 	"strconv"
 	"strings"
 	"testing"
@@ -27,24 +26,6 @@ const (
 	topicName1          = "topic-1"
 	shareGroupID1       = "share-group-1"
 )
-
-// allowedTopicConfigNames are the topic configs the mock Kafka REST server accepts on
-// topic create and update. confluent.key/value.association hold JSON string values (APIE-1106).
-var allowedTopicConfigNames = []string{
-	"retention.ms",
-	"compression.type",
-	"confluent.key.association",
-	"confluent.value.association",
-}
-
-// expectedAssociationConfigValues are the exact JSON values in
-// test/fixtures/input/kafka/topic/topic-config-json.properties, keyed by config name. The mock
-// asserts the CLI forwards each byte-for-byte, proving GetMap read the file without un-escaping
-// the value (APIE-1106).
-var expectedAssociationConfigValues = map[string]string{
-	"confluent.key.association":   `{"subject":"kafkaCLISubject"}`,
-	"confluent.value.association": `{"schema":"{\"type\":\"record\",\"name\":\"TestRecord\",\"doc\":\"Basic test.\\na=b.\",\"fields\":[{\"name\":\"field1\",\"type\":[\"null\",\"string\"]}]}"}`,
-}
 
 type route struct {
 	path    string
@@ -236,7 +217,7 @@ func handleKafkaRestTopics(t *testing.T) http.HandlerFunc {
 			}
 			// check configs
 			for _, config := range requestData.Configs {
-				if !slices.Contains(allowedTopicConfigNames, config.Name) {
+				if config.Name != "retention.ms" && config.Name != "compression.type" {
 					require.NoError(t, writeErrorResponse(w, http.StatusBadRequest, 40002, fmt.Sprintf("Unknown topic config name: %s", config.Name)))
 					return
 				} else if config.Name == "retention.ms" {
@@ -247,10 +228,6 @@ func handleKafkaRestTopics(t *testing.T) http.HandlerFunc {
 						require.NoError(t, writeErrorResponse(w, http.StatusBadRequest, 40002, fmt.Sprintf("Invalid value %s for configuration retention.ms: Not a number of type LONG", *config.Value)))
 						return
 					}
-				} else if expected, ok := expectedAssociationConfigValues[config.Name]; ok {
-					// APIE-1106: the JSON value must arrive byte-for-byte as written in the fixture file.
-					require.NotNil(t, config.Value)
-					require.Equal(t, expected, *config.Value)
 				}
 				// TODO: check for compression.type
 			}
@@ -325,16 +302,6 @@ func handleKafkaRestTopicConfigs(t *testing.T) http.HandlerFunc {
 						{
 							Name:  "retention.ms",
 							Value: ptrString("1"),
-						},
-						// APIE-1106: echo the association configs so a successful update lists their
-						// stored JSON values (same source of truth as the alter-handler assertion).
-						{
-							Name:  "confluent.key.association",
-							Value: ptrString(expectedAssociationConfigValues["confluent.key.association"]),
-						},
-						{
-							Name:  "confluent.value.association",
-							Value: ptrString(expectedAssociationConfigValues["confluent.value.association"]),
 						},
 					},
 				}
@@ -547,7 +514,7 @@ func handleKafkaRestConfigsAlter(t *testing.T) http.HandlerFunc {
 
 				// Check Alter Args if valid
 				for _, config := range requestData.Data {
-					if !slices.Contains(allowedTopicConfigNames, config.Name) {
+					if config.Name != "retention.ms" && config.Name != "compression.type" { // should be either retention.ms or compression.type
 						require.NoError(t, writeErrorResponse(w, http.StatusNotFound, 404, fmt.Sprintf("Config %s cannot be found for TOPIC topic-exist in cluster cluster-1.", config.Name)))
 						return
 					} else if config.Name == "retention.ms" {
@@ -558,10 +525,6 @@ func handleKafkaRestConfigsAlter(t *testing.T) http.HandlerFunc {
 							require.NoError(t, writeErrorResponse(w, http.StatusBadRequest, 40002, fmt.Sprintf("Invalid config value for resource ConfigResource(type=TOPIC, name='topic-exist'): Invalid value %s for configuration retention.ms: Not a number of type LONG", *config.Value)))
 							return
 						}
-					} else if expected, ok := expectedAssociationConfigValues[config.Name]; ok {
-						// APIE-1106: the JSON value must arrive byte-for-byte as written in the fixture file.
-						require.NotNil(t, config.Value)
-						require.Equal(t, expected, *config.Value)
 					}
 					// TODO check for compression.type values
 				}


### PR DESCRIPTION
This reverts https://github.com/confluentinc/cli/commit/315f41cee2fa51c13d816487295ae18c42f81d2b