### PR TITLE
fix(test): isolate `confluent update` tests from the shared test binary

### DIFF
--- a/test/cli_test.go
+++ b/test/cli_test.go
@@ -59,6 +59,9 @@ type CLITest struct {
 	exitCode int
 	// If true, don't reset the config/state between tests to enable testing CLI workflows
 	workflow bool
+	// If true, run the CLI from a private copy of the test binary; for tests which replace
+	// the running binary, such as `confluent update`
+	isolatedBin bool
 	// An optional function that allows you to specify other calls
 	wantFunc func(t *testing.T)
 	input    string
@@ -118,6 +121,11 @@ func (s *CLITestSuite) runIntegrationTest(test CLITest) {
 			resetConfiguration(t, test.arePluginsEnabled)
 		}
 
+		bin := testBin
+		if test.isolatedBin {
+			bin = copyTestBin(t)
+		}
+
 		// Executes login command if test specifies
 		switch test.login {
 		case "cloud":
@@ -135,34 +143,34 @@ func (s *CLITestSuite) runIntegrationTest(test CLITest) {
 				}
 			}()
 
-			output := runCommand(t, testBin, env, loginString, 0, "")
+			output := runCommand(t, bin, env, loginString, 0, "")
 			if *debug {
 				fmt.Println(output)
 			}
 		case "onprem":
 			loginURL := s.getLoginURL(false, test)
 			env := []string{pauth.ConfluentPlatformUsername + "=fake@user.com", pauth.ConfluentPlatformPassword + "=pass1"}
-			output := runCommand(t, testBin, env, "login --url "+loginURL, 0, "")
+			output := runCommand(t, bin, env, "login --url "+loginURL, 0, "")
 			if *debug {
 				fmt.Println(output)
 			}
 		}
 
 		if test.useKafka != "" {
-			output := runCommand(t, testBin, []string{}, fmt.Sprintf("kafka cluster use %s", test.useKafka), 0, "")
+			output := runCommand(t, bin, []string{}, fmt.Sprintf("kafka cluster use %s", test.useKafka), 0, "")
 			if *debug {
 				fmt.Println(output)
 			}
 		}
 
 		if test.authKafka {
-			output := runCommand(t, testBin, []string{}, fmt.Sprintf("api-key create --resource %s --use", test.useKafka), 0, "")
+			output := runCommand(t, bin, []string{}, fmt.Sprintf("api-key create --resource %s --use", test.useKafka), 0, "")
 			if *debug {
 				fmt.Println(output)
 			}
 		}
 
-		output := runCommand(t, testBin, test.env, test.args, test.exitCode, test.input)
+		output := runCommand(t, bin, test.env, test.args, test.exitCode, test.input)
 		if *debug {
 			fmt.Println(output)
 		}
@@ -205,6 +213,30 @@ func (s *CLITestSuite) validateTestOutput(test CLITest, t *testing.T, output str
 	}
 }
 
+// copyTestBin copies the test binary into its own temporary directory and returns the
+// absolute path to the copy. `confluent update` replaces the running binary and leaves a
+// `.confluent.exe.old` sidecar beside it; on Windows that sidecar stays locked by the
+// process which just exited, so consecutive updates sharing a directory fail to rename
+// over it. Giving each test its own directory keeps those sidecars from colliding, and
+// leaves the shared test binary untouched.
+func copyTestBin(t *testing.T) string {
+	// SetupSuite has already suffixed testBin with ".exe" on Windows.
+	binary, err := os.ReadFile(testBin)
+	require.NoError(t, err)
+
+	dir, err := os.MkdirTemp("", "confluent-test-bin")
+	require.NoError(t, err)
+
+	// Best effort: on Windows the sidecar may still be locked by the process which just
+	// exited, and failing to clean up a temporary directory shouldn't fail the test.
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+
+	path := filepath.Join(dir, filepath.Base(testBin))
+	require.NoError(t, os.WriteFile(path, binary, 0755))
+
+	return path
+}
+
 func runCommand(t *testing.T, binaryName string, env []string, argString string, exitCode int, input string) string {
 	dir, err := os.Getwd()
 	require.NoError(t, err)
@@ -221,7 +253,12 @@ func runCommand(t *testing.T, binaryName string, env []string, argString string,
 	args, err := shlex.Split(argString)
 	require.NoError(t, err)
 
-	cmd := exec.Command(filepath.Join(dir, binaryName), args...)
+	binaryPath := binaryName
+	if !filepath.IsAbs(binaryPath) {
+		binaryPath = filepath.Join(dir, binaryPath)
+	}
+
+	cmd := exec.Command(binaryPath, args...)
 	cmd.Env = append(os.Environ(), env...)
 	cmd.Stdin = strings.NewReader(input)
 

--- a/test/update_test.go
+++ b/test/update_test.go
@@ -1,12 +1,14 @@
 package test
 
 func (s *CLITestSuite) TestUpdate() {
+	// Tests which accept the update replace the running binary, so each one needs its own
+	// copy of it; declining the update leaves the binary alone.
 	tests := []CLITest{
-		{args: "update", fixture: "update/update.golden", input: "y\n"},
+		{args: "update", fixture: "update/update.golden", input: "y\n", isolatedBin: true},
 		{args: "update", fixture: "update/update-no.golden", input: "n\n"},
-		{args: "update --major", fixture: "update/update-major.golden", input: "y\n"},
-		{args: "update --no-verify", fixture: "update/update.golden", input: "y\n"},
-		{args: "update --yes", fixture: "update/update-yes.golden"},
+		{args: "update --major", fixture: "update/update-major.golden", input: "y\n", isolatedBin: true},
+		{args: "update --no-verify", fixture: "update/update.golden", input: "y\n", isolatedBin: true},
+		{args: "update --yes", fixture: "update/update-yes.golden", isolatedBin: true},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Release Notes
-------------
No user-facing changes. This PR touches integration test code only.

Checklist
---------
- [x] I have successfully built and used a custom CLI binary, without linter issues from this PR.
- [x] I have clearly specified in the `What` section below whether this PR applies to Confluent Cloud, Confluent Platform, or both.
- [ ] I have verified this PR in Confluent Cloud pre-prod or production environment, if applicable. — N/A, test-only change
- [ ] I have verified this PR in Confluent Platform on-premises environment, if applicable. — N/A, test-only change
- [x] I have attached manual CLI verification results or screenshots in the `Test & Review` section below.
- [x] I have added appropriate CLI integration or unit tests for any new or updated commands and functionality. — no new commands; this PR fixes existing integration tests
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [x] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [ ] I have put checkmarks below confirming that the feature associated with this PR is enabled in: — N/A, no feature
  - [ ] Confluent Cloud prod
  - [ ] Confluent Cloud stag
  - [ ] Confluent Platform
  - [ ] Check this box if the feature is enabled for certain organizations only

What
----
Applies to **neither Cloud nor Platform** — this changes integration test code only, no shipped CLI behavior.

Fixes the `windows/amd64` CI job, which has failed on **every push to `main` since 2026-08-12**.

`confluent update` replaces the running binary. `go-update`'s `Apply` renames the
current binary to a `.confluent.exe.old` sidecar, swaps the new binary into place, then
deletes the sidecar. On Windows that final delete *always* fails, because the process is
still executing from that image — `go-update` swallows the error and hides the file
instead. The sidecar therefore survives the test.

All five `TestUpdate` subtests shared one binary at `test/bin/confluent`, so the next
subtest to accept an update found a stale sidecar still locked by the process that had
just exited. Its rename onto that path failed:

```
Error: rename ...\test\bin\confluent.exe ...\test\bin\.confluent.exe.old:
The process cannot access the file because it is being used by another process.
```

Which subtests fail varies run to run (`--major` alone, or `--major` + `--no-verify`),
but the job itself has failed every time since Aug 12.

**Fix:** each subtest that accepts an update now runs from its own copy of the binary in
its own temp directory, so the sidecars can no longer collide. As a side benefit the
shared `test/bin/confluent` is no longer swapped out from under the rest of the suite
mid-run.

Two notes for reviewers:

- The latent defect has been there since the `confluent update` rewrite (#2876); nothing
  in the CLI changed on Aug 12 to trigger it. The suspicious correlate is that the
  integration suite got 36–51% slower on the Windows agents at exactly that point
  (981s → 1335–1481s) while the unit step got *faster*, which is consistent with slower
  process teardown widening the race. Same agent AMI before and after, so it isn't an
  image rollover. The fix doesn't depend on identifying the trigger — the test was racy
  by construction.
- The `windows/amd64` block in `.semaphore/semaphore.yml` is gated `run: when: "branch =
  'main'"`, so **PR CI will not exercise this fix**. It can only be confirmed green after
  merge. That gating is also why the breakage kept landing on `main` undetected.

Blast Radius
----
None for customers. Test-only change; no shipped CLI code paths are modified. If the fix
is wrong, the impact is confined to CI: the `windows/amd64` job stays red exactly as it is
today.

References
----------
- Failing pipeline: https://semaphore.ci.confluent.io/workflows/f9e4296e-8a34-4edf-abc0-a6bf7251fa4e
- `go-update` `Apply` sidecar logic: `apply.go` lines 135–138 (the ignored `os.Remove`, then the failing `os.Rename`)

Test & Review
-------------
Verified locally on darwin/arm64 (Go 1.26.5, matching `.go-version`).

The inode of `test/bin/confluent` is the clean signal: a rename-swap changes it, while the
rebuild `SetupSuite` performs on every run does not.

| | `test/bin/confluent` inode after `TestUpdate` |
|---|---|
| before this PR | `143822062` → `143840893` (rename-swapped) |
| with this PR | unchanged across two consecutive runs |

- `go test ./test/ -run 'TestCLI/TestUpdate'` passes; no `.old` sidecar is left in `test/bin/`.
- `go vet ./test/`, `golangci-lint run ./test/...`, and `gofmt` are all clean.
- Full `go test ./test/` run: the only failures are 11 `TestCLI/TestFlinkShell` and
  `TestCLI/TestFlinkShellOnPrem` subtests. Running those same two suites against unmodified
  `origin/main` produces a byte-identical failure set, so this PR introduces no new failures.
  They are a pre-existing, macOS-specific failure in interactive-shell tests that build their
  own `exec.Cmd` and never go through `runIntegrationTest`/`runCommand`; the Linux CI job
  passes, so they do not affect CI. Unrelated to this change.

Note that the actual Windows failure cannot be reproduced on macOS — POSIX allows unlinking
a running binary, so the sidecar never survives there. The change is verified by the
mechanism (no shared sidecar path) rather than by reproducing the platform-specific symptom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
