### PR TITLE
[APIE-1516][APIE-1313] Fix docs drift and acl delete output stream

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -219,7 +219,7 @@ Add the following line to `internal/command.go`, and make sure to import its pac
 To build the CLI binary, run `make build`. After this, we can run our command in the following way, and see that it (hopefully) works!
 
     make build
-    dist/confluent_<os>_<arch>/confluent config file describe 3
+    dist/confluent_<os>_<arch>/confluent config describe 3
 
 #### Integration Testing
 

--- a/internal/kafka/command_acl_delete.go
+++ b/internal/kafka/command_acl_delete.go
@@ -97,7 +97,7 @@ func (c *aclCommand) delete(cmd *cobra.Command, _ []string) error {
 		deleteResp, err := kafkaREST.CloudClient.DeleteKafkaAcls(filter)
 		if err != nil {
 			if i > 0 {
-				output.ErrPrintln(c.Config.EnableColor, printAclsDeleted(count))
+				output.Println(c.Config.EnableColor, printAclsDeleted(count))
 			}
 			return err
 		}
@@ -105,7 +105,7 @@ func (c *aclCommand) delete(cmd *cobra.Command, _ []string) error {
 		count += len(deleteResp.Data)
 	}
 
-	output.ErrPrintln(c.Config.EnableColor, printAclsDeleted(count))
+	output.Println(c.Config.EnableColor, printAclsDeleted(count))
 	return nil
 }
 

--- a/pkg/errors/error_message.go
+++ b/pkg/errors/error_message.go
@@ -17,7 +17,7 @@ const (
 	MustSetAllowOrDenyErrorMsg        = "`--allow` or `--deny` must be set when adding or deleting an ACL"
 	MustSetResourceTypeErrorMsg       = "exactly one resource type (%s) must be set"
 	ServiceAccountNotFoundErrorMsg    = `service account "%s" not found`
-	ServiceAccountNotFoundSuggestions = "List service accounts with `confluent service-account list`."
+	ServiceAccountNotFoundSuggestions = "List service accounts with `confluent iam service-account list`."
 	SpecifyKafkaIdErrorMsg            = "must specify `--kafka-cluster` to uniquely identify the scope"
 	SpecifyCmfErrorMsg                = "must specify `--cmf` to uniquely identify the Flink environment scope"
 	UnknownConnectorIdErrorMsg        = `unknown connector ID "%s"`

--- a/test/fixtures/output/api-key/39.golden
+++ b/test/fixtures/output/api-key/39.golden
@@ -1,4 +1,4 @@
 Error: service account "sa-123456" not found
 
 Suggestions:
-    List service accounts with `confluent service-account list`.
+    List service accounts with `confluent iam service-account list`.

--- a/test/fixtures/output/iam/service-account/service-account-not-found.golden
+++ b/test/fixtures/output/iam/service-account/service-account-not-found.golden
@@ -1,4 +1,4 @@
 Error: service account not found or access forbidden: resource not found
 
 Suggestions:
-    List service accounts with `confluent service-account list`.
+    List service accounts with `confluent iam service-account list`.


### PR DESCRIPTION
Release Notes
-------------

Bug Fixes
- `confluent service-account` error suggestions pointed to a nonexistent top-level command; corrected to `confluent iam service-account list`. (APIE-1516)
- `confluent kafka acl delete` now prints its confirmation message to stdout instead of stderr, consistent with `confluent api-key delete` and `confluent kafka cluster delete`. (APIE-1313)

Checklist
---------
- [ ] I have successfully built and used a custom CLI binary, without linter issues from this PR.
- [x] I have clearly specified in the `What` section below whether this PR applies to Confluent Cloud, Confluent Platform, or both.
- [ ] I have verified this PR in Confluent Cloud pre-prod or production environment, if applicable.
- [ ] I have verified this PR in Confluent Platform on-premises environment, if applicable.
- [ ] I have attached manual CLI verification results or screenshots in the `Test & Review` section below.
- [ ] I have added appropriate CLI integration or unit tests for any new or updated commands and functionality.
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [x] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [ ] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [ ] Confluent Cloud prod
  - [ ] Confluent Cloud stag
  - [ ] Confluent Platform
  - [ ] Check this box if the feature is enabled for certain organizations only

**Unchecked items are not yet done and need human follow-up before merge** — see Test & Review for exactly what could/couldn't be verified in this environment (no Go toolchain available, so no build/lint/test run, no live verification, no screenshots). Opening as a draft for that reason.

What
----
Confluent Cloud only — both fixes are on cloud-specific code paths (`ServiceAccountNotFoundSuggestions` is only reached via `CatchCCloudV2Error`; `internal/kafka/command_acl_delete.go` is the cloud ACL delete command, distinct from `command_acl_delete_onprem.go`, which was not touched and does not have this issue).

Three small, independent fixes bundled as one papercuts batch:
1. **APIE-1516** — `pkg/errors/error_message.go`: `ServiceAccountNotFoundSuggestions` told users to run `confluent service-account list`, but there is no top-level `service-account` command — it's registered under `iam` (`internal/iam/command_service_account.go`). Corrected to `confluent iam service-account list`, matching every other message in the codebase that already gets this right (e.g. `pkg/errors/catcher.go:301`). Also fixed a stray extra "file" segment in a `CONTRIBUTING.md` tutorial command (`confluent config file describe 3` → `confluent config describe 3`), inconsistent with the rest of that same section.
2. **APIE-1313** — `internal/kafka/command_acl_delete.go`: the delete confirmation ("Deleted N ACL(s).") was printed via `output.ErrPrintln` (stderr). Every comparable delete command (`api-key delete`, `kafka cluster delete`, via the shared `pkg/deletion` helper) uses stdout (`output.Printf`). Switched to `output.Println` for consistency.

Blast Radius
----
- **Error-message fix**: purely a suggestion-text correction shown alongside a "service account not found" error. No serialized/JSON output field changes. Two existing golden fixtures (`test/fixtures/output/api-key/39.golden`, `test/fixtures/output/iam/service-account/service-account-not-found.golden`) pinned the old, incorrect text and have been updated to match — confirmed both exercise the exact constant that changed.
- **CONTRIBUTING.md**: contributor-facing docs only, zero runtime/customer impact.
- **ACL delete stream change**: customers with scripts that specifically redirect or parse this command's `stderr` separately from `stdout` (e.g. `confluent kafka acl delete ... 2>/dev/null` to suppress it) will now see the confirmation line on stdout instead. This is a consistency fix matching the established convention elsewhere, not new information being surfaced, but it is a real stream-visibility change for any automation depending on the old (inconsistent) behavior.

References
----------
- https://confluentinc.atlassian.net/browse/APIE-1516
- https://confluentinc.atlassian.net/browse/APIE-1313

Test & Review
-------------
No Go toolchain was available in the environment this PR was prepared in, so `make build`, `make lint`, and `make test` were not run here — please run these before merging.

What was actually verified:
- Confirmed both fixes against source directly (exact file/line matches for both tickets' descriptions).
- Confirmed via `pkg/errors/catcher.go` that `ServiceAccountNotFoundSuggestions` is only reachable through `CatchCCloudV2Error` (Confluent Cloud only).
- Found two existing integration-test golden fixtures that pinned the old, incorrect suggestion text and updated them to match; confirmed via `test/api_key_test.go:93` and `test/iam_test.go:177` that these are live, currently-passing tests that would otherwise break.
- Confirmed via `test/cli_test.go`'s `runCommand` (`cmd.CombinedOutput()`) that the integration harness merges stdout/stderr for comparison — so the ACL-delete stream change doesn't break any existing golden, but also means **no existing test actually pins which stream this message goes to**. Worth a reviewer's judgment call on whether a dedicated test asserting the stream is warranted.
