### PR TITLE
[FSE-1855] Read Flink statement warnings from status.warnings

### DIFF
--- a/internal/flink/command_statement.go
+++ b/internal/flink/command_statement.go
@@ -24,13 +24,12 @@ func printStatementWarnings(cmd *cobra.Command, warnings []types.StatementWarnin
 }
 
 type statementOut struct {
-	CreationDate time.Time `human:"Creation Date" serialized:"creation_date"`
-	Name         string    `human:"Name" serialized:"name"`
-	Statement    string    `human:"Statement" serialized:"statement"`
-	ComputePool  string    `human:"Compute Pool,omitempty" serialized:"compute_pool,omitempty"`
-	Status       string    `human:"Status" serialized:"status"`
-	StatusDetail string    `human:"Status Detail,omitempty" serialized:"status_detail,omitempty"`
-	// Rendered below the table, since a warning message is too long for a cell.
+	CreationDate           time.Time                `human:"Creation Date" serialized:"creation_date"`
+	Name                   string                   `human:"Name" serialized:"name"`
+	Statement              string                   `human:"Statement" serialized:"statement"`
+	ComputePool            string                   `human:"Compute Pool,omitempty" serialized:"compute_pool,omitempty"`
+	Status                 string                   `human:"Status" serialized:"status"`
+	StatusDetail           string                   `human:"Status Detail,omitempty" serialized:"status_detail,omitempty"`
 	Warnings               []types.StatementWarning `human:"-" serialized:"warnings,omitempty"`
 	LatestOffsets          map[string]string        `human:"Latest Offsets" serialized:"latest_offsets"`
 	LatestOffsetsTimestamp *time.Time               `human:"Latest Offsets Timestamp" serialized:"latest_offsets_timestamp"`

--- a/internal/flink/command_statement.go
+++ b/internal/flink/command_statement.go
@@ -4,17 +4,36 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+
+	"github.com/confluentinc/cli/v4/pkg/flink/types"
+	"github.com/confluentinc/cli/v4/pkg/output"
 )
 
+// printStatementWarnings renders warnings below the table, on stderr so that stdout stays the
+// command's data. Serialized output already carries them in the warnings field.
+func printStatementWarnings(cmd *cobra.Command, warnings []types.StatementWarning) {
+	if output.GetFormat(cmd) != output.Human {
+		return
+	}
+
+	if block := types.FormatStatementWarnings(warnings); block != "" {
+		output.ErrPrintln(false, "")
+		output.ErrPrintln(false, block)
+		output.ErrPrintln(false, "")
+	}
+}
+
 type statementOut struct {
-	CreationDate           time.Time         `human:"Creation Date" serialized:"creation_date"`
-	Name                   string            `human:"Name" serialized:"name"`
-	Statement              string            `human:"Statement" serialized:"statement"`
-	ComputePool            string            `human:"Compute Pool,omitempty" serialized:"compute_pool,omitempty"`
-	Status                 string            `human:"Status" serialized:"status"`
-	StatusDetail           string            `human:"Status Detail,omitempty" serialized:"status_detail,omitempty"`
-	LatestOffsets          map[string]string `human:"Latest Offsets" serialized:"latest_offsets"`
-	LatestOffsetsTimestamp *time.Time        `human:"Latest Offsets Timestamp" serialized:"latest_offsets_timestamp"`
+	CreationDate time.Time `human:"Creation Date" serialized:"creation_date"`
+	Name         string    `human:"Name" serialized:"name"`
+	Statement    string    `human:"Statement" serialized:"statement"`
+	ComputePool  string    `human:"Compute Pool,omitempty" serialized:"compute_pool,omitempty"`
+	Status       string    `human:"Status" serialized:"status"`
+	StatusDetail string    `human:"Status Detail,omitempty" serialized:"status_detail,omitempty"`
+	// Rendered below the table, since a warning message is too long for a cell.
+	Warnings               []types.StatementWarning `human:"-" serialized:"warnings,omitempty"`
+	LatestOffsets          map[string]string        `human:"Latest Offsets" serialized:"latest_offsets"`
+	LatestOffsetsTimestamp *time.Time               `human:"Latest Offsets Timestamp" serialized:"latest_offsets_timestamp"`
 }
 
 func (c *command) newStatementCommand() *cobra.Command {

--- a/internal/flink/command_statement.go
+++ b/internal/flink/command_statement.go
@@ -27,13 +27,12 @@ func printStatementWarnings(cmd *cobra.Command, warnings []types.StatementWarnin
 }
 
 type statementOut struct {
-	CreationDate time.Time `human:"Creation Date" serialized:"creation_date"`
-	Name         string    `human:"Name" serialized:"name"`
-	Statement    string    `human:"Statement" serialized:"statement"`
-	ComputePool  string    `human:"Compute Pool,omitempty" serialized:"compute_pool,omitempty"`
-	Status       string    `human:"Status" serialized:"status"`
-	StatusDetail string    `human:"Status Detail,omitempty" serialized:"status_detail,omitempty"`
-	// Rendered below the table, since a warning message is too long for a cell.
+	CreationDate           time.Time                `human:"Creation Date" serialized:"creation_date"`
+	Name                   string                   `human:"Name" serialized:"name"`
+	Statement              string                   `human:"Statement" serialized:"statement"`
+	ComputePool            string                   `human:"Compute Pool,omitempty" serialized:"compute_pool,omitempty"`
+	Status                 string                   `human:"Status" serialized:"status"`
+	StatusDetail           string                   `human:"Status Detail,omitempty" serialized:"status_detail,omitempty"`
 	Warnings               []types.StatementWarning `human:"-" serialized:"warnings,omitempty"`
 	LatestOffsets          map[string]string        `human:"Latest Offsets" serialized:"latest_offsets"`
 	LatestOffsetsTimestamp *time.Time               `human:"Latest Offsets Timestamp" serialized:"latest_offsets_timestamp"`

--- a/internal/flink/command_statement.go
+++ b/internal/flink/command_statement.go
@@ -8,17 +8,35 @@ import (
 	cmfsdk "github.com/confluentinc/cmf-sdk-go/v1"
 
 	"github.com/confluentinc/cli/v4/pkg/config"
+	"github.com/confluentinc/cli/v4/pkg/flink/types"
+	"github.com/confluentinc/cli/v4/pkg/output"
 )
 
+// printStatementWarnings renders warnings below the table, on stderr so that stdout stays the
+// command's data. Serialized output already carries them in the warnings field.
+func printStatementWarnings(cmd *cobra.Command, warnings []types.StatementWarning) {
+	if output.GetFormat(cmd) != output.Human {
+		return
+	}
+
+	if block := types.FormatStatementWarnings(warnings); block != "" {
+		output.ErrPrintln(false, "")
+		output.ErrPrintln(false, block)
+		output.ErrPrintln(false, "")
+	}
+}
+
 type statementOut struct {
-	CreationDate           time.Time         `human:"Creation Date" serialized:"creation_date"`
-	Name                   string            `human:"Name" serialized:"name"`
-	Statement              string            `human:"Statement" serialized:"statement"`
-	ComputePool            string            `human:"Compute Pool,omitempty" serialized:"compute_pool,omitempty"`
-	Status                 string            `human:"Status" serialized:"status"`
-	StatusDetail           string            `human:"Status Detail,omitempty" serialized:"status_detail,omitempty"`
-	LatestOffsets          map[string]string `human:"Latest Offsets" serialized:"latest_offsets"`
-	LatestOffsetsTimestamp *time.Time        `human:"Latest Offsets Timestamp" serialized:"latest_offsets_timestamp"`
+	CreationDate time.Time `human:"Creation Date" serialized:"creation_date"`
+	Name         string    `human:"Name" serialized:"name"`
+	Statement    string    `human:"Statement" serialized:"statement"`
+	ComputePool  string    `human:"Compute Pool,omitempty" serialized:"compute_pool,omitempty"`
+	Status       string    `human:"Status" serialized:"status"`
+	StatusDetail string    `human:"Status Detail,omitempty" serialized:"status_detail,omitempty"`
+	// Rendered below the table, since a warning message is too long for a cell.
+	Warnings               []types.StatementWarning `human:"-" serialized:"warnings,omitempty"`
+	LatestOffsets          map[string]string        `human:"Latest Offsets" serialized:"latest_offsets"`
+	LatestOffsetsTimestamp *time.Time               `human:"Latest Offsets Timestamp" serialized:"latest_offsets_timestamp"`
 }
 
 type statementOutOnPrem struct {

--- a/internal/flink/command_statement_create.go
+++ b/internal/flink/command_statement_create.go
@@ -173,6 +173,8 @@ func (c *command) statementCreate(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	warnings := types.NewStatementWarnings(statement.Status.GetWarnings())
+
 	table := output.NewTable(cmd)
 	table.Add(&statementOut{
 		CreationDate: statement.Metadata.GetCreatedAt(),
@@ -181,7 +183,13 @@ func (c *command) statementCreate(cmd *cobra.Command, args []string) error {
 		ComputePool:  statement.Spec.GetComputePoolId(),
 		Status:       statement.Status.GetPhase(),
 		StatusDetail: statement.Status.GetDetail(),
+		Warnings:     warnings,
 	})
-	table.Filter([]string{"CreationDate", "Name", "Statement", "ComputePool", "Status", "StatusDetail"})
-	return table.Print()
+	table.Filter([]string{"CreationDate", "Name", "Statement", "ComputePool", "Status", "StatusDetail", "Warnings"})
+	if err := table.Print(); err != nil {
+		return err
+	}
+
+	printStatementWarnings(cmd, warnings)
+	return nil
 }

--- a/internal/flink/command_statement_describe.go
+++ b/internal/flink/command_statement_describe.go
@@ -13,13 +13,12 @@ import (
 )
 
 type describeStatementOut struct {
-	CreationDate time.Time `human:"Creation Date" serialized:"creation_date"`
-	Name         string    `human:"Name" serialized:"name"`
-	Statement    string    `human:"Statement" serialized:"statement"`
-	ComputePool  string    `human:"Compute Pool" serialized:"compute_pool"`
-	Status       string    `human:"Status" serialized:"status"`
-	StatusDetail string    `human:"Status Detail,omitempty" serialized:"status_detail,omitempty"`
-	// Rendered below the table, since a warning message is too long for a cell.
+	CreationDate           time.Time                `human:"Creation Date" serialized:"creation_date"`
+	Name                   string                   `human:"Name" serialized:"name"`
+	Statement              string                   `human:"Statement" serialized:"statement"`
+	ComputePool            string                   `human:"Compute Pool" serialized:"compute_pool"`
+	Status                 string                   `human:"Status" serialized:"status"`
+	StatusDetail           string                   `human:"Status Detail,omitempty" serialized:"status_detail,omitempty"`
 	Warnings               []types.StatementWarning `human:"-" serialized:"warnings,omitempty"`
 	LatestOffsets          map[string]string        `human:"Latest Offsets" serialized:"latest_offsets"`
 	LatestOffsetsTimestamp *time.Time               `human:"Latest Offsets Timestamp" serialized:"latest_offsets_timestamp"`

--- a/internal/flink/command_statement_describe.go
+++ b/internal/flink/command_statement_describe.go
@@ -8,20 +8,23 @@ import (
 	flinkgatewayv1 "github.com/confluentinc/ccloud-sdk-go-v2/flink-gateway/v1"
 
 	pcmd "github.com/confluentinc/cli/v4/pkg/cmd"
+	"github.com/confluentinc/cli/v4/pkg/flink/types"
 	"github.com/confluentinc/cli/v4/pkg/output"
 )
 
 type describeStatementOut struct {
-	CreationDate           time.Time         `human:"Creation Date" serialized:"creation_date"`
-	Name                   string            `human:"Name" serialized:"name"`
-	Statement              string            `human:"Statement" serialized:"statement"`
-	ComputePool            string            `human:"Compute Pool" serialized:"compute_pool"`
-	Status                 string            `human:"Status" serialized:"status"`
-	StatusDetail           string            `human:"Status Detail,omitempty" serialized:"status_detail,omitempty"`
-	LatestOffsets          map[string]string `human:"Latest Offsets" serialized:"latest_offsets"`
-	LatestOffsetsTimestamp *time.Time        `human:"Latest Offsets Timestamp" serialized:"latest_offsets_timestamp"`
-	Properties             map[string]string `human:"Properties" serialized:"properties"`
-	Principal              string            `human:"Principal" serialized:"principal"`
+	CreationDate time.Time `human:"Creation Date" serialized:"creation_date"`
+	Name         string    `human:"Name" serialized:"name"`
+	Statement    string    `human:"Statement" serialized:"statement"`
+	ComputePool  string    `human:"Compute Pool" serialized:"compute_pool"`
+	Status       string    `human:"Status" serialized:"status"`
+	StatusDetail string    `human:"Status Detail,omitempty" serialized:"status_detail,omitempty"`
+	// Rendered below the table, since a warning message is too long for a cell.
+	Warnings               []types.StatementWarning `human:"-" serialized:"warnings,omitempty"`
+	LatestOffsets          map[string]string        `human:"Latest Offsets" serialized:"latest_offsets"`
+	LatestOffsetsTimestamp *time.Time               `human:"Latest Offsets Timestamp" serialized:"latest_offsets_timestamp"`
+	Properties             map[string]string        `human:"Properties" serialized:"properties"`
+	Principal              string                   `human:"Principal" serialized:"principal"`
 }
 
 func (c *command) newStatementDescribeCommand() *cobra.Command {
@@ -58,6 +61,8 @@ func (c *command) statementDescribe(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	warnings := types.NewStatementWarnings(statement.Status.GetWarnings())
+
 	table := output.NewTable(cmd)
 	table.Add(&describeStatementOut{
 		CreationDate:           statement.Metadata.GetCreatedAt(),
@@ -66,10 +71,16 @@ func (c *command) statementDescribe(cmd *cobra.Command, args []string) error {
 		ComputePool:            statement.Spec.GetComputePoolId(),
 		Status:                 statement.Status.GetPhase(),
 		StatusDetail:           statement.Status.GetDetail(),
+		Warnings:               warnings,
 		LatestOffsets:          statement.Status.GetLatestOffsets(),
 		LatestOffsetsTimestamp: flinkgatewayv1.PtrTime(statement.Status.GetLatestOffsetsTimestamp()),
 		Properties:             statement.Spec.GetProperties(),
 		Principal:              statement.Spec.GetPrincipal(),
 	})
-	return table.Print()
+	if err := table.Print(); err != nil {
+		return err
+	}
+
+	printStatementWarnings(cmd, warnings)
+	return nil
 }

--- a/internal/flink/command_statement_list.go
+++ b/internal/flink/command_statement_list.go
@@ -13,6 +13,7 @@ import (
 	pcmd "github.com/confluentinc/cli/v4/pkg/cmd"
 	"github.com/confluentinc/cli/v4/pkg/errors"
 	"github.com/confluentinc/cli/v4/pkg/examples"
+	"github.com/confluentinc/cli/v4/pkg/flink/types"
 	"github.com/confluentinc/cli/v4/pkg/log"
 	"github.com/confluentinc/cli/v4/pkg/output"
 	"github.com/confluentinc/cli/v4/pkg/utils"
@@ -100,6 +101,7 @@ func (c *command) statementList(cmd *cobra.Command, _ []string) error {
 			ComputePool:            statement.Spec.GetComputePoolId(),
 			Status:                 statement.Status.GetPhase(),
 			StatusDetail:           statement.Status.GetDetail(),
+			Warnings:               types.NewStatementWarnings(statement.Status.GetWarnings()),
 			LatestOffsets:          statement.Status.GetLatestOffsets(),
 			LatestOffsetsTimestamp: flinkgatewayv1.PtrTime(statement.Status.GetLatestOffsetsTimestamp()),
 		})

--- a/pkg/flink/internal/controller/.snapshots/TestStatementControllerTestSuite-TestExecuteStatementWithStructuredWarnings
+++ b/pkg/flink/internal/controller/.snapshots/TestStatementControllerTestSuite-TestExecuteStatementWithStructuredWarnings
@@ -1,0 +1,14 @@
+Statement successfully submitted.
+Waiting for statement to be ready. Statement phase: PENDING.
+Warnings:
+
+CRITICAL [UPSERT_PRIMARY_KEY_MISMATCH] (Logged: 2026-07-30T09:15:00Z)
+The primary key does not match the upsert key derived from the query.
+
+MODERATE [MISSING_WINDOW_START_END] (Logged: 2026-07-30T08:00:00Z)
+The GROUP BY clause contains only `window_start` with no corresponding `window_end`.
+
+Statement phase is RUNNING.
+Listening for execution errors. Press Enter to detach.
+Finished statement execution. Statement phase: COMPLETED.
+

--- a/pkg/flink/internal/controller/statement_controller_test.go
+++ b/pkg/flink/internal/controller/statement_controller_test.go
@@ -333,6 +333,43 @@ func (s *StatementControllerTestSuite) TestExecuteStatementWithWarning() {
 	cupaloy.SnapshotT(s.T(), stdout)
 }
 
+func (s *StatementControllerTestSuite) TestExecuteStatementWithStructuredWarnings() {
+	statementToExecute := "insert into users values ('test');"
+	legacyDetail := "[Warning] The primary key does not match the upsert key derived from the query."
+	windowWarningTime := time.Date(2026, 7, 30, 8, 0, 0, 0, time.UTC)
+	upsertWarningTime := time.Date(2026, 7, 30, 9, 15, 0, 0, time.UTC)
+	warnings := []types.StatementWarning{
+		{
+			Severity:  "MODERATE",
+			Reason:    "MISSING_WINDOW_START_END",
+			Message:   "The GROUP BY clause contains only `window_start` with no corresponding `window_end`.",
+			CreatedAt: &windowWarningTime,
+		},
+		{
+			Severity:  "CRITICAL",
+			Reason:    "UPSERT_PRIMARY_KEY_MISMATCH",
+			Message:   "The primary key does not match the upsert key derived from the query.",
+			CreatedAt: &upsertWarningTime,
+		},
+	}
+	processedStatement := types.ProcessedStatement{Status: types.PENDING, Principal: "sa-123", StatusDetail: legacyDetail, Warnings: warnings}
+	runningStatement := types.ProcessedStatement{Status: types.RUNNING, StatusDetail: legacyDetail, Warnings: warnings}
+	completedStatement := types.ProcessedStatement{Status: types.COMPLETED}
+	s.store.EXPECT().ProcessStatement(statementToExecute).Return(&processedStatement, nil)
+	s.consoleParser.EXPECT().Read().Return(nil, nil).AnyTimes()
+	s.store.EXPECT().WaitPendingStatement(gomock.Any(), processedStatement).Return(&runningStatement, nil)
+	s.store.EXPECT().FetchStatementResults(runningStatement).Return(&runningStatement, nil)
+	s.store.EXPECT().WaitForTerminalStatementState(gomock.Any(), runningStatement).Return(&completedStatement, nil)
+
+	stdout := testUtils.RunAndCaptureSTDOUT(s.T(), func() {
+		returnedStatement, err := s.statementController.ExecuteStatement(statementToExecute)
+		require.Nil(s.T(), err)
+		require.Equal(s.T(), &completedStatement, returnedStatement)
+	})
+
+	cupaloy.SnapshotT(s.T(), stdout)
+}
+
 func (s *StatementControllerTestSuite) TestRenderMsgAndStatusLocalStatements() {
 	tests := []struct {
 		name      string

--- a/pkg/flink/internal/store/store.go
+++ b/pkg/flink/internal/store/store.go
@@ -351,6 +351,8 @@ func (s *Store) WaitForTerminalStatementState(ctx context.Context, statement typ
 
 			statement.Status = types.PHASE(statementObj.Status.GetPhase())
 			statement.StatusDetail = statusDetail
+			// Warnings can be added after submission, so refresh them on every poll.
+			statement.Warnings = types.NewStatementWarnings(statementObj.Status.GetWarnings())
 			if statement.IsTerminalState() {
 				break
 			}

--- a/pkg/flink/types/processed_statement.go
+++ b/pkg/flink/types/processed_statement.go
@@ -23,13 +23,14 @@ const (
 
 // ProcessedStatement Custom Internal type that shall be used internally by the client
 type ProcessedStatement struct {
-	Statement            string `json:"statement"`
-	StatementName        string `json:"statement_name"`
-	Kind                 string `json:"kind"`
-	ComputePool          string `json:"compute_pool"`
-	Principal            string `json:"principal"` // Cloud only
-	Status               PHASE  `json:"status"`
-	StatusDetail         string `json:"status_detail,omitempty"` // Shown at the top before the table
+	Statement            string             `json:"statement"`
+	StatementName        string             `json:"statement_name"`
+	Kind                 string             `json:"kind"`
+	ComputePool          string             `json:"compute_pool"`
+	Principal            string             `json:"principal"` // Cloud only
+	Status               PHASE              `json:"status"`
+	StatusDetail         string             `json:"status_detail,omitempty"` // Shown at the top before the table
+	Warnings             []StatementWarning `json:"warnings,omitempty"`
 	IsLocalStatement     bool
 	IsSensitiveStatement bool
 	PageToken            string
@@ -46,6 +47,7 @@ func NewProcessedStatement(statementObj flinkgatewayv1.SqlV1Statement) *Processe
 		ComputePool:   statementObj.Spec.GetComputePoolId(),
 		Principal:     statementObj.Spec.GetPrincipal(),
 		StatusDetail:  statementObj.Status.GetDetail(),
+		Warnings:      NewStatementWarnings(statementObj.Status.GetWarnings()),
 		Status:        PHASE(statementObj.Status.GetPhase()),
 		Properties:    statementObj.Spec.GetProperties(),
 		Traits:        StatementTraits{FlinkGatewayV1StatementTraits: &traits},
@@ -92,9 +94,20 @@ func (s ProcessedStatement) printStatusMessageOfNonLocalStatement() {
 		}
 	}
 
-	if s.StatusDetail != "" {
+	// The status detail can repeat the warnings, so only print it when there are none. A failed
+	// statement is the exception: its detail holds the failure reason.
+	if s.StatusDetail != "" && (s.Status == FAILED || len(s.Warnings) == 0) {
 		utils.OutputInfof("Details: ")
 		utils.OutputWarn(s.StatusDetail)
+	}
+
+	s.printWarnings()
+}
+
+func (s ProcessedStatement) printWarnings() {
+	if warnings := FormatStatementWarnings(s.Warnings); warnings != "" {
+		utils.OutputWarn(warnings)
+		utils.OutputInfo("")
 	}
 }
 
@@ -110,6 +123,8 @@ func (s ProcessedStatement) PrintOutputDryRunStatement() {
 		utils.OutputInfof("Details: ")
 		utils.OutputErr(s.StatusDetail)
 	}
+
+	s.printWarnings()
 }
 
 func (s ProcessedStatement) GetPageSize() int {

--- a/pkg/flink/types/processed_statement_test.go
+++ b/pkg/flink/types/processed_statement_test.go
@@ -1,0 +1,69 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	testUtils "github.com/confluentinc/cli/v4/pkg/flink/test"
+)
+
+func TestPrintStatusMessagePrintsStructuredWarningsInsteadOfStatusDetail(t *testing.T) {
+	statement := ProcessedStatement{
+		Status:       RUNNING,
+		StatusDetail: "[Warning] legacy inlined warning",
+		Warnings:     []StatementWarning{{Severity: "CRITICAL", Reason: "SOME_REASON", Message: "Fix the query."}},
+	}
+
+	stdout := testUtils.RunAndCaptureSTDOUT(t, statement.PrintStatusMessage)
+
+	require.Contains(t, stdout, "CRITICAL [SOME_REASON]")
+	require.Contains(t, stdout, "Fix the query.")
+	require.NotContains(t, stdout, "legacy inlined warning")
+	require.NotContains(t, stdout, "Details: ")
+}
+
+func TestPrintStatusMessagePrintsStatusDetailOfFailedStatementAlongsideWarnings(t *testing.T) {
+	statement := ProcessedStatement{
+		Status:       FAILED,
+		StatusDetail: "the failure reason",
+		Warnings:     []StatementWarning{{Severity: "LOW", Reason: "SOME_REASON", Message: "Fix the query."}},
+	}
+
+	stdout := testUtils.RunAndCaptureSTDOUT(t, statement.PrintStatusMessage)
+
+	require.Contains(t, stdout, "the failure reason")
+	require.Contains(t, stdout, "LOW [SOME_REASON]")
+}
+
+func TestPrintStatusMessagePrintsStatusDetailWhenThereAreNoWarnings(t *testing.T) {
+	statement := ProcessedStatement{Status: RUNNING, StatusDetail: "something worth knowing"}
+
+	stdout := testUtils.RunAndCaptureSTDOUT(t, statement.PrintStatusMessage)
+
+	require.Contains(t, stdout, "Details: ")
+	require.Contains(t, stdout, "something worth knowing")
+	require.NotContains(t, stdout, "Warnings:")
+}
+
+func TestPrintStatusMessagePrintsNoWarningsBlockWhenThereAreNoWarnings(t *testing.T) {
+	statement := ProcessedStatement{Status: RUNNING}
+
+	stdout := testUtils.RunAndCaptureSTDOUT(t, statement.PrintStatusMessage)
+
+	require.Contains(t, stdout, "Statement successfully submitted.")
+	require.NotContains(t, stdout, "Warnings:")
+	require.NotContains(t, stdout, "Details: ")
+}
+
+func TestPrintOutputDryRunStatementPrintsWarnings(t *testing.T) {
+	statement := ProcessedStatement{
+		Status:   COMPLETED,
+		Warnings: []StatementWarning{{Severity: "MODERATE", Reason: "SOME_REASON", Message: "Fix the query."}},
+	}
+
+	stdout := testUtils.RunAndCaptureSTDOUT(t, statement.PrintOutputDryRunStatement)
+
+	require.Contains(t, stdout, "MODERATE [SOME_REASON]")
+	require.Contains(t, stdout, "Fix the query.")
+}

--- a/pkg/flink/types/statement_warning.go
+++ b/pkg/flink/types/statement_warning.go
@@ -1,0 +1,97 @@
+package types
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+	"time"
+
+	flinkgatewayv1 "github.com/confluentinc/ccloud-sdk-go-v2/flink-gateway/v1"
+)
+
+// severityOrder ranks severities for display, most severe first. Severity is an extensible enum, so
+// an unrecognized value is still displayed, sorted last.
+var severityOrder = []string{"CRITICAL", "MODERATE", "LOW"}
+
+// StatementWarning is a non-fatal issue reported for a statement.
+type StatementWarning struct {
+	Severity string `json:"severity" yaml:"severity"`
+	Reason   string `json:"reason" yaml:"reason"`
+	Message  string `json:"message" yaml:"message"`
+	// A pointer so that a missing timestamp is omitted from serialized output. `omitempty` does not
+	// omit a zero `time.Time` value, only a nil pointer.
+	CreatedAt *time.Time `json:"created_at,omitempty" yaml:"created_at,omitempty"`
+}
+
+// NewStatementWarnings converts a statement's warnings, ordered most severe first.
+func NewStatementWarnings(warnings []flinkgatewayv1.SqlV1StatementWarning) []StatementWarning {
+	if len(warnings) == 0 {
+		return nil
+	}
+
+	converted := make([]StatementWarning, len(warnings))
+	for i, warning := range warnings {
+		converted[i] = StatementWarning{
+			Severity: warning.GetSeverity(),
+			Reason:   warning.GetReason(),
+			Message:  warning.GetMessage(),
+		}
+		// The API models the timestamp as a value, so an absent one arrives as the zero time.
+		if createdAt := warning.GetCreatedAt(); !createdAt.IsZero() {
+			converted[i].CreatedAt = &createdAt
+		}
+	}
+
+	sortBySeverity(converted)
+
+	return converted
+}
+
+// FormatStatementWarnings renders warnings for terminal output, most severe first. It returns an
+// empty string when there are no warnings.
+func FormatStatementWarnings(warnings []StatementWarning) string {
+	if len(warnings) == 0 {
+		return ""
+	}
+
+	// Sort a copy so the order holds however the caller built the slice.
+	sorted := slices.Clone(warnings)
+	sortBySeverity(sorted)
+
+	entries := make([]string, len(sorted))
+	for i, warning := range sorted {
+		entries[i] = fmt.Sprintf("%s\n%s", warning.header(), warning.Message)
+	}
+
+	return fmt.Sprintf("Warnings:\n\n%s", strings.Join(entries, "\n\n"))
+}
+
+func sortBySeverity(warnings []StatementWarning) {
+	slices.SortStableFunc(warnings, func(a, b StatementWarning) int {
+		return severityRank(a.Severity) - severityRank(b.Severity)
+	})
+}
+
+func (w StatementWarning) header() string {
+	severity := w.Severity
+	if severity == "" {
+		severity = "WARNING"
+	}
+
+	header := severity
+	if w.Reason != "" {
+		header += fmt.Sprintf(" [%s]", w.Reason)
+	}
+	if w.CreatedAt != nil {
+		header += fmt.Sprintf(" (Logged: %s)", w.CreatedAt.UTC().Format(time.RFC3339))
+	}
+
+	return header
+}
+
+func severityRank(severity string) int {
+	if i := slices.Index(severityOrder, strings.ToUpper(severity)); i >= 0 {
+		return i
+	}
+	return len(severityOrder)
+}

--- a/pkg/flink/types/statement_warning_test.go
+++ b/pkg/flink/types/statement_warning_test.go
@@ -1,0 +1,148 @@
+package types
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	flinkgatewayv1 "github.com/confluentinc/ccloud-sdk-go-v2/flink-gateway/v1"
+)
+
+func ptrTime(t time.Time) *time.Time {
+	return &t
+}
+
+func TestNewStatementWarningsReturnsNilWhenThereAreNoWarnings(t *testing.T) {
+	require.Nil(t, NewStatementWarnings(nil))
+	require.Nil(t, NewStatementWarnings([]flinkgatewayv1.SqlV1StatementWarning{}))
+}
+
+func TestNewStatementWarningsSortsMostSevereFirst(t *testing.T) {
+	warnings := NewStatementWarnings([]flinkgatewayv1.SqlV1StatementWarning{
+		{Severity: "LOW", Reason: "LOW_ONE"},
+		{Severity: "CRITICAL", Reason: "CRITICAL_ONE"},
+		{Severity: "MODERATE", Reason: "MODERATE_ONE"},
+		{Severity: "CRITICAL", Reason: "CRITICAL_TWO"},
+	})
+
+	reasons := make([]string, len(warnings))
+	for i, warning := range warnings {
+		reasons[i] = warning.Reason
+	}
+
+	require.Equal(t, []string{"CRITICAL_ONE", "CRITICAL_TWO", "MODERATE_ONE", "LOW_ONE"}, reasons)
+}
+
+func TestNewStatementWarningsSortsUnrecognizedSeverityLast(t *testing.T) {
+	warnings := NewStatementWarnings([]flinkgatewayv1.SqlV1StatementWarning{
+		{Severity: "SOMETHING_NEW", Reason: "NEW_ONE"},
+		{Severity: "LOW", Reason: "LOW_ONE"},
+	})
+
+	require.Equal(t, "LOW_ONE", warnings[0].Reason)
+	require.Equal(t, "NEW_ONE", warnings[1].Reason)
+}
+
+func TestNewStatementWarningsCopiesEveryField(t *testing.T) {
+	createdAt := time.Date(2026, 7, 30, 9, 15, 0, 0, time.UTC)
+
+	warnings := NewStatementWarnings([]flinkgatewayv1.SqlV1StatementWarning{{
+		Severity:  "CRITICAL",
+		Reason:    "HIGH_STATE_OPERATOR_WITHOUT_TTL",
+		Message:   "Your query includes one or more highly state-intensive operators.",
+		CreatedAt: createdAt,
+	}})
+
+	require.Equal(t, []StatementWarning{{
+		Severity:  "CRITICAL",
+		Reason:    "HIGH_STATE_OPERATOR_WITHOUT_TTL",
+		Message:   "Your query includes one or more highly state-intensive operators.",
+		CreatedAt: &createdAt,
+	}}, warnings)
+}
+
+func TestNewStatementWarningsLeavesAnAbsentTimestampUnset(t *testing.T) {
+	warnings := NewStatementWarnings([]flinkgatewayv1.SqlV1StatementWarning{
+		{Severity: "LOW", Reason: "SOME_REASON", Message: "Something to know."},
+	})
+
+	require.Nil(t, warnings[0].CreatedAt)
+
+	serialized, err := json.Marshal(warnings)
+	require.NoError(t, err)
+	require.NotContains(t, string(serialized), "created_at")
+	require.NotContains(t, string(serialized), "0001-01-01")
+}
+
+func TestFormatStatementWarningsReturnsEmptyStringWhenThereAreNoWarnings(t *testing.T) {
+	require.Empty(t, FormatStatementWarnings(nil))
+	require.Empty(t, FormatStatementWarnings([]StatementWarning{}))
+}
+
+func TestFormatStatementWarnings(t *testing.T) {
+	warnings := []StatementWarning{
+		{
+			Severity:  "CRITICAL",
+			Reason:    "HIGH_STATE_OPERATOR_WITHOUT_TTL",
+			Message:   "Your query includes one or more highly state-intensive operators.",
+			CreatedAt: ptrTime(time.Date(2026, 7, 30, 9, 15, 0, 0, time.UTC)),
+		},
+		{
+			Severity:  "MODERATE",
+			Reason:    "MISSING_WINDOW_START_END",
+			Message:   "The GROUP BY clause contains only `window_start`.",
+			CreatedAt: ptrTime(time.Date(2026, 7, 30, 8, 0, 0, 0, time.UTC)),
+		},
+	}
+
+	expected := `Warnings:
+
+CRITICAL [HIGH_STATE_OPERATOR_WITHOUT_TTL] (Logged: 2026-07-30T09:15:00Z)
+Your query includes one or more highly state-intensive operators.
+
+MODERATE [MISSING_WINDOW_START_END] (Logged: 2026-07-30T08:00:00Z)
+The GROUP BY clause contains only ` + "`window_start`" + `.`
+
+	require.Equal(t, expected, FormatStatementWarnings(warnings))
+}
+
+func TestFormatStatementWarningsSortsMostSevereFirstWithoutMutatingTheInput(t *testing.T) {
+	warnings := []StatementWarning{
+		{Severity: "LOW", Reason: "LOW_ONE", Message: "Low."},
+		{Severity: "CRITICAL", Reason: "CRITICAL_ONE", Message: "Critical."},
+	}
+
+	formatted := FormatStatementWarnings(warnings)
+
+	require.Less(t, strings.Index(formatted, "CRITICAL_ONE"), strings.Index(formatted, "LOW_ONE"))
+	require.Equal(t, "LOW_ONE", warnings[0].Reason)
+}
+
+func TestFormatStatementWarningsOmitsMissingHeaderParts(t *testing.T) {
+	warnings := []StatementWarning{{Severity: "LOW", Message: "Something to know."}}
+
+	require.Equal(t, "Warnings:\n\nLOW\nSomething to know.", FormatStatementWarnings(warnings))
+}
+
+func TestFormatStatementWarningsFallsBackWhenSeverityIsMissing(t *testing.T) {
+	warnings := []StatementWarning{{Reason: "SOME_REASON", Message: "Something to know."}}
+
+	require.Equal(t, "Warnings:\n\nWARNING [SOME_REASON]\nSomething to know.", FormatStatementWarnings(warnings))
+}
+
+func TestFormatStatementWarningsRendersTimestampInUtc(t *testing.T) {
+	berlin, err := time.LoadLocation("Europe/Berlin")
+	require.NoError(t, err)
+
+	warnings := []StatementWarning{{
+		Severity:  "LOW",
+		Reason:    "SOME_REASON",
+		Message:   "Something to know.",
+		CreatedAt: ptrTime(time.Date(2026, 7, 30, 11, 15, 0, 0, berlin)),
+	}}
+
+	require.Contains(t, FormatStatementWarnings(warnings), "(Logged: 2026-07-30T09:15:00Z)")
+}

--- a/test/fixtures/output/flink/statement/describe-warnings-yaml.golden
+++ b/test/fixtures/output/flink/statement/describe-warnings-yaml.golden
@@ -1,0 +1,22 @@
+creation_date: 2022-01-01T00:00:00Z
+name: my-statement-with-warnings
+statement: CREATE TABLE test;
+compute_pool: lfcp-123456
+status: COMPLETED
+status_detail: SQL statement is completed
+warnings:
+    - severity: CRITICAL
+      reason: HIGH_STATE_OPERATOR_WITHOUT_TTL
+      message: Your query includes one or more highly state-intensive operators but does not set a time-to-live (TTL) value.
+      created_at: 2022-01-01T00:00:00Z
+    - severity: MODERATE
+      reason: MISSING_WINDOW_START_END
+      message: The GROUP BY clause contains only `window_start` with no corresponding `window_end`.
+      created_at: 2022-01-01T00:00:00Z
+latest_offsets:
+    customers_source: partition:0,offset:9223372036854775808
+latest_offsets_timestamp: 2022-01-01T00:00:00Z
+properties:
+    sql.current-catalog: default
+    sql.current-database: my-cluster
+principal: u-123456

--- a/test/fixtures/output/flink/statement/describe-warnings.golden
+++ b/test/fixtures/output/flink/statement/describe-warnings.golden
@@ -1,0 +1,22 @@
++--------------------------+---------------------------------------------------------+
+| Creation Date            | 2022-01-01 00:00:00 +0000 UTC                           |
+| Name                     | my-statement-with-warnings                              |
+| Statement                | CREATE TABLE test;                                      |
+| Compute Pool             | lfcp-123456                                             |
+| Status                   | COMPLETED                                               |
+| Status Detail            | SQL statement is completed                              |
+| Latest Offsets           | customers_source=partition:0,offset:9223372036854775808 |
+| Latest Offsets Timestamp | 2022-01-01 00:00:00 +0000 UTC                           |
+| Properties               | sql.current-catalog=default                             |
+|                          | sql.current-database=my-cluster                         |
+| Principal                | u-123456                                                |
++--------------------------+---------------------------------------------------------+
+
+Warnings:
+
+CRITICAL [HIGH_STATE_OPERATOR_WITHOUT_TTL] (Logged: 2022-01-01T00:00:00Z)
+Your query includes one or more highly state-intensive operators but does not set a time-to-live (TTL) value.
+
+MODERATE [MISSING_WINDOW_START_END] (Logged: 2022-01-01T00:00:00Z)
+The GROUP BY clause contains only `window_start` with no corresponding `window_end`.
+

--- a/test/flink_test.go
+++ b/test/flink_test.go
@@ -442,6 +442,8 @@ func (s *CLITestSuite) TestFlinkStatement() {
 		{args: "flink statement delete my-statement --force --cloud aws --region eu-west-1", fixture: "flink/statement/delete.golden"},
 		{args: "flink statement describe my-statement --cloud aws --region eu-west-1 -o yaml", fixture: "flink/statement/describe-yaml.golden"},
 		{args: "flink statement describe my-statement --cloud aws --region eu-west-1", fixture: "flink/statement/describe.golden"},
+		{args: "flink statement describe my-statement-with-warnings --cloud aws --region eu-west-1", fixture: "flink/statement/describe-warnings.golden"},
+		{args: "flink statement describe my-statement-with-warnings --cloud aws --region eu-west-1 -o yaml", fixture: "flink/statement/describe-warnings-yaml.golden"},
 		{args: "flink statement list --cloud aws --region eu-west-1", fixture: "flink/statement/list.golden"},
 		{args: "flink statement list --cloud aws --region eu-west-1 -o yaml", fixture: "flink/statement/list-yaml.golden"},
 		{args: "flink statement list --cloud aws --region eu-west-1 --status completed", fixture: "flink/statement/list-completed.golden"},

--- a/test/flink_test.go
+++ b/test/flink_test.go
@@ -443,6 +443,8 @@ func (s *CLITestSuite) TestFlinkStatement() {
 		{args: "flink statement delete my-statement --force --cloud aws --region eu-west-1", fixture: "flink/statement/delete.golden"},
 		{args: "flink statement describe my-statement --cloud aws --region eu-west-1 -o yaml", fixture: "flink/statement/describe-yaml.golden"},
 		{args: "flink statement describe my-statement --cloud aws --region eu-west-1", fixture: "flink/statement/describe.golden"},
+		{args: "flink statement describe my-statement-with-warnings --cloud aws --region eu-west-1", fixture: "flink/statement/describe-warnings.golden"},
+		{args: "flink statement describe my-statement-with-warnings --cloud aws --region eu-west-1 -o yaml", fixture: "flink/statement/describe-warnings-yaml.golden"},
 		{args: "flink statement list --cloud aws --region eu-west-1", fixture: "flink/statement/list.golden"},
 		{args: "flink statement list --cloud aws --region eu-west-1 -o yaml", fixture: "flink/statement/list-yaml.golden"},
 		{args: "flink statement list --cloud aws --region eu-west-1 --status completed", fixture: "flink/statement/list-completed.golden"},

--- a/test/test-server/flink_gateway_router.go
+++ b/test/test-server/flink_gateway_router.go
@@ -248,6 +248,23 @@ func handleStatementGet(t *testing.T) http.HandlerFunc {
 			Metadata: &flinkgatewayv1.StatementObjectMeta{CreatedAt: flinkgatewayv1.PtrTime(time.Date(2022, 1, 1, 0, 0, 0, 0, time.UTC))},
 		}
 
+		if statement.GetName() == "my-statement-with-warnings" {
+			statement.Status.Warnings = &[]flinkgatewayv1.SqlV1StatementWarning{
+				{
+					Severity:  "MODERATE",
+					Reason:    "MISSING_WINDOW_START_END",
+					Message:   "The GROUP BY clause contains only `window_start` with no corresponding `window_end`.",
+					CreatedAt: time.Date(2022, 1, 1, 0, 0, 0, 0, time.UTC),
+				},
+				{
+					Severity:  "CRITICAL",
+					Reason:    "HIGH_STATE_OPERATOR_WITHOUT_TTL",
+					Message:   "Your query includes one or more highly state-intensive operators but does not set a time-to-live (TTL) value.",
+					CreatedAt: time.Date(2022, 1, 1, 0, 0, 0, 0, time.UTC),
+				},
+			}
+		}
+
 		err := json.NewEncoder(w).Encode(statement)
 		require.NoError(t, err)
 	}


### PR DESCRIPTION
### Release Notes

New Features
- Show Flink SQL statement warnings with their severity, reason, and timestamp in the Flink SQL shell, on dry runs, and in confluent flink statement describe and confluent flink statement create. Warnings are listed most severe first.
- Add a warnings field to the serialized output of confluent flink statement describe, confluent flink statement create, and confluent flink statement list so -o json and -o yaml consumers can read each warning's severity, reason, message, and creation time.

Bug Fixes
- Fix Flink SQL statement warnings disappearing shortly after a statement was submitted, and multiple warnings being joined into a single unreadable line.

Checklist

- [x] I have successfully built and used a custom CLI binary, without linter issues from this PR.
- [x] I have clearly specified in the What section below whether this PR applies to Confluent Cloud, Confluent Platform, or both.
- [ ] I have verified this PR in Confluent Cloud pre-prod or production environment, if applicable. Not yet done. Verified against the integration test server only, see Test & Review.
- [ ] I have verified this PR in Confluent Platform on-premises environment, if applicable. Not applicable, see What.
- [x] I have attached manual CLI verification results or screenshots in the Test & Review section below.
- [x] I have added appropriate CLI integration or unit tests for any new or updated commands and functionality.
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [x] I have indicated the potential customer impact if something goes wrong in the Blast Radius section below.
- [x] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [x] Confluent Cloud prod
  - [x] Confluent Cloud stag
  - [ ] Confluent Platform
  - [ ] Check this box if the feature is enabled for certain organizations only

The CLI only renders the warnings the API returns. Where a statement has no warnings, output is unchanged, so no CLI-side enablement is needed.

### What

Applies to Confluent Cloud only. The warnings field is part of the Confluent Cloud Flink statement status. The Confluent Platform on-premises code paths are untouched.

The CLI displayed statement warnings by printing status.detail as a warning banner. That field is a single flat string. It has no severity, no machine-readable reason, and no timestamp, and it is rewritten as a statement moves through its lifecycle. Two consequences for users: warnings vanished from view shortly after submission, and several warnings arrived concatenated into one long line that was hard to read and impossible to render as a list.

Statement warnings are now read from the structured status.warnings array. Each warning is rendered with its severity, reason, and creation time, most severe first:
```
Warnings:

CRITICAL [HIGH_STATE_OPERATOR_WITHOUT_TTL] (Logged: 2022-01-01T00:00:00Z)
Your query includes one or more highly state-intensive operators but does not set a time-to-live (TTL) value.

MODERATE [MISSING_WINDOW_START_END] (Logged: 2022-01-01T00:00:00Z)
The GROUP BY clause contains only `window_start` with no corresponding `window_end`.
```
### Notes on the approach:

- Surfaces covered. The Flink SQL shell, dry runs, confluent flink statement describe, and confluent flink statement create. confluent flink statement list carries the warnings in serialized output but does not render a block per row, which would bury the table.
- Serialized output. A new warnings field is added to describe, create, and list. It is omitempty, so output for statements without warnings is byte-for-byte unchanged. This is an additive field only.
- Human output keeps prose out of the table. A warning message is a paragraph, so it is printed below the table rather than in a cell.
- status.detail is still printed when a statement has no warnings, and always for a failed statement, where the detail carries the failure reason. Skipping it when warnings are present avoids showing the same warning twice, since the detail can still repeat the warning text.
- Unrecognized severities are displayed, not dropped. Severity is an extensible enum, so a value this version of the CLI does not know is still shown and sorted last.

### Blast Radius

Confluent Cloud customers using confluent flink shell, confluent flink statement describe, confluent flink statement create, or confluent flink statement list.

If something goes wrong, the worst case is a display defect: warnings are not shown, are shown in the wrong order, or the Status Detail line is omitted for a statement that has warnings. Statement submission, execution, and results are not touched, so no customer would be blocked from running a statement. Serialized output gains a field and loses none, so existing scripts that parse -o json or -o yaml continue to work.

Confluent Platform on-premises users are unaffected.

### References

- FSE-1855

### Test & Review

Automated:

- Unit tests for the conversion from the API type, severity ordering, unrecognized severities, timestamp rendering in UTC, and the header format. See pkg/flink/types/statement_warning_test.go.
- Unit tests for the print rules, including that a failed statement still shows its detail alongside its warnings, and that a statement without warnings prints exactly what it did before. See pkg/flink/types/processed_statement_test.go.
- A snapshot test for the shell path in pkg/flink/internal/controller/statement_controller_test.go. Writing this caught a real bug: the formatter only produced sorted output when the slice came from the converter, so a caller-built slice printed unsorted. The formatter now sorts a copy of its input.
- Integration tests for describe in human and YAML output, with new golden files. The test server returns warnings only for a dedicated statement name, so no existing golden file changed.

Commands run:
```
go test ./internal/... ./pkg/...
golangci-lint run
make integration-test INTEGRATION_TEST_ARGS="-run TestCLI/TestFlinkStatement"
```

Verified output, human format:
```
+--------------------------+---------------------------------------------------------+
| Creation Date            | 2022-01-01 00:00:00 +0000 UTC                           |
| Name                     | my-statement-with-warnings                              |
| Statement                | CREATE TABLE test;                                      |
| Compute Pool             | lfcp-123456                                             |
| Status                   | COMPLETED                                               |
| Status Detail            | SQL statement is completed                              |
| Latest Offsets           | customers_source=partition:0,offset:9223372036854775808 |
| Latest Offsets Timestamp | 2022-01-01 00:00:00 +0000 UTC                           |
| Properties               | sql.current-catalog=default                             |
|                          | sql.current-database=my-cluster                         |
| Principal                | u-123456                                                |
+--------------------------+---------------------------------------------------------+

Warnings:

CRITICAL [HIGH_STATE_OPERATOR_WITHOUT_TTL] (Logged: 2022-01-01T00:00:00Z)
Your query includes one or more highly state-intensive operators but does not set a time-to-live (TTL) value.

MODERATE [MISSING_WINDOW_START_END] (Logged: 2022-01-01T00:00:00Z)
The GROUP BY clause contains only `window_start` with no corresponding `window_end`.
```

Verified output, -o yaml:
```
creation_date: 2022-01-01T00:00:00Z
name: my-statement-with-warnings
statement: CREATE TABLE test;
compute_pool: lfcp-123456
status: COMPLETED
status_detail: SQL statement is completed
warnings:
    - severity: CRITICAL
      reason: HIGH_STATE_OPERATOR_WITHOUT_TTL
      message: Your query includes one or more highly state-intensive operators but does not set a time-to-live (TTL) value.
      created_at: 2022-01-01T00:00:00Z
    - severity: MODERATE
      reason: MISSING_WINDOW_START_END
      message: The GROUP BY clause contains only `window_start` with no corresponding `window_end`.
      created_at: 2022-01-01T00:00:00Z
latest_offsets:
    customers_source: partition:0,offset:9223372036854775808
latest_offsets_timestamp: 2022-01-01T00:00:00Z
properties:
    sql.current-catalog: default
    sql.current-database: my-cluster
principal: u-123456
```


Built and tested locally

Describe output:
<img width="1761" height="760" alt="image" src="https://github.com/user-attachments/assets/201cdbf7-2928-481f-a9be-22eacb7edf8f" />

From Flink Shell
<img width="1762" height="540" alt="image" src="https://github.com/user-attachments/assets/b0ffa158-3cb1-469d-a410-4485e2f7f7b1" />