### PR TITLE
CF-4076 : Add stable sort to paginated CMF list commands

### DIFF
--- a/pkg/flink/cmf_rest_client.go
+++ b/pkg/flink/cmf_rest_client.go
@@ -45,6 +45,12 @@ type CmfRestClient struct {
 	AuthToken string
 }
 
+// sortByName gives paginated list calls a stable order so offset paging cannot
+// silently skip or duplicate rows. Each list below is scoped (by environment,
+// catalog, or parent), and within that scope "name" resolves to a unique column.
+// Don't reuse it where "name" isn't unique in scope — see ListSecretMappings.
+var sortByName = []string{"name"}
+
 func NewCmfRestHttpClient(restFlags *OnPremCMFRestFlagValues) (*http.Client, error) {
 	var err error
 	httpClient := utils.DefaultClient()
@@ -197,7 +203,7 @@ func (cmfClient *CmfRestClient) ListApplications(ctx context.Context, environmen
 	done := false
 
 	for !done {
-		applicationsPage, httpResponse, err := cmfClient.FlinkApplicationsApi.GetApplications(ctx, environment).Page(currentPageNumber).Size(pageSize).Execute()
+		applicationsPage, httpResponse, err := cmfClient.FlinkApplicationsApi.GetApplications(ctx, environment).Sort(sortByName).Page(currentPageNumber).Size(pageSize).Execute()
 		if parsedErr := parseSdkError(httpResponse, err); parsedErr != nil {
 			return nil, fmt.Errorf(`failed to list applications in the environment "%s": %s`, environment, parsedErr)
 		}
@@ -237,7 +243,8 @@ func (cmfClient *CmfRestClient) ListApplicationEvents(ctx context.Context, envir
 	done := false
 
 	for !done {
-		eventsPage, httpResponse, err := cmfClient.FlinkApplicationsApi.GetApplicationEvents(ctx, environment, application).Page(currentPageNumber).Size(pageSize).Execute()
+		// Sort newest-first, with the unique "name" as a tiebreaker so paging is stable.
+		eventsPage, httpResponse, err := cmfClient.FlinkApplicationsApi.GetApplicationEvents(ctx, environment, application).Sort([]string{"creationTimestamp,desc", "name"}).Page(currentPageNumber).Size(pageSize).Execute()
 		if parsedErr := parseSdkError(httpResponse, err); parsedErr != nil {
 			return nil, fmt.Errorf(`failed to list events for application "%s" in the environment "%s": %s`, application, environment, parsedErr)
 		}
@@ -289,7 +296,7 @@ func (cmfClient *CmfRestClient) ListEnvironments(ctx context.Context) ([]cmfsdk.
 	var currentPageNumber int32 = 0
 
 	for !done {
-		environmentsPage, httpResponse, err := cmfClient.EnvironmentsApi.GetEnvironments(ctx).Page(currentPageNumber).Size(pageSize).Execute()
+		environmentsPage, httpResponse, err := cmfClient.EnvironmentsApi.GetEnvironments(ctx).Sort(sortByName).Page(currentPageNumber).Size(pageSize).Execute()
 		if parsedErr := parseSdkError(httpResponse, err); parsedErr != nil {
 			return nil, fmt.Errorf("failed to list environments: %s", parsedErr)
 		}
@@ -382,9 +389,9 @@ func (cmfClient *CmfRestClient) ListSavepoint(ctx context.Context, environment, 
 		var httpResponse *_nethttp.Response
 		var err error
 		if isStatement {
-			savepointsPage, httpResponse, err = cmfClient.SavepointsApi.GetSavepointsForFlinkStatement(ctx, environment, statement).Page(currentPageNumber).Size(pageSize).Execute()
+			savepointsPage, httpResponse, err = cmfClient.SavepointsApi.GetSavepointsForFlinkStatement(ctx, environment, statement).Sort(sortByName).Page(currentPageNumber).Size(pageSize).Execute()
 		} else {
-			savepointsPage, httpResponse, err = cmfClient.SavepointsApi.GetSavepointsForFlinkApplication(ctx, environment, application).Page(currentPageNumber).Size(pageSize).Execute()
+			savepointsPage, httpResponse, err = cmfClient.SavepointsApi.GetSavepointsForFlinkApplication(ctx, environment, application).Sort(sortByName).Page(currentPageNumber).Size(pageSize).Execute()
 		}
 		if parsedErr := parseSdkError(httpResponse, err); parsedErr != nil {
 			return nil, fmt.Errorf(`failed to list savepoints in the environment "%s": %s`, environment, parsedErr)
@@ -412,7 +419,7 @@ func (cmfClient *CmfRestClient) ListDetachedSavepoint(ctx context.Context, filte
 	var currentPageNumber int32 = 0
 
 	for !done {
-		savepointsPage, httpResponse, err := cmfClient.DetachedSavepointsApi.ListDetachedSavepoints(ctx).Page(currentPageNumber).Size(pageSize).Name(filter).Execute()
+		savepointsPage, httpResponse, err := cmfClient.DetachedSavepointsApi.ListDetachedSavepoints(ctx).Sort(sortByName).Page(currentPageNumber).Size(pageSize).Name(filter).Execute()
 		if parsedErr := parseSdkError(httpResponse, err); parsedErr != nil {
 			return nil, fmt.Errorf(`failed to list detached savepoints %s`, parsedErr)
 		}
@@ -461,7 +468,7 @@ func (cmfClient *CmfRestClient) ListComputePools(ctx context.Context, environmen
 	var currentPageNumber int32 = 0
 
 	for !done {
-		computePoolsPage, httpResponse, err := cmfClient.SQLApi.GetComputePools(ctx, environment).Page(currentPageNumber).Size(pageSize).Execute()
+		computePoolsPage, httpResponse, err := cmfClient.SQLApi.GetComputePools(ctx, environment).Sort(sortByName).Page(currentPageNumber).Size(pageSize).Execute()
 		if parsedErr := parseSdkError(httpResponse, err); parsedErr != nil {
 			return nil, fmt.Errorf(`failed to list compute pools in the environment "%s": %s`, environment, parsedErr)
 		}
@@ -509,7 +516,7 @@ func (cmfClient *CmfRestClient) ListStatements(ctx context.Context, environment,
 	const pageSize = 100
 	var currentPageNumber int32 = 0
 
-	request := cmfClient.SQLApi.GetStatements(ctx, environment)
+	request := cmfClient.SQLApi.GetStatements(ctx, environment).Sort(sortByName)
 	if computePool != "" {
 		request = request.ComputePool(computePool)
 	}
@@ -614,7 +621,7 @@ func (cmfClient *CmfRestClient) ListCatalog(ctx context.Context) ([]cmfsdk.Kafka
 	var currentPageNumber int32 = 0
 
 	for !done {
-		catalogPage, httpResponse, err := cmfClient.SQLApi.GetKafkaCatalogs(ctx).Page(currentPageNumber).Size(pageSize).Execute()
+		catalogPage, httpResponse, err := cmfClient.SQLApi.GetKafkaCatalogs(ctx).Sort(sortByName).Page(currentPageNumber).Size(pageSize).Execute()
 		if parsedErr := parseSdkError(httpResponse, err); parsedErr != nil {
 			return nil, fmt.Errorf(`failed to list Kafka Catalog: %s`, parsedErr)
 		}
@@ -654,7 +661,7 @@ func (cmfClient *CmfRestClient) ListApplicationInstances(ctx context.Context, en
 	done := false
 
 	for !done {
-		instancesPage, httpResponse, err := cmfClient.FlinkApplicationsApi.GetApplicationInstances(ctx, environment, application).Page(currentPageNumber).Size(pageSize).Execute()
+		instancesPage, httpResponse, err := cmfClient.FlinkApplicationsApi.GetApplicationInstances(ctx, environment, application).Sort(sortByName).Page(currentPageNumber).Size(pageSize).Execute()
 		if parsedErr := parseSdkError(httpResponse, err); parsedErr != nil {
 			return nil, fmt.Errorf(`failed to list instances of application "%s" in the environment "%s": %s`, application, environment, parsedErr)
 		}
@@ -692,7 +699,8 @@ func (cmfClient *CmfRestClient) ListSecretMappings(ctx context.Context, envName 
 	var currentPageNumber int32 = 0
 
 	for !done {
-		mappingsPage, httpResponse, err := cmfClient.EnvironmentsApi.GetEnvironmentSecretMappings(ctx, envName).Page(currentPageNumber).Size(pageSize).Execute()
+		// "name" is not unique for mappings, so add "uid" (the primary key) as a tiebreaker.
+		mappingsPage, httpResponse, err := cmfClient.EnvironmentsApi.GetEnvironmentSecretMappings(ctx, envName).Sort([]string{"name", "uid"}).Page(currentPageNumber).Size(pageSize).Execute()
 		if parsedErr := parseSdkError(httpResponse, err); parsedErr != nil {
 			return nil, fmt.Errorf(`failed to list secret mappings in the environment "%s": %s`, envName, parsedErr)
 		}
@@ -740,7 +748,7 @@ func (cmfClient *CmfRestClient) ListSecrets(ctx context.Context) ([]cmfsdk.Secre
 	var currentPageNumber int32 = 0
 
 	for !done {
-		secretsPage, httpResponse, err := cmfClient.SecretsApi.GetSecrets(ctx).Page(currentPageNumber).Size(pageSize).Execute()
+		secretsPage, httpResponse, err := cmfClient.SecretsApi.GetSecrets(ctx).Sort(sortByName).Page(currentPageNumber).Size(pageSize).Execute()
 		if parsedErr := parseSdkError(httpResponse, err); parsedErr != nil {
 			return nil, fmt.Errorf(`failed to list secrets: %s`, parsedErr)
 		}
@@ -804,7 +812,7 @@ func (cmfClient *CmfRestClient) ListDatabases(ctx context.Context, catalogName s
 	var currentPageNumber int32 = 0
 
 	for !done {
-		databasePage, httpResponse, err := cmfClient.SQLApi.GetKafkaDatabases(ctx, catalogName).Page(currentPageNumber).Size(pageSize).Execute()
+		databasePage, httpResponse, err := cmfClient.SQLApi.GetKafkaDatabases(ctx, catalogName).Sort(sortByName).Page(currentPageNumber).Size(pageSize).Execute()
 		if parsedErr := parseSdkError(httpResponse, err); parsedErr != nil {
 			return nil, fmt.Errorf(`failed to list databases in catalog "%s": %s`, catalogName, parsedErr)
 		}

--- a/pkg/flink/cmf_rest_client_test.go
+++ b/pkg/flink/cmf_rest_client_test.go
@@ -1,0 +1,136 @@
+package flink
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	cmfsdk "github.com/confluentinc/cmf-sdk-go/v1"
+)
+
+// newTestCmfClient builds a CmfRestClient that talks to srv.
+func newTestCmfClient(srv *httptest.Server) *CmfRestClient {
+	cfg := cmfsdk.NewConfiguration()
+	cfg.Servers = cmfsdk.ServerConfigurations{{URL: srv.URL}}
+	cfg.HTTPClient = srv.Client()
+	return &CmfRestClient{APIClient: cmfsdk.NewAPIClient(cfg)}
+}
+
+// sortRecorder captures the sort query params of the most recent request.
+type sortRecorder struct {
+	mu   sync.Mutex
+	last []string
+}
+
+func (s *sortRecorder) set(v []string) {
+	s.mu.Lock()
+	s.last = v
+	s.mu.Unlock()
+}
+
+func (s *sortRecorder) get() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.last
+}
+
+// TestListStatements_ReturnsAllItemsAcrossPages guards the paging regression: a
+// paginated list of >100 items must return every item exactly once. The mock pages
+// a stable order only when the request carries the unique "name" sort; without it
+// the order rotates per page (as Postgres would with no ORDER BY), skipping and
+// duplicating rows across page boundaries.
+func TestListStatements_ReturnsAllItemsAcrossPages(t *testing.T) {
+	const total = 250 // spans page boundaries at 100 and 200
+
+	names := make([]string, total)
+	for i := range names {
+		names[i] = fmt.Sprintf("stmt-%04d", i)
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+		sortParam := q["sort"]
+		page, _ := strconv.Atoi(q.Get("page"))
+		size, _ := strconv.Atoi(q.Get("size"))
+
+		// A unique sort makes paging deterministic. Without it, rotate each page's
+		// window so pages overlap and leave gaps, as unordered OFFSET paging would.
+		stable := len(sortParam) == 1 && sortParam[0] == "name"
+
+		var items []cmfsdk.Statement
+		for i := page * size; i < min((page+1)*size, total); i++ {
+			idx := i
+			if !stable {
+				idx = (i + page*size) % total
+			}
+			items = append(items, cmfsdk.Statement{Metadata: cmfsdk.StatementMetadata{Name: names[idx]}})
+		}
+		out := cmfsdk.StatementsPage{}
+		out.SetItems(items)
+		w.Header().Set("Content-Type", "application/json")
+		require.NoError(t, json.NewEncoder(w).Encode(out))
+	}))
+	defer srv.Close()
+
+	got, err := newTestCmfClient(srv).ListStatements(context.Background(), "env", "", "")
+	require.NoError(t, err)
+
+	seen := make(map[string]int, total)
+	for _, s := range got {
+		seen[s.Metadata.Name]++
+	}
+	require.Len(t, seen, total, "every statement returned exactly once")
+	for name, count := range seen {
+		require.Equal(t, 1, count, "statement %q returned %d times", name, count)
+	}
+}
+
+// TestListCommands_SendUniqueSortKey locks in the per-resource sort key sent by
+// every paginated list call. An empty page ends the loop after one request, so
+// the recorder holds exactly that call's sort params.
+func TestListCommands_SendUniqueSortKey(t *testing.T) {
+	rec := &sortRecorder{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rec.set(r.URL.Query()["sort"])
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"items":[]}`))
+	}))
+	defer srv.Close()
+
+	c := newTestCmfClient(srv)
+	ctx := context.Background()
+
+	cases := []struct {
+		name   string
+		invoke func() error
+		want   []string
+	}{
+		{"statements", func() error { _, e := c.ListStatements(ctx, "env", "", ""); return e }, []string{"name"}},
+		{"applications", func() error { _, e := c.ListApplications(ctx, "env"); return e }, []string{"name"}},
+		{"application-instances", func() error { _, e := c.ListApplicationInstances(ctx, "env", "app"); return e }, []string{"name"}},
+		{"application-events", func() error { _, e := c.ListApplicationEvents(ctx, "env", "app"); return e }, []string{"creationTimestamp,desc", "name"}},
+		{"savepoints-statement", func() error { _, e := c.ListSavepoint(ctx, "env", "stmt", "", true); return e }, []string{"name"}},
+		{"savepoints-application", func() error { _, e := c.ListSavepoint(ctx, "env", "", "app", false); return e }, []string{"name"}},
+		{"detached-savepoints", func() error { _, e := c.ListDetachedSavepoint(ctx, ""); return e }, []string{"name"}},
+		{"compute-pools", func() error { _, e := c.ListComputePools(ctx, "env"); return e }, []string{"name"}},
+		{"environments", func() error { _, e := c.ListEnvironments(ctx); return e }, []string{"name"}},
+		{"catalogs", func() error { _, e := c.ListCatalog(ctx); return e }, []string{"name"}},
+		{"databases", func() error { _, e := c.ListDatabases(ctx, "cat"); return e }, []string{"name"}},
+		{"secrets", func() error { _, e := c.ListSecrets(ctx); return e }, []string{"name"}},
+		{"secret-mappings", func() error { _, e := c.ListSecretMappings(ctx, "env"); return e }, []string{"name", "uid"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rec.set(nil)
+			require.NoError(t, tc.invoke())
+			require.Equal(t, tc.want, rec.get())
+		})
+	}
+}


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- PLACEHOLDER

New Features
- PLACEHOLDER

Bug Fixes
- Fixed Confluent Platform `confluent flink ... list` commands silently omitting or duplicating items when a resource has more than 100 items.

Checklist
---------
- [x] I have successfully built and used a custom CLI binary, without linter issues from this PR.
- [x] I have clearly specified in the `What` section below whether this PR applies to Confluent Cloud, Confluent Platform, or both.
- [ ] I have attached manual CLI verification results or screenshots in the `Test & Review` section below.
- [x] I have added appropriate CLI integration or unit tests for any new or updated commands and functionality.
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [x] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [ ] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [ ] Confluent Cloud prod
  - [ ] Confluent Cloud stag
  - [x] Confluent Platform
  - [ ] Check this box if the feature is enabled for certain organizations only

What
----
This PR fixes **CF-4076** for **Confluent Platform / CP Flink (CMF on-prem)**.

The on-prem (CMF) `confluent flink ... list` commands page through results with offset pagination (`.Page(n).Size(100)`) but requested no sort order. CMF applies no default `ORDER BY`, so each page is a separate `LIMIT/OFFSET` query with no ordering. PostgreSQL does not guarantee a stable row order across separate queries, so once a (filtered) result set exceeds the page size of 100, rows near a page boundary can be **silently skipped or duplicated** between page requests — with no error. The most-frequently-updated row (e.g. an actively `RUNNING` statement) is the most likely to shift and disappear.

Fix: request a unique, stable sort on every paginated CMF list call in `pkg/flink/cmf_rest_client.go`, so offset paging is deterministic. `"name"` maps server-side (via each resource's `SortPropertyMapper`) to that resource's unique id column.

Per-resource sort keys:
- Most list commands → `["name"]`
- `secret-mapping list` → `["name", "uid"]` — `name` has no unique constraint; `uid` (the PK) is the tiebreaker
- `application event list` → `["creationTimestamp,desc", "name"]` — CMF applies no ordering to events today, so this both introduces newest-first ordering (the useful order for an event log) and makes paging stable; `creationTimestamp` is not unique on its own, so `name` is the tiebreaker

This works against existing CMF servers (incl. 2.3.0); no server change is required.

Blast Radius
----
- Scope is limited to the on-prem `confluent flink ... list` commands; the change only adds a `sort` query parameter to the existing paginated list requests. No writes, no persistence changes, no config or migration changes.
- Human table output is unchanged (`output.NewList` already sorts client-side); the only user-visible change is that `-o json`/`-o yaml` list output is now deterministically ordered — and for `application event list` specifically, that order is now newest-first rather than arbitrary.
- If something goes wrong, impact is confined to these list commands (e.g. a list call surfacing a CMF error). Other `confluent flink` and all `confluent kafka` commands are unaffected.
- Depends on CMF honoring the `sort` param, which is verified in `cp-flink-cmf` (`SortPropertyMapper.transformSort` + per-resource mappers map `name` to each resource's unique id).
- There are **no breaking changes**; the change is a one-line-per-call addition and is trivially revertible.

References
----------
- Jira: [CF-4076](https://confluentinc.atlassian.net/browse/CF-4076)
- Not the same as [CF-1784](https://confluentinc.atlassian.net/browse/CF-1784) (phase-filter case-sensitivity, already fixed in CMF 2.3.0) — this pagination defect is independent.
- A complementary CMF-side default sort (benefiting the UI/API/all clients) is a separate follow-up on `cp-flink-cmf`.

Test & Review
-------------
**Automated tests** (`pkg/flink/cmf_rest_client_test.go`):
- `TestListStatements_ReturnsAllItemsAcrossPages` — paginates a 250-item list (spanning the 100/200 page boundaries) and asserts every item is returned exactly once; the mock server rejects any request that omits `sort`.
- `TestListCommands_SendUniqueSortKey` — table-driven across all 13 paginated call sites, asserting the exact sort key each sends (`name`; `name,uid` for secret-mappings; `creationTimestamp,desc` + `name` for events).

**Results**
- `pkg/flink` and `internal/flink` unit suites pass (including `-race`).
- Flink on-prem integration tests: all `List*` (golden) tests pass; output unchanged (the mock ignores `sort`).
- `gofmt` and `go vet` clean.

**Deterministic repro of the bug** — driving the real `ListStatements` against a server that mimics unordered `OFFSET` paging: without a sort, 149/150 statements were returned (one silently dropped); with the fix's sort, 150/150 were returned.



[CF-4076]: https://confluentinc.atlassian.net/browse/CF-4076?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
