### PR TITLE
Role-binding flag text, linter bool-flag exception, logout no-op.

### DIFF
--- a/internal/iam/command_rbac_role_binding_list.go
+++ b/internal/iam/command_rbac_role_binding_list.go
@@ -114,7 +114,7 @@ func (c *roleBindingCommand) newListCommand() *cobra.Command {
 	}
 
 	cmd.Flags().String("resource", "", `Resource type and identifier using "Prefix:ID" format. If specified with "--role" and no principals, list all principals and role bindings.`)
-	cmd.Flags().Bool("inclusive", false, "List role bindings for specified scopes and nested scopes. Otherwise, list role bindings for the specified scopes. If scopes are unspecified, list role bindings across all scopes.")
+	cmd.Flags().Bool("inclusive", false, "List role bindings for specified scopes and nested scopes. Otherwise, list role bindings for the specified scopes. If scopes are unspecified, list role bindings across all scopes. Only applies to Confluent Cloud.")
 	pcmd.AddOutputFlag(cmd)
 
 	return cmd

--- a/internal/iam/command_rbac_role_binding_list.go
+++ b/internal/iam/command_rbac_role_binding_list.go
@@ -114,7 +114,7 @@ func (c *roleBindingCommand) newListCommand() *cobra.Command {
 	}
 
 	cmd.Flags().String("resource", "", `Resource type and identifier using "Prefix:ID" format. If specified with "--role" and no principals, list all principals and role bindings.`)
-	cmd.Flags().Bool("inclusive", false, "List role bindings for specified scopes and nested scopes. Otherwise, list role bindings for the specified scopes. If scopes are unspecified, list only organization-scoped role bindings.")
+	cmd.Flags().Bool("inclusive", false, "List role bindings for specified scopes and nested scopes. Otherwise, list role bindings for the specified scopes. If scopes are unspecified, list role bindings across all scopes.")
 	pcmd.AddOutputFlag(cmd)
 
 	return cmd

--- a/internal/logout/command.go
+++ b/internal/logout/command.go
@@ -1,6 +1,7 @@
 package logout
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/spf13/cobra"
@@ -12,11 +13,12 @@ import (
 	"github.com/confluentinc/cli/v4/pkg/ccloudv2"
 	pcmd "github.com/confluentinc/cli/v4/pkg/cmd"
 	"github.com/confluentinc/cli/v4/pkg/config"
+	"github.com/confluentinc/cli/v4/pkg/log"
 	"github.com/confluentinc/cli/v4/pkg/output"
 )
 
 type command struct {
-	*pcmd.AuthenticatedCLICommand
+	*pcmd.CLICommand
 	cfg              *config.Config
 	authTokenHandler pauth.AuthTokenHandler
 }
@@ -28,16 +30,18 @@ func New(cfg *config.Config, prerunner pcmd.PreRunner, authTokenHandler pauth.Au
 	}
 
 	context := "Confluent Cloud or Confluent Platform"
-	c := &command{
-		AuthenticatedCLICommand: pcmd.NewAuthenticatedCLICommand(cmd, prerunner),
-		cfg:                     cfg,
-		authTokenHandler:        authTokenHandler,
-	}
 	if cfg.IsCloudLogin() {
 		context = "Confluent Cloud"
 	} else if cfg.IsOnPremLogin() {
 		context = "Confluent Platform"
-		c.AuthenticatedCLICommand = pcmd.NewAuthenticatedWithMDSCLICommand(cmd, prerunner)
+	}
+
+	c := &command{
+		// Anonymous (not Authenticated): logout must not require being logged in, and must not
+		// trigger an auto-login via env-var credentials only to immediately log back out.
+		CLICommand:       pcmd.NewAnonymousCLICommand(cmd, prerunner),
+		cfg:              cfg,
+		authTokenHandler: authTokenHandler,
 	}
 
 	cmd.Short = fmt.Sprintf("Log out of %s.", context)
@@ -49,11 +53,14 @@ func New(cfg *config.Config, prerunner pcmd.PreRunner, authTokenHandler pauth.Au
 
 func (c *command) logout(_ *cobra.Command, _ []string) error {
 	ctx := c.Config.Context()
-	if ctx != nil {
-		if ccloudv2.IsCCloudURL(ctx.Platform.Server, c.cfg.IsTest) {
-			if _, err := c.revokeCCloudRefreshToken(ctx); err != nil {
-				return err
-			}
+	if ctx == nil {
+		// Already logged out: do nothing.
+		return nil
+	}
+
+	if ccloudv2.IsCCloudURL(ctx.Platform.Server, c.cfg.IsTest) {
+		if _, err := c.revokeCCloudRefreshToken(ctx); err != nil {
+			return err
 		}
 	}
 
@@ -71,10 +78,16 @@ func (c *command) revokeCCloudRefreshToken(ctx *config.Context) (*ccloudv1.Authe
 		return nil, err
 	}
 
+	client := ccloudv1.NewClientWithJWT(context.Background(), contextState.AuthToken, &ccloudv1.Params{
+		BaseURL:   ctx.GetPlatformServer(),
+		Logger:    log.CliLogger,
+		UserAgent: c.Version.UserAgent,
+	})
+
 	req := &ccloudv1.AuthenticateRequest{IdToken: contextState.AuthToken}
 	if sso.IsOkta(ctx.Platform.Server) {
-		return c.Client.Auth.OktaLogout(req)
+		return client.Auth.OktaLogout(req)
 	} else {
-		return c.Client.Auth.Logout(req)
+		return client.Auth.Logout(req)
 	}
 }

--- a/internal/logout/command.go
+++ b/internal/logout/command.go
@@ -78,10 +78,14 @@ func (c *command) revokeCCloudRefreshToken(ctx *config.Context) (*ccloudv1.Authe
 		return nil, err
 	}
 
+	var userAgent string
+	if c.Version != nil {
+		userAgent = c.Version.UserAgent
+	}
 	client := ccloudv1.NewClientWithJWT(context.Background(), contextState.AuthToken, &ccloudv1.Params{
 		BaseURL:   ctx.GetPlatformServer(),
 		Logger:    log.CliLogger,
-		UserAgent: c.Version.UserAgent,
+		UserAgent: userAgent,
 	})
 
 	req := &ccloudv1.AuthenticateRequest{IdToken: contextState.AuthToken}

--- a/pkg/linter/command_rules.go
+++ b/pkg/linter/command_rules.go
@@ -221,6 +221,7 @@ func RequireValidExamples() CommandRule {
 	return func(cmd *cobra.Command) error {
 		requiredFlags := getRequiredFlags(cmd.Flags())
 		allFlags := getAllFlags(cmd.Flags())
+		boolFlags := getBoolFlags(cmd.Flags())
 
 		errs := new(multierror.Error)
 
@@ -238,7 +239,12 @@ func RequireValidExamples() CommandRule {
 			}
 
 			for _, match := range regexp.MustCompile(`--[a-z\-]+=`).FindAllString(example, -1) {
-				errs = multierror.Append(errs, fmt.Errorf("%s: flag `%s` must not use \"=\" in example %d", cmd.CommandPath(), strings.TrimSuffix(match, "="), i+1))
+				flag := strings.TrimSuffix(match, "=")
+				// Boolean flags legitimately need "=" to set the non-default value, e.g. --flag=false.
+				if slices.Contains(boolFlags, flag) {
+					continue
+				}
+				errs = multierror.Append(errs, fmt.Errorf("%s: flag `%s` must not use \"=\" in example %d", cmd.CommandPath(), flag, i+1))
 			}
 		}
 
@@ -272,6 +278,16 @@ func getAllFlags(flags *pflag.FlagSet) []string {
 		all = append(all, "--"+flag.Name)
 	})
 	return all
+}
+
+func getBoolFlags(flags *pflag.FlagSet) []string {
+	var boolFlags []string
+	flags.VisitAll(func(flag *pflag.Flag) {
+		if flag.Value.Type() == "bool" {
+			boolFlags = append(boolFlags, "--"+flag.Name)
+		}
+	})
+	return boolFlags
 }
 
 func getValueByName(obj any, name string) string {

--- a/test/fixtures/output/iam/rbac/role-binding/list-failure-help-cloud.golden
+++ b/test/fixtures/output/iam/rbac/role-binding/list-failure-help-cloud.golden
@@ -39,7 +39,7 @@ Flags:
       --ksql-cluster string              ksqlDB cluster name, which specifies the ksqlDB cluster scope.
       --flink-region string              Flink region for the role binding, formatted as "cloud.region".
       --resource string                  Resource type and identifier using "Prefix:ID" format. If specified with "--role" and no principals, list all principals and role bindings.
-      --inclusive                        List role bindings for specified scopes and nested scopes. Otherwise, list role bindings for the specified scopes. If scopes are unspecified, list role bindings across all scopes.
+      --inclusive                        List role bindings for specified scopes and nested scopes. Otherwise, list role bindings for the specified scopes. If scopes are unspecified, list role bindings across all scopes. Only applies to Confluent Cloud.
   -o, --output string                    Specify the output format as "human", "json", or "yaml". (default "human")
 
 Global Flags:

--- a/test/fixtures/output/iam/rbac/role-binding/list-failure-help-cloud.golden
+++ b/test/fixtures/output/iam/rbac/role-binding/list-failure-help-cloud.golden
@@ -39,7 +39,7 @@ Flags:
       --ksql-cluster string              ksqlDB cluster name, which specifies the ksqlDB cluster scope.
       --flink-region string              Flink region for the role binding, formatted as "cloud.region".
       --resource string                  Resource type and identifier using "Prefix:ID" format. If specified with "--role" and no principals, list all principals and role bindings.
-      --inclusive                        List role bindings for specified scopes and nested scopes. Otherwise, list role bindings for the specified scopes. If scopes are unspecified, list only organization-scoped role bindings.
+      --inclusive                        List role bindings for specified scopes and nested scopes. Otherwise, list role bindings for the specified scopes. If scopes are unspecified, list role bindings across all scopes.
   -o, --output string                    Specify the output format as "human", "json", or "yaml". (default "human")
 
 Global Flags:

--- a/test/fixtures/output/iam/rbac/role-binding/list-failure-help-onprem.golden
+++ b/test/fixtures/output/iam/rbac/role-binding/list-failure-help-onprem.golden
@@ -38,7 +38,7 @@ Flags:
       --context string                   CLI context name.
       --cluster-name string              Cluster name, which specifies the cluster scope.
       --resource string                  Resource type and identifier using "Prefix:ID" format. If specified with "--role" and no principals, list all principals and role bindings.
-      --inclusive                        List role bindings for specified scopes and nested scopes. Otherwise, list role bindings for the specified scopes. If scopes are unspecified, list role bindings across all scopes.
+      --inclusive                        List role bindings for specified scopes and nested scopes. Otherwise, list role bindings for the specified scopes. If scopes are unspecified, list role bindings across all scopes. Only applies to Confluent Cloud.
   -o, --output string                    Specify the output format as "human", "json", or "yaml". (default "human")
 
 Global Flags:

--- a/test/fixtures/output/iam/rbac/role-binding/list-failure-help-onprem.golden
+++ b/test/fixtures/output/iam/rbac/role-binding/list-failure-help-onprem.golden
@@ -38,7 +38,7 @@ Flags:
       --context string                   CLI context name.
       --cluster-name string              Cluster name, which specifies the cluster scope.
       --resource string                  Resource type and identifier using "Prefix:ID" format. If specified with "--role" and no principals, list all principals and role bindings.
-      --inclusive                        List role bindings for specified scopes and nested scopes. Otherwise, list role bindings for the specified scopes. If scopes are unspecified, list only organization-scoped role bindings.
+      --inclusive                        List role bindings for specified scopes and nested scopes. Otherwise, list role bindings for the specified scopes. If scopes are unspecified, list role bindings across all scopes.
   -o, --output string                    Specify the output format as "human", "json", or "yaml". (default "human")
 
 Global Flags:

--- a/test/fixtures/output/iam/rbac/role-binding/list-help-onprem.golden
+++ b/test/fixtures/output/iam/rbac/role-binding/list-help-onprem.golden
@@ -39,7 +39,7 @@ Flags:
       --context string                   CLI context name.
       --cluster-name string              Cluster name, which specifies the cluster scope.
       --resource string                  Resource type and identifier using "Prefix:ID" format. If specified with "--role" and no principals, list all principals and role bindings.
-      --inclusive                        List role bindings for specified scopes and nested scopes. Otherwise, list role bindings for the specified scopes. If scopes are unspecified, list only organization-scoped role bindings.
+      --inclusive                        List role bindings for specified scopes and nested scopes. Otherwise, list role bindings for the specified scopes. If scopes are unspecified, list role bindings across all scopes.
   -o, --output string                    Specify the output format as "human", "json", or "yaml". (default "human")
 
 Global Flags:

--- a/test/fixtures/output/iam/rbac/role-binding/list-help-onprem.golden
+++ b/test/fixtures/output/iam/rbac/role-binding/list-help-onprem.golden
@@ -39,7 +39,7 @@ Flags:
       --context string                   CLI context name.
       --cluster-name string              Cluster name, which specifies the cluster scope.
       --resource string                  Resource type and identifier using "Prefix:ID" format. If specified with "--role" and no principals, list all principals and role bindings.
-      --inclusive                        List role bindings for specified scopes and nested scopes. Otherwise, list role bindings for the specified scopes. If scopes are unspecified, list role bindings across all scopes.
+      --inclusive                        List role bindings for specified scopes and nested scopes. Otherwise, list role bindings for the specified scopes. If scopes are unspecified, list role bindings across all scopes. Only applies to Confluent Cloud.
   -o, --output string                    Specify the output format as "human", "json", or "yaml". (default "human")
 
 Global Flags:

--- a/test/fixtures/output/iam/rbac/role-binding/list-help.golden
+++ b/test/fixtures/output/iam/rbac/role-binding/list-help.golden
@@ -40,7 +40,7 @@ Flags:
       --ksql-cluster string              ksqlDB cluster name, which specifies the ksqlDB cluster scope.
       --flink-region string              Flink region for the role binding, formatted as "cloud.region".
       --resource string                  Resource type and identifier using "Prefix:ID" format. If specified with "--role" and no principals, list all principals and role bindings.
-      --inclusive                        List role bindings for specified scopes and nested scopes. Otherwise, list role bindings for the specified scopes. If scopes are unspecified, list only organization-scoped role bindings.
+      --inclusive                        List role bindings for specified scopes and nested scopes. Otherwise, list role bindings for the specified scopes. If scopes are unspecified, list role bindings across all scopes.
   -o, --output string                    Specify the output format as "human", "json", or "yaml". (default "human")
 
 Global Flags:

--- a/test/fixtures/output/iam/rbac/role-binding/list-help.golden
+++ b/test/fixtures/output/iam/rbac/role-binding/list-help.golden
@@ -40,7 +40,7 @@ Flags:
       --ksql-cluster string              ksqlDB cluster name, which specifies the ksqlDB cluster scope.
       --flink-region string              Flink region for the role binding, formatted as "cloud.region".
       --resource string                  Resource type and identifier using "Prefix:ID" format. If specified with "--role" and no principals, list all principals and role bindings.
-      --inclusive                        List role bindings for specified scopes and nested scopes. Otherwise, list role bindings for the specified scopes. If scopes are unspecified, list role bindings across all scopes.
+      --inclusive                        List role bindings for specified scopes and nested scopes. Otherwise, list role bindings for the specified scopes. If scopes are unspecified, list role bindings across all scopes. Only applies to Confluent Cloud.
   -o, --output string                    Specify the output format as "human", "json", or "yaml". (default "human")
 
 Global Flags:


### PR DESCRIPTION
Release Notes
-------------

Bug Fixes
- `confluent iam rbac role-binding list --inclusive` had a help-text description that contradicted its own documented example and actual behavior. (APIE-1362)
- The `RequireValidExamples()` lint rule incorrectly flagged boolean flags using `--flag=value` syntax in command examples. (APIE-1286)
- `confluent logout` errored or silently auto-logged-in-then-out instead of being a no-op when already logged out. (APIE-1314)

Checklist
---------
- [ ] I have successfully built and used a custom CLI binary, without linter issues from this PR.
- [x] I have clearly specified in the `What` section below whether this PR applies to Confluent Cloud, Confluent Platform, or both.
- [ ] I have verified this PR in Confluent Cloud pre-prod or production environment, if applicable.
- [ ] I have verified this PR in Confluent Platform on-premises environment, if applicable.
- [ ] I have attached manual CLI verification results or screenshots in the `Test & Review` section below.
- [ ] I have added appropriate CLI integration or unit tests for any new or updated commands and functionality.
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [x] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [ ] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [ ] Confluent Cloud prod
  - [ ] Confluent Cloud stag
  - [ ] Confluent Platform
  - [ ] Check this box if the feature is enabled for certain organizations only

**Unchecked items need human follow-up before merge** — no Go toolchain was available in the environment this PR was prepared in, so no build/lint/test run or live verification was possible. This is more important than usual for this PR since APIE-1314 changes which PreRun a command uses — please run `make build && make lint && make test` (especially `TestLogout_RemoveUsernamePassword` and `TestLogout_RemoveUsernamePasswordFail`) before merging. Opening as a draft for that reason.

What
----
Confluent Cloud and Confluent Platform (on-prem) both — all three fixes touch shared code paths used by both login modes.

1. **APIE-1362** — the `--inclusive` flag's help text said *"If scopes are unspecified, list only organization-scoped role bindings"*, contradicting the command's own documented example (*"for all scopes"*) and the reporter's confirmed actual behavior. Corrected the text and the 4 golden fixtures that pinned the old wording.
2. **APIE-1286** — `RequireValidExamples()` (`pkg/linter/command_rules.go`) flagged any `--flag=value` in an example. Boolean flags legitimately need `=` to set the non-default value (e.g. `--flag=false`). Added a `getBoolFlags()` helper and excluded boolean flags from that check.
3. **APIE-1314** — `confluent logout` used `NewAuthenticatedCLICommand`, which requires being logged in. With no active session this produced `Error: not logged in`; with `CONFLUENT_CLOUD_API_KEY`/`SECRET` env vars set, it auto-logged-in only to immediately log back out. Switched to `NewAnonymousCLICommand` (the same pattern `login` itself uses) and return immediately with no error when there's no active context. The ccloud client used to revoke the refresh token (previously populated by the `Authenticated` PreRun) is now constructed directly inside `revokeCCloudRefreshToken`, only when a real session is confirmed to exist.

Blast Radius
----
- **APIE-1362**: text-only fix to a `--help` description string. No behavior or serialized-output change.
- **APIE-1286**: dev-tooling only (`make lint-cli`); no runtime CLI behavior changes for customers.
- **APIE-1314**: behavior change, but narrowly scoped to `confluent logout`. Customers who are genuinely logged in see no change (still revokes the token, persists logout, prints the same success message). Customers who run `logout` while already logged out previously saw an error or an auto-login/logout cycle; they'll now see nothing happen at all, matching the ticket's explicit ask. Worth a careful look during review since it changes which PreRun the command uses.

References
----------
- https://confluentinc.atlassian.net/browse/APIE-1362
- https://confluentinc.atlassian.net/browse/APIE-1286
- https://confluentinc.atlassian.net/browse/APIE-1314

Test & Review
-------------
No Go toolchain was available in the environment this PR was prepared in, so `make build`/`make lint`/`make test` were not run here — please run these before merging, and pay particular attention to `test/logout_test.go` given the APIE-1314 change.

What was actually verified:
- **APIE-1362**: confirmed the exact flag text and updated all 4 golden fixtures that reference it.
- **APIE-1286**: confirmed no existing test file covers `RequireValidExamples()`, so nothing to break; the new `getBoolFlags()` helper mirrors the existing `getAllFlags()`/`getRequiredFlags()` pattern in the same file.
- **APIE-1314**: confirmed `NewAnonymousCLICommand` is the same constructor already used by `internal/login/command.go`; traced `command.Version = r.Version` into the `Anonymous()` PreRun function (`pkg/cmd/prerunner.go:108`) to confirm `c.Version` is populated before `revokeCCloudRefreshToken` needs it; confirmed the existing `test/logout_test.go` tests always log in immediately before logging out, so the no-op path isn't exercised by them (a new test for the no-op case would be worth adding).
