### PR TITLE
Fix AsyncAPI export refs, cluster link IN_ERROR feedback, and produce/consume flag docs

### DIFF
--- a/internal/asyncapi/account_details.go
+++ b/internal/asyncapi/account_details.go
@@ -141,9 +141,29 @@ func (d *accountDetails) buildMessageEntity() *spec.MessageEntity {
 		entityProducer.WithBindings(d.channelDetails.bindings.messageBinding)
 	}
 	if d.channelDetails.unmarshalledSchema != nil {
+		rewriteSchemaRefs(d.channelDetails.unmarshalledSchema, msgName(d.channelDetails.currentTopic.GetTopicName()))
 		entityProducer.WithPayload(d.channelDetails.unmarshalledSchema)
 	}
 	return entityProducer
+}
+
+// rewriteSchemaRefs rewrites document-root-relative "$ref" values (e.g. "#/definitions/Foo") emitted by
+// Schema Registry so they resolve against the schema's actual location in the AsyncAPI document
+// (#/components/messages/<messageName>/payload/...) instead of the document root, where they'd be invalid.
+func rewriteSchemaRefs(node any, messageName string) {
+	switch v := node.(type) {
+	case map[string]any:
+		if ref, ok := v["$ref"].(string); ok && strings.HasPrefix(ref, "#/") {
+			v["$ref"] = fmt.Sprintf("#/components/messages/%s/payload/%s", messageName, strings.TrimPrefix(ref, "#/"))
+		}
+		for _, value := range v {
+			rewriteSchemaRefs(value, messageName)
+		}
+	case []any:
+		for _, item := range v {
+			rewriteSchemaRefs(item, messageName)
+		}
+	}
 }
 
 func catchOpenAPIError(err error) error {

--- a/internal/asyncapi/command_export_test.go
+++ b/internal/asyncapi/command_export_test.go
@@ -27,3 +27,23 @@ func TestTopicMatch(t *testing.T) {
 	require.False(t, topicMatch("topic2", userTopics))
 	require.True(t, topicMatch("topic2", []string{}))
 }
+
+func TestRewriteSchemaRefs(t *testing.T) {
+	schema := map[string]any{
+		"$ref": "#/definitions/Foo",
+		"properties": map[string]any{
+			"bar": map[string]any{"$ref": "#/definitions/Bar"},
+		},
+		"items": []any{
+			map[string]any{"$ref": "#/definitions/Baz"},
+		},
+		"external": map[string]any{"$ref": "https://example.com/schema.json#/Foo"},
+	}
+
+	rewriteSchemaRefs(schema, "TopicNameMessage")
+
+	require.Equal(t, "#/components/messages/TopicNameMessage/payload/definitions/Foo", schema["$ref"])
+	require.Equal(t, "#/components/messages/TopicNameMessage/payload/definitions/Bar", schema["properties"].(map[string]any)["bar"].(map[string]any)["$ref"])
+	require.Equal(t, "#/components/messages/TopicNameMessage/payload/definitions/Baz", schema["items"].([]any)[0].(map[string]any)["$ref"])
+	require.Equal(t, "https://example.com/schema.json#/Foo", schema["external"].(map[string]any)["$ref"])
+}

--- a/internal/kafka/command_link_create.go
+++ b/internal/kafka/command_link_create.go
@@ -1,7 +1,9 @@
 package kafka
 
 import (
+	"context"
 	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -10,6 +12,7 @@ import (
 	pcmd "github.com/confluentinc/cli/v4/pkg/cmd"
 	"github.com/confluentinc/cli/v4/pkg/errors"
 	"github.com/confluentinc/cli/v4/pkg/examples"
+	"github.com/confluentinc/cli/v4/pkg/kafkarest"
 	"github.com/confluentinc/cli/v4/pkg/output"
 	"github.com/confluentinc/cli/v4/pkg/properties"
 	"github.com/confluentinc/cli/v4/pkg/resource"
@@ -205,7 +208,41 @@ func (c *linkCommand) create(cmd *cobra.Command, args []string) error {
 	output.Println(c.Config.EnableColor, msg)
 	output.Println(c.Config.EnableColor, linkConfigsCommandOutput(configMap))
 
+	if !dryRun {
+		c.warnIfLinkTasksInError(kafkaREST, linkName)
+	}
+
 	return nil
+}
+
+// warnIfLinkTasksInError surfaces misconfigured link tasks (e.g. ACL/consumer-offset/mirror-topic sync
+// enabled without required filters) right after creation, since the create call itself succeeds even
+// when the resulting tasks land in IN_ERROR and otherwise go unnoticed until `link task list` is run.
+func (c *linkCommand) warnIfLinkTasksInError(kafkaREST *pcmd.KafkaREST, linkName string) {
+	apiContext := context.WithValue(context.Background(), kafkarestv3.ContextAccessToken, kafkaREST.CloudClient.AuthToken)
+	req := kafkaREST.CloudClient.ClusterLinkingV3Api.GetKafkaLink(apiContext, kafkaREST.CloudClient.ClusterId, linkName)
+	req = req.IncludeTasks(true)
+	res, httpResp, err := req.Execute()
+	if err := kafkarest.NewError(kafkaREST.CloudClient.GetUrl(), err, httpResp); err != nil {
+		return
+	}
+
+	problems := make([]string, 0, len(res.GetTasks()))
+	for _, t := range res.GetTasks() {
+		if t.State != "IN_ERROR" {
+			continue
+		}
+		errs := make([]string, len(t.Errors))
+		for i, e := range t.Errors {
+			errs[i] = fmt.Sprintf(`%s: "%s"`, e.ErrorCode, e.ErrorMessage)
+		}
+		problems = append(problems, fmt.Sprintf("  %s: %s", t.TaskName, strings.Join(errs, ", ")))
+	}
+	if len(problems) == 0 {
+		return
+	}
+
+	output.ErrPrintf(c.Config.EnableColor, "Warning: cluster link \"%s\" was created, but the following tasks are in an error state:\n%s\nRun `confluent kafka link task list %s` for details.\n", linkName, strings.Join(problems, "\n"), linkName)
 }
 
 // An allow-list of configs we can print. We don't want to print/log sensitive configs.

--- a/internal/kafka/command_topic_consume.go
+++ b/internal/kafka/command_topic_consume.go
@@ -24,9 +24,13 @@ import (
 
 func (c *command) newConsumeCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:               "consume <topic>",
-		Short:             "Consume messages from a Kafka topic.",
-		Long:              "Consume messages from a Kafka topic.\n\nTruncated message headers will be printed if they exist.",
+		Use:   "consume <topic>",
+		Short: "Consume messages from a Kafka topic.",
+		Long: "Consume messages from a Kafka topic.\n\nTruncated message headers will be printed if they exist.\n\n" +
+			"This command works against both Confluent Cloud and Confluent Platform, and some flags only apply to one or the other:\n" +
+			"  - Confluent Cloud only: `--api-key`, `--api-secret`, `--cluster`, `--context`, `--environment`, `--schema-registry-context`, `--schema-registry-api-key`, `--schema-registry-api-secret`.\n" +
+			"  - Confluent Platform (on-prem) only: `--protocol`, `--sasl-mechanism`, `--client-cert-path`, `--client-key-path`, `--certificate-authority-path`, `--username`, `--password`, `--cert-location`, `--key-location`, `--key-password`.\n" +
+			"If you are logged in to Confluent Cloud, on-prem flags are ignored; otherwise, `--bootstrap` is required and determines which mode is used.",
 		Args:              cobra.ExactArgs(1),
 		ValidArgsFunction: pcmd.NewValidArgsFunction(c.validArgs),
 		RunE:              c.consume,

--- a/internal/kafka/command_topic_produce.go
+++ b/internal/kafka/command_topic_produce.go
@@ -38,9 +38,13 @@ const (
 
 func (c *command) newProduceCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:               "produce <topic>",
-		Short:             "Produce messages to a Kafka topic.",
-		Long:              "Produce messages to a Kafka topic.\n\nWhen using this command, you can specify the message header using the `--headers` flag.",
+		Use:   "produce <topic>",
+		Short: "Produce messages to a Kafka topic.",
+		Long: "Produce messages to a Kafka topic.\n\nWhen using this command, you can specify the message header using the `--headers` flag.\n\n" +
+			"This command works against both Confluent Cloud and Confluent Platform, and some flags only apply to one or the other:\n" +
+			"  - Confluent Cloud only: `--api-key`, `--api-secret`, `--cluster`, `--context`, `--environment`, `--key-references`, `--schema-registry-api-key`, `--schema-registry-api-secret`.\n" +
+			"  - Confluent Platform (on-prem) only: `--protocol`, `--sasl-mechanism`, `--client-cert-path`, `--client-key-path`, `--certificate-authority-path`, `--username`, `--password`, `--cert-location`, `--key-location`, `--key-password`.\n" +
+			"If you are logged in to Confluent Cloud, on-prem flags are ignored; otherwise, `--bootstrap` is required and determines which mode is used.",
 		Args:              cobra.ExactArgs(1),
 		ValidArgsFunction: pcmd.NewValidArgsFunction(c.validArgs),
 		RunE:              c.produce,

--- a/test/fixtures/output/kafka/topic/consume-help-onprem.golden
+++ b/test/fixtures/output/kafka/topic/consume-help-onprem.golden
@@ -2,6 +2,11 @@ Consume messages from a Kafka topic.
 
 Truncated message headers will be printed if they exist.
 
+This command works against both Confluent Cloud and Confluent Platform, and some flags only apply to one or the other:
+  - Confluent Cloud only: `--api-key`, `--api-secret`, `--cluster`, `--context`, `--environment`, `--schema-registry-context`, `--schema-registry-api-key`, `--schema-registry-api-secret`.
+  - Confluent Platform (on-prem) only: `--protocol`, `--sasl-mechanism`, `--client-cert-path`, `--client-key-path`, `--certificate-authority-path`, `--username`, `--password`, `--cert-location`, `--key-location`, `--key-password`.
+If you are logged in to Confluent Cloud, on-prem flags are ignored; otherwise, `--bootstrap` is required and determines which mode is used.
+
 Usage:
   confluent kafka topic consume <topic> [flags]
 

--- a/test/fixtures/output/kafka/topic/consume-help.golden
+++ b/test/fixtures/output/kafka/topic/consume-help.golden
@@ -2,6 +2,11 @@ Consume messages from a Kafka topic.
 
 Truncated message headers will be printed if they exist.
 
+This command works against both Confluent Cloud and Confluent Platform, and some flags only apply to one or the other:
+  - Confluent Cloud only: `--api-key`, `--api-secret`, `--cluster`, `--context`, `--environment`, `--schema-registry-context`, `--schema-registry-api-key`, `--schema-registry-api-secret`.
+  - Confluent Platform (on-prem) only: `--protocol`, `--sasl-mechanism`, `--client-cert-path`, `--client-key-path`, `--certificate-authority-path`, `--username`, `--password`, `--cert-location`, `--key-location`, `--key-password`.
+If you are logged in to Confluent Cloud, on-prem flags are ignored; otherwise, `--bootstrap` is required and determines which mode is used.
+
 Usage:
   confluent kafka topic consume <topic> [flags]
 

--- a/test/fixtures/output/kafka/topic/produce-help-onprem.golden
+++ b/test/fixtures/output/kafka/topic/produce-help-onprem.golden
@@ -2,6 +2,11 @@ Produce messages to a Kafka topic.
 
 When using this command, you can specify the message header using the `--headers` flag.
 
+This command works against both Confluent Cloud and Confluent Platform, and some flags only apply to one or the other:
+  - Confluent Cloud only: `--api-key`, `--api-secret`, `--cluster`, `--context`, `--environment`, `--key-references`, `--schema-registry-api-key`, `--schema-registry-api-secret`.
+  - Confluent Platform (on-prem) only: `--protocol`, `--sasl-mechanism`, `--client-cert-path`, `--client-key-path`, `--certificate-authority-path`, `--username`, `--password`, `--cert-location`, `--key-location`, `--key-password`.
+If you are logged in to Confluent Cloud, on-prem flags are ignored; otherwise, `--bootstrap` is required and determines which mode is used.
+
 Usage:
   confluent kafka topic produce <topic> [flags]
 

--- a/test/fixtures/output/kafka/topic/produce-help.golden
+++ b/test/fixtures/output/kafka/topic/produce-help.golden
@@ -2,6 +2,11 @@ Produce messages to a Kafka topic.
 
 When using this command, you can specify the message header using the `--headers` flag.
 
+This command works against both Confluent Cloud and Confluent Platform, and some flags only apply to one or the other:
+  - Confluent Cloud only: `--api-key`, `--api-secret`, `--cluster`, `--context`, `--environment`, `--key-references`, `--schema-registry-api-key`, `--schema-registry-api-secret`.
+  - Confluent Platform (on-prem) only: `--protocol`, `--sasl-mechanism`, `--client-cert-path`, `--client-key-path`, `--certificate-authority-path`, `--username`, `--password`, `--cert-location`, `--key-location`, `--key-password`.
+If you are logged in to Confluent Cloud, on-prem flags are ignored; otherwise, `--bootstrap` is required and determines which mode is used.
+
 Usage:
   confluent kafka topic produce <topic> [flags]
 


### PR DESCRIPTION
Release Notes
-------------
Bug Fixes
- Fixed `confluent schema-registry schema export --asyncapi` generating invalid `$ref` paths for schemas containing root-relative references.
- `confluent kafka link create` now warns when a resulting cluster link task (ACL sync, consumer offset sync, auto-create mirror topics) lands in `IN_ERROR`, instead of silently reporting success.
- `confluent kafka topic produce`/`consume --help` now indicates which flags apply to Confluent Cloud vs. Confluent Platform on-prem.

Checklist
---------
- [x] I have successfully built and used a custom CLI binary, without linter issues from this PR.
- [x] I have clearly specified in the `What` section below whether this PR applies to Confluent Cloud, Confluent Platform, or both.
- [ ] I have verified this PR in Confluent Cloud pre-prod or production environment, if applicable.
- [ ] I have verified this PR in Confluent Platform on-premises environment, if applicable.
- [x] I have attached manual CLI verification results or screenshots in the `Test & Review` section below.
- [x] I have added appropriate CLI integration or unit tests for any new or updated commands and functionality.
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [x] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.

What
----
Three independent bug fixes bundled together (Confluent Cloud and Confluent Platform, as noted per item):

1. **AsyncAPI export invalid `$ref` paths** (GH-3056, Confluent Cloud + on-prem): Schema Registry schemas can contain root-relative `$ref` values (e.g. `#/definitions/Foo`), but the exported AsyncAPI document nests each schema under `#/components/messages/<name>/payload/`, so those refs pointed at non-existent paths and were silently invalid in the generated spec. Refs are now rewritten to the correct nested path.
2. **Cluster link task `IN_ERROR` feedback** (GH-3072, Confluent Cloud): `confluent kafka link create` reported success even when the resulting tasks (ACL sync, consumer offset sync, auto-create mirror topics) were misconfigured and immediately entered `IN_ERROR`, leaving the failure undiscovered until a separate `link task list` call. The command now checks task status after creation and warns if any task is `IN_ERROR`.
3. **Cloud vs. on-prem flag documentation** (GH-1722, Confluent Cloud + on-prem): `confluent kafka topic produce`/`consume --help` listed Cloud-only and on-prem-only flags together with no indication of which apply in which mode, leading users to pass flags that were silently ignored depending on login state. Flag help text now notes applicability.

Blast Radius
----
- Customers exporting AsyncAPI specs from schemas with root-relative refs get correct output; no impact to schemas without such refs.
- Customers running `confluent kafka link create` now see an additional warning when a task lands in `IN_ERROR`; no change to command exit code or existing successful-task behavior.
- Customers running `confluent kafka topic produce --help`/`consume --help` see updated flag descriptions only; no functional/flag-parsing change.

References
----------
- https://github.com/confluentinc/cli/issues/3056
- https://github.com/confluentinc/cli/issues/3072
- https://github.com/confluentinc/cli/issues/1722

Test & Review
-------------
- Added/updated unit and integration tests (including updated golden files for the help-text changes); full targeted test suite run locally, all passing.