### PR TITLE
DGS-25000 Add exporter cluster-link config describe command

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -62,7 +62,7 @@ require (
 	github.com/confluentinc/mds-sdk-go-public/mdsv1 v0.0.0-20240923163156-b922b35891f9
 	github.com/confluentinc/mds-sdk-go-public/mdsv2alpha1 v0.0.0-20240923163156-b922b35891f9
 	github.com/confluentinc/properties v0.0.0-20190814194548-42c10394a787
-	github.com/confluentinc/schema-registry-sdk-go v0.1.1-0.20251021214222-018e0cd35bf9
+	github.com/confluentinc/schema-registry-sdk-go v0.1.3-0.20260812213011-262e9f97627b
 	github.com/davecgh/go-spew v1.1.1
 	github.com/dghubble/sling v1.4.2
 	github.com/fatih/color v1.17.0

--- a/go.sum
+++ b/go.sum
@@ -265,6 +265,8 @@ github.com/confluentinc/proto-go-setter v0.3.0 h1:6BhgpDV5rWdEa+6LsnQWGV1udFboCa
 github.com/confluentinc/proto-go-setter v0.3.0/go.mod h1:WJkmDZf4f/nxGzjYJ+o3AsXI2hk64gLM5XlZrmlzs1s=
 github.com/confluentinc/schema-registry-sdk-go v0.1.1-0.20251021214222-018e0cd35bf9 h1:8rPUxlx0J0VVIOqF1pO25divMhyPZfD64bq1HDQnyUY=
 github.com/confluentinc/schema-registry-sdk-go v0.1.1-0.20251021214222-018e0cd35bf9/go.mod h1:yuuBwRHiqXeYbeuiUX8R7HgbquPJh8XTGpW7O08ErmU=
+github.com/confluentinc/schema-registry-sdk-go v0.1.3-0.20260812213011-262e9f97627b h1:vfMHWJhsDWlzRTDFugCw1JZm8I6tWK9TABHYnxjvqqw=
+github.com/confluentinc/schema-registry-sdk-go v0.1.3-0.20260812213011-262e9f97627b/go.mod h1:p5zwkMP5gyR4mgsoVQFjCI1EZMbYtxhzsJNnflrECPE=
 github.com/containerd/errdefs v1.0.0 h1:tg5yIfIlQIrxYtu9ajqY42W3lpS19XqdxRQeEwYG8PI=
 github.com/containerd/errdefs v1.0.0/go.mod h1:+YBYIdtsnF4Iw6nWZhJcqGSg/dwvV7tyJ/kCkyJ2k+M=
 github.com/containerd/errdefs/pkg v0.3.0 h1:9IKJ06FvyNlexW690DXuQNx2KA2cUJXx151Xdx3ZPPE=

--- a/internal/schema-registry/command_exporter_configuration.go
+++ b/internal/schema-registry/command_exporter_configuration.go
@@ -12,6 +12,7 @@ func (c *command) newExporterConfigurationCommand(cfg *config.Config) *cobra.Com
 		Short: "Manage the schema exporter configuration.",
 	}
 
+	cmd.AddCommand(c.newExporterConfigurationClusterLinkCommand(cfg))
 	cmd.AddCommand(c.newExporterConfigurationDescribeCommand(cfg))
 
 	return cmd

--- a/internal/schema-registry/command_exporter_configuration.go
+++ b/internal/schema-registry/command_exporter_configuration.go
@@ -12,7 +12,11 @@ func (c *command) newExporterConfigurationCommand(cfg *config.Config) *cobra.Com
 		Short: "Manage the schema exporter configuration.",
 	}
 
-	cmd.AddCommand(c.newExporterConfigurationClusterLinkCommand(cfg))
+	if cfg.IsCloudLogin() {
+		cmd.AddCommand(c.newExporterConfigurationClusterLinkCommand())
+	} else {
+		cmd.AddCommand(c.newExporterConfigurationClusterLinkCommandOnPrem())
+	}
 	cmd.AddCommand(c.newExporterConfigurationDescribeCommand(cfg))
 
 	return cmd

--- a/internal/schema-registry/command_exporter_configuration_cluster_link.go
+++ b/internal/schema-registry/command_exporter_configuration_cluster_link.go
@@ -3,16 +3,17 @@ package schemaregistry
 import (
 	"github.com/spf13/cobra"
 
-	"github.com/confluentinc/cli/v4/pkg/config"
+	pcmd "github.com/confluentinc/cli/v4/pkg/cmd"
 )
 
-func (c *command) newExporterConfigurationClusterLinkCommand(cfg *config.Config) *cobra.Command {
+func (c *command) newExporterConfigurationClusterLinkCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "cluster-link",
-		Short: "Manage the schema exporter's Cluster Link config.",
+		Use:         "cluster-link",
+		Short:       "Manage the schema exporter's Cluster Link config.",
+		Annotations: map[string]string{pcmd.RunRequirement: pcmd.RequireCloudLogin},
 	}
 
-	cmd.AddCommand(c.newExporterConfigurationClusterLinkDescribeCommand(cfg))
+	cmd.AddCommand(c.newExporterConfigurationClusterLinkDescribeCommand())
 
 	return cmd
 }

--- a/internal/schema-registry/command_exporter_configuration_cluster_link.go
+++ b/internal/schema-registry/command_exporter_configuration_cluster_link.go
@@ -1,0 +1,18 @@
+package schemaregistry
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/confluentinc/cli/v4/pkg/config"
+)
+
+func (c *command) newExporterConfigurationClusterLinkCommand(cfg *config.Config) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "cluster-link",
+		Short: "Manage the schema exporter's Cluster Link config.",
+	}
+
+	cmd.AddCommand(c.newExporterConfigurationClusterLinkDescribeCommand(cfg))
+
+	return cmd
+}

--- a/internal/schema-registry/command_exporter_configuration_cluster_link_describe.go
+++ b/internal/schema-registry/command_exporter_configuration_cluster_link_describe.go
@@ -1,0 +1,46 @@
+package schemaregistry
+
+import (
+	"github.com/spf13/cobra"
+
+	pcmd "github.com/confluentinc/cli/v4/pkg/cmd"
+	"github.com/confluentinc/cli/v4/pkg/config"
+	"github.com/confluentinc/cli/v4/pkg/output"
+)
+
+func (c *command) newExporterConfigurationClusterLinkDescribeCommand(cfg *config.Config) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "describe <name>",
+		Short: "Describe the schema exporter's Cluster Link config.",
+		Long:  "Derive the Cluster Link config(s) that replicate a schema exporter's subject/context translation, so they don't have to be hand-copied.",
+		Args:  cobra.ExactArgs(1),
+		RunE:  c.exporterConfigurationClusterLinkDescribe,
+	}
+
+	pcmd.AddContextFlag(cmd, c.CLICommand)
+	if cfg.IsCloudLogin() {
+		pcmd.AddEnvironmentFlag(cmd, c.AuthenticatedCLICommand)
+	} else {
+		addCaLocationAndClientPathFlags(cmd)
+	}
+	addSchemaRegistryEndpointFlag(cmd)
+	pcmd.AddOutputFlagWithDefaultValue(cmd, output.JSON.String())
+
+	return cmd
+}
+
+func (c *command) exporterConfigurationClusterLinkDescribe(cmd *cobra.Command, args []string) error {
+	client, err := c.GetSchemaRegistryClient(cmd)
+	if err != nil {
+		return err
+	}
+
+	configs, err := client.GetExporterClusterLinkConfig(args[0])
+	if err != nil {
+		return err
+	}
+
+	table := output.NewTable(cmd)
+	table.Add(configs)
+	return table.Print()
+}

--- a/internal/schema-registry/command_exporter_configuration_cluster_link_describe_onprem.go
+++ b/internal/schema-registry/command_exporter_configuration_cluster_link_describe_onprem.go
@@ -7,7 +7,7 @@ import (
 	"github.com/confluentinc/cli/v4/pkg/output"
 )
 
-func (c *command) newExporterConfigurationClusterLinkDescribeCommand() *cobra.Command {
+func (c *command) newExporterConfigurationClusterLinkDescribeCommandOnPrem() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "describe <name>",
 		Short: "Describe the schema exporter's Cluster Link config.",
@@ -17,25 +17,9 @@ func (c *command) newExporterConfigurationClusterLinkDescribeCommand() *cobra.Co
 	}
 
 	pcmd.AddContextFlag(cmd, c.CLICommand)
-	pcmd.AddEnvironmentFlag(cmd, c.AuthenticatedCLICommand)
+	addCaLocationAndClientPathFlags(cmd)
 	addSchemaRegistryEndpointFlag(cmd)
 	pcmd.AddOutputFlagWithDefaultValue(cmd, output.JSON.String())
 
 	return cmd
-}
-
-func (c *command) exporterConfigurationClusterLinkDescribe(cmd *cobra.Command, args []string) error {
-	client, err := c.GetSchemaRegistryClient(cmd)
-	if err != nil {
-		return err
-	}
-
-	configs, err := client.GetExporterClusterLinkConfig(args[0])
-	if err != nil {
-		return err
-	}
-
-	table := output.NewTable(cmd)
-	table.Add(configs)
-	return table.Print()
 }

--- a/internal/schema-registry/command_exporter_configuration_cluster_link_onprem.go
+++ b/internal/schema-registry/command_exporter_configuration_cluster_link_onprem.go
@@ -1,0 +1,19 @@
+package schemaregistry
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// No RunRequirement annotation: like its sibling command_exporter_configuration_describe.go,
+// this connects directly to a Schema Registry endpoint via --schema-registry-endpoint and
+// certificate flags, with no MDS login required.
+func (c *command) newExporterConfigurationClusterLinkCommandOnPrem() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "cluster-link",
+		Short: "Manage the schema exporter's Cluster Link config.",
+	}
+
+	cmd.AddCommand(c.newExporterConfigurationClusterLinkDescribeCommandOnPrem())
+
+	return cmd
+}

--- a/pkg/schemaregistry/client.go
+++ b/pkg/schemaregistry/client.go
@@ -124,6 +124,11 @@ func (c *Client) GetExporterConfig(name string) (map[string]string, error) {
 	return res, err
 }
 
+func (c *Client) GetExporterClusterLinkConfig(name string) (map[string]string, error) {
+	res, _, err := c.DefaultApi.GetExporterClusterLinkConfig(c.context(), name).Execute()
+	return res, err
+}
+
 func (c *Client) ResumeExporter(name string) (srsdk.UpdateExporterResponse, error) {
 	res, _, err := c.DefaultApi.ResumeExporter(c.context(), name).Execute()
 	return res, err

--- a/test/fixtures/output/schema-registry/exporter/configuration/cluster-link-describe-json.golden
+++ b/test/fixtures/output/schema-registry/exporter/configuration/cluster-link-describe-json.golden
@@ -1,0 +1,3 @@
+{
+  "topic.config.sync.associations.filters": "{\"topicsToInclude\":[\"*\"],\"topicsToExclude\":[],\"contextType\":\"AUTO\",\"subjectRenameFormat\":\"my-${subject}\",\"sourceSRDeployment\":\"CONFLUENT_CLOUD\",\"sourceLSRC\":\"lsrc-abc123\"}"
+}

--- a/test/fixtures/output/schema-registry/exporter/configuration/cluster-link-describe-yaml.golden
+++ b/test/fixtures/output/schema-registry/exporter/configuration/cluster-link-describe-yaml.golden
@@ -1,0 +1,1 @@
+topic.config.sync.associations.filters: '{"topicsToInclude":["*"],"topicsToExclude":[],"contextType":"AUTO","subjectRenameFormat":"my-${subject}","sourceSRDeployment":"CONFLUENT_CLOUD","sourceLSRC":"lsrc-abc123"}'

--- a/test/schema_registry_test.go
+++ b/test/schema_registry_test.go
@@ -91,6 +91,8 @@ func (s *CLITestSuite) TestSchemaRegistryExporter() {
 		{args: fmt.Sprintf(`schema-registry exporter delete myexporter myexporter2 --environment %s --force`, testserver.SRApiEnvId), fixture: "schema-registry/exporter/delete-multiple-success.golden"},
 		{args: fmt.Sprintf("schema-registry exporter delete myexporter --environment %s", testserver.SRApiEnvId), input: "y\n", fixture: "schema-registry/exporter/delete-prompt.golden"},
 		{args: fmt.Sprintf("schema-registry exporter status describe myexporter --environment %s", testserver.SRApiEnvId), fixture: "schema-registry/exporter/status/describe.golden"},
+		{args: fmt.Sprintf("schema-registry exporter configuration cluster-link describe myexporter --output json --environment %s", testserver.SRApiEnvId), fixture: "schema-registry/exporter/configuration/cluster-link-describe-json.golden"},
+		{args: fmt.Sprintf("schema-registry exporter configuration cluster-link describe myexporter --output yaml --environment %s", testserver.SRApiEnvId), fixture: "schema-registry/exporter/configuration/cluster-link-describe-yaml.golden"},
 		{args: fmt.Sprintf("schema-registry exporter configuration describe myexporter --output json --environment %s", testserver.SRApiEnvId), fixture: "schema-registry/exporter/configuration/describe-json.golden"},
 		{args: fmt.Sprintf("schema-registry exporter configuration describe myexporter --output yaml --environment %s", testserver.SRApiEnvId), fixture: "schema-registry/exporter/configuration/describe-yaml.golden"},
 		{args: fmt.Sprintf("schema-registry exporter pause myexporter --environment %s", testserver.SRApiEnvId), fixture: "schema-registry/exporter/pause.golden"},

--- a/test/test-server/schema_registry_handlers.go
+++ b/test/test-server/schema_registry_handlers.go
@@ -389,6 +389,20 @@ func handleSRExporterConfig(t *testing.T) http.HandlerFunc {
 	}
 }
 
+// Handler for: "/exporters/{name}/config/clusterlink"
+func handleSRExporterClusterLinkConfig(t *testing.T) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		filterConfig := `{"topicsToInclude":["*"],"topicsToExclude":[],"contextType":"AUTO",` +
+			`"subjectRenameFormat":"my-${subject}","sourceSRDeployment":"CONFLUENT_CLOUD",` +
+			`"sourceLSRC":"lsrc-abc123"}`
+		config := map[string]string{
+			"topic.config.sync.associations.filters": filterConfig,
+		}
+		err := json.NewEncoder(w).Encode(config)
+		require.NoError(t, err)
+	}
+}
+
 // Handler for: "/exporters/{name}/pause"
 func handleSRExporterPause(t *testing.T) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {

--- a/test/test-server/schema_registry_router.go
+++ b/test/test-server/schema_registry_router.go
@@ -29,6 +29,7 @@ var schemaRegistryRoutes = []route{
 	{"/exporters/{name}", handleSRExporter},
 	{"/exporters/{name}/status", handleSRExporterStatus},
 	{"/exporters/{name}/config", handleSRExporterConfig},
+	{"/exporters/{name}/config/clusterlink", handleSRExporterClusterLinkConfig},
 	{"/exporters/{name}/pause", handleSRExporterPause},
 	{"/exporters/{name}/resume", handleSRExporterResume},
 	{"/exporters/{name}/reset", handleSRExporterReset},


### PR DESCRIPTION
Release Notes
-------------

New Features
- Add `confluent schema-registry exporter configuration cluster-link describe` to derive the Cluster Link config(s) that replicate a schema exporter's subject/context translation.

Checklist
---------
- [x] I have successfully built and used a custom CLI binary, without linter issues from this PR.
- [x] I have clearly specified in the `What` section below whether this PR applies to Confluent Cloud, Confluent Platform, or both.
- [ ] I have verified this PR in Confluent Cloud pre-prod or production environment, if applicable.
- [ ] I have verified this PR in Confluent Platform on-premises environment, if applicable.
- [ ] I have attached manual CLI verification results or screenshots in the `Test & Review` section below.
- [x] I have added appropriate CLI integration or unit tests for any new or updated commands and functionality.
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [x] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [ ] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [ ] Confluent Cloud prod
  - [ ] Confluent Cloud stag
  - [ ] Confluent Platform
  - [ ] Check this box if the feature is enabled for certain organizations only

What
----
Confluent Cloud only. Adds a new CLI command, `confluent schema-registry exporter configuration cluster-link describe <name>`, which calls the new SR management endpoint `GET /exporters/{name}/config/clusterlink` (confluentinc/schema-registry-plugins#2134) and prints the derived Cluster Link config(s) for that exporter, so they don't have to be hand-copied.

Blast Radius
----
New, additive command under `schema-registry exporter configuration`; no existing commands or behavior are changed.

References
----------
JIRA: DGS-25000
Backend: confluentinc/schema-registry-plugins#2134
SDK: schema-registry-sdk-go@v0.1.3-0.20260812213011-262e9f97627b

Test & Review
-------------
Added CLI integration test coverage (`test/schema_registry_test.go`, JSON/YAML golden fixtures) and test-server route/handler for the new endpoint.
Manual verification Doc: 
[DGS-25000-cluster-link-config-cli-tf-verification.md](https://github.com/user-attachments/files/31715098/DGS-25000-cluster-link-config-cli-tf-verification.md)
