### PR TITLE
[IDENTITY-7909] Scope logout revocation to the CLI Auth0 client

### DIFF
--- a/internal/logout/command.go
+++ b/internal/logout/command.go
@@ -2,6 +2,8 @@ package logout
 
 import (
 	"fmt"
+	"net/http"
+	"net/url"
 
 	"github.com/spf13/cobra"
 
@@ -12,6 +14,7 @@ import (
 	"github.com/confluentinc/cli/v4/pkg/ccloudv2"
 	pcmd "github.com/confluentinc/cli/v4/pkg/cmd"
 	"github.com/confluentinc/cli/v4/pkg/config"
+	"github.com/confluentinc/cli/v4/pkg/log"
 	"github.com/confluentinc/cli/v4/pkg/output"
 )
 
@@ -51,8 +54,11 @@ func (c *command) logout(_ *cobra.Command, _ []string) error {
 	ctx := c.Config.Context()
 	if ctx != nil {
 		if ccloudv2.IsCCloudURL(ctx.Platform.Server, c.cfg.IsTest) {
-			if _, err := c.revokeCCloudRefreshToken(ctx); err != nil {
-				return err
+			if err := c.revokeCCloudSession(ctx); err != nil {
+				// Local credentials are cleared regardless, so a failed revocation
+				// cannot strand the user in a logged-in state.
+				log.CliLogger.Warnf("Failed to revoke session: %v", err)
+				output.ErrPrintln(c.Config.EnableColor, "Warning: your session could not be revoked and may still be active. Local credentials were removed.")
 			}
 		}
 	}
@@ -65,16 +71,45 @@ func (c *command) logout(_ *cobra.Command, _ []string) error {
 	return nil
 }
 
-func (c *command) revokeCCloudRefreshToken(ctx *config.Context) (*ccloudv1.AuthenticateReply, error) {
-	contextState := c.Config.ContextStates[ctx.Name]
-	if err := contextState.DecryptAuthToken(ctx.Name); err != nil {
-		return nil, err
+func (c *command) revokeCCloudSession(ctx *config.Context) error {
+	if sso.IsOkta(ctx.Platform.Server) {
+		contextState := c.Config.ContextStates[ctx.Name]
+		if err := contextState.DecryptAuthToken(ctx.Name); err != nil {
+			return err
+		}
+
+		_, err := c.Client.Auth.OktaLogout(&ccloudv1.AuthenticateRequest{IdToken: contextState.AuthToken})
+		return err
 	}
 
-	req := &ccloudv1.AuthenticateRequest{IdToken: contextState.AuthToken}
-	if sso.IsOkta(ctx.Platform.Server) {
-		return c.Client.Auth.OktaLogout(req)
-	} else {
-		return c.Client.Auth.Logout(req)
+	return c.deleteSession()
+}
+
+// deleteSession scopes revocation to the CLI's own Auth0 client, leaving the user's
+// browser and IDE sessions intact.
+func (c *command) deleteSession() error {
+	u, err := url.Parse(c.Client.BaseURL)
+	if err != nil {
+		return err
 	}
+	u = u.JoinPath("api", "iam", "v2", "sessions")
+	u.RawQuery = url.Values{"client_id": []string{sso.GetAuth0CCloudClientIdFromBaseUrl(c.Client.BaseURL)}}.Encode()
+
+	req, err := http.NewRequest(http.MethodDelete, u.String(), nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("User-Agent", c.Client.UserAgent)
+
+	res, err := c.Client.HttpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode < 200 || res.StatusCode >= 300 {
+		return fmt.Errorf("%s returned %s", req.URL.Path, res.Status)
+	}
+
+	return nil
 }

--- a/internal/logout/command_test.go
+++ b/internal/logout/command_test.go
@@ -1,6 +1,8 @@
 package logout
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -14,6 +16,7 @@ import (
 	pauth "github.com/confluentinc/cli/v4/pkg/auth"
 	pcmd "github.com/confluentinc/cli/v4/pkg/cmd"
 	"github.com/confluentinc/cli/v4/pkg/config"
+	"github.com/confluentinc/cli/v4/pkg/log"
 )
 
 const (
@@ -51,6 +54,48 @@ func TestLogout(t *testing.T) {
 	_, err := pcmd.ExecuteCommand(logoutCmd)
 	req.NoError(err)
 	verifyLoggedOutState(t, cfg, contextName)
+}
+
+func TestDeleteSession(t *testing.T) {
+	var req *http.Request
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		req = r
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	require.NoError(t, newDeleteSessionCmd(server.URL).deleteSession())
+
+	require.Equal(t, http.MethodDelete, req.Method)
+	require.Equal(t, "/api/iam/v2/sessions", req.URL.Path)
+	// A httptest URL matches no known environment, so the client ID falls through to prod's.
+	require.Equal(t, "oX2nvSKl5jvBKVgwehZfvR4K8RhsZIEs", req.URL.Query().Get("client_id"))
+}
+
+func TestDeleteSessionNoContent(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	require.NoError(t, newDeleteSessionCmd(server.URL).deleteSession())
+}
+
+func TestDeleteSessionError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	err := newDeleteSessionCmd(server.URL).deleteSession()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "/api/iam/v2/sessions")
+}
+
+func newDeleteSessionCmd(baseUrl string) *command {
+	return &command{AuthenticatedCLICommand: &pcmd.AuthenticatedCLICommand{
+		Client: ccloudv1.NewClient(&ccloudv1.Params{BaseURL: baseUrl, HttpClient: ccloudv1.BaseClient, Logger: log.CliLogger}),
+	}}
 }
 
 func newLogoutCmd(auth *ccloudv1mock.Auth, userInterface *ccloudv1mock.UserInterface, isCloud bool, req *require.Assertions, authTokenHandler pauth.AuthTokenHandler, contextName string) (*cobra.Command, *config.Config) {

--- a/test/test-server/ccloud_handlers.go
+++ b/test/test-server/ccloud_handlers.go
@@ -109,6 +109,15 @@ func handleMe(t *testing.T, isAuditLogEnabled bool) http.HandlerFunc {
 	}
 }
 
+// Handler for: "/api/iam/v2/sessions"
+func handleDeleteSession(t *testing.T) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodDelete, r.Method)
+		require.NotEmpty(t, r.URL.Query().Get("client_id"))
+		w.WriteHeader(http.StatusOK)
+	}
+}
+
 // Handler for: "/api/sessions"
 func handleLogin(t *testing.T) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {

--- a/test/test-server/ccloud_router.go
+++ b/test/test-server/ccloud_router.go
@@ -13,6 +13,7 @@ var ccloudHandlers = []route{
 	{"/api/env_metadata", handleEnvMetadata},
 	{"/api/external_identities", handleExternalIdentities},
 	{"/api/growth/v1/free-trial-info", handleFreeTrialInfo},
+	{"/api/iam/v2/sessions", handleDeleteSession},
 	{"/api/login/realm", handleLoginRealm},
 	{"/api/metadata/security/v2alpha1/authenticate", handleV2Authenticate},
 	{"/api/organizations/{id}/payment_info", handlePaymentInfo},


### PR DESCRIPTION
Release Notes
-------------

Bug Fixes
- `confluent logout` now revokes only the CLI's own Confluent Cloud session. It previously revoked every Auth0 refresh token for the account, which signed the user out of the web UI and other clients as well.

Checklist
---------
- [x] I have successfully built and used a custom CLI binary, without linter issues from this PR.
- [x] I have clearly specified in the `What` section below whether this PR applies to Confluent Cloud, Confluent Platform, or both.
- [ ] I have verified this PR in Confluent Cloud pre-prod or production environment, if applicable.
- [ ] I have verified this PR in Confluent Platform on-premises environment, if applicable.
- [x] I have attached manual CLI verification results or screenshots in the `Test & Review` section below.
- [x] I have added appropriate CLI integration or unit tests for any new or updated commands and functionality.
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [x] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [ ] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [ ] Confluent Cloud prod
  - [ ] Confluent Cloud stag
  - [ ] Confluent Platform
  - [ ] Check this box if the feature is enabled for certain organizations only

**This PR must not merge until cc-flow-service#3440 is deployed to prod.** See `References`.

What
----

Confluent Cloud only; Confluent Platform and gov (Okta) logout are untouched.

`confluent logout` called `DELETE /api/sessions`, which revokes **every** rotating refresh token belonging to the user's email across all Auth0 clients. Logging out of a terminal therefore also tore down the user's browser session and any IDE-plugin sessions.

`DELETE /iam/v2/sessions` scopes revocation to a single Auth0 client when given a client ID. This switches the Auth0 logout path to that endpoint, passing the CLI's own client ID — the same value already sent to cc-flow-service at login in `pkg/auth/auth_token_handler.go`. The session JWT rides along as a bearer token via the existing OAuth2 transport on `c.Client.HttpClient`, so no new auth plumbing is involved.

Two deliberate behaviour changes beyond the endpoint swap:

**Revocation failures no longer abort logout.** Previously a transport error returned before local credentials were cleared, leaving the user logged in locally with no way to log out offline. The v1 SDK also swallowed non-200 responses entirely, so server-side failures were invisible. Now local credentials are always cleared, and a failure is both logged and printed to stderr — the user is told their remote session may still be active. Exit code stays 0 so scripted `logout` calls don't start failing on a transient error.

**Any 2xx counts as success.** The endpoint returns 200 today; accepting the range avoids a false failure if it ever returns 204.

The request is hand-rolled rather than routed through an SDK. `ccloud-sdk-go-v1-public` has no v2 sessions method, and the generated `SessionsV2Api` in `ccloud-sdk-go-v2-internal` only exposes `CreateV2Session` (POST) — there is no generated DELETE, and that module isn't currently a dependency of the CLI. Happy to move this into `ccloud-sdk-go-v1-public` as a `LogoutV2` method if reviewers would rather keep all session calls behind `Client.Auth`; it just costs an extra repo and release.

Blast Radius
----

Confluent Cloud users running `confluent logout`. If the new endpoint misbehaves, logout still completes locally — credentials are removed and the user sees a warning — but the Auth0 session and refresh tokens may survive until they expire on their own (30 minutes for refresh tokens, up to 8 hours for the Auth0 session). The failure mode is a session that outlives the logout, not a user who cannot log out.

Gov/FedRAMP users are unaffected: `sso.IsOkta` still routes them to `DELETE /api/okta/auth/sessions`, and the upstream revocation RPCs reject FedRAMP calls regardless.

If this ships before cc-flow-service#3440 reaches prod, the `client_id` parameter is ignored and revocation silently falls back to the old unscoped behaviour — no error, but no improvement either. That is the reason for the merge gate above.

References
----------

- Jira: [IDENTITY-7909](https://confluentinc.atlassian.net/browse/IDENTITY-7909)
- Epic: [IDENTITY-5096](https://confluentinc.atlassian.net/browse/IDENTITY-5096) (Login/Session Re-architecture)
- Prerequisite: [confluentinc/cc-flow-service#3440](https://github.com/confluentinc/cc-flow-service/pull/3440) — adds the `client_id` query param to `DELETE /iam/v2/sessions`

Test & Review
-------------

Unit tests in `internal/logout/command_test.go` cover the request shape (method, path, `client_id`), a 204 response, and a non-2xx response surfacing an error.

```
go test ./internal/logout/
--- PASS: TestLogout
--- PASS: TestDeleteSession
--- PASS: TestDeleteSessionNoContent
--- PASS: TestDeleteSessionError
ok  	github.com/confluentinc/cli/v4/internal/logout
```

The test server gained a `/api/iam/v2/sessions` route asserting the method and a non-empty `client_id`, so the existing logout integration tests now exercise the new path end to end. I confirmed the route is genuinely reached by temporarily failing inside the handler and watching the suite fail — worth noting because a handler that is never called would otherwise pass silently.

```
make integration-test INTEGRATION_TEST_ARGS="-run 'TestCLI/(TestLogout|TestLogin)'"
--- PASS: TestCLI (11.97s)
```

Not yet verified against a deployed environment — that needs cc-flow-service#3440 in devel first, and I'll do that before marking this ready for review.

Two pre-existing failures in my local environment, both reproduced on an unmodified `main` checkout and unrelated to this change:
- `pkg/flink/internal/controller` panics with `open /dev/tty: device not configured` (needs a real TTY).
- `make lint-go` fails with `can't load config: unsupported version of the configuration` (local golangci-lint version vs `.golangci.yml`). `go vet ./...` is clean.


[IDENTITY-7909]: https://confluentinc.atlassian.net/browse/IDENTITY-7909?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ