### PR TITLE
Add Claude Code skills for issue dedup and docs drift detection

### DIFF
--- a/.claude/skills/docs-drift/SKILL.md
+++ b/.claude/skills/docs-drift/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: docs-drift
+description: Validates confluentinc/cli's in-code documentation (Short/Long/Example text on Cobra commands, plus root markdown like README.md/CONTRIBUTING.md) against the live command tree to catch stale references to deprecated or hidden commands/flags, wrong/missing/extra flags in examples, typos, and broken links. Use when asked to check for documentation drift, validate CLI examples/help text, or audit docs for staleness. Read-only by default — only edits a file when explicitly asked to fix something.
+---
+
+# Docs Drift — confluentinc/cli
+
+The CLI has no separate hand-maintained `docs/` tree. Its "docs" are the `Short`/`Long`/`Example` fields embedded directly in each Cobra command (e.g. `internal/kafka/command_topic_create.go`), plus root-level markdown. Ground truth is the live command/flag tree, not any static file.
+
+## 1. Reuse the existing linter — don't re-derive it
+
+```
+make lint-cli
+```
+
+This runs `pkg/linter.RequireValidExamples()` (`pkg/linter/command_rules.go:220`) over the live command tree: every `IsFlagRequired` flag must appear in the example, every `--flag` token in an example must exist on that command's `pflag.FlagSet`, and `--flag=value` syntax is rejected outright. It also runs hunspell-backed `CommandRule`/`FlagRule` checks (naming, capitalization, punctuation) on `Use`/`Short`/`Long`/flag usage strings. Capture and categorize this output as doc-drift findings rather than reimplementing the flag-matching logic by hand.
+
+## 2. Find deprecated/hidden surface still referenced in prose
+
+There's no `Deprecated:` cobra convention here — commands/flags are retired via:
+- `cmd.Flags().MarkHidden("flag-name")` (scattered across command files, e.g. `internal/kafka/command_topic_produce.go`)
+- `command.Hidden = true` (see `internal/command.go:229`)
+- `pkg/featureflags.DisableHelpText(cmd, flags)` — LaunchDarkly-driven hiding (`pkg/featureflags/disable.go`)
+
+Grep for all three patterns repo-wide to build a list of hidden/disabled commands and flags, then cross-reference each name against every `Example:`/`Long:` string that still mentions it by exact name. A flag or subcommand that's hidden/disabled elsewhere but still shown in another command's example or help text is stale — report the file:line of both the hide-call and the stale reference.
+
+## 3. Cross-check subcommands mentioned in prose
+
+Some `Long:` fields reference other subcommands by name (e.g. "run `confluent kafka topic list` first"). Build the live command tree the same way `cmd/docs/main.go` and `cmd/lint/main.go` do (`internal.NewConfluentCommand(cfg)`), then verify every `confluent <subcommand path>` mentioned in prose still resolves to a real, non-hidden command. A renamed or removed subcommand referenced this way is a direct hit — this is the CLI-side analog of a doc pointing at a resource/attribute that no longer exists.
+
+## 4. Root markdown: typos and broken links
+
+For `README.md`, `CONTRIBUTING.md`, and any other repo-root markdown:
+- Extract `[text](url)` links. For relative links, verify the target file exists. For `http(s)://` links, do a quick reachability check (`curl -sI -o /dev/null -w '%{http_code}' <url>`), treating 4xx/5xx as broken; skip anything pointing at internal/non-public infrastructure.
+- Cross-reference command/flag names mentioned in prose against the real command surface built in step 3 — a misspelled command (`confluent kafak topic`) won't resolve and is a giveaway.
+
+## 5. Optional: regenerate the full reference tree for a manual pass
+
+`go run cmd/docs/main.go` renders the entire live command tree to `.rst` under `docs/` (gitignored, not committed, and not wired into `make`/CI). Regenerating and skimming it is useful for a broader manual read beyond the automated checks above, but there's no prior committed version to diff against — don't treat it as a source of drift by itself, just as an on-demand snapshot.
+
+## Output
+
+Report findings grouped by category — `lint-cli` failures, stale deprecated/hidden reference, broken subcommand reference, typo, broken link — each with a file:line and a one-line concrete explanation (not "looks wrong"). Stay read-only: only edit a file if the user explicitly asks you to fix something, and show the diff before/after.

--- a/.claude/skills/docs-drift/SKILL.md
+++ b/.claude/skills/docs-drift/SKILL.md
@@ -17,12 +17,12 @@ This runs `pkg/linter.RequireValidExamples()` (`pkg/linter/command_rules.go:220`
 
 ## 2. Find deprecated/hidden surface still referenced in prose
 
-There's no `Deprecated:` cobra convention here — commands/flags are retired via:
+Commands and flags are hidden or disabled via:
 - `cmd.Flags().MarkHidden("flag-name")` (scattered across command files, e.g. `internal/kafka/command_topic_produce.go`)
 - `command.Hidden = true` (see `internal/command.go:229`)
 - `pkg/featureflags.DisableHelpText(cmd, flags)` — LaunchDarkly-driven hiding (`pkg/featureflags/disable.go`)
 
-Grep for all three patterns repo-wide to build a list of hidden/disabled commands and flags, then cross-reference each name against every `Example:`/`Long:` string that still mentions it by exact name. A flag or subcommand that's hidden/disabled elsewhere but still shown in another command's example or help text is stale — report the file:line of both the hide-call and the stale reference.
+LaunchDarkly can also deprecate visible surface area via `featureflags.DeprecateCommandTree` and `featureflags.DeprecateFlags`, which prefix command `Short`/`Long` text or flag `Usage` with `DEPRECATED:`. Grep for all hiding, disabling, and deprecation patterns repo-wide to build a list of affected commands and flags, then cross-reference each name against every `Example:`/`Long:` string that still mentions it by exact name. A hidden/disabled command or flag shown in another example is stale; a deprecated one shown without an appropriate warning is a drift candidate. Report the file:line of both the mechanism and the stale reference.
 
 ## 3. Cross-check subcommands mentioned in prose
 
@@ -31,7 +31,7 @@ Some `Long:` fields reference other subcommands by name (e.g. "run `confluent ka
 ## 4. Root markdown: typos and broken links
 
 For `README.md`, `CONTRIBUTING.md`, and any other repo-root markdown:
-- Extract `[text](url)` links. For relative links, verify the target file exists. For `http(s)://` links, do a quick reachability check (`curl -sI -o /dev/null -w '%{http_code}' <url>`), treating 4xx/5xx as broken; skip anything pointing at internal/non-public infrastructure.
+- Extract `[text](url)` links. For relative links, verify the target file exists. For `http(s)://` links, follow redirects during a quick HEAD check (`curl -sSIL -o /dev/null -w '%{http_code}' <url>`). If the server rejects HEAD with `405` or `501`, retry with a lightweight GET that discards the body (`curl -sSL -o /dev/null -w '%{http_code}' <url>`). Treat other final 4xx/5xx responses as broken, and skip anything pointing at internal/non-public infrastructure.
 - Cross-reference command/flag names mentioned in prose against the real command surface built in step 3 — a misspelled command (`confluent kafak topic`) won't resolve and is a giveaway.
 
 ## 5. Optional: regenerate the full reference tree for a manual pass

--- a/.claude/skills/issue-dedup/SKILL.md
+++ b/.claude/skills/issue-dedup/SKILL.md
@@ -9,11 +9,17 @@ Two phases in one skill: **Scan** (read-only, always safe to run) and **Resolve*
 
 ## Phase 1 — Scan (read-only)
 
-1. **Scope**: default to all open issues in `confluentinc/cli`. If the user narrows it (a label, a time window, a keyword), use that instead. If there are more than ~500 open issues, report the count and ask whether to filter before pulling everything.
+1. **Scope**: default to all open issues in `confluentinc/cli`. If the user narrows it (a label, a time window, a keyword), use that instead. First obtain the total matching count without truncation:
+
+   ```
+   gh api --method GET search/issues -f q='repo:confluentinc/cli is:issue is:open' --jq '.total_count'
+   ```
+
+   Include any user-supplied label, time-window, or keyword filters in the search query. If the count is more than ~500, report it and ask whether to narrow the scope or explicitly approve fetching the larger result set. Only then fetch the issues, setting `--limit` to at least the reported count so the scan is not silently capped:
 
    ```
    gh issue list --repo confluentinc/cli --state open \
-     --json number,title,body,labels,createdAt,updatedAt,comments,url --limit 500
+     --json number,title,body,labels,createdAt,updatedAt,comments,url --limit <reported-count>
    ```
 
 2. **Normalize**: strip issue-template boilerplate (fixed headers, checkbox scaffolding) before comparing bodies — it inflates similarity between unrelated issues that just used the same template. Focus on what varies: error messages, exact commands, stack traces, version strings, repro steps.

--- a/.claude/skills/issue-dedup/SKILL.md
+++ b/.claude/skills/issue-dedup/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: issue-dedup
+description: Finds and resolves duplicate GitHub issues in confluentinc/cli, with a lightweight check for related issues in the sibling confluentinc/terraform-provider-confluent repo. Scans open issues, clusters likely duplicates with a suggested canonical issue, and — only after explicit confirmation — comments, labels, and closes confirmed duplicates. Use when asked to find, flag, merge, close, or clean up duplicate issues in this repo. Scanning is read-only; resolving mutates GitHub and always confirms first.
+---
+
+# Issue Dedup — confluentinc/cli
+
+Two phases in one skill: **Scan** (read-only, always safe to run) and **Resolve** (mutates GitHub, requires explicit confirmation). Do not skip straight to Resolve — always scan (or accept a prior scan's output) first.
+
+## Phase 1 — Scan (read-only)
+
+1. **Scope**: default to all open issues in `confluentinc/cli`. If the user narrows it (a label, a time window, a keyword), use that instead. If there are more than ~500 open issues, report the count and ask whether to filter before pulling everything.
+
+   ```
+   gh issue list --repo confluentinc/cli --state open \
+     --json number,title,body,labels,createdAt,updatedAt,comments,url --limit 500
+   ```
+
+2. **Normalize**: strip issue-template boilerplate (fixed headers, checkbox scaffolding) before comparing bodies — it inflates similarity between unrelated issues that just used the same template. Focus on what varies: error messages, exact commands, stack traces, version strings, repro steps.
+
+3. **Cluster** (don't do a naive O(n²) full-text pass):
+   - Block by shared signals first: same error string/exit code, same subcommand (e.g. `confluent kafka topic create`), overlapping title tokens, same label.
+   - Within a block, actually read the normalized bodies and judge whether they're the same bug/request, not just the same topic. "Topic creation fails" with two different root causes is not a duplicate pair.
+
+4. **Cross-repo check**: for clusters that look like they might stem from a platform/API behavior rather than a CLI-specific bug, do one targeted search against the sibling repo before concluding:
+
+   ```
+   gh issue list --repo confluentinc/terraform-provider-confluent --state open --search "<keyword>"
+   ```
+
+   If you find a match, flag it as **cross-repo related** rather than a same-repo duplicate — see classification below.
+
+5. **Pick a canonical issue** per group: prefer most complete repro/description, then oldest by `createdAt`, then most comments/reactions. State which rule decided it.
+
+6. **Classify**:
+   - **Same-repo duplicate** (High/Medium/Low confidence) — candidate for closing in Phase 2.
+   - **Cross-repo related** (High/Medium/Low confidence) — same underlying platform behavior surfacing in both repos. Default action is cross-linking, not closing either side.
+
+   For every group, give one or two sentences of *concrete* reasoning (shared error text, same command, same field) — never just "these look similar."
+
+7. **Output**: write a markdown report (default `./issue-dedup-report-<YYYY-MM-DD>.md`) with one entry per group:
+
+   ```markdown
+   ## Group 1 — [same-repo duplicate | cross-repo related] — confidence: High/Medium/Low
+   Canonical: #123 <title> (<url>)
+   Duplicates:
+   - #456 <title> (<url>)
+   Reasoning: <concrete, specific>
+   ```
+
+   Then summarize in chat: issues scanned, groups found, top few by confidence. Stop here unless the user asks you to resolve.
+
+## Phase 2 — Resolve (mutates GitHub, confirm first)
+
+Only enter this phase against a scan you (or a prior run) just produced, or a group the user hands you directly. Never invent duplicate judgments from scratch here.
+
+1. **Re-verify** each issue in each group before trusting the report — reports go stale:
+
+   ```
+   gh issue view <number> --repo confluentinc/cli --json state,title,labels,comments,body
+   ```
+
+   Drop/flag a group if an issue is already closed, has picked up substantial new discussion diverging from the canonical thread (treat as "needs manual review"), or its body has changed enough to undercut the original judgment.
+
+2. **Show the exact plan before acting** — literal comment text and commands, not a summary:
+
+   ```
+   Canonical: #123 <title>
+   Will close as duplicate: #456 <title>
+     Comment: "Closing as a duplicate of #123. If this doesn't fully capture your issue, please reopen or comment on the original with details."
+     Label: duplicate
+     Close reason: not planned
+   ```
+
+   For **cross-repo related** groups, default to cross-linking only (a comment on each issue pointing at the other) — do not close either side unless the user explicitly says to.
+
+3. **Wait for explicit confirmation.** Confirm per group unless the user explicitly approves the whole batch — and even then, show every group's plan first.
+
+4. **Execute only confirmed groups:**
+
+   ```
+   gh issue comment <dup> --repo confluentinc/cli --body "<comment>"
+   gh issue edit <dup> --repo confluentinc/cli --add-label duplicate
+   gh issue close <dup> --repo confluentinc/cli --reason "not planned"
+   ```
+
+   For a cross-repo cross-link, the corresponding comment goes on the `confluentinc/terraform-provider-confluent` issue via the same `gh issue comment` pattern with that repo. If `gh` reports a permissions error, stop and tell the user — don't retry or route around it.
+
+5. **Log and summarize**: append each executed action (issue, action, timestamp) to `./issue-dedup-actions-<YYYY-MM-DD>.md`, then report groups resolved, groups skipped (why), and groups left for manual review.
+
+## Defaults
+
+- Treat every run as dry-run (show the plan, don't execute) unless the user's message already contains clear approval to act ("go ahead", "do it", "apply these").
+- Never bulk-close a group with materially divergent discussion — surface it for manual review instead.


### PR DESCRIPTION
## What changed

Adds two project-scoped Claude Code skills:

- `issue-dedup` scans open CLI issues for likely duplicates, checks relevant Terraform-provider issues, and requires explicit confirmation before mutating GitHub.
- `docs-drift` validates CLI help text, examples, command/flag references, spelling, and links against the live command tree and existing linters.

## Why

These workflows are repeated, repository-specific maintenance tasks. Keeping their instructions in the repository makes the checks consistent and gives contributors safer defaults, especially around issue-closing operations.

## Impact

No product or runtime behavior changes. Claude Code users gain reusable maintenance workflows scoped to this repository.

## Validation

- Reviewed the complete committed diff.
- Verified both skill files exist with valid YAML frontmatter fields.
- Confirmed the PR contains only the two new `SKILL.md` files.
