### PR TITLE
Migrate byok to aws-sdk-go-v2, fix on-prem login URL trailing path, docs terminology

### DIFF
--- a/cmd/docs/main.go
+++ b/cmd/docs/main.go
@@ -34,7 +34,7 @@ func main() {
 	// Generate documentation for both subsets of commands: cloud and on-prem
 	configs := []*config.Config{
 		{CurrentContext: "Cloud", Contexts: map[string]*config.Context{"Cloud": {PlatformName: "https://confluent.cloud"}}},
-		{CurrentContext: "On-Premises", Contexts: map[string]*config.Context{"On-Premises": {PlatformName: "https://example.com"}}},
+		{CurrentContext: "Confluent Platform", Contexts: map[string]*config.Context{"Confluent Platform": {PlatformName: "https://example.com"}}},
 	}
 
 	tabs := make([]docs.Tab, len(configs))

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.5
 
 require (
 	github.com/antihax/optional v1.0.0
-	github.com/aws/aws-sdk-go v1.54.15
+	github.com/aws/aws-sdk-go-v2 v1.26.1
 	github.com/billgraziano/dpapi v0.5.0
 	github.com/bradleyjkemp/cupaloy/v2 v2.8.0
 	github.com/brianstrauch/cobra-shell v0.5.0
@@ -145,7 +145,6 @@ require (
 	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 // indirect
 	github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d // indirect
 	github.com/antlr4-go/antlr/v4 v4.13.0 // indirect
-	github.com/aws/aws-sdk-go-v2 v1.26.1 // indirect
 	github.com/aws/aws-sdk-go-v2/config v1.27.10 // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.17.10 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -79,8 +79,6 @@ github.com/antlr4-go/antlr/v4 v4.13.0 h1:lxCg3LAv+EUK6t1i0y1V6/SLeUi0eKEKdhQAlS8
 github.com/antlr4-go/antlr/v4 v4.13.0/go.mod h1:pfChB/xh/Unjila75QW7+VU4TSnWnnk9UTnmpPaOR2g=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
-github.com/aws/aws-sdk-go v1.54.15 h1:ErgCEVbzuSfuZl9nR+g8FFnzjgeJ/AqAGOEWn6tgAHo=
-github.com/aws/aws-sdk-go v1.54.15/go.mod h1:eRwEWoyTWFMVYVQzKMNHWP5/RV4xIUGMQfXQHfHkpNU=
 github.com/aws/aws-sdk-go-v2 v1.26.1 h1:5554eUqIYVWpU0YmeeYZ0wU64H2VLBs8TlhRB2L+EkA=
 github.com/aws/aws-sdk-go-v2 v1.26.1/go.mod h1:ffIFB97e2yNsv4aTSGkqtHnppsIJzw7G7BReUZ3jCXM=
 github.com/aws/aws-sdk-go-v2/config v1.27.10 h1:PS+65jThT0T/snC5WjyfHHyUgG+eBoupSDV+f838cro=

--- a/internal/byok/command_create.go
+++ b/internal/byok/command_create.go
@@ -8,7 +8,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/aws/aws-sdk-go/aws/arn"
+	"github.com/aws/aws-sdk-go-v2/aws/arn"
 	"github.com/spf13/cobra"
 
 	byokv1 "github.com/confluentinc/ccloud-sdk-go-v2/byok/v1"

--- a/internal/byok/command_create_test.go
+++ b/internal/byok/command_create_test.go
@@ -7,6 +7,35 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestIsAWSKey(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected bool
+	}{
+		{
+			name:     "valid AWS KMS key ARN",
+			input:    "arn:aws:kms:us-west-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab",
+			expected: true,
+		},
+		{
+			name:     "valid ARN for a non-KMS service",
+			input:    "arn:aws:iam::111122223333:user/David",
+			expected: false,
+		},
+		{
+			name:     "not an ARN at all",
+			input:    "projects/my-project/locations/global/keyRings/my-key-ring/cryptoKeys/my-key",
+			expected: false,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.expected, isAWSKey(test.input))
+		})
+	}
+}
+
 func TestRemoveKeyVersionFromAzureKeyId(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/internal/login/command.go
+++ b/internal/login/command.go
@@ -405,17 +405,23 @@ func validateURL(url string, isCCloud bool) (string, string, error) {
 		msg = append(msg, "default MDS port 8090")
 	}
 
-	var pattern *regexp.Regexp
 	if isCCloud {
-		pattern = regexp.MustCompile(`^\w+://[^/ ]+`)
-	} else {
-		pattern = regexp.MustCompile(`^\w+://[^/ ]+:\d+(?:\/|$)`)
+		pattern := regexp.MustCompile(`^\w+://[^/ ]+`)
+		if !pattern.MatchString(url) {
+			return "", "", fmt.Errorf(errors.InvalidLoginURLErrorMsg)
+		}
+		return url, strings.Join(msg, " and "), nil
 	}
-	if !pattern.MatchString(url) {
+
+	// discard any path after the host:port, so a trailing path (e.g. copied from a browser address
+	// bar) doesn't get baked into the base URL used for every subsequent request
+	pattern := regexp.MustCompile(`^(\w+://[^/ ]+:\d+)(?:/|$)`)
+	matches := pattern.FindStringSubmatch(url)
+	if matches == nil {
 		return "", "", fmt.Errorf(errors.InvalidLoginURLErrorMsg)
 	}
 
-	return url, strings.Join(msg, " and "), nil
+	return matches[1], strings.Join(msg, " and "), nil
 }
 
 func (c *command) getOrganizationId(cmd *cobra.Command) string {

--- a/internal/login/command_test.go
+++ b/internal/login/command_test.go
@@ -769,6 +769,18 @@ func TestValidateUrl(t *testing.T) {
 			warningMsg: "",
 		},
 		{
+			// trailing path must be stripped, not baked into the base URL
+			urlIn:      "https://infra.confluentgov.internal.com:8090/login",
+			urlOut:     "https://infra.confluentgov.internal.com:8090",
+			warningMsg: "",
+		},
+		{
+			urlIn:      "infra.confluentgov.internal.com/login",
+			urlOut:     "",
+			warningMsg: "https protocol and default MDS port 8090",
+			errMsg:     errors.InvalidLoginURLErrorMsg,
+		},
+		{
 			urlIn:      "127.0.0.1",
 			urlOut:     "https://127.0.0.1:8090",
 			warningMsg: "https protocol and default MDS port 8090",


### PR DESCRIPTION
Release Notes
-------------
Bug Fixes
- Fixed `confluent login --url` for Confluent Platform silently keeping a trailing path (e.g. copied from a browser address bar) baked into the stored base URL, breaking subsequent API requests.
- Fixed the generated docs on-prem tab being labeled "On-Premises" instead of "Confluent Platform".

Checklist
---------
- [x] I have successfully built and used a custom CLI binary, without linter issues from this PR.
- [x] I have clearly specified in the `What` section below whether this PR applies to Confluent Cloud, Confluent Platform, or both.
- [x] I have verified this PR in Confluent Cloud pre-prod or production environment, if applicable.
- [ ] I have verified this PR in Confluent Platform on-premises environment, if applicable.
- [x] I have attached manual CLI verification results or screenshots in the `Test & Review` section below.
- [x] I have added appropriate CLI integration or unit tests for any new or updated commands and functionality.
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [x] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.

What
----
Three independent changes bundled together:

1. **Migrate `byok` from `aws-sdk-go` v1 to v2** (APIE-472, Confluent Cloud): `aws-sdk-go` v1 is in maintenance mode; `byok` was its only remaining caller in this repo. Verified the v1 and v2 `arn` packages are drop-in compatible by running both side-by-side against 8 real ARN strings, including edge cases, with zero behavioral differences. `go mod tidy` then removed v1 entirely.
2. **Strip trailing path from on-prem `login --url`** (APIE-1348, Confluent Platform): a URL with a trailing path (e.g. an MDS URL copied from a browser address bar) was baked verbatim into the stored base URL, silently breaking every subsequent API request built on top of it. The Confluent Cloud branch of the same validation function was left untouched to avoid changing existing accepted behavior there (e.g. trailing-slash URLs).
3. **Docs terminology fix** (Confluent Platform): the generated docs on-prem tab was labeled "On-Premises"; changed to "Confluent Platform" to match current product naming.

Blast Radius
----
- The `byok` AWS SDK migration is an internal dependency swap with verified drop-in-compatible behavior; no customer-facing change expected.
- Customers logging into Confluent Platform with a `--url` containing a trailing path now get a correctly stripped base URL instead of silently broken subsequent requests; no impact to URLs without a trailing path.
- The docs label change has no functional impact.

References
----------
- Jira APIE-472
- Jira APIE-1348

Test & Review
-------------
- Added `TestIsAWSKey` unit test and 2 new `TestValidateUrl` cases covering the trailing-path fix; full targeted test suite (`internal/login`, `internal/byok`) run locally, all passing.