### PR TITLE
fix(CI): use specific files for publishing test results

### DIFF
--- a/.semaphore/macos.yml
+++ b/.semaphore/macos.yml
@@ -27,4 +27,5 @@ blocks:
       epilogue:
         always:
           commands:
-            - test-results publish . -N "darwin/arm64"
+            # --ignore-missing: build-only jobs run no tests; an early failure can leave one unwritten
+            - test-results publish unit-test-report.xml integration-test-report.xml -N "darwin/arm64" --ignore-missing

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -41,7 +41,8 @@ blocks:
       epilogue:
         always:
           commands:
-            - test-results publish . -N "linux/amd64"
+            # --ignore-missing: build-only jobs run no tests; an early failure can leave one unwritten
+            - test-results publish unit-test-report.xml integration-test-report.xml -N "linux/amd64" --ignore-missing
 
   - name: linux/arm64
     run:
@@ -96,7 +97,7 @@ blocks:
       epilogue:
         always:
           commands:
-            - test-results publish . -N "windows/amd64"
+            - test-results publish unit-test-report.xml integration-test-report.xml -N "windows/amd64" --ignore-missing
 
 after_pipeline:
   task:


### PR DESCRIPTION
Release Notes
-------------

No user-facing changes. This is CI pipeline configuration only.

Checklist
---------

Most items below concern CLI binary behavior and are not applicable, since this PR changes only `.semaphore/` pipeline YAML and ships no code.

- [ ] I have successfully built and used a custom CLI binary, without linter issues from this PR.
- [ ] I have clearly specified in the `What` section below whether this PR applies to Confluent Cloud, Confluent Platform, or both.
- [ ] I have verified this PR in Confluent Cloud pre-prod or production environment, if applicable.
- [ ] I have verified this PR in Confluent Platform on-premises environment, if applicable.
- [x] I have attached manual CLI verification results or screenshots in the `Test & Review` section below.
- [ ] I have added appropriate CLI integration or unit tests for any new or updated commands and functionality.
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [x] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [ ] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [ ] Confluent Cloud prod
  - [ ] Confluent Cloud stag
  - [ ] Confluent Platform
  - [ ] Check this box if the feature is enabled for certain organizations only

What
----

Every `Confluent CLI` pipeline run ends with a red `Publish Results` job, and the Semaphore test report has been empty the whole time. This is CI infrastructure only, and applies to neither Confluent Cloud nor Confluent Platform.

Each block's epilogue (the cleanup step Semaphore runs after every job in a block) ran `test-results publish .`, which scans the entire repo looking for test reports. It trips on `pkg/config/test_json/account_overwrite.json`, a CLI config fixture rather than a test report, and exits 1. An epilogue's exit code doesn't fail a Semaphore job, so every test job still reported PASSED while publishing nothing, leaving the final aggregation step with nothing to collect.

This names the two JUnit XML reports that `gotestsum` (the test-runner wrapper) actually writes, instead of scanning, and adds `--ignore-missing` for the jobs that legitimately produce none.

Now publishing cleanly:

<img width="690" height="293" alt="image" src="https://github.com/user-attachments/assets/57888f81-caad-4e3d-860d-87a91b9fe46a" />

<details>
<summary>Mechanism, and why <code>--ignore-missing</code> is required rather than defensive</summary>

The exact failure, from the `Test linux/amd64` job:

```
* Using golang parser
* Could not find parser: no applicable parsers found for pkg/config/test_json/account_overwrite.json
```

"Using golang parser" is `test-results` guessing how to read each file it finds. That guess is correct for gotestsum output and fatal for a config fixture.

Downstream, the `after_pipeline` job (Semaphore's final step, which aggregates every job's report) tried to pull results that were never uploaded and failed with `hub returned 404`, where "hub" is Semaphore's artifact store. That 404 is the only visible red mark in an otherwise green pipeline.

`--ignore-missing` is load-bearing because a Semaphore epilogue is block-scoped and there is no job-level equivalent, so it also runs for jobs that never run tests: `Build linux/amd64 (Alpine)` and `Build darwin/amd64`. Reports are also legitimately absent when `make lint` fails before `make test`, or when `make test` (`unit-test integration-test`) aborts after unit tests so `integration-test-report.xml` is never written.

`.semaphore/live-tests.yml` and `.semaphore/smoke-tests.yml` never call `test-results`, so no other pipeline needs this change.

</details>

Blast Radius
----

None for customers. This touches only `.semaphore/*.yml` (no CLI code, no command behavior, nothing in the released binary, and no change for Confluent Cloud or Confluent Platform users).

The realistic downside is limited to CI visibility. If the new invocation is wrong, the test report stays empty and `Publish Results` stays red, exactly the state on `main` today.

References
----------

- Failing `Publish Results` job: https://semaphore.ci.confluent.io/jobs/92ecbcbc-7aff-44e9-af62-b1f3f5f38cb8
- The `publish` failure that causes it, in `Test linux/amd64`: https://semaphore.ci.confluent.io/jobs/7008f4f4-889c-4f22-8adb-bddd0c3615c5
- Same failure on the previous `main` pipeline, confirming this is longstanding rather than a new regression: https://semaphore.ci.confluent.io/jobs/74ac0554-ef94-4efe-ba31-9805bd8a6d99

Test & Review
-------------

`test-results` is a CI-only binary, so the publish call itself can only be verified by this PR's own pipeline run. What was verified locally is that the files it now names are the files that actually get written:

1. `go install gotest.tools/gotestsum@v1.13.0` (the version pinned in `Makefile`)
2. `gotestsum --junitfile unit-test-report.xml -- -timeout 0 -race -coverprofile=coverage.unit.out -covermode=atomic ./pkg/log/...`
3. Confirm `unit-test-report.xml` lands at the repo root, which is the epilogue's working directory
4. Confirm it parses as JUnit XML: `<testsuites>` root, one `<testsuite>` per Go package, `classname` set to the import path

Also verified, in a throwaway module, that `gotestsum` still writes the report when tests **fail** (exit 1, `failures=1`) and when a package **fails to compile** (exit 1, `errors=1`). That is what makes `epilogue: always:` the right place to publish from.

Note that `make test` only emits JUnit XML under `ifdef CI` (`Makefile:91`), so a plain local `make test` produces no reports at all.

**What to watch on this PR's pipeline run:** `Publish Results` should go green, the test report should be populated for `linux/amd64` and `windows/amd64`, and the two build-only jobs should not error in their epilogue.
