### PR TITLE
fix(log): emit the buffered lines `Flush()` dropped

### DIFF
--- a/pkg/log/logger.go
+++ b/pkg/log/logger.go
@@ -150,7 +150,9 @@ func (l *Logger) append(level Level, message string) {
 
 func (l *Logger) Flush() {
 	for _, lm := range l.buffer {
-		if lm.level < l.Level {
+		// Higher levels are more verbose, so a buffered message is emitted only if the level it
+		// was logged at is now within the threshold.
+		if lm.level > l.Level {
 			continue
 		}
 

--- a/pkg/log/logger_test.go
+++ b/pkg/log/logger_test.go
@@ -2,6 +2,7 @@ package log
 
 import (
 	"bytes"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -41,6 +42,21 @@ func TestLogger_Flush(t *testing.T) {
 			} else {
 				require.Empty(t, buf.String())
 			}
+		})
+	}
+}
+
+func TestLogger_FlushAfterRaisingVerbosity(t *testing.T) {
+	for _, verbosity := range []Level{DEBUG, TRACE, UNSAFE_TRACE} {
+		t.Run(fmt.Sprintf("raised to %d", verbosity), func(t *testing.T) {
+			buf := new(bytes.Buffer)
+			l := New(ERROR, buf)
+
+			l.Debug("hi there")
+			l.SetVerbosity(int(verbosity))
+			l.Flush()
+
+			require.Contains(t, buf.String(), "hi there")
 		})
 	}
 }

--- a/pkg/log/logger_test.go
+++ b/pkg/log/logger_test.go
@@ -2,7 +2,6 @@ package log
 
 import (
 	"bytes"
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -46,17 +45,38 @@ func TestLogger_Flush(t *testing.T) {
 	}
 }
 
-func TestLogger_FlushAfterRaisingVerbosity(t *testing.T) {
-	for _, verbosity := range []Level{DEBUG, TRACE, UNSAFE_TRACE} {
-		t.Run(fmt.Sprintf("raised to %d", verbosity), func(t *testing.T) {
-			buf := new(bytes.Buffer)
-			l := New(ERROR, buf)
-
-			l.Debug("hi there")
-			l.SetVerbosity(int(verbosity))
-			l.Flush()
-
-			require.Contains(t, buf.String(), "hi there")
-		})
+func TestLogger_Flush_EmitsAtOrBelowThreshold(t *testing.T) {
+	// Logged at the least-verbose level, so every line buffers instead of emitting; the threshold
+	// is then raised before the flush.
+	buffered := map[Level]string{
+		WARN:         "warn: rare but handled",
+		INFO:         "info: steady-state",
+		DEBUG:        "debug: low-level detail",
+		TRACE:        "trace: action tracing",
+		UNSAFE_TRACE: "unsafe: sensitive detail",
 	}
+
+	buf := new(bytes.Buffer)
+	l := New(ERROR, buf)
+	l.Warn(buffered[WARN])
+	l.Info(buffered[INFO])
+	l.Debug(buffered[DEBUG])
+	l.Trace(buffered[TRACE])
+	l.UnsafeTrace(buffered[UNSAFE_TRACE])
+	require.Len(t, l.buffer, len(buffered))
+
+	l.SetVerbosity(int(DEBUG))
+	l.Flush()
+
+	// A buffered line emits only when its level is at or below the threshold. DEBUG sits on the
+	// boundary, so an off-by-one comparison would drop it.
+	out := buf.String()
+	for level, message := range buffered {
+		if level <= DEBUG {
+			require.Contains(t, out, message)
+		} else {
+			require.NotContains(t, out, message)
+		}
+	}
+	require.Empty(t, l.buffer)
 }

--- a/pkg/log/logger_test.go
+++ b/pkg/log/logger_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestLogger_Flush(t *testing.T) {
+func TestLoggerFlush(t *testing.T) {
 	tests := []struct {
 		name     string
 		level    Level
@@ -45,7 +45,7 @@ func TestLogger_Flush(t *testing.T) {
 	}
 }
 
-func TestLogger_Flush_EmitsAtOrBelowThreshold(t *testing.T) {
+func TestLoggerFlushEmitsAtOrBelowThreshold(t *testing.T) {
 	// Logged at the least-verbose level, so every line buffers instead of emitting; the threshold
 	// is then raised before the flush.
 	buffered := map[Level]string{


### PR DESCRIPTION
Release Notes
-------------

Bug Fixes

- Fixed verbose logging (`-v`) dropping buffered log lines it should have emitted, and emitting the low-priority ones instead.

Checklist
---------

- [x] I have successfully built and used a custom CLI binary, without linter issues from this PR.
- [x] I have clearly specified in the `What` section below whether this PR applies to Confluent Cloud, Confluent Platform, or both.
- [ ] I have verified this PR in Confluent Cloud pre-prod or production environment, if applicable.
- [ ] I have verified this PR in Confluent Platform on-premises environment, if applicable.
- [x] I have attached manual CLI verification results or screenshots in the `Test & Review` section below.
- [x] I have added appropriate CLI integration or unit tests for any new or updated commands and functionality.
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [x] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [ ] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [ ] Confluent Cloud prod
  - [ ] Confluent Cloud stag
  - [ ] Confluent Platform
  - [ ] Check this box if the feature is enabled for certain organizations only

_Applies to both Cloud and Platform (shared logging). Feature-flag items are N/A - this is a bug fix, not a gated feature._

What
----

The CLI buffers log lines and flushes them later (for example, to attach context to an error). The flush filter that decides which buffered lines to emit was inverted, so it dropped exactly the lines it should have kept - the more important, less verbose ones - and emitted the rest.

`pkg/log/logger.go`'s `Flush()` had `if lm.level < l.Level { continue }`. Higher level values mean more verbose, so a buffered line should be emitted when its level is **at or below** the current threshold (`lm.level <= l.Level`), not skipped when it is below. The one-character fix flips the comparison to `>`, and a regression test pins the behavior so it cannot silently invert again.

Same command at `-vvv` (verbosity = `DEBUG`), with four lines buffered before verbosity was parsed:

```
# before (buggy `<`): drops the WARN and INFO lines the user should see
[DEBUG] debug: low-level detail

# after (fixed `>`): everything at or below the requested level is emitted
[WARN]  warn: rare but handled
[INFO]  info: steady-state
[DEBUG] debug: low-level detail
```

(`TRACE` is correctly withheld in both - it is more verbose than the requested `DEBUG`.)

Applies to: both Confluent Cloud and Confluent Platform (shared logging code).

Blast Radius
----

Very small, and confined to diagnostic logging. The logger writes only to stderr, and `Flush()` runs once at startup purely for its logging side effect - it returns nothing and touches no command result, exit code, or stdout, so machine-readable output (`-o json` / `-o yaml`) is unaffected. If the filter were wrong, the effect is limited to which buffered lines land on stderr, and only in the under-emitting direction: the per-level emit methods re-gate each line, so a wrong filter still cannot surface a line more verbose than the active level (credential-bearing `UNSAFE_TRACE` output stays gated behind `--unsafe-trace` regardless). No customer-facing command would break.

Test & Review
-------------

- Added a regression test in `pkg/log/logger_test.go` asserting `Flush()` emits buffered lines at or below the threshold and drops the more-verbose ones.
- A/B verified by hand: at `-vvvv`, the same command emitted **0** buffered `[DEBUG]` lines before the fix and **4** after.
- `go test ./pkg/log/...` passes.
