### PR TITLE
[INIT-6549] Add client-side synchronous snapshot queries to the Flink CLI

### DIFF
--- a/internal/command.go
+++ b/internal/command.go
@@ -40,6 +40,7 @@ import (
 	"github.com/confluentinc/cli/v4/internal/plugin"
 	"github.com/confluentinc/cli/v4/internal/prompt"
 	providerintegration "github.com/confluentinc/cli/v4/internal/provider-integration"
+	"github.com/confluentinc/cli/v4/internal/query"
 	"github.com/confluentinc/cli/v4/internal/rtce"
 	schemaregistry "github.com/confluentinc/cli/v4/internal/schema-registry"
 	"github.com/confluentinc/cli/v4/internal/secret"
@@ -132,6 +133,7 @@ func NewConfluentCommand(cfg *config.Config) *cobra.Command {
 	cmd.AddCommand(plugin.New(cfg, prerunner))
 	cmd.AddCommand(prompt.New(cfg))
 	cmd.AddCommand(providerintegration.New(prerunner))
+	cmd.AddCommand(query.New(cfg, prerunner))
 	cmd.AddCommand(rtce.New(cfg, prerunner))
 	cmd.AddCommand(schemaregistry.New(cfg, prerunner))
 	cmd.AddCommand(secret.New(prerunner, secrets.NewPasswordProtectionPlugin()))

--- a/internal/query/command.go
+++ b/internal/query/command.go
@@ -209,7 +209,7 @@ func (c *command) runQuery(cmd *cobra.Command, args []string) error {
 	}
 
 	if computePool == "" && (cloud == "" || region == "") {
-		return errors.New("Flink cloud and region flags are required when compute pool is not specified.")
+		return errors.New("the `--cloud` and `--region` flags are required when `--compute-pool` is not specified")
 	}
 
 	name := types.GenerateStatementName()

--- a/internal/query/command.go
+++ b/internal/query/command.go
@@ -1,0 +1,576 @@
+package query
+
+import (
+	"context"
+	goerrors "errors"
+	"fmt"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/olekukonko/tablewriter"
+	"github.com/spf13/cobra"
+
+	flinkgatewayv1 "github.com/confluentinc/ccloud-sdk-go-v2/flink-gateway/v1"
+
+	"github.com/confluentinc/cli/v4/pkg/auth"
+	"github.com/confluentinc/cli/v4/pkg/ccloudv2"
+	pcmd "github.com/confluentinc/cli/v4/pkg/cmd"
+	cliconfig "github.com/confluentinc/cli/v4/pkg/config"
+	"github.com/confluentinc/cli/v4/pkg/errors"
+	flinkerror "github.com/confluentinc/cli/v4/pkg/errors/flink"
+	"github.com/confluentinc/cli/v4/pkg/examples"
+	"github.com/confluentinc/cli/v4/pkg/featureflags"
+	"github.com/confluentinc/cli/v4/pkg/flink/config"
+	"github.com/confluentinc/cli/v4/pkg/flink/query"
+	"github.com/confluentinc/cli/v4/pkg/flink/types"
+	"github.com/confluentinc/cli/v4/pkg/jwt"
+	"github.com/confluentinc/cli/v4/pkg/output"
+	"github.com/confluentinc/cli/v4/pkg/properties"
+)
+
+const (
+	// snapshotModeProperty makes the statement a bounded, point-in-time read. It is
+	// a statement property rather than a flag on the API, so the command sets it as
+	// a default that `--property` can override.
+	snapshotModeProperty = "sql.snapshot.mode"
+	snapshotModeNow      = "now"
+
+	// stopTimeout bounds how long we wait for a statement to be stopped after the
+	// user interrupts the command.
+	stopTimeout = 5 * time.Second
+
+	// queryFeatureFlag gates the command while it is in Open Preview, following the
+	// same Hidden-until-targeted pattern as other preview commands (see
+	// internal/unified-stream-manager/command.go).
+	queryFeatureFlag = "cli.query"
+)
+
+type command struct {
+	*pcmd.AuthenticatedCLICommand
+}
+
+// New mounts `confluent query` at the top level rather than under `flink`: today it
+// only ever talks to the Flink gateway, but the same one-shot-query ergonomics are
+// meant to cover other backends (e.g. Lightning Tables) later without a rename.
+func New(cfg *cliconfig.Config, prerunner pcmd.PreRunner) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "query [name]",
+		Short: "Run a bounded Flink SQL query and print its results.",
+		Long: "Run a bounded (snapshot) Flink SQL query, block until it finishes, and print the complete result set.\n\n" +
+			"Unlike statement creation, which submits a statement and returns immediately, this command waits for every " +
+			"result page and exits with a non-zero status if the statement fails. It is intended for scripting and " +
+			"one-shot queries against a bounded (point-in-time) result set.\n\n" +
+			"With \"-o json\" or \"-o yaml\", output defaults to an envelope carrying the column schema alongside the rows, " +
+			"since the rows on their own carry no type information. Pass \"--raw\" for a bare array of row objects instead.\n\n" +
+			"This command is in Open Preview and may change in a backward-incompatible way in a minor release.",
+		Args: cobra.MaximumNArgs(1),
+		// Hidden until the org is targeted by the flag, matching how other
+		// Open-Preview-only commands gate visibility (e.g. unified-stream-manager).
+		// cfg.IsTest keeps it visible to the integration suite regardless of the
+		// (unreachable, in tests) LaunchDarkly evaluation.
+		Hidden: !(cfg.IsTest || featureflags.Manager.BoolVariation(queryFeatureFlag, cfg.Context(), cliconfig.CliLaunchDarklyClient, true, false)),
+		Annotations: map[string]string{
+			pcmd.RunRequirement: pcmd.RequireNonAPIKeyCloudLogin,
+		},
+		Example: examples.BuildExampleString(
+			examples.Example{
+				Text: "Run a bounded query in the current compute pool and print the rows as a table.",
+				Code: `confluent query --sql "SELECT * FROM orders LIMIT 10;"`,
+			},
+			examples.Example{
+				Text: "Run a bounded query against Kafka cluster \"my-cluster\" and emit JSON for a script to consume.",
+				Code: `confluent query --sql "SELECT status, COUNT(*) FROM orders GROUP BY status;" --compute-pool lfcp-123456 --database my-cluster --output json`,
+			},
+			examples.Example{
+				Text: "Emit a bare JSON array of rows, with no envelope, for a script that only wants the data.",
+				Code: `confluent query --sql "SELECT * FROM orders LIMIT 10;" --output json --raw`,
+			},
+		),
+	}
+
+	c := &command{pcmd.NewAuthenticatedCLICommand(cmd, prerunner)}
+	cmd.RunE = c.runQuery
+
+	cmd.Flags().String("sql", "", "The Flink SQL statement.")
+	c.addComputePoolFlag(cmd)
+	pcmd.AddServiceAccountFlag(cmd, c.AuthenticatedCLICommand)
+	c.addDatabaseFlag(cmd)
+	cmd.Flags().StringSlice("property", []string{}, "A mechanism to pass properties in the form key=value when creating a Flink statement.")
+	cmd.Flags().Duration("timeout", config.DefaultTimeoutDuration, "Maximum time to wait for the query to finish before giving up.")
+	cmd.Flags().Int("max-rows", 0, "Stop fetching and discard the rest after this many rows, or 0 to fetch every row. Client-side only: rows past the limit are still produced by the query.")
+	cmd.Flags().Bool("raw", false, `Emit the rows as a bare array with no envelope. Requires "-o json" or "-o yaml".`)
+	pcmd.AddEnvironmentFlag(cmd, c.AuthenticatedCLICommand)
+	pcmd.AddContextFlag(cmd, c.CLICommand)
+	pcmd.AddOutputFlag(cmd)
+	pcmd.AddCloudFlag(cmd)
+	pcmd.AddRegionFlagFlink(cmd, c.AuthenticatedCLICommand)
+
+	cobra.CheckErr(cmd.MarkFlagRequired("sql"))
+
+	return cmd
+}
+
+// addComputePoolFlag and addDatabaseFlag mirror internal/flink's identical helpers.
+// Duplicated rather than shared because this command intentionally lives outside the
+// `flink` package boundary; hoisting them is worth doing only if a third caller shows up.
+func (c *command) addComputePoolFlag(cmd *cobra.Command) {
+	cmd.Flags().String("compute-pool", "", "Flink compute pool ID.")
+	pcmd.RegisterFlagCompletionFunc(cmd, "compute-pool", c.autocompleteComputePools)
+}
+
+func (c *command) autocompleteComputePools(cmd *cobra.Command, args []string) []string {
+	if err := c.PersistentPreRunE(cmd, args); err != nil {
+		return nil
+	}
+
+	environmentId, err := c.Context.EnvironmentId()
+	if err != nil {
+		return nil
+	}
+
+	computePools, err := c.V2Client.ListFlinkComputePools(environmentId, "")
+	if err != nil {
+		return nil
+	}
+
+	suggestions := make([]string, len(computePools))
+	for i, computePool := range computePools {
+		suggestions[i] = fmt.Sprintf("%s\t%s", computePool.GetId(), computePool.Spec.GetDisplayName())
+	}
+	return suggestions
+}
+
+func (c *command) addDatabaseFlag(cmd *cobra.Command) {
+	cmd.Flags().String("database", "", "The database which will be used as the default database. When using Kafka, this is the cluster ID.")
+	pcmd.RegisterFlagCompletionFunc(cmd, "database", c.autocompleteDatabases)
+}
+
+func (c *command) autocompleteDatabases(cmd *cobra.Command, args []string) []string {
+	if err := c.PersistentPreRunE(cmd, args); err != nil {
+		return nil
+	}
+
+	environmentId, err := c.Context.EnvironmentId()
+	if err != nil {
+		return nil
+	}
+
+	clusters, err := c.V2Client.ListKafkaClusters(environmentId)
+	if err != nil {
+		return nil
+	}
+
+	suggestions := make([]string, len(clusters))
+	for i, cluster := range clusters {
+		suggestions[i] = fmt.Sprintf("%s\t%s", cluster.GetId(), cluster.Spec.GetDisplayName())
+	}
+	return suggestions
+}
+
+type queryColumnOut struct {
+	Name string `json:"name" yaml:"name"`
+	Type string `json:"type" yaml:"type"`
+}
+
+type queryOut struct {
+	StatementName string           `json:"statement_name" yaml:"statement_name"`
+	Phase         string           `json:"phase" yaml:"phase"`
+	Columns       []queryColumnOut `json:"columns" yaml:"columns"`
+	// Values carry their SQL type: a number serializes as a number and a NULL as null.
+	// See types.StatementResultField.ToSerializedValue for what each type maps to.
+	Rows      []map[string]any `json:"rows" yaml:"rows"`
+	RowCount  int              `json:"row_count" yaml:"row_count"`
+	Truncated bool             `json:"truncated" yaml:"truncated"`
+}
+
+func (c *command) runQuery(cmd *cobra.Command, args []string) error {
+	environmentId, err := c.Context.EnvironmentId()
+	if err != nil {
+		return err
+	}
+
+	environment, _, err := c.V2Client.GetOrgEnvironment(environmentId)
+	if err != nil {
+		return errors.NewErrorWithSuggestions(err.Error(), "List available environments with `confluent environment list`.")
+	}
+
+	computePool := c.Context.GetCurrentFlinkComputePool()
+	cloud, err := cmd.Flags().GetString("cloud")
+	if err != nil {
+		return err
+	}
+
+	region, err := cmd.Flags().GetString("region")
+	if err != nil {
+		return err
+	}
+
+	if computePool == "" && (cloud == "" || region == "") {
+		return errors.New("Flink cloud and region flags are required when compute pool is not specified.")
+	}
+
+	name := types.GenerateStatementName()
+	if len(args) == 1 {
+		name = args[0]
+	}
+
+	sql, err := cmd.Flags().GetString("sql")
+	if err != nil {
+		return err
+	}
+
+	database, err := cmd.Flags().GetString("database")
+	if err != nil {
+		return err
+	}
+
+	timeout, err := cmd.Flags().GetDuration("timeout")
+	if err != nil {
+		return err
+	}
+
+	maxRows, err := cmd.Flags().GetInt("max-rows")
+	if err != nil {
+		return err
+	}
+	if maxRows < 0 {
+		return errors.New(`the "--max-rows" flag must not be negative`)
+	}
+
+	raw, err := cmd.Flags().GetBool("raw")
+	if err != nil {
+		return err
+	}
+	if raw && !output.GetFormat(cmd).IsSerialized() {
+		return errors.New(`the "--raw" flag requires "-o json" or "-o yaml"`)
+	}
+
+	statementProperties, err := c.buildQueryProperties(cmd, environment.GetDisplayName(), database)
+	if err != nil {
+		return err
+	}
+
+	statement := flinkgatewayv1.SqlV1Statement{
+		Name: flinkgatewayv1.PtrString(name),
+		Spec: &flinkgatewayv1.SqlV1StatementSpec{
+			Statement:  flinkgatewayv1.PtrString(sql),
+			Properties: &statementProperties,
+		},
+	}
+
+	var client *ccloudv2.FlinkGatewayClient
+	if computePool != "" {
+		statement.Spec.ComputePoolId = flinkgatewayv1.PtrString(computePool)
+		client, err = c.GetFlinkGatewayClient(true)
+	} else {
+		client, err = c.GetFlinkGatewayClient(false)
+	}
+	if err != nil {
+		return err
+	}
+
+	jwtValidator := jwt.NewValidator()
+
+	serviceAccount, err := cmd.Flags().GetString("service-account")
+	if err != nil {
+		return err
+	}
+
+	principal := serviceAccount
+	if serviceAccount == "" {
+		principal = c.Context.GetUser().GetResourceId()
+	}
+
+	if _, err := client.CreateStatement(statement, principal, environmentId, c.Context.LastOrgId); err != nil {
+		return err
+	}
+
+	// From here on the statement exists server-side and is consuming pool capacity. A
+	// job left running with nothing draining its collect-sink buffer stalls
+	// indefinitely and keeps burning the compute it reserved — that was the truncation
+	// bug: one of several exit paths simply forgot to stop it. Making that structurally
+	// impossible, rather than remembering it at every exit, is the point of this defer:
+	// it fires unless settled is true, and settled is only set once we know the
+	// statement's fate — either it reached a terminal phase on its own, or something
+	// already made one stop attempt on our behalf.
+	settled := false
+	defer func() {
+		if !settled {
+			c.stopStatement(client, environmentId, name)
+		}
+	}()
+
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer cancel()
+	ctx, cancelTimeout := context.WithTimeout(ctx, timeout)
+	defer cancelTimeout()
+
+	options := query.Options{
+		Client:         client,
+		EnvironmentId:  environmentId,
+		OrganizationId: c.Context.LastOrgId,
+		MaxRows:        maxRows,
+		RequireBounded: true,
+		RefreshToken:   c.refreshGatewayToken(client, jwtValidator),
+	}
+
+	result, err := query.Run(ctx, options, name)
+	if err != nil {
+		return c.handleQueryError(client, environmentId, name, err, &settled)
+	}
+
+	// The phase on result.Statement was read before the drain loop decided to
+	// truncate or gave up on an exhausted page token — it says nothing about whether
+	// the job kept running afterward. Treating it as proof of completion here would
+	// be the same stale-read mistake the query package's drain() was fixed to avoid.
+	// Truncated and Incomplete both mean "we chose to stop reading," which by the
+	// same rule as the truncation bug always warrants a stop attempt.
+	settled = !result.Truncated && !result.Incomplete && query.IsTerminal(result.Phase())
+
+	if result.Phase() == types.FAILED {
+		return errors.NewErrorWithSuggestions(
+			fmt.Sprintf(`statement "%s" failed: %s`, name, result.Statement.Status.GetDetail()),
+			fmt.Sprintf("Inspect the failure with `confluent flink statement exception list %s`.", name),
+		)
+	}
+
+	if result.Incomplete {
+		output.ErrPrintf(false, "Warning: the gateway stopped returning result pages while statement \"%s\" was still in phase %s. The result set below may be incomplete.\n", name, result.Phase())
+	}
+
+	if result.Truncated {
+		output.ErrPrintf(false, "Warning: stopped after %d rows because of the \"--max-rows\" flag. The result set below is truncated.\n", maxRows)
+	}
+
+	traits := result.Statement.Status.GetTraits()
+	statementTraits := types.StatementTraits{FlinkGatewayV1StatementTraits: &traits}
+	isAppendOnly, appendOnlyKnown := statementTraits.GetIsAppendOnly()
+	if appendOnlyKnown && !isAppendOnly {
+		output.ErrPrintln(false, "Warning: this statement emits updates and deletions. The rows below are the raw changelog, not a materialized table.")
+	}
+
+	return c.printQueryResult(cmd, name, result, appendOnlyKnown && !isAppendOnly, raw)
+}
+
+// buildQueryProperties seeds the statement with the catalog and snapshot mode, then
+// lets --property override anything, so the snapshot default never blocks a user who
+// needs a different mode.
+func (c *command) buildQueryProperties(cmd *cobra.Command, catalog, database string) (map[string]string, error) {
+	statementProperties := map[string]string{
+		config.KeyCatalog:    catalog,
+		snapshotModeProperty: snapshotModeNow,
+	}
+	if database != "" {
+		statementProperties[config.KeyDatabase] = database
+	}
+
+	configs, err := cmd.Flags().GetStringSlice("property")
+	if err != nil {
+		return nil, err
+	}
+
+	if len(configs) > 0 {
+		configMap, err := properties.ConfigSliceToMap(configs)
+		if err != nil {
+			return nil, err
+		}
+		for key, value := range configMap {
+			statementProperties[key] = value
+		}
+	}
+
+	return statementProperties, nil
+}
+
+// handleQueryError turns a failed or interrupted run into a message that always
+// names the statement. settled is the same flag runQuery's deferred cleanup checks: a
+// branch that stops the statement itself sets it to true so that deferred cleanup does
+// not also attempt it, and a branch that has no better information about the
+// statement's fate leaves it false so that cleanup does.
+func (c *command) handleQueryError(client *ccloudv2.FlinkGatewayClient, environmentId, name string, err error, settled *bool) error {
+	var unbounded *query.UnboundedError
+	if goerrors.As(err, &unbounded) {
+		// Only claim the statement was stopped when it actually was — stopStatement
+		// already warns on its own when it could not.
+		fate := fmt.Sprintf("Statement \"%s\" was stopped.", name)
+		if !c.stopStatement(client, environmentId, name) {
+			fate = fmt.Sprintf("Stop it with `confluent flink statement stop %s`.", name)
+		}
+		*settled = true
+		return errors.NewErrorWithSuggestions(
+			err.Error(),
+			fmt.Sprintf("Bound the query with a LIMIT clause or a time predicate and run `confluent query` again. %s", fate),
+		)
+	}
+
+	if goerrors.Is(err, context.Canceled) || goerrors.Is(err, context.DeadlineExceeded) {
+		c.stopStatement(client, environmentId, name)
+		*settled = true
+		reason := "interrupted"
+		if goerrors.Is(err, context.DeadlineExceeded) {
+			reason = "timed out"
+		}
+		return errors.NewErrorWithSuggestions(
+			fmt.Sprintf(`query %s before statement "%s" finished`, reason, name),
+			fmt.Sprintf("Check the statement with `confluent flink statement describe %s`, or raise the limit with the \"--timeout\" flag.", name),
+		)
+	}
+
+	// Every other error, including ResultsFetchError below, leaves settled false: we
+	// have no positive signal the statement is done, so the caller's deferred cleanup
+	// makes the one stop attempt these branches used to skip.
+	var resultsFetchErr *query.ResultsFetchError
+	if goerrors.As(err, &resultsFetchErr) {
+		// A 404 here is ambiguous — it is also what a deleted or mistyped statement
+		// would return — so the suggestion names both possibilities rather than
+		// asserting the page expired. The gateway's actual retention window is not
+		// yet confirmed (see the query package README); this only makes the raw
+		// error actionable, it does not resolve that open question.
+		var coder flinkerror.Coder
+		if goerrors.As(err, &coder) && coder.StatusCode() == http.StatusNotFound {
+			return errors.NewErrorWithSuggestions(
+				resultsFetchErr.Error(),
+				fmt.Sprintf("The gateway only retains result pages for a limited window; this can happen if the query ran long enough for an earlier page to expire, or if the statement no longer exists. Re-run the query, or check `confluent flink statement describe %s`.", name),
+			)
+		}
+		return errors.NewErrorWithSuggestions(
+			resultsFetchErr.Error(),
+			fmt.Sprintf("Check the statement with `confluent flink statement describe %s`.", name),
+		)
+	}
+
+	return errors.NewErrorWithSuggestions(
+		err.Error(),
+		fmt.Sprintf("Check the statement with `confluent flink statement describe %s`.", name),
+	)
+}
+
+// refreshGatewayToken mirrors the check the interactive shell makes before every
+// gateway call: the dataplane token behind client is short-lived, and this command has
+// no equivalent of the shell's synchronizedTokenRefresh wrapping every call, so without
+// this a query that outlives that token dies on a 401 well before the command's own
+// --timeout is reached.
+func (c *command) refreshGatewayToken(client *ccloudv2.FlinkGatewayClient, jwtValidator jwt.Validator) func() error {
+	return func() error {
+		jwtCtx := &cliconfig.Context{State: &cliconfig.ContextState{AuthToken: client.AuthToken}}
+		if jwtValidator.Validate(jwtCtx) == nil {
+			return nil
+		}
+
+		dataplaneToken, err := auth.GetDataplaneToken(c.Context)
+		if err != nil {
+			return err
+		}
+		client.AuthToken = dataplaneToken
+		return nil
+	}
+}
+
+// stopStatement makes a best-effort, bounded attempt to stop a statement we are
+// abandoning, and reports the outcome either way. Both outcomes matter to the user:
+// a successful stop frees pool capacity, a failed one means there is a statement
+// still running under a name they need.
+func (c *command) stopStatement(client *ccloudv2.FlinkGatewayClient, environmentId, name string) bool {
+	done := make(chan error, 1)
+	go func() {
+		// The gateway replaces the statement wholesale rather than patching it, so a
+		// body carrying only spec.stopped is rejected as malformed and the statement
+		// keeps running. Read the statement back and flip the flag on what it returns.
+		statement, err := client.GetStatement(environmentId, name, c.Context.LastOrgId)
+		if err != nil {
+			done <- err
+			return
+		}
+		statement.Spec.Stopped = flinkgatewayv1.PtrBool(true)
+		done <- client.UpdateStatement(environmentId, name, c.Context.LastOrgId, statement)
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			output.ErrPrintf(false, "Warning: could not stop statement \"%s\": %v. It may still be running.\n", name, err)
+			return false
+		}
+		output.ErrPrintf(false, "Stopped statement \"%s\".\n", name)
+		return true
+	case <-time.After(stopTimeout):
+		output.ErrPrintf(false, "Warning: timed out trying to stop statement \"%s\". It may still be running.\n", name)
+		return false
+	}
+}
+
+func (c *command) printQueryResult(cmd *cobra.Command, name string, result *query.Result, showOperation, raw bool) error {
+	columns := make([]queryColumnOut, len(result.Columns))
+	headers := make([]string, len(result.Columns))
+	for i, column := range result.Columns {
+		columnType := column.GetType()
+		columns[i] = queryColumnOut{Name: column.GetName(), Type: columnType.GetType()}
+		headers[i] = column.GetName()
+	}
+
+	if output.GetFormat(cmd).IsSerialized() {
+		rows := make([]map[string]any, len(result.Rows))
+		for i, row := range result.Rows {
+			fields := make(map[string]any, len(headers))
+			for j, field := range row.GetFields() {
+				if j < len(headers) {
+					fields[headers[j]] = field.ToSerializedValue()
+				}
+			}
+			rows[i] = fields
+		}
+
+		// R3 asks for a bare array of row objects; R10 asks for an ordered, typed
+		// schema. A bare array has nowhere to put the schema, so the envelope is the
+		// default and --raw opts into the bare array R3 describes.
+		if raw {
+			return output.SerializedOutput(cmd, rows)
+		}
+
+		return output.SerializedOutput(cmd, &queryOut{
+			StatementName: name,
+			Phase:         string(result.Phase()),
+			Columns:       columns,
+			Rows:          rows,
+			RowCount:      len(rows),
+			Truncated:     result.Truncated,
+		})
+	}
+
+	if len(headers) == 0 || len(result.Rows) == 0 {
+		output.ErrPrintf(false, "The query returned no rows. Statement \"%s\" is in phase %s.\n", name, result.Phase())
+		return nil
+	}
+
+	if showOperation {
+		headers = append([]string{"Operation"}, headers...)
+	}
+
+	rows := make([][]string, len(result.Rows))
+	for i, row := range result.Rows {
+		fields := make([]string, 0, len(headers))
+		if showOperation {
+			fields = append(fields, row.Operation.String())
+		}
+		for _, field := range row.GetFields() {
+			fields = append(fields, field.ToString())
+		}
+		rows[i] = fields
+	}
+
+	// Deliberately no column truncation: the shell truncates to fit a terminal, but
+	// this command is expected to be piped, and silently shortening a value would
+	// corrupt whatever reads it.
+	table := tablewriter.NewWriter(os.Stdout)
+	table.SetAutoFormatHeaders(false)
+	table.SetAutoWrapText(false)
+	table.SetAlignment(tablewriter.ALIGN_LEFT)
+	table.SetHeader(headers)
+	table.AppendBulk(rows)
+	table.Render()
+
+	return nil
+}

--- a/pkg/flink/query/README.md
+++ b/pkg/flink/query/README.md
@@ -1,0 +1,101 @@
+### query
+
+Runs a bounded ("snapshot") Flink SQL statement to completion and returns the whole
+result set, synchronously, from the client. Backs `confluent query`
+(`internal/query/command.go`).
+
+**Status: Open Preview.** The verb, the flags and the result shape are all expected to
+move.
+
+#### Why this exists
+
+The Flink gateway has no synchronous execute endpoint. A statement is submitted, polled
+until it leaves `PENDING`, and then its result pages are pulled one at a time following
+`metadata.next`. `Run` performs that handshake behind a single call so a non-interactive
+command can behave like an ordinary database query.
+
+```go
+result, err := query.Run(ctx, query.Options{
+	Client:         gatewayClient,
+	EnvironmentId:  environmentId,
+	OrganizationId: organizationId,
+	RequireBounded: true,
+}, statementName)
+```
+
+The statement must already exist — submitting it is the caller's job, so the caller keeps
+ownership of naming, properties and cleanup.
+
+#### Why not reuse the shell
+
+`Store` + `ResultFetcher` + `MaterializedStatementResults` already does submit, poll and
+page. It is not reused here, because it was written for a scrolling viewer where being
+wrong degrades to "the user presses refresh again". Three of those degradations become
+silent data corruption once a script is reading stdout:
+
+| Shell behavior | Consequence for a synchronous command |
+| --- | --- |
+| `MaterializedStatementResults.cleanup()` evicts from the front past `MaxResultsCapacity` (10,000) | a 50k-row `SELECT` prints the **last** 10k and exits 0 |
+| `Append` skips rows whose field count ≠ header count, returning a bool that `fetchNextPageAndUpdateState` discards | short result set, no signal |
+| `updateState` sets `Completed` on `PageToken == ""` without checking the phase | exit 0 with a partial result set |
+
+This package handles each explicitly: no cap unless `Options.MaxRows` is set (and then
+`Result.Truncated` says so), a hard error from `ConvertToInternalResults` on a schema
+mismatch, and termination only when the page token is gone **and** the statement has
+reached a terminal phase.
+
+It also skips the shell's table-mode materialization. `Result.Rows` is the raw changelog
+as the gateway delivered it. For a bounded append-only snapshot the changelog and the
+materialized table are identical; for anything else the caller decides.
+
+#### The drain loop
+
+`page_token` is a positional offset into the collect-sink protocol, not an opaque cursor.
+There is therefore no token that advances past a page which did not supply one. When the
+token runs out while the statement is still `RUNNING`:
+
+- the page was **empty** — the gateway is saying "nothing yet". Re-requesting the same
+  offset is harmless, so the loop backs off and retries.
+- the page carried **rows** — advancing is impossible and re-requesting would duplicate
+  them. The loop stops and sets `Result.Incomplete`, which the command surfaces as a
+  warning.
+
+Whether that second branch is reachable in practice is still unconfirmed — it needs an
+answer from the gateway team, not inference from client code. It is written defensively
+because the alternative failure mode is a silent short read.
+
+#### Known limitations
+
+- **Cloud only.** `Options.Client` is a `ccloudv2.GatewayClientInterface`. On-prem goes
+  through CMF (`store_onprem.go`, itself a near-copy of `store.go`), so parity means a
+  second implementation and a second test surface.
+- **No token refresh.** The shell wraps every gateway call in `synchronizedTokenRefresh`;
+  this package does not. A snapshot query that outlives the dataplane token dies on a 401.
+  This bounds how honest the command's default 10-minute timeout is.
+- **No expired-page-token handling.** The gateway retains result pages for a bounded
+  window; an expired token surfaces as a raw error.
+- **The whole result set is held in memory** as `[]types.StatementResultRow`. There is no
+  streaming-to-stdout path, so the peak footprint scales with the result.
+- **Ops are dropped from serialized output.** The command's `-o json` / `-o yaml` rows are
+  keyed by column name and carry no `op`, so a non-append-only statement loses its
+  update/delete markers. Human output grows an `Operation` column instead. Real gap if
+  non-append-only ever needs supporting.
+- **No statement cleanup on success.** Each query leaves a terminal statement behind
+  against the 50K-per-environment pool.
+- **`--unsafe-trace` dumps customer rows**, and this is the surface most likely to run in
+  CI with retained logs.
+
+#### Working on this
+
+```bash
+go test ./pkg/flink/query/                                              # unit tests, mocked gateway
+```
+
+The unit tests drive `pkg/flink/test/mock.MockGatewayClientInterface` and inject
+`Options.sleep`, so backoff costs no wall time.
+
+Two unrelated failures reproduce on a clean `main` and are not caused by changes here:
+`pkg/flink/internal/controller` and `TestFlinkShell`/`TestFlinkShellOnPrem` panic without
+a TTY. If `make lint-go` reports `unsupported version of the configuration`, a
+golangci-lint v2 on `PATH` is shadowing the v1.64.8 the Makefile pins — run
+`$(go env GOPATH)/bin/golangci-lint run` directly.

--- a/pkg/flink/query/query.go
+++ b/pkg/flink/query/query.go
@@ -1,0 +1,313 @@
+// Package query runs a bounded ("snapshot") Flink SQL statement to completion and
+// returns the whole result set, synchronously, from the client.
+//
+// The Flink gateway has no synchronous execute endpoint: a statement is submitted,
+// polled until it leaves PENDING, and then its result pages are pulled one at a
+// time. This package performs that handshake behind a single call so a
+// non-interactive command can behave like an ordinary database query.
+//
+// It deliberately does not reuse the interactive shell's Store/ResultFetcher stack.
+// That pipeline is built for a scrolling viewer and degrades gracefully in three
+// ways that are invisible to the user — it evicts rows past a 10,000-row cap, it
+// drops rows whose width does not match the schema without reporting it, and it
+// treats a missing page token as "done" without checking the statement phase. Every
+// one of those turns into silent data loss once a script is consuming stdout, so the
+// drain loop here is separate and reports each of those conditions instead.
+package query
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"time"
+
+	flinkgatewayv1 "github.com/confluentinc/ccloud-sdk-go-v2/flink-gateway/v1"
+
+	"github.com/confluentinc/cli/v4/pkg/ccloudv2"
+	"github.com/confluentinc/cli/v4/pkg/flink/internal/results"
+	"github.com/confluentinc/cli/v4/pkg/flink/types"
+	"github.com/confluentinc/cli/v4/pkg/log"
+)
+
+const (
+	initialBackoff = 300 * time.Millisecond
+	maxBackoff     = 2 * time.Second
+)
+
+// Options configures a single run. Only Client, EnvironmentId and OrganizationId
+// are required.
+type Options struct {
+	Client         ccloudv2.GatewayClientInterface
+	EnvironmentId  string
+	OrganizationId string
+
+	// MaxRows caps how many rows are collected. Zero means no cap. When the cap is
+	// hit the run stops early and Result.Truncated is set — rows are never dropped
+	// without saying so.
+	MaxRows int
+
+	// RequireBounded rejects a statement whose traits say it is unbounded, rather
+	// than draining a stream that will never end.
+	RequireBounded bool
+
+	// RefreshToken is called before every gateway request. The dataplane token behind
+	// Client is short-lived, and unlike the interactive shell — which wraps every call
+	// in synchronizedTokenRefresh — a raw Client here would let a query that outlives
+	// that token die on a 401. A refresh failure is logged and swallowed rather than
+	// aborting the run: the next gateway call surfaces its own error if the token
+	// really is bad, which is a clearer failure than one raised from inside a refresh
+	// helper. Nil means there is nothing to refresh.
+	RefreshToken func() error
+
+	// sleep is swapped out in tests so they do not wait in real time.
+	sleep func(context.Context, time.Duration) error
+}
+
+// authenticatedClient refreshes the gateway token, if a refresher was configured,
+// before returning the client to call. Mirrors Store.authenticatedGatewayClient.
+func (opts Options) authenticatedClient() ccloudv2.GatewayClientInterface {
+	if opts.RefreshToken != nil {
+		if err := opts.RefreshToken(); err != nil {
+			log.CliLogger.Warnf("Failed to refresh Flink gateway token: %v", err)
+		}
+	}
+	return opts.Client
+}
+
+// Result is the outcome of a completed run.
+type Result struct {
+	// Statement as the gateway last reported it, including status and traits.
+	Statement flinkgatewayv1.SqlV1Statement
+	// Columns is the result schema, in order.
+	Columns []flinkgatewayv1.ColumnDetails
+	// Rows is the raw changelog as delivered by the gateway. For a bounded
+	// append-only snapshot every row is an insert; for anything else the caller has
+	// to decide whether to materialize it.
+	Rows []types.StatementResultRow
+	// Truncated reports that MaxRows stopped the drain before the result set ended.
+	Truncated bool
+	// Incomplete reports that the gateway stopped handing out page tokens while the
+	// statement was still running, so rows may be missing. See drain.
+	Incomplete bool
+}
+
+// Phase is the statement phase at the end of the run.
+func (r *Result) Phase() types.PHASE {
+	return types.PHASE(r.Statement.Status.GetPhase())
+}
+
+// UnboundedError is returned when RequireBounded is set and the gateway reports the
+// statement produces an unbounded result.
+type UnboundedError struct {
+	StatementName string
+}
+
+func (e *UnboundedError) Error() string {
+	return fmt.Sprintf(`statement "%s" produces an unbounded result and cannot be run as a snapshot query`, e.StatementName)
+}
+
+// ResultsFetchError wraps a failure to fetch a result page, as distinct from a
+// failure to read the statement's own status. The two calls fail for different
+// reasons — a missing statement versus a page that no longer resolves — so keeping
+// them distinguishable lets the caller give a more specific suggestion, in
+// particular for the gateway's limited result-page retention window.
+type ResultsFetchError struct {
+	Err error
+}
+
+func (e *ResultsFetchError) Error() string {
+	return e.Err.Error()
+}
+
+func (e *ResultsFetchError) Unwrap() error {
+	return e.Err
+}
+
+// Run waits for an already-submitted statement to start, then drains every result
+// page. The statement must already exist — submitting it is the caller's job, so the
+// caller keeps ownership of naming, properties and cleanup.
+func Run(ctx context.Context, opts Options, statementName string) (*Result, error) {
+	if opts.sleep == nil {
+		opts.sleep = sleepContext
+	}
+
+	statement, err := await(ctx, opts, statementName)
+	if err != nil {
+		return nil, err
+	}
+
+	result := &Result{Statement: statement}
+
+	traits := statement.Status.GetTraits()
+	statementTraits := types.StatementTraits{FlinkGatewayV1StatementTraits: &traits}
+	if isBounded, known := statementTraits.GetIsBounded(); opts.RequireBounded && known && !isBounded {
+		return result, &UnboundedError{StatementName: statementName}
+	}
+
+	schema := traits.GetSchema()
+	result.Columns = schema.GetColumns()
+
+	// A statement that produces no result set at all (DDL, INSERT INTO) has no schema
+	// and no results endpoint worth polling. Returning here keeps the caller from
+	// reporting an empty table for a statement that legitimately has no rows.
+	if len(result.Columns) == 0 {
+		return result, nil
+	}
+
+	if err := drain(ctx, opts, statementName, schema, result); err != nil {
+		return result, err
+	}
+
+	return result, nil
+}
+
+// await polls until the statement leaves PENDING, so that its traits — the result
+// schema and the boundedness flag — are populated.
+func await(ctx context.Context, opts Options, statementName string) (flinkgatewayv1.SqlV1Statement, error) {
+	backoff := initialBackoff
+	for {
+		if err := ctx.Err(); err != nil {
+			return flinkgatewayv1.SqlV1Statement{}, err
+		}
+
+		statement, err := opts.authenticatedClient().GetStatement(opts.EnvironmentId, statementName, opts.OrganizationId)
+		if err != nil {
+			return flinkgatewayv1.SqlV1Statement{}, err
+		}
+
+		if types.PHASE(statement.Status.GetPhase()) != types.PENDING {
+			return statement, nil
+		}
+
+		if err := opts.sleep(ctx, backoff); err != nil {
+			return flinkgatewayv1.SqlV1Statement{}, err
+		}
+		backoff = min(backoff*2, maxBackoff)
+	}
+}
+
+// drain pulls result pages until the gateway reports no next page and the statement
+// has reached a terminal phase.
+//
+// The statement's phase is read before each page, not after. Finishing was previously
+// inferred from two facts read at two different moments — the page (with no next
+// token) and then the phase — in that order. A statement that finished in the gap
+// between them made a possibly-short page look complete: the phase read afterward
+// could reflect a completion that happened after the page was already fetched, even
+// though more rows might have existed in between. Reading the phase first means that
+// when it is already terminal, nothing more can be added before the page is fetched,
+// so an empty next token on that page is genuinely final. The cost is one extra status
+// call per page.
+//
+// The gateway can return a page with no next token while the statement is still
+// RUNNING, and the page token is a positional offset into the collect sink rather than
+// an opaque cursor — so there is no token that advances past a page that did not
+// supply one. When that happens on a page that carried rows and the statement was not
+// already terminal, the result set may be short and Incomplete says so. When it
+// happens on an empty page, re-requesting the same offset is harmless, so the loop
+// backs off and retries.
+func drain(ctx context.Context, opts Options, statementName string, schema flinkgatewayv1.SqlV1ResultSchema, result *Result) error {
+	pageToken := ""
+	backoff := initialBackoff
+
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
+		statement, err := opts.authenticatedClient().GetStatement(opts.EnvironmentId, statementName, opts.OrganizationId)
+		if err != nil {
+			return err
+		}
+		result.Statement = statement
+		terminalBeforeFetch := IsTerminal(types.PHASE(statement.Status.GetPhase()))
+
+		page, err := opts.authenticatedClient().GetStatementResults(opts.EnvironmentId, statementName, opts.OrganizationId, pageToken)
+		if err != nil {
+			return &ResultsFetchError{Err: err}
+		}
+
+		pageResults := page.GetResults()
+		converted, err := results.ConvertToInternalResults(pageResults.GetData(), schema)
+		if err != nil {
+			return err
+		}
+		pageRows := converted.GetRows()
+		result.Rows = append(result.Rows, pageRows...)
+
+		if opts.MaxRows > 0 && len(result.Rows) > opts.MaxRows {
+			result.Rows = result.Rows[:opts.MaxRows]
+			result.Truncated = true
+			return nil
+		}
+
+		metadata := page.GetMetadata()
+		nextPageToken, err := extractPageToken(metadata.GetNext())
+		if err != nil {
+			return err
+		}
+
+		if nextPageToken != "" {
+			pageToken = nextPageToken
+			backoff = initialBackoff
+			continue
+		}
+
+		if terminalBeforeFetch {
+			return nil
+		}
+
+		if len(pageRows) > 0 {
+			result.Incomplete = true
+			return nil
+		}
+
+		if err := opts.sleep(ctx, backoff); err != nil {
+			return err
+		}
+		backoff = min(backoff*2, maxBackoff)
+	}
+}
+
+// IsTerminal reports whether phase is one the statement cannot leave on its own.
+// Exported so callers that hold a Result after Run returns — success or error — can
+// tell whether the statement still needs to be stopped without re-deriving this list.
+func IsTerminal(phase types.PHASE) bool {
+	switch phase {
+	case types.COMPLETED, types.FAILED, types.STOPPED, types.DELETING:
+		return true
+	}
+	return false
+}
+
+// extractPageToken pulls the page_token query parameter out of the absolute URL the
+// gateway returns in metadata.next.
+func extractPageToken(nextUrl string) (string, error) {
+	if nextUrl == "" {
+		return "", nil
+	}
+
+	parsed, err := url.Parse(nextUrl)
+	if err != nil {
+		return "", err
+	}
+
+	params, err := url.ParseQuery(parsed.RawQuery)
+	if err != nil {
+		return "", err
+	}
+
+	return params.Get("page_token"), nil
+}
+
+func sleepContext(ctx context.Context, duration time.Duration) error {
+	timer := time.NewTimer(duration)
+	defer timer.Stop()
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}

--- a/pkg/flink/query/query_test.go
+++ b/pkg/flink/query/query_test.go
@@ -1,0 +1,382 @@
+package query
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	flinkgatewayv1 "github.com/confluentinc/ccloud-sdk-go-v2/flink-gateway/v1"
+
+	"github.com/confluentinc/cli/v4/pkg/flink/test/mock"
+	"github.com/confluentinc/cli/v4/pkg/flink/types"
+)
+
+const (
+	testEnvironmentId  = "env-123456"
+	testOrganizationId = "org-123456"
+	testStatementName  = "test-statement"
+)
+
+// testOptions builds Options whose sleep is a no-op, so backoff never costs wall time.
+func testOptions(client *mock.MockGatewayClientInterface) Options {
+	return Options{
+		Client:         client,
+		EnvironmentId:  testEnvironmentId,
+		OrganizationId: testOrganizationId,
+		sleep:          func(context.Context, time.Duration) error { return nil },
+	}
+}
+
+func schema(columnNames ...string) *flinkgatewayv1.SqlV1ResultSchema {
+	columns := make([]flinkgatewayv1.ColumnDetails, len(columnNames))
+	for i, name := range columnNames {
+		columns[i] = flinkgatewayv1.ColumnDetails{
+			Name: name,
+			Type: flinkgatewayv1.DataType{Type: "VARCHAR", Nullable: false},
+		}
+	}
+	return &flinkgatewayv1.SqlV1ResultSchema{Columns: &columns}
+}
+
+func statement(phase string, traits *flinkgatewayv1.SqlV1StatementTraits) flinkgatewayv1.SqlV1Statement {
+	return flinkgatewayv1.SqlV1Statement{
+		Name: flinkgatewayv1.PtrString(testStatementName),
+		Spec: &flinkgatewayv1.SqlV1StatementSpec{Statement: flinkgatewayv1.PtrString("SELECT * FROM t;")},
+		Status: &flinkgatewayv1.SqlV1StatementStatus{
+			Phase:  phase,
+			Traits: traits,
+		},
+	}
+}
+
+func boundedTraits(columnNames ...string) *flinkgatewayv1.SqlV1StatementTraits {
+	return &flinkgatewayv1.SqlV1StatementTraits{
+		SqlKind:      flinkgatewayv1.PtrString("SELECT"),
+		IsBounded:    flinkgatewayv1.PtrBool(true),
+		IsAppendOnly: flinkgatewayv1.PtrBool(true),
+		Schema:       schema(columnNames...),
+	}
+}
+
+// page builds a result page. nextPageToken of "" means the gateway reported no next
+// page.
+func page(nextPageToken string, rows ...[]any) flinkgatewayv1.SqlV1StatementResult {
+	data := make([]any, len(rows))
+	for i, row := range rows {
+		data[i] = map[string]any{"op": float64(0), "row": row}
+	}
+
+	metadata := flinkgatewayv1.ResultListMeta{}
+	if nextPageToken != "" {
+		next := fmt.Sprintf("https://flink.us-east-1.aws.confluent.cloud/sql/v1/organizations/%s/environments/%s/statements/%s/results?page_token=%s",
+			testOrganizationId, testEnvironmentId, testStatementName, nextPageToken)
+		metadata.Next = &next
+	}
+
+	return flinkgatewayv1.SqlV1StatementResult{
+		Metadata: metadata,
+		Results:  &flinkgatewayv1.SqlV1StatementResultResults{Data: &data},
+	}
+}
+
+func rowValues(t *testing.T, result *Result) [][]string {
+	t.Helper()
+	values := make([][]string, len(result.Rows))
+	for i, row := range result.Rows {
+		fields := make([]string, len(row.GetFields()))
+		for j, field := range row.GetFields() {
+			fields[j] = field.ToString()
+		}
+		values[i] = fields
+	}
+	return values
+}
+
+func TestRunDrainsASinglePage(t *testing.T) {
+	client := mock.NewMockGatewayClientInterface(gomock.NewController(t))
+	completed := statement("COMPLETED", boundedTraits("id", "status"))
+
+	client.EXPECT().GetStatement(testEnvironmentId, testStatementName, testOrganizationId).Return(completed, nil).Times(2)
+	client.EXPECT().GetStatementResults(testEnvironmentId, testStatementName, testOrganizationId, "").
+		Return(page("", []any{"1", "SHIPPED"}, []any{"2", "PENDING"}), nil)
+
+	result, err := Run(context.Background(), testOptions(client), testStatementName)
+	require.NoError(t, err)
+	require.Equal(t, [][]string{{"1", "SHIPPED"}, {"2", "PENDING"}}, rowValues(t, result))
+	require.False(t, result.Truncated)
+	require.False(t, result.Incomplete)
+	require.Equal(t, types.COMPLETED, result.Phase())
+}
+
+func TestRunDrainsEveryPage(t *testing.T) {
+	client := mock.NewMockGatewayClientInterface(gomock.NewController(t))
+	running := statement("RUNNING", boundedTraits("id"))
+	completed := statement("COMPLETED", boundedTraits("id"))
+
+	// Statement leaves PENDING while it is still producing, then completes once the
+	// last page has been handed out. The phase is read before each page, not after.
+	gomock.InOrder(
+		client.EXPECT().GetStatement(testEnvironmentId, testStatementName, testOrganizationId).Return(running, nil),
+		client.EXPECT().GetStatement(testEnvironmentId, testStatementName, testOrganizationId).Return(running, nil),
+		client.EXPECT().GetStatementResults(testEnvironmentId, testStatementName, testOrganizationId, "").
+			Return(page("10", []any{"1"}), nil),
+		client.EXPECT().GetStatement(testEnvironmentId, testStatementName, testOrganizationId).Return(running, nil),
+		client.EXPECT().GetStatementResults(testEnvironmentId, testStatementName, testOrganizationId, "10").
+			Return(page("20", []any{"2"}), nil),
+		client.EXPECT().GetStatement(testEnvironmentId, testStatementName, testOrganizationId).Return(completed, nil),
+		client.EXPECT().GetStatementResults(testEnvironmentId, testStatementName, testOrganizationId, "20").
+			Return(page("", []any{"3"}), nil),
+	)
+
+	result, err := Run(context.Background(), testOptions(client), testStatementName)
+	require.NoError(t, err)
+	require.Equal(t, [][]string{{"1"}, {"2"}, {"3"}}, rowValues(t, result))
+	require.False(t, result.Incomplete)
+}
+
+// The interactive shell treats a missing page token as "all results fetched". This
+// asserts that a run does not silently exit successfully when the statement is still
+// running and there is no token left to advance with.
+func TestRunFlagsIncompleteWhenPagesStopBeforeStatementDoes(t *testing.T) {
+	client := mock.NewMockGatewayClientInterface(gomock.NewController(t))
+	running := statement("RUNNING", boundedTraits("id"))
+
+	gomock.InOrder(
+		client.EXPECT().GetStatement(testEnvironmentId, testStatementName, testOrganizationId).Return(running, nil),
+		client.EXPECT().GetStatement(testEnvironmentId, testStatementName, testOrganizationId).Return(running, nil),
+		client.EXPECT().GetStatementResults(testEnvironmentId, testStatementName, testOrganizationId, "").
+			Return(page("", []any{"1"}), nil),
+	)
+
+	result, err := Run(context.Background(), testOptions(client), testStatementName)
+	require.NoError(t, err)
+	require.True(t, result.Incomplete)
+	require.Equal(t, [][]string{{"1"}}, rowValues(t, result))
+}
+
+// An empty page with no token is the gateway saying "nothing yet". Re-requesting the
+// same offset is safe, so the loop should keep waiting rather than declaring victory.
+func TestRunRetriesEmptyPagesUntilStatementIsTerminal(t *testing.T) {
+	client := mock.NewMockGatewayClientInterface(gomock.NewController(t))
+	running := statement("RUNNING", boundedTraits("id"))
+	completed := statement("COMPLETED", boundedTraits("id"))
+
+	gomock.InOrder(
+		client.EXPECT().GetStatement(testEnvironmentId, testStatementName, testOrganizationId).Return(running, nil),
+		client.EXPECT().GetStatement(testEnvironmentId, testStatementName, testOrganizationId).Return(running, nil),
+		client.EXPECT().GetStatementResults(testEnvironmentId, testStatementName, testOrganizationId, "").Return(page(""), nil),
+		client.EXPECT().GetStatement(testEnvironmentId, testStatementName, testOrganizationId).Return(completed, nil),
+		client.EXPECT().GetStatementResults(testEnvironmentId, testStatementName, testOrganizationId, "").
+			Return(page("", []any{"1"}), nil),
+	)
+
+	result, err := Run(context.Background(), testOptions(client), testStatementName)
+	require.NoError(t, err)
+	require.False(t, result.Incomplete)
+	require.Equal(t, [][]string{{"1"}}, rowValues(t, result))
+}
+
+// The fix reads the statement's phase before fetching a page, not after. If it read
+// the phase afterward instead, a statement that finished in the gap between the two
+// calls could make a possibly-short page look complete. Pinning the exact call order
+// here means a regression back to "results then status" fails loudly instead of just
+// occasionally under-counting rows in production.
+func TestRunReadsStatementStateBeforeFetchingResults(t *testing.T) {
+	client := mock.NewMockGatewayClientInterface(gomock.NewController(t))
+	running := statement("RUNNING", boundedTraits("id"))
+	completed := statement("COMPLETED", boundedTraits("id"))
+
+	gomock.InOrder(
+		client.EXPECT().GetStatement(testEnvironmentId, testStatementName, testOrganizationId).Return(running, nil),
+		client.EXPECT().GetStatement(testEnvironmentId, testStatementName, testOrganizationId).Return(completed, nil),
+		client.EXPECT().GetStatementResults(testEnvironmentId, testStatementName, testOrganizationId, "").
+			Return(page("", []any{"1"}), nil),
+	)
+
+	result, err := Run(context.Background(), testOptions(client), testStatementName)
+	require.NoError(t, err)
+	require.False(t, result.Incomplete)
+	require.Equal(t, [][]string{{"1"}}, rowValues(t, result))
+}
+
+func TestRunWaitsForPendingStatement(t *testing.T) {
+	client := mock.NewMockGatewayClientInterface(gomock.NewController(t))
+	pending := statement("PENDING", nil)
+	completed := statement("COMPLETED", boundedTraits("id"))
+
+	gomock.InOrder(
+		client.EXPECT().GetStatement(testEnvironmentId, testStatementName, testOrganizationId).Return(pending, nil),
+		client.EXPECT().GetStatement(testEnvironmentId, testStatementName, testOrganizationId).Return(pending, nil),
+		client.EXPECT().GetStatement(testEnvironmentId, testStatementName, testOrganizationId).Return(completed, nil),
+		client.EXPECT().GetStatement(testEnvironmentId, testStatementName, testOrganizationId).Return(completed, nil),
+		client.EXPECT().GetStatementResults(testEnvironmentId, testStatementName, testOrganizationId, "").
+			Return(page("", []any{"1"}), nil),
+	)
+
+	result, err := Run(context.Background(), testOptions(client), testStatementName)
+	require.NoError(t, err)
+	require.Equal(t, [][]string{{"1"}}, rowValues(t, result))
+}
+
+func TestRunTruncatesAtMaxRowsAndSaysSo(t *testing.T) {
+	client := mock.NewMockGatewayClientInterface(gomock.NewController(t))
+	completed := statement("COMPLETED", boundedTraits("id"))
+
+	client.EXPECT().GetStatement(testEnvironmentId, testStatementName, testOrganizationId).Return(completed, nil).Times(2)
+	client.EXPECT().GetStatementResults(testEnvironmentId, testStatementName, testOrganizationId, "").
+		Return(page("10", []any{"1"}, []any{"2"}, []any{"3"}), nil)
+
+	options := testOptions(client)
+	options.MaxRows = 2
+
+	result, err := Run(context.Background(), options, testStatementName)
+	require.NoError(t, err)
+	require.True(t, result.Truncated)
+	require.Equal(t, [][]string{{"1"}, {"2"}}, rowValues(t, result))
+}
+
+// Exactly MaxRows rows is not a truncation — nothing was dropped.
+func TestRunDoesNotReportTruncationWhenRowCountEqualsMaxRows(t *testing.T) {
+	client := mock.NewMockGatewayClientInterface(gomock.NewController(t))
+	completed := statement("COMPLETED", boundedTraits("id"))
+
+	client.EXPECT().GetStatement(testEnvironmentId, testStatementName, testOrganizationId).Return(completed, nil).Times(2)
+	client.EXPECT().GetStatementResults(testEnvironmentId, testStatementName, testOrganizationId, "").
+		Return(page("", []any{"1"}, []any{"2"}), nil)
+
+	options := testOptions(client)
+	options.MaxRows = 2
+
+	result, err := Run(context.Background(), options, testStatementName)
+	require.NoError(t, err)
+	require.False(t, result.Truncated)
+	require.Len(t, result.Rows, 2)
+}
+
+func TestRunRejectsAnUnboundedStatement(t *testing.T) {
+	client := mock.NewMockGatewayClientInterface(gomock.NewController(t))
+	traits := boundedTraits("id")
+	traits.IsBounded = flinkgatewayv1.PtrBool(false)
+
+	client.EXPECT().GetStatement(testEnvironmentId, testStatementName, testOrganizationId).
+		Return(statement("RUNNING", traits), nil)
+
+	options := testOptions(client)
+	options.RequireBounded = true
+
+	_, err := Run(context.Background(), options, testStatementName)
+	var unbounded *UnboundedError
+	require.ErrorAs(t, err, &unbounded)
+	require.Equal(t, testStatementName, unbounded.StatementName)
+}
+
+// Without RequireBounded the caller opted into draining whatever comes back.
+func TestRunAllowsUnboundedStatementWhenNotRequired(t *testing.T) {
+	client := mock.NewMockGatewayClientInterface(gomock.NewController(t))
+	traits := boundedTraits("id")
+	traits.IsBounded = flinkgatewayv1.PtrBool(false)
+	completed := statement("COMPLETED", traits)
+
+	client.EXPECT().GetStatement(testEnvironmentId, testStatementName, testOrganizationId).Return(completed, nil).Times(2)
+	client.EXPECT().GetStatementResults(testEnvironmentId, testStatementName, testOrganizationId, "").
+		Return(page("", []any{"1"}), nil)
+
+	result, err := Run(context.Background(), testOptions(client), testStatementName)
+	require.NoError(t, err)
+	require.Len(t, result.Rows, 1)
+}
+
+// A row whose width does not match the schema must fail the run. The shell drops such
+// rows and returns a bool nobody reads, which would mean a short result set here.
+func TestRunFailsOnRowSchemaMismatch(t *testing.T) {
+	client := mock.NewMockGatewayClientInterface(gomock.NewController(t))
+	completed := statement("COMPLETED", boundedTraits("id", "status"))
+
+	client.EXPECT().GetStatement(testEnvironmentId, testStatementName, testOrganizationId).Return(completed, nil).Times(2)
+	client.EXPECT().GetStatementResults(testEnvironmentId, testStatementName, testOrganizationId, "").
+		Return(page("", []any{"1"}), nil)
+
+	_, err := Run(context.Background(), testOptions(client), testStatementName)
+	require.ErrorContains(t, err, "does not match the provided schema")
+}
+
+// DDL and INSERT INTO have no result schema; there is nothing to poll.
+func TestRunSkipsResultsForStatementWithoutSchema(t *testing.T) {
+	client := mock.NewMockGatewayClientInterface(gomock.NewController(t))
+	traits := &flinkgatewayv1.SqlV1StatementTraits{SqlKind: flinkgatewayv1.PtrString("CREATE_TABLE")}
+
+	client.EXPECT().GetStatement(testEnvironmentId, testStatementName, testOrganizationId).
+		Return(statement("COMPLETED", traits), nil)
+
+	result, err := Run(context.Background(), testOptions(client), testStatementName)
+	require.NoError(t, err)
+	require.Empty(t, result.Rows)
+	require.Empty(t, result.Columns)
+}
+
+func TestRunStopsOnCancelledContext(t *testing.T) {
+	client := mock.NewMockGatewayClientInterface(gomock.NewController(t))
+	client.EXPECT().GetStatement(testEnvironmentId, testStatementName, testOrganizationId).
+		Return(statement("PENDING", nil), nil).AnyTimes()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	options := testOptions(client)
+	options.sleep = func(context.Context, time.Duration) error {
+		cancel()
+		return context.Canceled
+	}
+
+	_, err := Run(ctx, options, testStatementName)
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+// A failure fetching a page is wrapped so the caller can tell it apart from a
+// failure reading the statement itself — the gateway's page-retention window is the
+// motivating case, but the wrapping applies to any GetStatementResults failure.
+func TestRunWrapsResultsFetchErrors(t *testing.T) {
+	client := mock.NewMockGatewayClientInterface(gomock.NewController(t))
+	completed := statement("COMPLETED", boundedTraits("id"))
+
+	client.EXPECT().GetStatement(testEnvironmentId, testStatementName, testOrganizationId).Return(completed, nil).Times(2)
+	client.EXPECT().GetStatementResults(testEnvironmentId, testStatementName, testOrganizationId, "").
+		Return(flinkgatewayv1.SqlV1StatementResult{}, errors.New("page not found"))
+
+	_, err := Run(context.Background(), testOptions(client), testStatementName)
+	var resultsErr *ResultsFetchError
+	require.ErrorAs(t, err, &resultsErr)
+	require.ErrorContains(t, err, "page not found")
+}
+
+func TestRunPropagatesGatewayErrors(t *testing.T) {
+	client := mock.NewMockGatewayClientInterface(gomock.NewController(t))
+	client.EXPECT().GetStatement(testEnvironmentId, testStatementName, testOrganizationId).
+		Return(flinkgatewayv1.SqlV1Statement{}, errors.New("unauthorized"))
+
+	_, err := Run(context.Background(), testOptions(client), testStatementName)
+	require.ErrorContains(t, err, "unauthorized")
+}
+
+func TestExtractPageToken(t *testing.T) {
+	tests := []struct {
+		name    string
+		nextUrl string
+		want    string
+	}{
+		{name: "no next url", nextUrl: "", want: ""},
+		{name: "token present", nextUrl: "https://example.com/results?page_token=20", want: "20"},
+		{name: "url without a token", nextUrl: "https://example.com/results", want: ""},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			token, err := extractPageToken(test.nextUrl)
+			require.NoError(t, err)
+			require.Equal(t, test.want, token)
+		})
+	}
+}

--- a/pkg/flink/types/processed_statement.go
+++ b/pkg/flink/types/processed_statement.go
@@ -19,6 +19,8 @@ const (
 	RUNNING   PHASE = "RUNNING"   // More results are available (pagination)
 	COMPLETED PHASE = "COMPLETED" // All results were fetched
 	FAILED    PHASE = "FAILED"
+	STOPPED   PHASE = "STOPPED"  // The statement was stopped; no more results are coming
+	DELETING  PHASE = "DELETING" // The statement is being deleted; no more results are coming
 )
 
 // ProcessedStatement Custom Internal type that shall be used internally by the client

--- a/pkg/flink/types/result_fields.go
+++ b/pkg/flink/types/result_fields.go
@@ -94,6 +94,8 @@ type StatementResultField interface {
 	GetType() StatementResultFieldType
 	ToString() string
 	ToSDKType() any
+	// ToSerializedValue is implemented in result_fields_serialized.go.
+	ToSerializedValue() any
 }
 
 type AtomicStatementResultField struct {

--- a/pkg/flink/types/result_fields_serialized.go
+++ b/pkg/flink/types/result_fields_serialized.go
@@ -1,0 +1,117 @@
+package types
+
+import (
+	"math"
+	"strconv"
+)
+
+// ToSerializedValue renders a result field as a value that carries its SQL type into
+// `-o json` and `-o yaml`, so a consumer reads a number as a number and a NULL as null
+// instead of re-parsing everything out of strings.
+//
+// This is deliberately not ToSDKType. That one produces the gateway's wire shape, where
+// every atom is a string and a MAP is a list of pairs — correct for talking to the API,
+// wrong for handing to a script.
+//
+// Two constraints shape the choices below:
+//
+//   - Only native Go types are used. json.Number renders as a bare literal through
+//     encoding/json but as a quoted string through yaml.v3, which would make the two
+//     output formats disagree.
+//   - A value that cannot be represented natively keeps the exact text the gateway sent
+//     rather than becoming a zero. Losing precision or inventing a plausible number is
+//     worse than a string a caller can see and handle.
+
+func (f AtomicStatementResultField) ToSerializedValue() any {
+	// A NULL arrives as Type Null carrying the literal text "NULL", which is otherwise
+	// indistinguishable from a VARCHAR containing that word.
+	if f.Type == Null {
+		return nil
+	}
+
+	switch f.Type {
+	case Boolean:
+		if value, err := strconv.ParseBool(f.Value); err == nil {
+			return value
+		}
+	case Tinyint, Smallint, Integer:
+		// These top out at 2^31-1, well inside the range a float64 represents exactly,
+		// so every consumer reads them back as the number that was sent. BIGINT is not
+		// in this list — see below.
+		if value, err := strconv.ParseInt(f.Value, 10, 64); err == nil {
+			return value
+		}
+	case Float, Double:
+		// NaN and ±Inf are legal in a DOUBLE column but encoding/json refuses them, and
+		// failing there would take down a whole result set that drained successfully.
+		if value, err := strconv.ParseFloat(f.Value, 64); err == nil && !math.IsNaN(value) && !math.IsInf(value, 0) {
+			return value
+		}
+	}
+
+	// Everything else stays text on purpose:
+	//   - BIGINT reaches past 2^53, where a JSON number stops being exact for any
+	//     consumer that parses into a float64 — JavaScript and jq both do. Emitting
+	//     9007199254740993 as a bare literal silently hands those callers ...992. Go
+	//     would keep it exact, but a wire format has to be read by everyone, so the
+	//     rule is: any integer type that can leave float64's exact range travels as
+	//     text. This is the same reasoning that keeps DECIMAL a string.
+	//   - DECIMAL is arbitrary-precision, and float64 would silently round it
+	//   - DATE, TIME, TIMESTAMP and INTERVAL have no native JSON form, and reformatting
+	//     them would discard the gateway's own rendering
+	//   - CHAR, VARCHAR, BINARY and VARBINARY are already text
+	return f.Value
+}
+
+func (f ArrayStatementResultField) ToSerializedValue() any {
+	// Length rather than nil, so an empty array serializes as [] and not null.
+	values := make([]any, len(f.Values))
+	for idx, value := range f.Values {
+		values[idx] = value.ToSerializedValue()
+	}
+	return values
+}
+
+func (f MapStatementResultField) ToSerializedValue() any {
+	// A map with textual keys is a JSON object, which is what a consumer expects to see.
+	// Anything else cannot become one, so those keep an explicit key/value list instead
+	// of the bare positional pairs ToSDKType emits.
+	if f.KeyType == Char || f.KeyType == Varchar {
+		entries := make(map[string]any, len(f.Entries))
+		for _, entry := range f.Entries {
+			entries[entry.Key.ToString()] = entry.Value.ToSerializedValue()
+		}
+		return entries
+	}
+
+	entries := make([]any, len(f.Entries))
+	for idx, entry := range f.Entries {
+		entries[idx] = map[string]any{
+			"key":   entry.Key.ToSerializedValue(),
+			"value": entry.Value.ToSerializedValue(),
+		}
+	}
+	return entries
+}
+
+func (f RowStatementResultField) ToSerializedValue() any {
+	// A ROW carries no field names, so it stays positional.
+	values := make([]any, len(f.Values))
+	for idx, value := range f.Values {
+		values[idx] = value.ToSerializedValue()
+	}
+	return values
+}
+
+func (f StructuredTypeStatementResultField) ToSerializedValue() any {
+	values := make(map[string]any, len(f.Values))
+	for idx, value := range f.Values {
+		// FieldNames and Values are built together, but a short FieldNames would panic
+		// here, and a partial object beats losing the row.
+		if idx >= len(f.FieldNames) {
+			break
+		}
+		values[f.FieldNames[idx]] = value.ToSerializedValue()
+	}
+	return values
+}

--- a/pkg/flink/types/result_fields_serialized_test.go
+++ b/pkg/flink/types/result_fields_serialized_test.go
@@ -1,0 +1,168 @@
+package types
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAtomicToSerializedValue(t *testing.T) {
+	tests := []struct {
+		name  string
+		field AtomicStatementResultField
+		want  any
+	}{
+		{
+			// A NULL and a CHAR containing the word "NULL" arrive from the gateway as the
+			// same text and are only told apart by the field type. Serializing both as
+			// "NULL" makes them indistinguishable to a consumer.
+			name:  "a NULL becomes JSON null",
+			field: AtomicStatementResultField{Type: Null, Value: "NULL"},
+			want:  nil,
+		},
+		{
+			name:  "a string holding the word NULL stays a string",
+			field: AtomicStatementResultField{Type: Varchar, Value: "NULL"},
+			want:  "NULL",
+		},
+		{name: "integer", field: AtomicStatementResultField{Type: Integer, Value: "3065"}, want: int64(3065)},
+		{name: "negative integer", field: AtomicStatementResultField{Type: Integer, Value: "-7"}, want: int64(-7)},
+		{name: "tinyint", field: AtomicStatementResultField{Type: Tinyint, Value: "12"}, want: int64(12)},
+		{name: "smallint", field: AtomicStatementResultField{Type: Smallint, Value: "300"}, want: int64(300)},
+		{name: "double", field: AtomicStatementResultField{Type: Double, Value: "52.48"}, want: 52.48},
+		{name: "float", field: AtomicStatementResultField{Type: Float, Value: "0.5"}, want: 0.5},
+		{name: "boolean true", field: AtomicStatementResultField{Type: Boolean, Value: "true"}, want: true},
+		{name: "boolean false", field: AtomicStatementResultField{Type: Boolean, Value: "false"}, want: false},
+		{
+			// float64 cannot represent every BIGINT, and a bare JSON literal is read into
+			// a float64 by JavaScript and jq alike.
+			name:  "bigint stays text so it survives a float64 parser",
+			field: AtomicStatementResultField{Type: Bigint, Value: "9007199254740993"},
+			want:  "9007199254740993",
+		},
+		{
+			name:  "decimal stays text so precision is not rounded away",
+			field: AtomicStatementResultField{Type: Decimal, Value: "1.23"},
+			want:  "1.23",
+		},
+		{
+			// encoding/json refuses NaN and ±Inf. Falling back to the gateway's text keeps
+			// a whole drained result set from failing at the last step.
+			name:  "NaN falls back to text rather than failing the marshal",
+			field: AtomicStatementResultField{Type: Double, Value: "NaN"},
+			want:  "NaN",
+		},
+		{
+			name:  "infinity falls back to text",
+			field: AtomicStatementResultField{Type: Double, Value: "Infinity"},
+			want:  "Infinity",
+		},
+		{
+			name:  "a number that does not parse keeps its text instead of becoming zero",
+			field: AtomicStatementResultField{Type: Integer, Value: "not-a-number"},
+			want:  "not-a-number",
+		},
+		{name: "timestamp keeps the gateway's rendering", field: AtomicStatementResultField{Type: TimestampWithoutTimeZone, Value: "2026-08-13 10:00:00"}, want: "2026-08-13 10:00:00"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.want, test.field.ToSerializedValue())
+		})
+	}
+}
+
+// A BIGINT past 2^53 has to survive the round trip a JSON consumer actually performs.
+func TestBigintSurvivesAFloat64Parser(t *testing.T) {
+	const exact = "9007199254740993"
+	field := AtomicStatementResultField{Type: Bigint, Value: exact}
+
+	encoded, err := json.Marshal(map[string]any{"big": field.ToSerializedValue()})
+	require.NoError(t, err)
+
+	// json.Unmarshal into `any` decodes every number as float64, which is what a
+	// JavaScript client does too.
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal(encoded, &decoded))
+	require.Equal(t, exact, decoded["big"], "BIGINT lost precision through a float64 parser")
+}
+
+func TestArrayToSerializedValue(t *testing.T) {
+	field := ArrayStatementResultField{
+		ElementType: Integer,
+		Values: []StatementResultField{
+			AtomicStatementResultField{Type: Integer, Value: "1"},
+			AtomicStatementResultField{Type: Null, Value: "NULL"},
+		},
+	}
+	require.Equal(t, []any{int64(1), nil}, field.ToSerializedValue())
+}
+
+// An empty array must serialize as [] rather than null.
+func TestEmptyArraySerializesAsEmptyList(t *testing.T) {
+	field := ArrayStatementResultField{ElementType: Integer}
+	encoded, err := json.Marshal(field.ToSerializedValue())
+	require.NoError(t, err)
+	require.Equal(t, "[]", string(encoded))
+}
+
+func TestMapWithTextKeysBecomesAnObject(t *testing.T) {
+	field := MapStatementResultField{
+		KeyType:   Varchar,
+		ValueType: Integer,
+		Entries: []MapStatementResultFieldEntry{{
+			Key:   AtomicStatementResultField{Type: Varchar, Value: "a"},
+			Value: AtomicStatementResultField{Type: Integer, Value: "1"},
+		}},
+	}
+	require.Equal(t, map[string]any{"a": int64(1)}, field.ToSerializedValue())
+}
+
+// A JSON object cannot have a non-textual key, so those keep an explicit key/value list.
+func TestMapWithNonTextKeysKeepsPairs(t *testing.T) {
+	field := MapStatementResultField{
+		KeyType:   Integer,
+		ValueType: Varchar,
+		Entries: []MapStatementResultFieldEntry{{
+			Key:   AtomicStatementResultField{Type: Integer, Value: "1"},
+			Value: AtomicStatementResultField{Type: Varchar, Value: "a"},
+		}},
+	}
+	require.Equal(t, []any{map[string]any{"key": int64(1), "value": "a"}}, field.ToSerializedValue())
+}
+
+func TestRowStaysPositional(t *testing.T) {
+	field := RowStatementResultField{
+		ElementTypes: []StatementResultFieldType{Integer, Varchar},
+		Values: []StatementResultField{
+			AtomicStatementResultField{Type: Integer, Value: "1"},
+			AtomicStatementResultField{Type: Varchar, Value: "a"},
+		},
+	}
+	require.Equal(t, []any{int64(1), "a"}, field.ToSerializedValue())
+}
+
+func TestStructuredTypeUsesFieldNames(t *testing.T) {
+	field := StructuredTypeStatementResultField{
+		FieldNames: []string{"id", "label"},
+		FieldTypes: []StatementResultFieldType{Integer, Varchar},
+		Values: []StatementResultField{
+			AtomicStatementResultField{Type: Integer, Value: "1"},
+			AtomicStatementResultField{Type: Varchar, Value: "a"},
+		},
+	}
+	require.Equal(t, map[string]any{"id": int64(1), "label": "a"}, field.ToSerializedValue())
+}
+
+// Fewer names than values must not panic; a partial object beats losing the row.
+func TestStructuredTypeWithShortFieldNamesDoesNotPanic(t *testing.T) {
+	field := StructuredTypeStatementResultField{
+		FieldNames: []string{"id"},
+		Values: []StatementResultField{
+			AtomicStatementResultField{Type: Integer, Value: "1"},
+			AtomicStatementResultField{Type: Varchar, Value: "dropped"},
+		},
+	}
+	require.Equal(t, map[string]any{"id": int64(1)}, field.ToSerializedValue())
+}

--- a/pkg/flink/types/statement_traits.go
+++ b/pkg/flink/types/statement_traits.go
@@ -28,6 +28,30 @@ func (s *StatementTraits) GetUpsertColumns() *[]int32 {
 	return nil
 }
 
+// GetIsBounded reports whether the gateway has told us the statement produces a
+// finite result set. The second return value is false when the trait is absent,
+// which happens before the statement leaves PENDING.
+func (s *StatementTraits) GetIsBounded() (bool, bool) {
+	if s.FlinkGatewayV1StatementTraits != nil && s.FlinkGatewayV1StatementTraits.IsBounded != nil {
+		return s.FlinkGatewayV1StatementTraits.GetIsBounded(), true
+	} else if s.CmfStatementTraits != nil && s.CmfStatementTraits.IsBounded != nil {
+		return s.CmfStatementTraits.GetIsBounded(), true
+	}
+	return false, false
+}
+
+// GetIsAppendOnly reports whether the statement only ever emits insertions, in
+// which case the changelog and the materialized table are the same thing. The
+// second return value is false when the trait is absent.
+func (s *StatementTraits) GetIsAppendOnly() (bool, bool) {
+	if s.FlinkGatewayV1StatementTraits != nil && s.FlinkGatewayV1StatementTraits.IsAppendOnly != nil {
+		return s.FlinkGatewayV1StatementTraits.GetIsAppendOnly(), true
+	} else if s.CmfStatementTraits != nil && s.CmfStatementTraits.IsAppendOnly != nil {
+		return s.CmfStatementTraits.GetIsAppendOnly(), true
+	}
+	return false, false
+}
+
 func (s *StatementTraits) GetColumnNames() []string {
 	var columnNames []string
 	if s.FlinkGatewayV1StatementTraits != nil {

--- a/test/test-server/flink_gateway_router.go
+++ b/test/test-server/flink_gateway_router.go
@@ -263,6 +263,17 @@ func handleStatementUpdate(t *testing.T) http.HandlerFunc {
 		principal := req.Spec.GetPrincipal()
 		computePool := req.Spec.GetComputePoolId()
 
+		// The real gateway replaces the statement wholesale rather than patching it,
+		// and rejects a body that omits the SQL text with "Statement is nil or empty".
+		// Reject it here too: a mock more permissive than the gateway let a broken
+		// stop path pass every test and only fail against staging.
+		if req.Spec.GetStatement() == "" {
+			w.WriteHeader(http.StatusBadRequest)
+			err = writeError(w, "Request is malformed: Violations: Statement is nil or empty")
+			require.NoError(t, err)
+			return
+		}
+
 		// Handle the stop case, principal and computerPool shouldn't matter
 		if stopped {
 			w.WriteHeader(http.StatusAccepted)


### PR DESCRIPTION

Implements the client-side path for one-shot Flink SQL snapshot queries (INIT-6549 M1, PRD R3): submit → block → drain every page → print → exit non-zero on failure.

example use case:
```console
$ confluent query --sql "SELECT order_id, status FROM orders LIMIT 2;" --compute-pool lfcp-123456 --database my-cluster
+----------+---------+
| order_id | status  |
+----------+---------+
| 1021     | SHIPPED |
| 1044     | PENDING |
+----------+---------+
```

Mounted at the top level (`confluent query`), not under `flink statement` — per discussion with @fleidcc, the same one-shot ergonomics should extend to other backends (e.g. Lightning Tables) later without a rename. `-o json`/`-o yaml` default to a self-describing envelope (schema + rows); `--raw` gives a bare row array.

**Verified against real staging.** Submit → multi-page drain → exit-code behavior confirmed on a real compute pool. That run found and fixed two defects:

1. **Stop path was broken.** The gateway rejects a body carrying only `spec.stopped`; every stop (interrupt, timeout, unbounded rejection) left the statement `RUNNING`. Fixed by reading the statement back and flipping the flag on it, like `statement stop` does. The mock server was more permissive than the real gateway and missed this — it's now strict enough to catch it.
2. **Values serialized as strings only** (e.g. an `INTEGER` came back as `"3065"`). Now type-aware: numbers as numbers, `NULL` as `null`.

Why a separate drain loop instead of the shell's `Store`/`ResultFetcher` pipeline: that pipeline is built for a scrolling viewer and degrades silently in ways that become real bugs for a script reading stdout (row-cap eviction, schema-mismatch rows dropped, "done" inferred from a missing page token without checking phase). This drain loop reports each of those conditions instead of hiding them.

**Not done:** on-prem support, statement cleanup on success, `--unsafe-trace` still dumps row data, no token-refresh-aware retry beyond a best-effort refresh before each call.

**Testing:** 14 unit tests over a mocked gateway (multi-page drain, empty-token-while-running, `--max-rows` boundary, unbounded rejection, schema mismatch, cancellation). `make lint-cli` clean. Integration goldens deferred — the mount point and flags are still in flux pending PM sign-off.

