### PR TITLE
fix(CI): read Vault secrets by field-agnostic import in Windows smoke job

### DIFF
--- a/.semaphore/smoke-tests.yml
+++ b/.semaphore/smoke-tests.yml
@@ -64,9 +64,36 @@ blocks:
             # following the pattern from cli-release/.semaphore/4-release-cli.yml).
             - $Env:VAULT_ADDR = "https://vault.cireops.gcp.internal.confluent.cloud"
             - vault login -no-print token=$(vault write -field=token "auth/semaphore_self_hosted/login" role="default" jwt="$Env:SEMAPHORE_OIDC_TOKEN")
-            - $Env:CONFLUENT_CLOUD_EMAIL = (vault kv get -field=CONFLUENT_CLOUD_EMAIL v1/ci/kv/apif/cli/live-testing-data)
-            - $Env:CONFLUENT_CLOUD_PASSWORD = (vault kv get -field=CONFLUENT_CLOUD_PASSWORD v1/ci/kv/apif/cli/live-testing-data)
-            - $Env:SLACK_WEBHOOK_URL = (vault kv get -field=SLACK_WEBHOOK_URL v1/ci/kv/apif/cli/slack-notifications-live-testing)
+            # Read whole secrets and export every field as an uppercased variable, which is
+            # what `vault-sem-get-secret` does for the linux/arm64 job above. Asking for
+            # named fields instead (`-field=CONFLUENT_CLOUD_EMAIL`) failed with `Field
+            # "CONFLUENT_CLOUD_EMAIL" not present in secret`, because the fields are not
+            # stored under those exact names -- the linux helper is what uppercases them.
+            # Never echo the values: only field names are ever printed.
+            - |
+              function Import-VaultSecret($Path) {
+                $secret = vault kv get -format=json $Path | ConvertFrom-Json
+                if ($LASTEXITCODE -ne 0) { throw "failed to read Vault secret $Path" }
+
+                # KV v2 nests fields under .data.data; KV v1 puts them directly on .data.
+                $fields = if ($secret.data.PSObject.Properties.Name -contains "data") { $secret.data.data } else { $secret.data }
+
+                foreach ($field in $fields.PSObject.Properties) {
+                  [Environment]::SetEnvironmentVariable($field.Name.ToUpper(), $field.Value)
+                }
+                Write-Host "Imported $Path fields: $(($fields.PSObject.Properties.Name | Sort-Object) -join ', ')"
+              }
+
+              Import-VaultSecret v1/ci/kv/apif/cli/live-testing-data
+              Import-VaultSecret v1/ci/kv/apif/cli/slack-notifications-live-testing
+
+              # Fail here rather than 20 minutes later inside `go test`, which would only
+              # report "required environment variable ... is not set".
+              foreach ($name in @("CONFLUENT_CLOUD_EMAIL", "CONFLUENT_CLOUD_PASSWORD", "SLACK_WEBHOOK_URL")) {
+                if (-not [Environment]::GetEnvironmentVariable($name)) {
+                  throw "$name is not set after importing Vault secrets"
+                }
+              }
 
             # Install Go (matches the pattern in semaphore.yml; chocolatey is community-maintained)
             - $ProgressPreference = 'SilentlyContinue'; Invoke-WebRequest -OutFile Go.zip -Uri https://go.dev/dl/go$(Get-Content .go-version).windows-amd64.zip -UseBasicParsing

--- a/.semaphore/smoke-tests.yml
+++ b/.semaphore/smoke-tests.yml
@@ -64,36 +64,45 @@ blocks:
             # following the pattern from cli-release/.semaphore/4-release-cli.yml).
             - $Env:VAULT_ADDR = "https://vault.cireops.gcp.internal.confluent.cloud"
             - vault login -no-print token=$(vault write -field=token "auth/semaphore_self_hosted/login" role="default" jwt="$Env:SEMAPHORE_OIDC_TOKEN")
-            # Read whole secrets and export every field as an uppercased variable, which is
-            # what `vault-sem-get-secret` does for the linux/arm64 job above. Asking for
-            # named fields instead (`-field=CONFLUENT_CLOUD_EMAIL`) failed with `Field
-            # "CONFLUENT_CLOUD_EMAIL" not present in secret`, because the fields are not
-            # stored under those exact names -- the linux helper is what uppercases them.
-            # Never echo the values: only field names are ever printed.
+            # Match fields case-insensitively rather than by exact name. Asking for
+            # `-field=CONFLUENT_CLOUD_EMAIL` failed with `Field "CONFLUENT_CLOUD_EMAIL" not
+            # present in secret`, because the fields are not stored under the names they are
+            # exported as -- on linux/arm64 above, `vault-sem-get-secret` is what maps them.
+            # Only the three variables the job needs are exported, so unrelated fields in
+            # these secrets never reach the environment of `go test` and its children.
+            # Values are never echoed; only field names appear, and only on failure.
             - |
-              function Import-VaultSecret($Path) {
-                $secret = vault kv get -format=json $Path | ConvertFrom-Json
+              function Get-VaultSecret($Path) {
+                # Check the exit code before parsing: on a partial or malformed response,
+                # ConvertFrom-Json can echo the offending input, which may hold secrets.
+                $json = vault kv get -format=json $Path
                 if ($LASTEXITCODE -ne 0) { throw "failed to read Vault secret $Path" }
 
-                # KV v2 nests fields under .data.data; KV v1 puts them directly on .data.
-                $fields = if ($secret.data.PSObject.Properties.Name -contains "data") { $secret.data.data } else { $secret.data }
+                $secret = $json | ConvertFrom-Json
 
-                foreach ($field in $fields.PSObject.Properties) {
-                  [Environment]::SetEnvironmentVariable($field.Name.ToUpper(), $field.Value)
-                }
-                Write-Host "Imported $Path fields: $(($fields.PSObject.Properties.Name | Sort-Object) -join ', ')"
+                # KV v2 nests fields under .data.data; KV v1 puts them directly on .data.
+                if ($secret.data.PSObject.Properties.Name -contains "data") { return $secret.data.data }
+                return $secret.data
               }
 
-              Import-VaultSecret v1/ci/kv/apif/cli/live-testing-data
-              Import-VaultSecret v1/ci/kv/apif/cli/slack-notifications-live-testing
+              function Export-VaultField($Fields, $Name) {
+                $field = $Fields.PSObject.Properties | Where-Object { $_.Name -ieq $Name } | Select-Object -First 1
+                if (-not $field) {
+                  throw "no field matching '$Name' in secret (available: $(($Fields.PSObject.Properties.Name | Sort-Object) -join ', '))"
+                }
+                if ([string]::IsNullOrEmpty($field.Value)) { throw "field matching '$Name' is empty" }
+
+                [Environment]::SetEnvironmentVariable($Name, $field.Value)
+              }
 
               # Fail here rather than 20 minutes later inside `go test`, which would only
               # report "required environment variable ... is not set".
-              foreach ($name in @("CONFLUENT_CLOUD_EMAIL", "CONFLUENT_CLOUD_PASSWORD", "SLACK_WEBHOOK_URL")) {
-                if (-not [Environment]::GetEnvironmentVariable($name)) {
-                  throw "$name is not set after importing Vault secrets"
-                }
-              }
+              $liveTestingData = Get-VaultSecret v1/ci/kv/apif/cli/live-testing-data
+              Export-VaultField $liveTestingData "CONFLUENT_CLOUD_EMAIL"
+              Export-VaultField $liveTestingData "CONFLUENT_CLOUD_PASSWORD"
+
+              $slackNotifications = Get-VaultSecret v1/ci/kv/apif/cli/slack-notifications-live-testing
+              Export-VaultField $slackNotifications "SLACK_WEBHOOK_URL"
 
             # Install Go (matches the pattern in semaphore.yml; chocolatey is community-maintained)
             - $ProgressPreference = 'SilentlyContinue'; Invoke-WebRequest -OutFile Go.zip -Uri https://go.dev/dl/go$(Get-Content .go-version).windows-amd64.zip -UseBasicParsing

--- a/.semaphore/smoke-tests.yml
+++ b/.semaphore/smoke-tests.yml
@@ -64,45 +64,50 @@ blocks:
             # following the pattern from cli-release/.semaphore/4-release-cli.yml).
             - $Env:VAULT_ADDR = "https://vault.cireops.gcp.internal.confluent.cloud"
             - vault login -no-print token=$(vault write -field=token "auth/semaphore_self_hosted/login" role="default" jwt="$Env:SEMAPHORE_OIDC_TOKEN")
-            # Match fields case-insensitively rather than by exact name. Asking for
+            # These secrets keep everything in a single field named "script", whose value is
+            # a shell script of `export NAME=value` lines. That is why asking for
             # `-field=CONFLUENT_CLOUD_EMAIL` failed with `Field "CONFLUENT_CLOUD_EMAIL" not
-            # present in secret`, because the fields are not stored under the names they are
-            # exported as -- on linux/arm64 above, `vault-sem-get-secret` is what maps them.
-            # Only the three variables the job needs are exported, so unrelated fields in
-            # these secrets never reach the environment of `go test` and its children.
-            # Values are never echoed; only field names appear, and only on failure.
+            # present in secret` -- no such field exists. The linux/arm64 job above sources
+            # that script; PowerShell cannot, so parse the assignments out of it instead.
+            # Only the variables the job needs are exported, so anything else these secrets
+            # define never reaches the environment of `go test` and its children.
+            # Values are never echoed; only variable names appear, and only on failure.
             - |
-              function Get-VaultSecret($Path) {
-                # Check the exit code before parsing: on a partial or malformed response,
-                # ConvertFrom-Json can echo the offending input, which may hold secrets.
-                $json = vault kv get -format=json $Path
+              function Import-VaultScript($Path, $Names) {
+                # Check the exit code before touching the output: on a partial response,
+                # downstream errors could echo the input, which holds secrets.
+                $script = vault kv get -field=script $Path
                 if ($LASTEXITCODE -ne 0) { throw "failed to read Vault secret $Path" }
 
-                $secret = $json | ConvertFrom-Json
+                $defined = @{}
+                foreach ($line in ($script -split "\r?\n")) {
+                  if ($line -notmatch '^\s*(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*)$') { continue }
 
-                # KV v2 nests fields under .data.data; KV v1 puts them directly on .data.
-                if ($secret.data.PSObject.Properties.Name -contains "data") { return $secret.data.data }
-                return $secret.data
-              }
+                  $name = $Matches[1]
+                  $value = $Matches[2].Trim()
 
-              function Export-VaultField($Fields, $Name) {
-                $field = $Fields.PSObject.Properties | Where-Object { $_.Name -ieq $Name } | Select-Object -First 1
-                if (-not $field) {
-                  throw "no field matching '$Name' in secret (available: $(($Fields.PSObject.Properties.Name | Sort-Object) -join ', '))"
+                  # Strip one layer of surrounding quotes, as `source` would.
+                  foreach ($quote in '"', "'") {
+                    if ($value.Length -ge 2 -and $value.StartsWith($quote) -and $value.EndsWith($quote)) {
+                      $value = $value.Substring(1, $value.Length - 2)
+                      break
+                    }
+                  }
+                  $defined[$name] = $value
                 }
-                if ([string]::IsNullOrEmpty($field.Value)) { throw "field matching '$Name' is empty" }
 
-                [Environment]::SetEnvironmentVariable($Name, $field.Value)
+                # Fail here rather than 20 minutes later inside `go test`, which would only
+                # report "required environment variable ... is not set".
+                foreach ($name in $Names) {
+                  if (-not $defined.ContainsKey($name) -or [string]::IsNullOrEmpty($defined[$name])) {
+                    throw "secret $Path does not define $name (defines: $(($defined.Keys | Sort-Object) -join ', '))"
+                  }
+                  [Environment]::SetEnvironmentVariable($name, $defined[$name])
+                }
               }
 
-              # Fail here rather than 20 minutes later inside `go test`, which would only
-              # report "required environment variable ... is not set".
-              $liveTestingData = Get-VaultSecret v1/ci/kv/apif/cli/live-testing-data
-              Export-VaultField $liveTestingData "CONFLUENT_CLOUD_EMAIL"
-              Export-VaultField $liveTestingData "CONFLUENT_CLOUD_PASSWORD"
-
-              $slackNotifications = Get-VaultSecret v1/ci/kv/apif/cli/slack-notifications-live-testing
-              Export-VaultField $slackNotifications "SLACK_WEBHOOK_URL"
+              Import-VaultScript v1/ci/kv/apif/cli/live-testing-data @("CONFLUENT_CLOUD_EMAIL", "CONFLUENT_CLOUD_PASSWORD")
+              Import-VaultScript v1/ci/kv/apif/cli/slack-notifications-live-testing @("SLACK_WEBHOOK_URL")
 
             # Install Go (matches the pattern in semaphore.yml; chocolatey is community-maintained)
             - $ProgressPreference = 'SilentlyContinue'; Invoke-WebRequest -OutFile Go.zip -Uri https://go.dev/dl/go$(Get-Content .go-version).windows-amd64.zip -UseBasicParsing

--- a/.semaphore/smoke-tests.yml
+++ b/.semaphore/smoke-tests.yml
@@ -76,24 +76,26 @@ blocks:
               function Import-VaultScript($Path, $Names) {
                 # Check the exit code before touching the output: on a partial response,
                 # downstream errors could echo the input, which holds secrets.
-                $script = vault kv get -field=script $Path
+                $exports = vault kv get -field=script $Path
                 if ($LASTEXITCODE -ne 0) { throw "failed to read Vault secret $Path" }
 
+                # Hashtable keys are case-insensitive, so the lookups below still succeed if
+                # the script happens to declare these names under a different case.
                 $defined = @{}
-                foreach ($line in ($script -split "\r?\n")) {
-                  if ($line -notmatch '^\s*(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*)$') { continue }
+                foreach ($line in ($exports -split "\r?\n")) {
+                  if ($line -match '^\s*(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*)$') {
+                    $name = $Matches[1]
+                    $value = $Matches[2].Trim()
 
-                  $name = $Matches[1]
-                  $value = $Matches[2].Trim()
-
-                  # Strip one layer of surrounding quotes, as `source` would.
-                  foreach ($quote in '"', "'") {
-                    if ($value.Length -ge 2 -and $value.StartsWith($quote) -and $value.EndsWith($quote)) {
-                      $value = $value.Substring(1, $value.Length - 2)
-                      break
+                    # Strip one layer of surrounding quotes, as `source` would.
+                    foreach ($quote in '"', "'") {
+                      if ($value.Length -ge 2 -and $value.StartsWith($quote) -and $value.EndsWith($quote)) {
+                        $value = $value.Substring(1, $value.Length - 2)
+                        break
+                      }
                     }
+                    $defined[$name] = $value
                   }
-                  $defined[$name] = $value
                 }
 
                 # Fail here rather than 20 minutes later inside `go test`, which would only


### PR DESCRIPTION
Release Notes
-------------
No user-facing changes. This PR touches CI pipeline configuration only.

Checklist
---------
- [ ] I have successfully built and used a custom CLI binary, without linter issues from this PR. — N/A, no Go code changed
- [x] I have clearly specified in the `What` section below whether this PR applies to Confluent Cloud, Confluent Platform, or both.
- [ ] I have verified this PR in Confluent Cloud pre-prod or production environment, if applicable. — N/A, CI-only change
- [ ] I have verified this PR in Confluent Platform on-premises environment, if applicable. — N/A, CI-only change
- [x] I have attached verification results in the `Test & Review` section below — including an explicit statement of what could **not** be verified.
- [ ] I have added appropriate CLI integration or unit tests for any new or updated commands and functionality. — N/A, no commands changed
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [x] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [ ] I have put checkmarks below confirming that the feature associated with this PR is enabled in: — N/A, no feature
  - [ ] Confluent Cloud prod
  - [ ] Confluent Cloud stag
  - [ ] Confluent Platform
  - [ ] Check this box if the feature is enabled for certain organizations only

What
----
Applies to **neither Cloud nor Platform** — this changes `.semaphore/smoke-tests.yml` only, no shipped CLI code.

The `Smoke windows/amd64` job has failed on **every run since it was introduced** in #3342 on 2026-05-01 — roughly 3.5 months at a 3-hourly cadence, each failure firing a Slack notification. It always dies on the same line:

```
Field "CONFLUENT_CLOUD_EMAIL" not present in secret
```

### Root cause

These CI secrets do not store one field per credential. They keep everything in a **single field named `script`**, whose value is a shell script of `export NAME=value` lines. The helper the `linux/arm64` job uses requests that one field and sources it; it performs no mapping or renaming of variable names, and the vault helper it calls beforehand only handles OIDC auth.

So there is no `CONFLUENT_CLOUD_EMAIL` field at all — which is exactly what Vault reported. The Windows job hand-rolled the read with `vault kv get -field=<VARIABLE NAME>` because the helper is Linux-only, and every lookup missed.

### Fix

Read the `script` field and parse the assignments out of it, since PowerShell cannot source a shell script. The parser tolerates `export` or bare assignments, surrounding single or double quotes, values containing `=`, and skips comments and blank lines.

Only the variables the job needs are exported. Deliberately **not** "export everything the script defines": that would put unrelated values into the environment inherited by `go test`, the CLI under test, and the metric emitter, for no benefit.

### This is a CLI-side bug, not a Vault or DevOps problem

Worth stating, since "Vault error" reads like someone else's issue:

| Evidence | What it rules out |
|---|---|
| `vault login` exits **0** on the Windows agent | Auth, OIDC role, network reachability, token issuance |
| Error is `Field ... not present in secret` | The read *succeeded*. Permission errors say `permission denied`; bad paths say `No value found at ...` |
| linux/arm64 reads the **same secret path** and passes | The secret exists, holds valid credentials, and the CI role can read it |
| These lines were never modified after the commit that added them | No previously-working state exists, so no Vault-side change broke it |

The job was merged having never passed once. Nothing needs to change in Vault or in DevOps tooling to fix it.

Blast Radius
----
**None for customers.** No shipped CLI code paths are modified.

CI risk is close to zero because the job fails 100% of the time today — there is no working behavior to regress. The worst case is that it keeps failing, which is the status quo. The `linux/arm64` block is byte-for-byte untouched, so existing smoke coverage is unaffected either way.

The one CI-level risk worth naming is a malformed pipeline definition, which could take the *passing* Linux job down with it. Mitigated: the YAML parses, and the `- |` multi-line PowerShell construct is already used twice in this file, including in this same Windows job.

No false-green risk: a missing or empty variable throws at import, and `requiredEnv` in the live tests fatals on an empty value. The job cannot pass without real credentials.

### Security notes

- **No change to what is read from Vault.** The same secret paths are read with the same token and the same read-only operation. Only what reaches the environment changes, and it is limited to the three variables the job needs.
- **The exit code is checked before the output is used**, so a partial or malformed response cannot end up echoed through a downstream parse error.
- **No values are ever echoed.** The success path prints nothing. The only error paths emit a vault path, a variable name, and — on a missing variable — the list of variable *names* the script defines.
- **Nothing sensitive is added to this public repo.** The diff contains only vault paths and variable names, all of which were already present in the file.

References
----------
- Introduced the broken job: #3342
- Latest failing run: https://semaphore.ci.confluent.io/workflows/3d4dfaed-4674-451b-8c2b-a37eb387a25e
- Companion CI fix (the `windows/amd64` build/test job, now green on main): #3445

Test & Review
-------------
Verified:

- The regex and quote-stripping semantics were run against representative `source`-able lines — `export NAME=value`, double- and single-quoted values, a quoted value containing `=`, a bare assignment with no `export`, extra whitespace, and comment/blank/garbage lines. All parsed or skipped as intended, and an empty value is caught by the guard. To be precise about the limitation: this was executed through an **equivalent port**, not in PowerShell, because no PowerShell is available on the authoring machine.
- YAML parses, the new PowerShell survives as exactly one command block rather than being split, the `#` lines inside it are preserved as PowerShell comments rather than stripped as YAML comments, and braces and parentheses balance.
- The `linux/arm64` block is byte-for-byte untouched.
- Reviewed by inspection: `$LASTEXITCODE` reflects `vault` as a direct native-command assignment (no intervening pipeline), and `[Environment]::SetEnvironmentVariable` with two arguments uses Process scope — the same scope the existing `$Env:...` lines in this job already rely on to persist across commands.
- The parse loop deliberately uses a positive `-match` rather than testing `-notmatch` and then reading `$Matches`. The latter does work, but it relies on non-obvious operator behavior that cannot be checked without PowerShell, so the dependency was removed.
- Multi-line native-command output is captured by PowerShell as a string array; splitting on `\r?\n` is correct for both that and the single-string case, and `.Trim()` removes any stray `\r`.

**Not verified:** there is no PowerShell, no Windows host, and no Vault access on the machine this was written on, so it has not been executed. The smoke pipeline is also scheduled against `main` only, so **PR CI will not exercise it** — the first real signal is the next scheduled run after merge.

The remaining unknown is narrow: the exact shell syntax inside the `script` field. The parser is deliberately tolerant of the plausible forms, and if it still cannot find a variable it fails immediately and lists the names the script *does* define, so one run would pin it down.

### Revision history of this PR

The first two commits diagnosed this incorrectly — they assumed one field per credential stored under a different casing, and matched case-insensitively. That would not have fixed the job. The third commit corrects the diagnosis after checking how the Linux helper actually behaves; the fourth is review cleanup with no intended behavior change. Reviewers should read the final state rather than the intermediate commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
