### PR TITLE
[USTORAGE-29421] Note GCP PORTABLE default in enable help text

### DIFF
--- a/internal/tableflow/command_topic_enable.go
+++ b/internal/tableflow/command_topic_enable.go
@@ -39,7 +39,7 @@ func (c *command) newTopicEnableCommand() *cobra.Command {
 	cmd.Flags().String("provider-integration", "", "Specify the provider integration id.")
 	cmd.Flags().String("bucket-name", "", "Specify the name of the AWS S3 bucket.")
 	cmd.Flags().String("table-formats", "ICEBERG", "Specify the table formats, one of DELTA or ICEBERG.")
-	cmd.Flags().String("metadata-column-naming-scheme", "", "Specify the naming scheme for Tableflow's internal metadata columns in the materialized table, one of DEFAULT or PORTABLE.")
+	cmd.Flags().String("metadata-column-naming-scheme", "", "Specify the naming scheme for Tableflow's internal metadata columns in the materialized table, one of DEFAULT or PORTABLE. If unset, new Google Cloud topics default to PORTABLE and topics on other clouds default to DEFAULT.")
 	cmd.Flags().String("storage-account-name", "", "Specify the storage account name for Azure Data Lake.")
 	cmd.Flags().String("container-name", "", "Specify the container name for Azure Data Lake.")
 	addErrorHandlingFlags(cmd)

--- a/test/fixtures/output/tableflow/topic/enable-help.golden
+++ b/test/fixtures/output/tableflow/topic/enable-help.golden
@@ -22,7 +22,7 @@ Flags:
       --provider-integration string            Specify the provider integration id.
       --bucket-name string                     Specify the name of the AWS S3 bucket.
       --table-formats string                   Specify the table formats, one of DELTA or ICEBERG. (default "ICEBERG")
-      --metadata-column-naming-scheme string   Specify the naming scheme for Tableflow's internal metadata columns in the materialized table, one of DEFAULT or PORTABLE.
+      --metadata-column-naming-scheme string   Specify the naming scheme for Tableflow's internal metadata columns in the materialized table, one of DEFAULT or PORTABLE. If unset, new Google Cloud topics default to PORTABLE and topics on other clouds default to DEFAULT.
       --storage-account-name string            Specify the storage account name for Azure Data Lake.
       --container-name string                  Specify the container name for Azure Data Lake.
       --error-handling string                  Specify the error handling strategy, one of SUSPEND, SKIP, or LOG.


### PR DESCRIPTION
## What
Update the `tableflow topic enable --metadata-column-naming-scheme` help text to note that new Google Cloud topics default to `PORTABLE` (BigQuery-compatible `cflt_metadata_` names) when the scheme is left unset, and topics on other clouds default to `DEFAULT`. Golden updated.

## Why
The per-cloud default is applied by the Tableflow publishers (cc-unified-storage#6559); this just documents it in the CLI help. No functional CLI change: the CLI still sends the field only when the user sets it.

Part of USTORAGE-29421 (epic USTORAGE-23793).