### PR TITLE
improve(build): add `make build-dev` for a dev CLI

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-exclude: ^.devcontainer/|^charts/|^mk-include/|^node_modules/|^test/fixtures/output/
+exclude: ^.devcontainer/|^charts/|^mk-include/|^node_modules/|^test/fixtures/output/|^debian/patches/
 fail_fast: false
 repos:
 # ### SERVICEBOT BEGIN - DO NOT EDIT THIS SECTION

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,7 @@ Place these commands in your immediate context — they're the operational core.
 ```bash
 # Build
 make build                                                       # → dist/confluent_<os>_<arch>/confluent
+make build-dev                                                   # → `confluent-dev` on $PATH, isolated in ~/.confluent-dev
 GOARCH=arm64 make build                                          # cross-compile, same OS
 GOOS=linux GOARCH=amd64 make cross-build                         # cross-OS (requires musl-cross or mingw-w64; see README)
 GOLANG_FIPS=1 make build                                         # FIPS-140 build on macOS (full setup in README.md, NOT CONTRIBUTING.md)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,6 +48,16 @@ We use `pre-commit` hooks and `gitleaks` to prevent secrets from being committed
     brew install pre-commit
     pre-commit install
 
+#### Running a Dev Build
+
+A CLI built from source keeps its state separate from an installed release. Every local build is tagged as a `dev` build, so its config, contexts, and cached tokens live in `~/.confluent-dev` rather than the usual `~/.confluent`, and it never reads or overwrites them from an installed `confluent`.
+
+    make build-dev              # builds confluent-dev into ~/.local/bin by default
+    confluent-dev version       # reports Version: v0.0.0-dev-<sha> and Development: true
+    confluent-dev context list  # empty until you log in with confluent-dev; your real login is untouched
+
+Override `CONFLUENT_DEV_BIN` to install it elsewhere. Two caveats. On macOS, a password saved with `confluent login --save` goes to the system keychain keyed by username and URL, which is not channel-scoped, so a dev build and a release logged into the same account still share that saved password; avoid `--save` when testing against a production account. And because `confluent-dev` matches the pattern the CLI uses to find plugins (any `PATH` executable named `confluent-<name>`), an installed `confluent` lists it as a `confluent dev` plugin - harmless, but naming the binary `confluent_dev` avoids the entry.
+
 ### File Layout
 
 This repo mostly follows the [Standard Go Project Layout](https://github.com/golang-standards/project-layout).
@@ -216,10 +226,10 @@ Add the following line to `internal/command.go`, and make sure to import its pac
 
 #### Running the Command
 
-To build the CLI binary, run `make build`. After this, we can run our command in the following way, and see that it (hopefully) works!
+Build the CLI and run your command. `make build-dev` puts an isolated `confluent-dev` on your PATH (see [Running a Dev Build](#running-a-dev-build)), so trying out a command cannot touch an installed release's config:
 
-    make build
-    dist/confluent_<os>_<arch>/confluent config describe 3
+    make build-dev
+    confluent-dev config describe 3
 
 #### Integration Testing
 
@@ -272,7 +282,7 @@ For most resource types, a `delete` command should support multiple arguments. T
 See [Supporting Multiple Deletion](pkg/deletion/README.md) for instructions on how to write such commands.
 
 ### Building the documentation
-You can build the CLI documentation locally by running this command from the root directory. This will generate documentation in [RST](https://www.sphinx-doc.org/en/master/index.html) format in the `cli/docs` directory. 
+You can build the CLI documentation locally by running this command from the root directory. This will generate documentation in [RST](https://www.sphinx-doc.org/en/master/index.html) format in the `cli/docs` directory.
 
 ```
 go run cmd/docs/main.go

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ CONFLUENT_DEV_VERSION ?= 0.0.0-dev-$(shell git rev-parse --short HEAD 2>/dev/nul
 .PHONY: build-dev
 build-dev:
 	@mkdir -p $(dir $(CONFLUENT_DEV_BIN))
-	go build -ldflags="-X main.version=$(CONFLUENT_DEV_VERSION) -X main.commit=$(shell git rev-parse HEAD 2>/dev/null || echo unknown) -X main.date=$(shell date -u +%Y-%m-%dT%H:%M:%SZ)" -o $(CONFLUENT_DEV_BIN) ./cmd/confluent
+	go build -ldflags="-X main.disableUpdates=true -X main.version=$(CONFLUENT_DEV_VERSION) -X main.commit=$(shell git rev-parse HEAD 2>/dev/null || echo unknown) -X main.date=$(shell date -u +%Y-%m-%dT%H:%M:%SZ)" -o $(CONFLUENT_DEV_BIN) ./cmd/confluent
 	@echo "Built confluent-dev at $(CONFLUENT_DEV_BIN)"
 	@echo "It keeps state in ~/.confluent-dev, isolated from the ~/.confluent of any installed release."
 	@echo "Make sure $(dir $(CONFLUENT_DEV_BIN)) is on your PATH."

--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,20 @@ else
 endif
 
 
+# Build a dev binary onto your PATH as `confluent-dev`. A local build reports the "dev" release
+# channel, so it keeps its state in ~/.confluent-dev, isolated from an installed release's
+# ~/.confluent. Debug symbols are kept, unlike the test builds, so delve can attach.
+CONFLUENT_DEV_BIN ?= $(HOME)/.local/bin/confluent-dev
+CONFLUENT_DEV_VERSION ?= 0.0.0-dev-$(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)
+
+.PHONY: build-dev
+build-dev:
+	@mkdir -p $(dir $(CONFLUENT_DEV_BIN))
+	go build -ldflags="-X main.version=$(CONFLUENT_DEV_VERSION) -X main.commit=$(shell git rev-parse HEAD 2>/dev/null || echo unknown) -X main.date=$(shell date -u +%Y-%m-%dT%H:%M:%SZ)" -o $(CONFLUENT_DEV_BIN) ./cmd/confluent
+	@echo "Built confluent-dev at $(CONFLUENT_DEV_BIN)"
+	@echo "It keeps state in ~/.confluent-dev, isolated from the ~/.confluent of any installed release."
+	@echo "Make sure $(dir $(CONFLUENT_DEV_BIN)) is on your PATH."
+
 
 .PHONY: clean
 clean:

--- a/cmd/confluent/main.go
+++ b/cmd/confluent/main.go
@@ -22,6 +22,10 @@ var (
 )
 
 func main() {
+	// Must precede both the config load and command construction, since each resolves paths that
+	// depend on the channel.
+	pversion.SetProcessChannel(pversion.ChannelOf(version))
+
 	cfg := config.New()
 
 	err := cfg.Load()

--- a/cmd/docs/main.go
+++ b/cmd/docs/main.go
@@ -17,6 +17,11 @@ import (
 // This code is adapted from https://github.com/spf13/cobra/blob/master/doc/rest_docs.md
 
 func main() {
+	// Docs describe the released CLI, so paths in them must be the stable channel's; this binary
+	// carries no version stamp and would otherwise resolve to a dev build. Set before anything
+	// else, since the channel is an unsynchronized global and the test server below is concurrent.
+	pversion.SetProcessChannel(pversion.Stable)
+
 	// Set up test server for feature flags called by the code
 	testBackend := testserver.StartTestCloudServer(&testing.T{}, true)
 	defer testBackend.Close()

--- a/cmd/lint/main.go
+++ b/cmd/lint/main.go
@@ -413,6 +413,10 @@ func init() {
 }
 
 func main() {
+	// Lint the released CLI's surface, so paths baked into flag defaults are the stable channel's.
+	// Must precede command construction; this binary carries no version stamp of its own.
+	pversion.SetProcessChannel(pversion.Stable)
+
 	// Set up test server for feature flags called by the code
 	testBackend := testserver.StartTestCloudServer(&testing.T{}, true)
 	defer testBackend.Close()

--- a/cmd/whitelist/main.go
+++ b/cmd/whitelist/main.go
@@ -26,6 +26,10 @@ var version = "v0.0.0"
 */
 
 func main() {
+	// Whitelist the released CLI's surface, so paths baked into flag defaults are the stable
+	// channel's. Must precede command construction; this binary carries no version stamp.
+	pversion.SetProcessChannel(pversion.Stable)
+
 	fmt.Println("BEGIN;")
 	fmt.Println("")
 	fmt.Println("INSERT INTO whitelist(version, keyword) VALUES")

--- a/debian/patches/standard_build_layout.patch
+++ b/debian/patches/standard_build_layout.patch
@@ -1,5 +1,5 @@
---- cli/Makefile	2026-08-21 17:38:28
-+++ debian/Makefile	2026-08-11 15:37:20
+--- cli/Makefile	2026-08-21 21:38:28.801439074 +0000
++++ debian/Makefile	2026-08-11 19:37:20.278886564 +0000
 @@ -1,256 +1,179 @@
 -SHELL := /bin/bash
 -GORELEASER_VERSION := v2.13.3
@@ -19,10 +19,8 @@
 -    endif
 -else # darwin
 -	$(MAKE) cli-builder
-+ifndef VERSION
-+	VERSION=$(CLI_VERSION)
- endif
-
+-endif
+-
 -# Cross-compile from darwin to any of the OS/Arch pairs below
 -.PHONY: cross-build
 -cross-build:
@@ -41,17 +39,11 @@
 -		$(MAKE) cli-builder
 -    endif
 -endif
-+export PACKAGE_TITLE=cli
-+export FULL_PACKAGE_TITLE=confluent-$(PACKAGE_TITLE)
-+export PACKAGE_NAME=$(FULL_PACKAGE_TITLE)-$(VERSION)
-
+-
 -.PHONY: cli-builder
 -cli-builder:
 -	GOOS="" GOARCH="" CC="" CXX="" CGO_LDFLAGS="" go install github.com/goreleaser/goreleaser/v2@$(GORELEASER_VERSION)
-+# Defaults that are likely to vary by platform. These are cleanly separated so
-+# it should be easy to maintain altered values on platform-specific branches
-+# when the values aren't overridden by the script invoking the Makefile
-
+-
 -ifeq ($(GOLANG_FIPS),1)
 -	wget "https://go.dev/dl/go$$(cat .go-version).src.tar.gz" && \
 -	tar -xf go$$(cat .go-version).src.tar.gz && \
@@ -66,6 +58,20 @@
 -	cd ../../
 -	PATH=$$(pwd)/go/bin:$$PATH GOROOT=$$(pwd)/go TAGS=$(TAGS) CC=$(CC) CXX=$(CXX) CGO_LDFLAGS=$(CGO_LDFLAGS) goreleaser build --clean --single-target --snapshot
 -	rm -rf go go-openssl go$$(cat .go-version).src.tar.gz
+-else
+-	TAGS=$(TAGS) CC=$(CC) CXX=$(CXX) CGO_LDFLAGS=$(CGO_LDFLAGS) goreleaser build --clean --single-target --snapshot
++ifndef VERSION
++	VERSION=$(CLI_VERSION)
+ endif
+
++export PACKAGE_TITLE=cli
++export FULL_PACKAGE_TITLE=confluent-$(PACKAGE_TITLE)
++export PACKAGE_NAME=$(FULL_PACKAGE_TITLE)-$(VERSION)
++
++# Defaults that are likely to vary by platform. These are cleanly separated so
++# it should be easy to maintain altered values on platform-specific branches
++# when the values aren't overridden by the script invoking the Makefile
++
 +APPLY_PATCHES?=yes
 +
 +# DESTDIR may be overridden by e.g. debian packaging
@@ -76,58 +82,33 @@
 +ifeq ($(PACKAGE_TYPE),archive)
 +PREFIX=$(PACKAGE_NAME)
 +SYSCONFDIR=$(PREFIX)/etc/$(PACKAGE_TITLE)
- else
--	TAGS=$(TAGS) CC=$(CC) CXX=$(CXX) CGO_LDFLAGS=$(CGO_LDFLAGS) goreleaser build --clean --single-target --snapshot
++else
 +PREFIX=/usr
 +SYSCONFDIR=/etc/$(PACKAGE_TITLE)
- endif
-
++endif
++
 +_empty :=
 +_space := $(_empty) $(empty)
 +split_version := $(subst .,$(_space),$(CLI_VERSION))
-
--# Build a dev binary onto your PATH as `confluent-dev`. A local build reports the "dev" release
--# channel, so it keeps its state in ~/.confluent-dev, isolated from an installed release's
--# ~/.confluent. Debug symbols are kept, unlike the test builds, so delve can attach.
--CONFLUENT_DEV_BIN ?= $(HOME)/.local/bin/confluent-dev
--CONFLUENT_DEV_VERSION ?= 0.0.0-dev-$(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)
++
 +S390X_AVAILABLE := $(shell [ $(word 1,$(split_version)) -ge 4 ] && [ $(word 2,$(split_version)) -ge 59 ] && echo yes)
-
--.PHONY: build-dev
--build-dev:
--	@mkdir -p $(dir $(CONFLUENT_DEV_BIN))
--	go build -ldflags="-X main.version=$(CONFLUENT_DEV_VERSION) -X main.commit=$(shell git rev-parse HEAD 2>/dev/null || echo unknown) -X main.date=$(shell date -u +%Y-%m-%dT%H:%M:%SZ)" -o $(CONFLUENT_DEV_BIN) ./cmd/confluent
--	@echo "Built confluent-dev at $(CONFLUENT_DEV_BIN)"
--	@echo "It keeps state in ~/.confluent-dev, isolated from the ~/.confluent of any installed release."
--	@echo "Make sure $(dir $(CONFLUENT_DEV_BIN)) is on your PATH."
++
 +all: install
-
++
 +archive: install
 +	rm -f $(CURDIR)/$(PACKAGE_NAME).tar.gz && cd $(DESTDIR) && tar -czf $(CURDIR)/$(PACKAGE_NAME).tar.gz $(PREFIX)
 +	rm -f $(CURDIR)/$(PACKAGE_NAME).zip && cd $(DESTDIR) && zip -r $(CURDIR)/$(PACKAGE_NAME).zip $(PREFIX)
-
--.PHONY: clean
--clean:
--	for dir in bin dist docs legal prebuilt release-notes; do \
--		[ -d $$dir ] && rm -r $$dir || true; \
--	done
++
 +apply-patches: $(wildcard debian/patches/*)
 +ifeq ($(APPLY_PATCHES),yes)
 +	git reset --hard HEAD
 +	cat debian/patches/series | xargs -iPATCH bash -c 'patch -p1 < debian/patches/PATCH'
 +endif
-
--.PHONY: lint
--lint: lint-go lint-cli
++
 +BINPATH=$(PREFIX)/bin
 +LIBPATH=$(PREFIX)/libexec/$(PACKAGE_TITLE)
 +DOCPATH=$(PREFIX)/share/doc/$(PACKAGE_TITLE)
-
--.PHONY: lint-go
--lint-go:
--	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.8 && \
--	golangci-lint run --timeout 10m
--	@echo "✅  golangci-lint"
++
 +# Notes on the archive download links:
 +# As of v3.0.0, the version number no longer has the 'v' prefix
 +# As of v3.43.0, we download the '_disableupdates' variant
@@ -135,23 +116,15 @@
 +install: apply-patches
 +	rm -rf $(DESTDIR)$(PREFIX)
 +	mkdir -p $(DESTDIR)$(PREFIX)
-
--.PHONY: lint-cli
--lint-cli: cmd/lint/en_US.aff cmd/lint/en_US.dic
--	go run cmd/lint/main.go -aff-file $(word 1,$^) -dic-file $(word 2,$^) $(ARGS)
--	@echo "✅  cmd/lint/main.go"
++
 +	mkdir -p $(DESTDIR)$(BINPATH)
 +	mkdir -p $(DESTDIR)$(LIBPATH)
 +	mkdir -p $(DESTDIR)$(DOCPATH)
 +	mkdir -p $(DESTDIR)$(SYSCONFDIR)
-
--cmd/lint/en_US.aff:
--	curl -s "https://chromium.googlesource.com/chromium/deps/hunspell_dictionaries/+/master/en_US.aff?format=TEXT" | base64 -D > $@
++
 +	cp packaging/confluent.sh $(DESTDIR)$(BINPATH)/confluent
 +	chmod 755 $(DESTDIR)$(BINPATH)/confluent
-
--cmd/lint/en_US.dic:
--	curl -s "https://chromium.googlesource.com/chromium/deps/hunspell_dictionaries/+/master/en_US.dic?format=TEXT" | base64 -D > $@
++
 +	cd $(DESTDIR)$(LIBPATH); \
 +	v=""; if [[ $(word 1,$(split_version)) -eq 2 ]]; then v="v"; fi; \
 +	disableupdates=""; if [[ $(word 1,$(split_version)) -ge 3 && $(word 2,$(split_version)) -ge 43 ]]; then disableupdates="_disableupdates"; fi; \
@@ -174,6 +147,50 @@
 +	curl -fs https://$${baseurl}/confluent-cli/binaries/$(CLI_VERSION)/confluent$${version}_windows_amd64.exe -o $${filepath}; \
 +	chmod 755 $${filepath}
 
+-# Build a dev binary onto your PATH as `confluent-dev`. A local build reports the "dev" release
+-# channel, so it keeps its state in ~/.confluent-dev, isolated from an installed release's
+-# ~/.confluent. Debug symbols are kept, unlike the test builds, so delve can attach.
+-CONFLUENT_DEV_BIN ?= $(HOME)/.local/bin/confluent-dev
+-CONFLUENT_DEV_VERSION ?= 0.0.0-dev-$(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)
+-
+-.PHONY: build-dev
+-build-dev:
+-	@mkdir -p $(dir $(CONFLUENT_DEV_BIN))
+-	go build -ldflags="-X main.version=$(CONFLUENT_DEV_VERSION) -X main.commit=$(shell git rev-parse HEAD 2>/dev/null || echo unknown) -X main.date=$(shell date -u +%Y-%m-%dT%H:%M:%SZ)" -o $(CONFLUENT_DEV_BIN) ./cmd/confluent
+-	@echo "Built confluent-dev at $(CONFLUENT_DEV_BIN)"
+-	@echo "It keeps state in ~/.confluent-dev, isolated from the ~/.confluent of any installed release."
+-	@echo "Make sure $(dir $(CONFLUENT_DEV_BIN)) is on your PATH."
++	cp LICENSE $(DESTDIR)$(DOCPATH)/LICENSE
++	$(DESTDIR)$(BINPATH)/confluent --version | awk -F' ' '{ print $3 }' > $(DESTDIR)$(DOCPATH)/version.txt
+
++	chown -R root:root $(DESTDIR)$(PREFIX)
+
+-.PHONY: clean
+ clean:
+-	for dir in bin dist docs legal prebuilt release-notes; do \
+-		[ -d $$dir ] && rm -r $$dir || true; \
+-	done
+-
+-.PHONY: lint
+-lint: lint-go lint-cli
+-
+-.PHONY: lint-go
+-lint-go:
+-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.8 && \
+-	golangci-lint run --timeout 10m
+-	@echo "✅  golangci-lint"
+-
+-.PHONY: lint-cli
+-lint-cli: cmd/lint/en_US.aff cmd/lint/en_US.dic
+-	go run cmd/lint/main.go -aff-file $(word 1,$^) -dic-file $(word 2,$^) $(ARGS)
+-	@echo "✅  cmd/lint/main.go"
+-
+-cmd/lint/en_US.aff:
+-	curl -s "https://chromium.googlesource.com/chromium/deps/hunspell_dictionaries/+/master/en_US.aff?format=TEXT" | base64 -D > $@
+-
+-cmd/lint/en_US.dic:
+-	curl -s "https://chromium.googlesource.com/chromium/deps/hunspell_dictionaries/+/master/en_US.dic?format=TEXT" | base64 -D > $@
+-
 -.PHONY: unit-test
 -unit-test:
 -ifdef CI
@@ -182,25 +199,6 @@
 -else
 -	go test -timeout 0 -v -coverprofile=coverage.unit.out -covermode=atomic $$(go list ./... | grep -v github.com/confluentinc/cli/v4/test) $(UNIT_TEST_ARGS)
 -endif
-+	cp LICENSE $(DESTDIR)$(DOCPATH)/LICENSE
-+	$(DESTDIR)$(BINPATH)/confluent --version | awk -F' ' '{ print $3 }' > $(DESTDIR)$(DOCPATH)/version.txt
-
--.PHONY: build-for-integration-test
--build-for-integration-test:
--ifdef CI
--	go build -cover -ldflags="-s -w -X main.commit="00000000" -X main.date="1970-01-01T00:00:00Z" -X main.isTest=true" -o test/bin/confluent ./cmd/confluent
--else
--	go build -cover -ldflags="-s -w -X main.commit="00000000" -X main.date="1970-01-01T00:00:00Z" -X main.isTest=true" -o test/bin/confluent ./cmd/confluent
--endif
-+	chown -R root:root $(DESTDIR)$(PREFIX)
-
--.PHONY: build-for-integration-test-windows
--build-for-integration-test-windows:
--ifdef CI
--	go build -cover -ldflags="-s -w -X main.commit="00000000" -X main.date="1970-01-01T00:00:00Z" -X main.isTest=true" -o test/bin/confluent.exe ./cmd/confluent
--else
--	go build -cover -ldflags="-s -w -X main.commit="00000000" -X main.date="1970-01-01T00:00:00Z" -X main.isTest=true" -o test/bin/confluent.exe ./cmd/confluent
-+clean:
 +	rm -rf $(CURDIR)/$(PACKAGE_NAME)*
 +	rm -rf $(FULL_PACKAGE_TITLE)-$(RPM_VERSION)*rpm
 +	rm -rf RPM_BUILDING
@@ -209,16 +207,8 @@
 +ifneq ($(PACKAGE_TYPE),deb)
 +	git reset --hard HEAD
 +	git status --ignored --porcelain | cut -d ' ' -f 2 | xargs rm -rf
- endif
-
--.PHONY: integration-test
--integration-test:
--ifdef CI
--	go install gotest.tools/gotestsum@v1.13.0 && \
--	export GOCOVERDIR=test/coverage && \
--	rm -rf $${GOCOVERDIR} && mkdir $${GOCOVERDIR} && \
--	gotestsum --junitfile integration-test-report.xml -- -timeout 0 -v -race $$(go list ./... | grep github.com/confluentinc/cli/v4/test) && \
--	go tool covdata textfmt -i $${GOCOVERDIR} -o coverage.integration.out
++endif
++
 +RPM_VERSION=$(shell echo $(VERSION) | sed -e 's/-alpha[0-9]*//' -e 's/-beta[0-9]*//' -e 's/-rc[0-9]*//' -e 's/-SNAPSHOT//' -e 's/-cp[0-9]*//' -e 's/-hotfix[0-9]*//' -e 's/-[0-9]*//')
 +
 +# Get any -alpha, -beta (preview), -rc (release candidate), -SNAPSHOT (nightly), -cp (confluent patch), -hotfix piece that we need to put into the Release part of
@@ -232,16 +222,10 @@
 +ifneq ($(RPM_RELEASE_POSTFIX),)
 +	RPM_RELEASE_POSTFIX_UNDERSCORE=_$(RPM_RELEASE_POSTFIX)
 +	RPM_RELEASE_ID=0.$(REVISION).$(RPM_RELEASE_POSTFIX)
- else
--	export GOCOVERDIR=test/coverage && \
--	rm -rf $${GOCOVERDIR} && mkdir $${GOCOVERDIR} && \
--	go test -timeout 0 -v $$(go list ./... | grep github.com/confluentinc/cli/v4/test) $(INTEGRATION_TEST_ARGS) && \
--	go tool covdata textfmt -i $${GOCOVERDIR} -o coverage.integration.out
++else
 +	RPM_RELEASE_ID=$(REVISION)
- endif
-
--.PHONY: test
--test: unit-test integration-test
++endif
++
 +rpm: rpm-amd64-build rpm-arm64-build $(if $(S390X_AVAILABLE),rpm-s390x-build)
 +	find RPM_BUILDING/{,S}RPMS/ -type f | xargs -n1 -iXXX mv XXX .
 +	@echo
@@ -249,41 +233,19 @@
 +	@echo "The RPMs have been created and can be found here:"
 +	@ls -laF $(FULL_PACKAGE_TITLE)*rpm
 +	@echo "================================================="
-
--.PHONY: build-for-live-test
--build-for-live-test:
--	go build -ldflags="-s -w -X main.disableUpdates=true" -o test/live/bin/confluent ./cmd/confluent
++
 +rpm-amd64-build: rpm-amd64-spec
 +	echo "Building the amd64 RPM"
 +	rpmbuild --target=x86_64 --define="_topdir `pwd`/RPM_BUILDING" --nodebuginfo -tb RPM_BUILDING/SOURCES/$(FULL_PACKAGE_TITLE)-$(RPM_VERSION).tar.gz || rpmbuild --target=x86_64 --define="_topdir `pwd`/RPM_BUILDING" -tb RPM_BUILDING/SOURCES/$(FULL_PACKAGE_TITLE)-$(RPM_VERSION).tar.gz
-
--.PHONY: live-test
--live-test: build-for-live-test
--	@if [ -z "$(CLI_LIVE_TEST_GROUPS)" ]; then \
--		CLI_LIVE_TEST=1 go test ./test/live/ -v -run=".*Live$$" \
--			-tags="live_test,all" -timeout 1440m -parallel 10; \
--	else \
--		TAGS="live_test"; \
--		for group in $$(echo "$(CLI_LIVE_TEST_GROUPS)" | tr ',' ' '); do \
--			TAGS="$$TAGS,$$group"; \
--		done; \
--		CLI_LIVE_TEST=1 go test ./test/live/ -v -run=".*Live$$" \
--			-tags="$$TAGS" -timeout 1440m -parallel 10; \
--	fi
++
 +rpm-arm64-build: rpm-arm64-spec
 +	echo "Building the arm64 RPM"
 +	rpmbuild --target=aarch64 --define="_topdir `pwd`/RPM_BUILDING" --nodebuginfo -tb RPM_BUILDING/SOURCES/$(FULL_PACKAGE_TITLE)-$(RPM_VERSION).tar.gz || rpmbuild --target=aarch64 --define="_topdir `pwd`/RPM_BUILDING" -tb RPM_BUILDING/SOURCES/$(FULL_PACKAGE_TITLE)-$(RPM_VERSION).tar.gz
-
--.PHONY: live-test-core
--live-test-core:
--	@$(MAKE) live-test CLI_LIVE_TEST_GROUPS="core"
++
 +rpm-s390x-build: rpm-s390x-spec
 +	echo "Building the s390x RPM"
 +	rpmbuild --target=s390x --define="_topdir `pwd`/RPM_BUILDING" --nodebuginfo -tb RPM_BUILDING/SOURCES/$(FULL_PACKAGE_TITLE)-$(RPM_VERSION).tar.gz || rpmbuild --target=s390x --define="_topdir `pwd`/RPM_BUILDING" -tb RPM_BUILDING/SOURCES/$(FULL_PACKAGE_TITLE)-$(RPM_VERSION).tar.gz
-
--.PHONY: live-test-kafka
--live-test-kafka:
--	@$(MAKE) live-test CLI_LIVE_TEST_GROUPS="kafka"
++
 +# Unfortunately, because of version naming issues and the way rpmbuild expects
 +# the paths in the tar file to be named, we need to rearchive the package. So
 +# instead of depending on archive, this target just uses the unarchived,
@@ -297,10 +259,7 @@
 +	sed "s/##RPMVERSION##/$(RPM_VERSION)/g; s/##RPMRELEASE##/$(RPM_RELEASE_ID)/g; s/##EXCLUDEARCH1##/arm64/g; s/##EXCLUDEARCH2##/s390x/g" < debian/$(FULL_PACKAGE_TITLE).spec.in > $(FULL_PACKAGE_TITLE)-$(RPM_VERSION)/$(FULL_PACKAGE_TITLE).spec
 +	rm -f $@ && tar -czf RPM_BUILDING/SOURCES/$(FULL_PACKAGE_TITLE)-$(RPM_VERSION).tar.gz $(FULL_PACKAGE_TITLE)-$(RPM_VERSION)
 +	rm -rf $(FULL_PACKAGE_TITLE)-$(RPM_VERSION)
-
--.PHONY: live-test-schema-registry
--live-test-schema-registry:
--	@$(MAKE) live-test CLI_LIVE_TEST_GROUPS="schema_registry"
++
 +rpm-arm64-spec: rpm-build-area install debian/$(FULL_PACKAGE_TITLE).spec.in RELEASE_$(RPM_VERSION)$(RPM_RELEASE_POSTFIX_UNDERSCORE)
 +	rm -rf $(FULL_PACKAGE_TITLE)-$(RPM_VERSION)
 +	mkdir $(FULL_PACKAGE_TITLE)-$(RPM_VERSION)
@@ -308,10 +267,7 @@
 +	sed "s/##RPMVERSION##/$(RPM_VERSION)/g; s/##RPMRELEASE##/$(RPM_RELEASE_ID)/g; s/##EXCLUDEARCH1##/amd64/g; s/##EXCLUDEARCH2##/s390x/g" < debian/$(FULL_PACKAGE_TITLE).spec.in > $(FULL_PACKAGE_TITLE)-$(RPM_VERSION)/$(FULL_PACKAGE_TITLE).spec
 +	rm -f $@ && tar -czf RPM_BUILDING/SOURCES/$(FULL_PACKAGE_TITLE)-$(RPM_VERSION).tar.gz $(FULL_PACKAGE_TITLE)-$(RPM_VERSION)
 +	rm -rf $(FULL_PACKAGE_TITLE)-$(RPM_VERSION)
-
--.PHONY: live-test-iam
--live-test-iam:
--	@$(MAKE) live-test CLI_LIVE_TEST_GROUPS="iam"
++
 +rpm-s390x-spec: rpm-build-area install debian/$(FULL_PACKAGE_TITLE).spec.in RELEASE_$(RPM_VERSION)$(RPM_RELEASE_POSTFIX_UNDERSCORE)
 +	rm -rf $(FULL_PACKAGE_TITLE)-$(RPM_VERSION)
 +	mkdir $(FULL_PACKAGE_TITLE)-$(RPM_VERSION)
@@ -320,17 +276,85 @@
 +	rm -f $@ && tar -czf RPM_BUILDING/SOURCES/$(FULL_PACKAGE_TITLE)-$(RPM_VERSION).tar.gz $(FULL_PACKAGE_TITLE)-$(RPM_VERSION)
 +	rm -rf $(FULL_PACKAGE_TITLE)-$(RPM_VERSION)
 
--.PHONY: live-test-auth
--live-test-auth:
--	@$(MAKE) live-test CLI_LIVE_TEST_GROUPS="auth"
+-.PHONY: build-for-integration-test
+-build-for-integration-test:
+-ifdef CI
+-	go build -cover -ldflags="-s -w -X main.commit="00000000" -X main.date="1970-01-01T00:00:00Z" -X main.isTest=true" -o test/bin/confluent ./cmd/confluent
+-else
+-	go build -cover -ldflags="-s -w -X main.commit="00000000" -X main.date="1970-01-01T00:00:00Z" -X main.isTest=true" -o test/bin/confluent ./cmd/confluent
+-endif
+-
+-.PHONY: build-for-integration-test-windows
+-build-for-integration-test-windows:
+-ifdef CI
+-	go build -cover -ldflags="-s -w -X main.commit="00000000" -X main.date="1970-01-01T00:00:00Z" -X main.isTest=true" -o test/bin/confluent.exe ./cmd/confluent
+-else
+-	go build -cover -ldflags="-s -w -X main.commit="00000000" -X main.date="1970-01-01T00:00:00Z" -X main.isTest=true" -o test/bin/confluent.exe ./cmd/confluent
+-endif
+-
+-.PHONY: integration-test
+-integration-test:
+-ifdef CI
+-	go install gotest.tools/gotestsum@v1.13.0 && \
+-	export GOCOVERDIR=test/coverage && \
+-	rm -rf $${GOCOVERDIR} && mkdir $${GOCOVERDIR} && \
+-	gotestsum --junitfile integration-test-report.xml -- -timeout 0 -v -race $$(go list ./... | grep github.com/confluentinc/cli/v4/test) && \
+-	go tool covdata textfmt -i $${GOCOVERDIR} -o coverage.integration.out
+-else
+-	export GOCOVERDIR=test/coverage && \
+-	rm -rf $${GOCOVERDIR} && mkdir $${GOCOVERDIR} && \
+-	go test -timeout 0 -v $$(go list ./... | grep github.com/confluentinc/cli/v4/test) $(INTEGRATION_TEST_ARGS) && \
+-	go tool covdata textfmt -i $${GOCOVERDIR} -o coverage.integration.out
+-endif
 +rpm-build-area: RPM_BUILDING/BUILD RPM_BUILDING/RPMS RPM_BUILDING/SOURCES RPM_BUILDING/SPECS RPM_BUILDING/SRPMS
 
--.PHONY: live-test-connect
--live-test-connect:
--	@$(MAKE) live-test CLI_LIVE_TEST_GROUPS="connect"
+-.PHONY: test
+-test: unit-test integration-test
 +RPM_BUILDING/%:
 +	mkdir -p $@
 
+-.PHONY: build-for-live-test
+-build-for-live-test:
+-	go build -ldflags="-s -w -X main.disableUpdates=true" -o test/live/bin/confluent ./cmd/confluent
+-
+-.PHONY: live-test
+-live-test: build-for-live-test
+-	@if [ -z "$(CLI_LIVE_TEST_GROUPS)" ]; then \
+-		CLI_LIVE_TEST=1 go test ./test/live/ -v -run=".*Live$$" \
+-			-tags="live_test,all" -timeout 1440m -parallel 10; \
+-	else \
+-		TAGS="live_test"; \
+-		for group in $$(echo "$(CLI_LIVE_TEST_GROUPS)" | tr ',' ' '); do \
+-			TAGS="$$TAGS,$$group"; \
+-		done; \
+-		CLI_LIVE_TEST=1 go test ./test/live/ -v -run=".*Live$$" \
+-			-tags="$$TAGS" -timeout 1440m -parallel 10; \
+-	fi
+-
+-.PHONY: live-test-core
+-live-test-core:
+-	@$(MAKE) live-test CLI_LIVE_TEST_GROUPS="core"
+-
+-.PHONY: live-test-kafka
+-live-test-kafka:
+-	@$(MAKE) live-test CLI_LIVE_TEST_GROUPS="kafka"
+-
+-.PHONY: live-test-schema-registry
+-live-test-schema-registry:
+-	@$(MAKE) live-test CLI_LIVE_TEST_GROUPS="schema_registry"
+-
+-.PHONY: live-test-iam
+-live-test-iam:
+-	@$(MAKE) live-test CLI_LIVE_TEST_GROUPS="iam"
+-
+-.PHONY: live-test-auth
+-live-test-auth:
+-	@$(MAKE) live-test CLI_LIVE_TEST_GROUPS="auth"
+-
+-.PHONY: live-test-connect
+-live-test-connect:
+-	@$(MAKE) live-test CLI_LIVE_TEST_GROUPS="connect"
+-
 -.PHONY: live-test-essential
 -live-test-essential:
 -	@$(MAKE) live-test CLI_LIVE_TEST_GROUPS="core,kafka,schema_registry,auth"

--- a/debian/patches/standard_build_layout.patch
+++ b/debian/patches/standard_build_layout.patch
@@ -1,10 +1,10 @@
---- cli/Makefile	2026-05-04 11:53:58.813568102 -0700
-+++ debian/Makefile	2026-05-04 11:53:51.900990793 -0700
-@@ -1,242 +1,179 @@
+--- cli/Makefile	2026-08-21 17:38:28
++++ debian/Makefile	2026-08-11 15:37:20
+@@ -1,256 +1,179 @@
 -SHELL := /bin/bash
 -GORELEASER_VERSION := v2.13.3
 +SHELL=/bin/bash
- 
+
 -# Compile natively based on the current system
 -.PHONY: build
 -build:
@@ -19,8 +19,10 @@
 -    endif
 -else # darwin
 -	$(MAKE) cli-builder
--endif
--
++ifndef VERSION
++	VERSION=$(CLI_VERSION)
+ endif
+
 -# Cross-compile from darwin to any of the OS/Arch pairs below
 -.PHONY: cross-build
 -cross-build:
@@ -39,11 +41,17 @@
 -		$(MAKE) cli-builder
 -    endif
 -endif
--
++export PACKAGE_TITLE=cli
++export FULL_PACKAGE_TITLE=confluent-$(PACKAGE_TITLE)
++export PACKAGE_NAME=$(FULL_PACKAGE_TITLE)-$(VERSION)
+
 -.PHONY: cli-builder
 -cli-builder:
 -	GOOS="" GOARCH="" CC="" CXX="" CGO_LDFLAGS="" go install github.com/goreleaser/goreleaser/v2@$(GORELEASER_VERSION)
--
++# Defaults that are likely to vary by platform. These are cleanly separated so
++# it should be easy to maintain altered values on platform-specific branches
++# when the values aren't overridden by the script invoking the Makefile
+
 -ifeq ($(GOLANG_FIPS),1)
 -	wget "https://go.dev/dl/go$$(cat .go-version).src.tar.gz" && \
 -	tar -xf go$$(cat .go-version).src.tar.gz && \
@@ -58,20 +66,6 @@
 -	cd ../../
 -	PATH=$$(pwd)/go/bin:$$PATH GOROOT=$$(pwd)/go TAGS=$(TAGS) CC=$(CC) CXX=$(CXX) CGO_LDFLAGS=$(CGO_LDFLAGS) goreleaser build --clean --single-target --snapshot
 -	rm -rf go go-openssl go$$(cat .go-version).src.tar.gz
--else
--	TAGS=$(TAGS) CC=$(CC) CXX=$(CXX) CGO_LDFLAGS=$(CGO_LDFLAGS) goreleaser build --clean --single-target --snapshot
-+ifndef VERSION
-+	VERSION=$(CLI_VERSION)
- endif
- 
-+export PACKAGE_TITLE=cli
-+export FULL_PACKAGE_TITLE=confluent-$(PACKAGE_TITLE)
-+export PACKAGE_NAME=$(FULL_PACKAGE_TITLE)-$(VERSION)
-+
-+# Defaults that are likely to vary by platform. These are cleanly separated so
-+# it should be easy to maintain altered values on platform-specific branches
-+# when the values aren't overridden by the script invoking the Makefile
-+
 +APPLY_PATCHES?=yes
 +
 +# DESTDIR may be overridden by e.g. debian packaging
@@ -82,33 +76,58 @@
 +ifeq ($(PACKAGE_TYPE),archive)
 +PREFIX=$(PACKAGE_NAME)
 +SYSCONFDIR=$(PREFIX)/etc/$(PACKAGE_TITLE)
-+else
+ else
+-	TAGS=$(TAGS) CC=$(CC) CXX=$(CXX) CGO_LDFLAGS=$(CGO_LDFLAGS) goreleaser build --clean --single-target --snapshot
 +PREFIX=/usr
 +SYSCONFDIR=/etc/$(PACKAGE_TITLE)
-+endif
-+
+ endif
+
 +_empty :=
 +_space := $(_empty) $(empty)
 +split_version := $(subst .,$(_space),$(CLI_VERSION))
-+
+
+-# Build a dev binary onto your PATH as `confluent-dev`. A local build reports the "dev" release
+-# channel, so it keeps its state in ~/.confluent-dev, isolated from an installed release's
+-# ~/.confluent. Debug symbols are kept, unlike the test builds, so delve can attach.
+-CONFLUENT_DEV_BIN ?= $(HOME)/.local/bin/confluent-dev
+-CONFLUENT_DEV_VERSION ?= 0.0.0-dev-$(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)
 +S390X_AVAILABLE := $(shell [ $(word 1,$(split_version)) -ge 4 ] && [ $(word 2,$(split_version)) -ge 59 ] && echo yes)
-+
+
+-.PHONY: build-dev
+-build-dev:
+-	@mkdir -p $(dir $(CONFLUENT_DEV_BIN))
+-	go build -ldflags="-X main.version=$(CONFLUENT_DEV_VERSION) -X main.commit=$(shell git rev-parse HEAD 2>/dev/null || echo unknown) -X main.date=$(shell date -u +%Y-%m-%dT%H:%M:%SZ)" -o $(CONFLUENT_DEV_BIN) ./cmd/confluent
+-	@echo "Built confluent-dev at $(CONFLUENT_DEV_BIN)"
+-	@echo "It keeps state in ~/.confluent-dev, isolated from the ~/.confluent of any installed release."
+-	@echo "Make sure $(dir $(CONFLUENT_DEV_BIN)) is on your PATH."
 +all: install
-+
+
 +archive: install
 +	rm -f $(CURDIR)/$(PACKAGE_NAME).tar.gz && cd $(DESTDIR) && tar -czf $(CURDIR)/$(PACKAGE_NAME).tar.gz $(PREFIX)
 +	rm -f $(CURDIR)/$(PACKAGE_NAME).zip && cd $(DESTDIR) && zip -r $(CURDIR)/$(PACKAGE_NAME).zip $(PREFIX)
-+
+
+-.PHONY: clean
+-clean:
+-	for dir in bin dist docs legal prebuilt release-notes; do \
+-		[ -d $$dir ] && rm -r $$dir || true; \
+-	done
 +apply-patches: $(wildcard debian/patches/*)
 +ifeq ($(APPLY_PATCHES),yes)
 +	git reset --hard HEAD
 +	cat debian/patches/series | xargs -iPATCH bash -c 'patch -p1 < debian/patches/PATCH'
 +endif
-+
+
+-.PHONY: lint
+-lint: lint-go lint-cli
 +BINPATH=$(PREFIX)/bin
 +LIBPATH=$(PREFIX)/libexec/$(PACKAGE_TITLE)
 +DOCPATH=$(PREFIX)/share/doc/$(PACKAGE_TITLE)
-+
+
+-.PHONY: lint-go
+-lint-go:
+-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.8 && \
+-	golangci-lint run --timeout 10m
+-	@echo "✅  golangci-lint"
 +# Notes on the archive download links:
 +# As of v3.0.0, the version number no longer has the 'v' prefix
 +# As of v3.43.0, we download the '_disableupdates' variant
@@ -116,15 +135,23 @@
 +install: apply-patches
 +	rm -rf $(DESTDIR)$(PREFIX)
 +	mkdir -p $(DESTDIR)$(PREFIX)
-+
+
+-.PHONY: lint-cli
+-lint-cli: cmd/lint/en_US.aff cmd/lint/en_US.dic
+-	go run cmd/lint/main.go -aff-file $(word 1,$^) -dic-file $(word 2,$^) $(ARGS)
+-	@echo "✅  cmd/lint/main.go"
 +	mkdir -p $(DESTDIR)$(BINPATH)
 +	mkdir -p $(DESTDIR)$(LIBPATH)
 +	mkdir -p $(DESTDIR)$(DOCPATH)
 +	mkdir -p $(DESTDIR)$(SYSCONFDIR)
-+
+
+-cmd/lint/en_US.aff:
+-	curl -s "https://chromium.googlesource.com/chromium/deps/hunspell_dictionaries/+/master/en_US.aff?format=TEXT" | base64 -D > $@
 +	cp packaging/confluent.sh $(DESTDIR)$(BINPATH)/confluent
 +	chmod 755 $(DESTDIR)$(BINPATH)/confluent
-+
+
+-cmd/lint/en_US.dic:
+-	curl -s "https://chromium.googlesource.com/chromium/deps/hunspell_dictionaries/+/master/en_US.dic?format=TEXT" | base64 -D > $@
 +	cd $(DESTDIR)$(LIBPATH); \
 +	v=""; if [[ $(word 1,$(split_version)) -eq 2 ]]; then v="v"; fi; \
 +	disableupdates=""; if [[ $(word 1,$(split_version)) -ge 3 && $(word 2,$(split_version)) -ge 43 ]]; then disableupdates="_disableupdates"; fi; \
@@ -146,38 +173,7 @@
 +	filepath=windows_amd64/confluent.exe; \
 +	curl -fs https://$${baseurl}/confluent-cli/binaries/$(CLI_VERSION)/confluent$${version}_windows_amd64.exe -o $${filepath}; \
 +	chmod 755 $${filepath}
-+
-+	cp LICENSE $(DESTDIR)$(DOCPATH)/LICENSE
-+	$(DESTDIR)$(BINPATH)/confluent --version | awk -F' ' '{ print $3 }' > $(DESTDIR)$(DOCPATH)/version.txt
- 
-+	chown -R root:root $(DESTDIR)$(PREFIX)
- 
--.PHONY: clean
- clean:
--	for dir in bin dist docs legal prebuilt release-notes; do \
--		[ -d $$dir ] && rm -r $$dir || true; \
--	done
--
--.PHONY: lint
--lint: lint-go lint-cli
--
--.PHONY: lint-go
--lint-go:
--	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.8 && \
--	golangci-lint run --timeout 10m
--	@echo "✅  golangci-lint"
--
--.PHONY: lint-cli
--lint-cli: cmd/lint/en_US.aff cmd/lint/en_US.dic
--	go run cmd/lint/main.go -aff-file $(word 1,$^) -dic-file $(word 2,$^) $(ARGS)
--	@echo "✅  cmd/lint/main.go"
--
--cmd/lint/en_US.aff:
--	curl -s "https://chromium.googlesource.com/chromium/deps/hunspell_dictionaries/+/master/en_US.aff?format=TEXT" | base64 -D > $@
--
--cmd/lint/en_US.dic:
--	curl -s "https://chromium.googlesource.com/chromium/deps/hunspell_dictionaries/+/master/en_US.dic?format=TEXT" | base64 -D > $@
--
+
 -.PHONY: unit-test
 -unit-test:
 -ifdef CI
@@ -186,6 +182,25 @@
 -else
 -	go test -timeout 0 -v -coverprofile=coverage.unit.out -covermode=atomic $$(go list ./... | grep -v github.com/confluentinc/cli/v4/test) $(UNIT_TEST_ARGS)
 -endif
++	cp LICENSE $(DESTDIR)$(DOCPATH)/LICENSE
++	$(DESTDIR)$(BINPATH)/confluent --version | awk -F' ' '{ print $3 }' > $(DESTDIR)$(DOCPATH)/version.txt
+
+-.PHONY: build-for-integration-test
+-build-for-integration-test:
+-ifdef CI
+-	go build -cover -ldflags="-s -w -X main.commit="00000000" -X main.date="1970-01-01T00:00:00Z" -X main.isTest=true" -o test/bin/confluent ./cmd/confluent
+-else
+-	go build -cover -ldflags="-s -w -X main.commit="00000000" -X main.date="1970-01-01T00:00:00Z" -X main.isTest=true" -o test/bin/confluent ./cmd/confluent
+-endif
++	chown -R root:root $(DESTDIR)$(PREFIX)
+
+-.PHONY: build-for-integration-test-windows
+-build-for-integration-test-windows:
+-ifdef CI
+-	go build -cover -ldflags="-s -w -X main.commit="00000000" -X main.date="1970-01-01T00:00:00Z" -X main.isTest=true" -o test/bin/confluent.exe ./cmd/confluent
+-else
+-	go build -cover -ldflags="-s -w -X main.commit="00000000" -X main.date="1970-01-01T00:00:00Z" -X main.isTest=true" -o test/bin/confluent.exe ./cmd/confluent
++clean:
 +	rm -rf $(CURDIR)/$(PACKAGE_NAME)*
 +	rm -rf $(FULL_PACKAGE_TITLE)-$(RPM_VERSION)*rpm
 +	rm -rf RPM_BUILDING
@@ -194,8 +209,16 @@
 +ifneq ($(PACKAGE_TYPE),deb)
 +	git reset --hard HEAD
 +	git status --ignored --porcelain | cut -d ' ' -f 2 | xargs rm -rf
-+endif
-+
+ endif
+
+-.PHONY: integration-test
+-integration-test:
+-ifdef CI
+-	go install gotest.tools/gotestsum@v1.13.0 && \
+-	export GOCOVERDIR=test/coverage && \
+-	rm -rf $${GOCOVERDIR} && mkdir $${GOCOVERDIR} && \
+-	gotestsum --junitfile integration-test-report.xml -- -timeout 0 -v -race $$(go list ./... | grep github.com/confluentinc/cli/v4/test) && \
+-	go tool covdata textfmt -i $${GOCOVERDIR} -o coverage.integration.out
 +RPM_VERSION=$(shell echo $(VERSION) | sed -e 's/-alpha[0-9]*//' -e 's/-beta[0-9]*//' -e 's/-rc[0-9]*//' -e 's/-SNAPSHOT//' -e 's/-cp[0-9]*//' -e 's/-hotfix[0-9]*//' -e 's/-[0-9]*//')
 +
 +# Get any -alpha, -beta (preview), -rc (release candidate), -SNAPSHOT (nightly), -cp (confluent patch), -hotfix piece that we need to put into the Release part of
@@ -209,10 +232,16 @@
 +ifneq ($(RPM_RELEASE_POSTFIX),)
 +	RPM_RELEASE_POSTFIX_UNDERSCORE=_$(RPM_RELEASE_POSTFIX)
 +	RPM_RELEASE_ID=0.$(REVISION).$(RPM_RELEASE_POSTFIX)
-+else
+ else
+-	export GOCOVERDIR=test/coverage && \
+-	rm -rf $${GOCOVERDIR} && mkdir $${GOCOVERDIR} && \
+-	go test -timeout 0 -v $$(go list ./... | grep github.com/confluentinc/cli/v4/test) $(INTEGRATION_TEST_ARGS) && \
+-	go tool covdata textfmt -i $${GOCOVERDIR} -o coverage.integration.out
 +	RPM_RELEASE_ID=$(REVISION)
-+endif
-+
+ endif
+
+-.PHONY: test
+-test: unit-test integration-test
 +rpm: rpm-amd64-build rpm-arm64-build $(if $(S390X_AVAILABLE),rpm-s390x-build)
 +	find RPM_BUILDING/{,S}RPMS/ -type f | xargs -n1 -iXXX mv XXX .
 +	@echo
@@ -220,90 +249,14 @@
 +	@echo "The RPMs have been created and can be found here:"
 +	@ls -laF $(FULL_PACKAGE_TITLE)*rpm
 +	@echo "================================================="
-+
-+rpm-amd64-build: rpm-amd64-spec
-+	echo "Building the amd64 RPM"
-+	rpmbuild --target=x86_64 --define="_topdir `pwd`/RPM_BUILDING" --nodebuginfo -tb RPM_BUILDING/SOURCES/$(FULL_PACKAGE_TITLE)-$(RPM_VERSION).tar.gz || rpmbuild --target=x86_64 --define="_topdir `pwd`/RPM_BUILDING" -tb RPM_BUILDING/SOURCES/$(FULL_PACKAGE_TITLE)-$(RPM_VERSION).tar.gz
-+
-+rpm-arm64-build: rpm-arm64-spec
-+	echo "Building the arm64 RPM"
-+	rpmbuild --target=aarch64 --define="_topdir `pwd`/RPM_BUILDING" --nodebuginfo -tb RPM_BUILDING/SOURCES/$(FULL_PACKAGE_TITLE)-$(RPM_VERSION).tar.gz || rpmbuild --target=aarch64 --define="_topdir `pwd`/RPM_BUILDING" -tb RPM_BUILDING/SOURCES/$(FULL_PACKAGE_TITLE)-$(RPM_VERSION).tar.gz
-+
-+rpm-s390x-build: rpm-s390x-spec
-+	echo "Building the s390x RPM"
-+	rpmbuild --target=s390x --define="_topdir `pwd`/RPM_BUILDING" --nodebuginfo -tb RPM_BUILDING/SOURCES/$(FULL_PACKAGE_TITLE)-$(RPM_VERSION).tar.gz || rpmbuild --target=s390x --define="_topdir `pwd`/RPM_BUILDING" -tb RPM_BUILDING/SOURCES/$(FULL_PACKAGE_TITLE)-$(RPM_VERSION).tar.gz
-+
-+# Unfortunately, because of version naming issues and the way rpmbuild expects
-+# the paths in the tar file to be named, we need to rearchive the package. So
-+# instead of depending on archive, this target just uses the unarchived,
-+# installed version to generate a new archive. Note that we always regenerate
-+# the symlink because the RPM_VERSION doesn't include all the version info -- it
-+# can leave of things like -beta, -rc1, etc.
-+rpm-amd64-spec: rpm-build-area install debian/$(FULL_PACKAGE_TITLE).spec.in RELEASE_$(RPM_VERSION)$(RPM_RELEASE_POSTFIX_UNDERSCORE)
-+	rm -rf $(FULL_PACKAGE_TITLE)-$(RPM_VERSION)
-+	mkdir $(FULL_PACKAGE_TITLE)-$(RPM_VERSION)
-+	cp -R $(DESTDIR)/* $(FULL_PACKAGE_TITLE)-$(RPM_VERSION)
-+	sed "s/##RPMVERSION##/$(RPM_VERSION)/g; s/##RPMRELEASE##/$(RPM_RELEASE_ID)/g; s/##EXCLUDEARCH1##/arm64/g; s/##EXCLUDEARCH2##/s390x/g" < debian/$(FULL_PACKAGE_TITLE).spec.in > $(FULL_PACKAGE_TITLE)-$(RPM_VERSION)/$(FULL_PACKAGE_TITLE).spec
-+	rm -f $@ && tar -czf RPM_BUILDING/SOURCES/$(FULL_PACKAGE_TITLE)-$(RPM_VERSION).tar.gz $(FULL_PACKAGE_TITLE)-$(RPM_VERSION)
-+	rm -rf $(FULL_PACKAGE_TITLE)-$(RPM_VERSION)
-+
-+rpm-arm64-spec: rpm-build-area install debian/$(FULL_PACKAGE_TITLE).spec.in RELEASE_$(RPM_VERSION)$(RPM_RELEASE_POSTFIX_UNDERSCORE)
-+	rm -rf $(FULL_PACKAGE_TITLE)-$(RPM_VERSION)
-+	mkdir $(FULL_PACKAGE_TITLE)-$(RPM_VERSION)
-+	cp -R $(DESTDIR)/* $(FULL_PACKAGE_TITLE)-$(RPM_VERSION)
-+	sed "s/##RPMVERSION##/$(RPM_VERSION)/g; s/##RPMRELEASE##/$(RPM_RELEASE_ID)/g; s/##EXCLUDEARCH1##/amd64/g; s/##EXCLUDEARCH2##/s390x/g" < debian/$(FULL_PACKAGE_TITLE).spec.in > $(FULL_PACKAGE_TITLE)-$(RPM_VERSION)/$(FULL_PACKAGE_TITLE).spec
-+	rm -f $@ && tar -czf RPM_BUILDING/SOURCES/$(FULL_PACKAGE_TITLE)-$(RPM_VERSION).tar.gz $(FULL_PACKAGE_TITLE)-$(RPM_VERSION)
-+	rm -rf $(FULL_PACKAGE_TITLE)-$(RPM_VERSION)
-+
-+rpm-s390x-spec: rpm-build-area install debian/$(FULL_PACKAGE_TITLE).spec.in RELEASE_$(RPM_VERSION)$(RPM_RELEASE_POSTFIX_UNDERSCORE)
-+	rm -rf $(FULL_PACKAGE_TITLE)-$(RPM_VERSION)
-+	mkdir $(FULL_PACKAGE_TITLE)-$(RPM_VERSION)
-+	cp -R $(DESTDIR)/* $(FULL_PACKAGE_TITLE)-$(RPM_VERSION)
-+	sed "s/##RPMVERSION##/$(RPM_VERSION)/g; s/##RPMRELEASE##/$(RPM_RELEASE_ID)/g; s/##EXCLUDEARCH1##/amd64/g; s/##EXCLUDEARCH2##/arm64/g" < debian/$(FULL_PACKAGE_TITLE).spec.in > $(FULL_PACKAGE_TITLE)-$(RPM_VERSION)/$(FULL_PACKAGE_TITLE).spec
-+	rm -f $@ && tar -czf RPM_BUILDING/SOURCES/$(FULL_PACKAGE_TITLE)-$(RPM_VERSION).tar.gz $(FULL_PACKAGE_TITLE)-$(RPM_VERSION)
-+	rm -rf $(FULL_PACKAGE_TITLE)-$(RPM_VERSION)
- 
--.PHONY: build-for-integration-test
--build-for-integration-test:
--ifdef CI
--	go build -cover -ldflags="-s -w -X main.commit="00000000" -X main.date="1970-01-01T00:00:00Z" -X main.isTest=true" -o test/bin/confluent ./cmd/confluent
--else
--	go build -cover -ldflags="-s -w -X main.commit="00000000" -X main.date="1970-01-01T00:00:00Z" -X main.isTest=true" -o test/bin/confluent ./cmd/confluent
--endif
-+rpm-build-area: RPM_BUILDING/BUILD RPM_BUILDING/RPMS RPM_BUILDING/SOURCES RPM_BUILDING/SPECS RPM_BUILDING/SRPMS
- 
--.PHONY: build-for-integration-test-windows
--build-for-integration-test-windows:
--ifdef CI
--	go build -cover -ldflags="-s -w -X main.commit="00000000" -X main.date="1970-01-01T00:00:00Z" -X main.isTest=true" -o test/bin/confluent.exe ./cmd/confluent
--else
--	go build -cover -ldflags="-s -w -X main.commit="00000000" -X main.date="1970-01-01T00:00:00Z" -X main.isTest=true" -o test/bin/confluent.exe ./cmd/confluent
--endif
-+RPM_BUILDING/%:
-+	mkdir -p $@
- 
--.PHONY: integration-test
--integration-test:
--ifdef CI
--	go install gotest.tools/gotestsum@v1.13.0 && \
--	export GOCOVERDIR=test/coverage && \
--	rm -rf $${GOCOVERDIR} && mkdir $${GOCOVERDIR} && \
--	gotestsum --junitfile integration-test-report.xml -- -timeout 0 -v -race $$(go list ./... | grep github.com/confluentinc/cli/v4/test) && \
--	go tool covdata textfmt -i $${GOCOVERDIR} -o coverage.integration.out
--else
--	export GOCOVERDIR=test/coverage && \
--	rm -rf $${GOCOVERDIR} && mkdir $${GOCOVERDIR} && \
--	go test -timeout 0 -v $$(go list ./... | grep github.com/confluentinc/cli/v4/test) $(INTEGRATION_TEST_ARGS) && \
--	go tool covdata textfmt -i $${GOCOVERDIR} -o coverage.integration.out
--endif
--
--.PHONY: test
--test: unit-test integration-test
--
+
 -.PHONY: build-for-live-test
 -build-for-live-test:
 -	go build -ldflags="-s -w -X main.disableUpdates=true" -o test/live/bin/confluent ./cmd/confluent
--
++rpm-amd64-build: rpm-amd64-spec
++	echo "Building the amd64 RPM"
++	rpmbuild --target=x86_64 --define="_topdir `pwd`/RPM_BUILDING" --nodebuginfo -tb RPM_BUILDING/SOURCES/$(FULL_PACKAGE_TITLE)-$(RPM_VERSION).tar.gz || rpmbuild --target=x86_64 --define="_topdir `pwd`/RPM_BUILDING" -tb RPM_BUILDING/SOURCES/$(FULL_PACKAGE_TITLE)-$(RPM_VERSION).tar.gz
+
 -.PHONY: live-test
 -live-test: build-for-live-test
 -	@if [ -z "$(CLI_LIVE_TEST_GROUPS)" ]; then \
@@ -317,31 +270,67 @@
 -		CLI_LIVE_TEST=1 go test ./test/live/ -v -run=".*Live$$" \
 -			-tags="$$TAGS" -timeout 1440m -parallel 10; \
 -	fi
--
++rpm-arm64-build: rpm-arm64-spec
++	echo "Building the arm64 RPM"
++	rpmbuild --target=aarch64 --define="_topdir `pwd`/RPM_BUILDING" --nodebuginfo -tb RPM_BUILDING/SOURCES/$(FULL_PACKAGE_TITLE)-$(RPM_VERSION).tar.gz || rpmbuild --target=aarch64 --define="_topdir `pwd`/RPM_BUILDING" -tb RPM_BUILDING/SOURCES/$(FULL_PACKAGE_TITLE)-$(RPM_VERSION).tar.gz
+
 -.PHONY: live-test-core
 -live-test-core:
 -	@$(MAKE) live-test CLI_LIVE_TEST_GROUPS="core"
--
++rpm-s390x-build: rpm-s390x-spec
++	echo "Building the s390x RPM"
++	rpmbuild --target=s390x --define="_topdir `pwd`/RPM_BUILDING" --nodebuginfo -tb RPM_BUILDING/SOURCES/$(FULL_PACKAGE_TITLE)-$(RPM_VERSION).tar.gz || rpmbuild --target=s390x --define="_topdir `pwd`/RPM_BUILDING" -tb RPM_BUILDING/SOURCES/$(FULL_PACKAGE_TITLE)-$(RPM_VERSION).tar.gz
+
 -.PHONY: live-test-kafka
 -live-test-kafka:
 -	@$(MAKE) live-test CLI_LIVE_TEST_GROUPS="kafka"
--
++# Unfortunately, because of version naming issues and the way rpmbuild expects
++# the paths in the tar file to be named, we need to rearchive the package. So
++# instead of depending on archive, this target just uses the unarchived,
++# installed version to generate a new archive. Note that we always regenerate
++# the symlink because the RPM_VERSION doesn't include all the version info -- it
++# can leave of things like -beta, -rc1, etc.
++rpm-amd64-spec: rpm-build-area install debian/$(FULL_PACKAGE_TITLE).spec.in RELEASE_$(RPM_VERSION)$(RPM_RELEASE_POSTFIX_UNDERSCORE)
++	rm -rf $(FULL_PACKAGE_TITLE)-$(RPM_VERSION)
++	mkdir $(FULL_PACKAGE_TITLE)-$(RPM_VERSION)
++	cp -R $(DESTDIR)/* $(FULL_PACKAGE_TITLE)-$(RPM_VERSION)
++	sed "s/##RPMVERSION##/$(RPM_VERSION)/g; s/##RPMRELEASE##/$(RPM_RELEASE_ID)/g; s/##EXCLUDEARCH1##/arm64/g; s/##EXCLUDEARCH2##/s390x/g" < debian/$(FULL_PACKAGE_TITLE).spec.in > $(FULL_PACKAGE_TITLE)-$(RPM_VERSION)/$(FULL_PACKAGE_TITLE).spec
++	rm -f $@ && tar -czf RPM_BUILDING/SOURCES/$(FULL_PACKAGE_TITLE)-$(RPM_VERSION).tar.gz $(FULL_PACKAGE_TITLE)-$(RPM_VERSION)
++	rm -rf $(FULL_PACKAGE_TITLE)-$(RPM_VERSION)
+
 -.PHONY: live-test-schema-registry
 -live-test-schema-registry:
 -	@$(MAKE) live-test CLI_LIVE_TEST_GROUPS="schema_registry"
--
++rpm-arm64-spec: rpm-build-area install debian/$(FULL_PACKAGE_TITLE).spec.in RELEASE_$(RPM_VERSION)$(RPM_RELEASE_POSTFIX_UNDERSCORE)
++	rm -rf $(FULL_PACKAGE_TITLE)-$(RPM_VERSION)
++	mkdir $(FULL_PACKAGE_TITLE)-$(RPM_VERSION)
++	cp -R $(DESTDIR)/* $(FULL_PACKAGE_TITLE)-$(RPM_VERSION)
++	sed "s/##RPMVERSION##/$(RPM_VERSION)/g; s/##RPMRELEASE##/$(RPM_RELEASE_ID)/g; s/##EXCLUDEARCH1##/amd64/g; s/##EXCLUDEARCH2##/s390x/g" < debian/$(FULL_PACKAGE_TITLE).spec.in > $(FULL_PACKAGE_TITLE)-$(RPM_VERSION)/$(FULL_PACKAGE_TITLE).spec
++	rm -f $@ && tar -czf RPM_BUILDING/SOURCES/$(FULL_PACKAGE_TITLE)-$(RPM_VERSION).tar.gz $(FULL_PACKAGE_TITLE)-$(RPM_VERSION)
++	rm -rf $(FULL_PACKAGE_TITLE)-$(RPM_VERSION)
+
 -.PHONY: live-test-iam
 -live-test-iam:
 -	@$(MAKE) live-test CLI_LIVE_TEST_GROUPS="iam"
--
++rpm-s390x-spec: rpm-build-area install debian/$(FULL_PACKAGE_TITLE).spec.in RELEASE_$(RPM_VERSION)$(RPM_RELEASE_POSTFIX_UNDERSCORE)
++	rm -rf $(FULL_PACKAGE_TITLE)-$(RPM_VERSION)
++	mkdir $(FULL_PACKAGE_TITLE)-$(RPM_VERSION)
++	cp -R $(DESTDIR)/* $(FULL_PACKAGE_TITLE)-$(RPM_VERSION)
++	sed "s/##RPMVERSION##/$(RPM_VERSION)/g; s/##RPMRELEASE##/$(RPM_RELEASE_ID)/g; s/##EXCLUDEARCH1##/amd64/g; s/##EXCLUDEARCH2##/arm64/g" < debian/$(FULL_PACKAGE_TITLE).spec.in > $(FULL_PACKAGE_TITLE)-$(RPM_VERSION)/$(FULL_PACKAGE_TITLE).spec
++	rm -f $@ && tar -czf RPM_BUILDING/SOURCES/$(FULL_PACKAGE_TITLE)-$(RPM_VERSION).tar.gz $(FULL_PACKAGE_TITLE)-$(RPM_VERSION)
++	rm -rf $(FULL_PACKAGE_TITLE)-$(RPM_VERSION)
+
 -.PHONY: live-test-auth
 -live-test-auth:
 -	@$(MAKE) live-test CLI_LIVE_TEST_GROUPS="auth"
--
++rpm-build-area: RPM_BUILDING/BUILD RPM_BUILDING/RPMS RPM_BUILDING/SOURCES RPM_BUILDING/SPECS RPM_BUILDING/SRPMS
+
 -.PHONY: live-test-connect
 -live-test-connect:
 -	@$(MAKE) live-test CLI_LIVE_TEST_GROUPS="connect"
--
++RPM_BUILDING/%:
++	mkdir -p $@
+
 -.PHONY: live-test-essential
 -live-test-essential:
 -	@$(MAKE) live-test CLI_LIVE_TEST_GROUPS="core,kafka,schema_registry,auth"
@@ -411,6 +400,5 @@
 -	@tail -n +2 coverage.integration.out >> coverage.txt
 -	@echo "Coverage data saved to: coverage.txt"
 -	@artifact push workflow coverage.txt
-\ No newline at end of file
 +RELEASE_%:
 +	echo 0 > $@

--- a/debian/patches/standard_build_layout.patch
+++ b/debian/patches/standard_build_layout.patch
@@ -1,10 +1,10 @@
---- cli/Makefile	2026-08-21 21:38:28.801439074 +0000
+--- cli/Makefile	2026-08-27 19:21:26.012703677 +0000
 +++ debian/Makefile	2026-08-11 19:37:20.278886564 +0000
 @@ -1,256 +1,179 @@
 -SHELL := /bin/bash
 -GORELEASER_VERSION := v2.13.3
 +SHELL=/bin/bash
-
+ 
 -# Compile natively based on the current system
 -.PHONY: build
 -build:
@@ -63,7 +63,7 @@
 +ifndef VERSION
 +	VERSION=$(CLI_VERSION)
  endif
-
+ 
 +export PACKAGE_TITLE=cli
 +export FULL_PACKAGE_TITLE=confluent-$(PACKAGE_TITLE)
 +export PACKAGE_NAME=$(FULL_PACKAGE_TITLE)-$(VERSION)
@@ -146,7 +146,7 @@
 +	filepath=windows_amd64/confluent.exe; \
 +	curl -fs https://$${baseurl}/confluent-cli/binaries/$(CLI_VERSION)/confluent$${version}_windows_amd64.exe -o $${filepath}; \
 +	chmod 755 $${filepath}
-
+ 
 -# Build a dev binary onto your PATH as `confluent-dev`. A local build reports the "dev" release
 -# channel, so it keeps its state in ~/.confluent-dev, isolated from an installed release's
 -# ~/.confluent. Debug symbols are kept, unlike the test builds, so delve can attach.
@@ -156,15 +156,15 @@
 -.PHONY: build-dev
 -build-dev:
 -	@mkdir -p $(dir $(CONFLUENT_DEV_BIN))
--	go build -ldflags="-X main.version=$(CONFLUENT_DEV_VERSION) -X main.commit=$(shell git rev-parse HEAD 2>/dev/null || echo unknown) -X main.date=$(shell date -u +%Y-%m-%dT%H:%M:%SZ)" -o $(CONFLUENT_DEV_BIN) ./cmd/confluent
+-	go build -ldflags="-X main.disableUpdates=true -X main.version=$(CONFLUENT_DEV_VERSION) -X main.commit=$(shell git rev-parse HEAD 2>/dev/null || echo unknown) -X main.date=$(shell date -u +%Y-%m-%dT%H:%M:%SZ)" -o $(CONFLUENT_DEV_BIN) ./cmd/confluent
 -	@echo "Built confluent-dev at $(CONFLUENT_DEV_BIN)"
 -	@echo "It keeps state in ~/.confluent-dev, isolated from the ~/.confluent of any installed release."
 -	@echo "Make sure $(dir $(CONFLUENT_DEV_BIN)) is on your PATH."
 +	cp LICENSE $(DESTDIR)$(DOCPATH)/LICENSE
 +	$(DESTDIR)$(BINPATH)/confluent --version | awk -F' ' '{ print $3 }' > $(DESTDIR)$(DOCPATH)/version.txt
-
+ 
 +	chown -R root:root $(DESTDIR)$(PREFIX)
-
+ 
 -.PHONY: clean
  clean:
 -	for dir in bin dist docs legal prebuilt release-notes; do \
@@ -275,7 +275,7 @@
 +	sed "s/##RPMVERSION##/$(RPM_VERSION)/g; s/##RPMRELEASE##/$(RPM_RELEASE_ID)/g; s/##EXCLUDEARCH1##/amd64/g; s/##EXCLUDEARCH2##/arm64/g" < debian/$(FULL_PACKAGE_TITLE).spec.in > $(FULL_PACKAGE_TITLE)-$(RPM_VERSION)/$(FULL_PACKAGE_TITLE).spec
 +	rm -f $@ && tar -czf RPM_BUILDING/SOURCES/$(FULL_PACKAGE_TITLE)-$(RPM_VERSION).tar.gz $(FULL_PACKAGE_TITLE)-$(RPM_VERSION)
 +	rm -rf $(FULL_PACKAGE_TITLE)-$(RPM_VERSION)
-
+ 
 -.PHONY: build-for-integration-test
 -build-for-integration-test:
 -ifdef CI
@@ -307,12 +307,12 @@
 -	go tool covdata textfmt -i $${GOCOVERDIR} -o coverage.integration.out
 -endif
 +rpm-build-area: RPM_BUILDING/BUILD RPM_BUILDING/RPMS RPM_BUILDING/SOURCES RPM_BUILDING/SPECS RPM_BUILDING/SRPMS
-
+ 
 -.PHONY: test
 -test: unit-test integration-test
 +RPM_BUILDING/%:
 +	mkdir -p $@
-
+ 
 -.PHONY: build-for-live-test
 -build-for-live-test:
 -	go build -ldflags="-s -w -X main.disableUpdates=true" -o test/live/bin/confluent ./cmd/confluent

--- a/internal/configuration/command_list.go
+++ b/internal/configuration/command_list.go
@@ -10,7 +10,7 @@ import (
 func (c *command) newListCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
-		Short: "List user-configurable fields in ~/.confluent/config.json.",
+		Short: "List user-configurable fields in the CLI configuration file.",
 		Args:  cobra.NoArgs,
 		RunE:  c.list,
 	}

--- a/internal/plugin/command_install.go
+++ b/internal/plugin/command_install.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 
+	"github.com/confluentinc/cli/v4/pkg/config"
 	"github.com/confluentinc/cli/v4/pkg/errors"
 	"github.com/confluentinc/cli/v4/pkg/output"
 	"github.com/confluentinc/cli/v4/pkg/plugin"
@@ -27,11 +28,11 @@ func (c *command) newInstallCommand() *cobra.Command {
 }
 
 func (c *command) install(_ *cobra.Command, args []string) error {
-	home, err := os.UserHomeDir()
+	confluentDir, err := config.StateDir()
 	if err != nil {
 		return err
 	}
-	confluentDir := filepath.Join(home, ".confluent")
+
 	dir, err := os.MkdirTemp(confluentDir, "cli-plugins")
 	if err != nil {
 		return err

--- a/internal/plugin/command_search.go
+++ b/internal/plugin/command_search.go
@@ -11,6 +11,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	pcmd "github.com/confluentinc/cli/v4/pkg/cmd"
+	"github.com/confluentinc/cli/v4/pkg/config"
 	"github.com/confluentinc/cli/v4/pkg/output"
 	"github.com/confluentinc/cli/v4/pkg/plugin"
 	"github.com/confluentinc/cli/v4/pkg/utils"
@@ -50,12 +51,12 @@ func (c *command) newSearchCommand() *cobra.Command {
 }
 
 func (c *command) search(cmd *cobra.Command, _ []string) error {
-	home, err := os.UserHomeDir()
+	stateDir, err := config.StateDir()
 	if err != nil {
 		return err
 	}
 
-	dir, err := os.MkdirTemp(filepath.Join(home, ".confluent"), "cli-plugins")
+	dir, err := os.MkdirTemp(stateDir, "cli-plugins")
 	if err != nil {
 		return err
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -648,9 +648,30 @@ func (c *Config) GetFilename() string {
 	return c.Filename
 }
 
+// StateDirName is the name of the CLI's state directory within the user's home directory. It is
+// scoped to the build's release channel so a production install, a prerelease, and a local build
+// cannot read or overwrite each other's state. A stable build returns ".confluent", unchanged.
+func StateDirName() string {
+	return ".confluent" + pversion.ProcessChannel().StateDirSuffix()
+}
+
+// StateDir is the absolute path of the CLI's state directory.
+func StateDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", errors.NewErrorWithSuggestions(
+			fmt.Sprintf("unable to determine the home directory holding the CLI's state: %v", err),
+			"Set the `HOME` environment variable (`USERPROFILE` on Windows) to a writable directory.",
+		)
+	}
+	return filepath.Join(home, StateDirName()), nil
+}
+
+// GetDefaultFilename swallows a missing home directory because it backs a flag default built at
+// command-construction time, where there is no error to return. Prefer StateDir where you can.
 func GetDefaultFilename() string {
 	home, _ := os.UserHomeDir()
-	return filepath.Join(home, ".confluent", "config.json")
+	return filepath.Join(home, StateDirName(), "config.json")
 }
 
 func (c *Config) CheckIsOnPremLogin() error {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -618,6 +618,34 @@ func TestStateDir_ErrorWhenHomeUnresolvable(t *testing.T) {
 	require.Error(t, err, "StateDir must fail rather than fall back to the working directory")
 }
 
+func TestStateDir_ByChannel(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Cleanup(func() { pversion.SetProcessChannel(pversion.Dev) })
+
+	tests := []struct {
+		name    string
+		channel pversion.Channel
+		dir     string
+	}{
+		{"stable keeps the historical path", pversion.Stable, ".confluent"},
+		{"prerelease is isolated", pversion.Prerelease, ".confluent-prerelease"},
+		{"dev is isolated", pversion.Dev, ".confluent-dev"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			pversion.SetProcessChannel(test.channel)
+
+			dir, err := StateDir()
+
+			require.NoError(t, err)
+			require.Equal(t, filepath.Join(home, test.dir), dir)
+		})
+	}
+}
+
 func TestConfig_AddContext(t *testing.T) {
 	filename := "/tmp/TestConfig_AddContext.json"
 	conf := AuthenticatedOnPremConfigMock()

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -602,6 +602,22 @@ func TestConfig_getFilename_perChannel(t *testing.T) {
 	}
 }
 
+func TestStateDir_ErrorWhenHomeUnresolvable(t *testing.T) {
+	// Clearing the home-directory env vars is what makes os.UserHomeDir fail: HOME on Unix,
+	// USERPROFILE on Windows. Both are cleared so the test is platform-agnostic.
+	t.Setenv("HOME", "")
+	t.Setenv("USERPROFILE", "")
+	if runtime.GOOS == "windows" {
+		// os.UserHomeDir consults HOMEDRIVE+HOMEPATH before erroring on Windows.
+		t.Setenv("HOMEDRIVE", "")
+		t.Setenv("HOMEPATH", "")
+	}
+
+	_, err := StateDir()
+
+	require.Error(t, err, "StateDir must fail rather than fall back to the working directory")
+}
+
 func TestConfig_AddContext(t *testing.T) {
 	filename := "/tmp/TestConfig_AddContext.json"
 	conf := AuthenticatedOnPremConfigMock()

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -565,8 +565,41 @@ func TestConfig_OverwrittenEnvironment(t *testing.T) {
 func TestConfig_getFilename(t *testing.T) {
 	home, err := os.UserHomeDir()
 	require.NoError(t, err)
-	path := filepath.Join(home, ".confluent", "config.json")
+
+	// Set explicitly rather than relying on the package default, so this cannot start passing or
+	// failing because of a channel another test left behind.
+	t.Cleanup(func() { pversion.SetProcessChannel(pversion.Dev) })
+	pversion.SetProcessChannel(pversion.Dev)
+
+	path := filepath.Join(home, ".confluent-dev", "config.json")
 	require.Equal(t, path, New().GetFilename())
+}
+
+func TestConfig_getFilename_perChannel(t *testing.T) {
+	home, err := os.UserHomeDir()
+	require.NoError(t, err)
+	t.Cleanup(func() { pversion.SetProcessChannel(pversion.Dev) })
+
+	// Driven by the version strings the build system actually produces, so this fails if either the
+	// classifier or the directory naming drifts.
+	tests := []struct {
+		name    string
+		version string
+		dir     string
+	}{
+		{"GA release", "4.72.0", ".confluent"},
+		{"release candidate", "5.0.0-rc1", ".confluent-prerelease"},
+		{"local goreleaser snapshot", "4.72.0-SNAPSHOT-d962911bb", ".confluent-dev"},
+		{"nothing stamped", "0.0.0", ".confluent-dev"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			pversion.SetProcessChannel(pversion.ChannelOf(test.version))
+
+			require.Equal(t, filepath.Join(home, test.dir, "config.json"), New().GetFilename())
+		})
+	}
 }
 
 func TestConfig_AddContext(t *testing.T) {

--- a/pkg/flink/config/env_variables.go
+++ b/pkg/flink/config/env_variables.go
@@ -3,3 +3,9 @@ package config
 // Overrides the directory under $HOME that Flink statement history is written to. The default is
 // no longer a constant here: it follows the build's release channel, via config.StateDirName.
 const HomeConfluentPathEnvVar = "HOME_CONFLUENT_PATH"
+
+// HomeConfluentPathDefault is the legacy stable-channel state directory name.
+//
+// Deprecated: the state directory now follows the build's release channel; use
+// config.StateDirName instead. Retained as an exported alias for source compatibility.
+const HomeConfluentPathDefault = ".confluent"

--- a/pkg/flink/config/env_variables.go
+++ b/pkg/flink/config/env_variables.go
@@ -1,5 +1,5 @@
 package config
 
-// Keys/values for environment variables in pairs followed by default values
+// Overrides the directory under $HOME that Flink statement history is written to. The default is
+// no longer a constant here: it follows the build's release channel, via config.StateDirName.
 const HomeConfluentPathEnvVar = "HOME_CONFLUENT_PATH"
-const HomeConfluentPathDefault = ".confluent"

--- a/pkg/flink/internal/history/history.go
+++ b/pkg/flink/internal/history/history.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 
+	pconfig "github.com/confluentinc/cli/v4/pkg/config"
 	"github.com/confluentinc/cli/v4/pkg/flink/config"
 	"github.com/confluentinc/cli/v4/pkg/log"
 )
@@ -58,9 +59,11 @@ func initPath(file string) *History {
 		return nil
 	}
 
+	// HOME_CONFLUENT_PATH predates channel-scoped state directories and still wins, so anyone
+	// relying on it keeps the layout they have.
 	confluentDir := os.Getenv(config.HomeConfluentPathEnvVar)
 	if confluentDir == "" {
-		confluentDir = config.HomeConfluentPathDefault
+		confluentDir = pconfig.StateDirName()
 	}
 	confluentPath := filepath.Join(home, confluentDir)
 	historyPath := filepath.Join(confluentPath, file)

--- a/pkg/flink/internal/history/history_test.go
+++ b/pkg/flink/internal/history/history_test.go
@@ -6,6 +6,10 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	pconfig "github.com/confluentinc/cli/v4/pkg/config"
+	"github.com/confluentinc/cli/v4/pkg/flink/config"
+	pversion "github.com/confluentinc/cli/v4/pkg/version"
 )
 
 func TestLoadHistory(t *testing.T) {
@@ -45,6 +49,49 @@ func TestLoadHistory(t *testing.T) {
 
 	// Reset history path
 	history.historyPath = prevPath
+}
+
+func TestInitPath_ScopesByChannel(t *testing.T) {
+	home, err := os.UserHomeDir()
+	require.NoError(t, err)
+	t.Setenv(config.HomeConfluentPathEnvVar, "")
+	t.Cleanup(func() { pversion.SetProcessChannel(pversion.Dev) })
+
+	tests := []struct {
+		name    string
+		channel pversion.Channel
+		dir     string
+	}{
+		{"stable keeps the historical path", pversion.Stable, ".confluent"},
+		{"dev is isolated", pversion.Dev, ".confluent-dev"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			pversion.SetProcessChannel(test.channel)
+
+			history := initPath(filename)
+
+			require.NotNil(t, history)
+			require.Equal(t, filepath.Join(home, test.dir), history.confluentPath)
+		})
+	}
+}
+
+func TestInitPath_HomeConfluentPathOverridesChannel(t *testing.T) {
+	home, err := os.UserHomeDir()
+	require.NoError(t, err)
+	t.Setenv(config.HomeConfluentPathEnvVar, ".confluent-custom")
+	t.Cleanup(func() { pversion.SetProcessChannel(pversion.Dev) })
+	pversion.SetProcessChannel(pversion.Stable)
+
+	history := initPath(filename)
+
+	require.NotNil(t, history)
+	require.Equal(t, filepath.Join(home, ".confluent-custom"), history.confluentPath,
+		"HOME_CONFLUENT_PATH must win over the channel default")
+	require.NotEqual(t, filepath.Join(home, pconfig.StateDirName()), history.confluentPath,
+		"the override must actually diverge from the channel default it is overriding")
 }
 
 func TestHistorySave(t *testing.T) {

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -27,17 +27,19 @@ type pluginInfo struct {
 
 // SearchPath goes through the files in the user's $PATH and checks if they are plugins
 func SearchPath(cfg *config.Config) map[string][]string {
-	if runtime.GOOS == "windows" {
-		log.CliLogger.Debugf(`Searching $PATH and %%USERPROFILE%%\.confluent\plugins for plugins. Plugins can be disabled in %s.`, cfg.GetFilename())
-	} else {
-		log.CliLogger.Debugf("Searching $PATH and ~/.confluent/plugins for plugins. Plugins can be disabled in %s.", cfg.GetFilename())
-	}
-
 	pathDirList := filepath.SplitList(os.Getenv("PATH"))
-	home, _ := os.UserHomeDir()
-	pluginDir := filepath.Join(home, ".confluent", "plugins")
-	if !slices.Contains(pathDirList, pluginDir) {
-		pathDirList = append(pathDirList, pluginDir)
+
+	// Degrading to $PATH alone is deliberate: a relative plugin directory would pick up executables
+	// from whatever directory the CLI happens to be run in.
+	stateDir, err := config.StateDir()
+	if err != nil {
+		log.CliLogger.Debugf("Searching only $PATH for plugins: %v. Plugins can be disabled in %s.", err, cfg.GetFilename())
+	} else {
+		pluginDir := filepath.Join(stateDir, "plugins")
+		log.CliLogger.Debugf("Searching $PATH and %s for plugins. Plugins can be disabled in %s.", pluginDir, cfg.GetFilename())
+		if !slices.Contains(pathDirList, pluginDir) {
+			pathDirList = append(pathDirList, pluginDir)
+		}
 	}
 
 	plugins := make(map[string][]string)

--- a/pkg/plugin/plugin_test.go
+++ b/pkg/plugin/plugin_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/confluentinc/cli/v4/pkg/config"
 	"github.com/confluentinc/cli/v4/pkg/mock"
+	pversion "github.com/confluentinc/cli/v4/pkg/version"
 )
 
 func TestIsExec_Dir(t *testing.T) {
@@ -99,6 +100,33 @@ func TestSearchPath(t *testing.T) {
 	pluginPaths, ok := pluginMap[pluginName]
 	require.True(t, ok)
 	require.Equal(t, fileName, filepath.Base(pluginPaths[0]))
+}
+
+// SearchPath also scans the channel-scoped state directory ($HOME/<StateDirName>/plugins), not just
+// $PATH; a regression there would make installed plugins undiscoverable while TestSearchPath (which
+// only exercises $PATH) still passed.
+func TestSearchPath_ChannelStateDir(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Cleanup(func() { pversion.SetProcessChannel(pversion.Dev) })
+	pversion.SetProcessChannel(pversion.Dev)
+
+	// An empty $PATH forces discovery through the state directory alone.
+	t.Setenv("PATH", t.TempDir())
+
+	pluginDir := filepath.Join(home, ".confluent-dev", "plugins")
+	require.NoError(t, os.MkdirAll(pluginDir, 0700))
+	name := "confluent-foo"
+	if runtime.GOOS == "windows" {
+		name += ".exe"
+	}
+	require.NoError(t, os.WriteFile(filepath.Join(pluginDir, name), nil, fs.ModePerm))
+
+	pluginPaths, ok := SearchPath(&config.Config{})["confluent-foo"]
+
+	require.True(t, ok, "a plugin under the channel state directory must be discovered")
+	require.Equal(t, name, filepath.Base(pluginPaths[0]))
 }
 
 func TestVersionRegex(t *testing.T) {

--- a/pkg/plugin/plugin_test.go
+++ b/pkg/plugin/plugin_test.go
@@ -117,16 +117,52 @@ func TestSearchPath_ChannelStateDir(t *testing.T) {
 
 	pluginDir := filepath.Join(home, ".confluent-dev", "plugins")
 	require.NoError(t, os.MkdirAll(pluginDir, 0700))
-	name := "confluent-foo"
-	if runtime.GOOS == "windows" {
-		name += ".exe"
-	}
-	require.NoError(t, os.WriteFile(filepath.Join(pluginDir, name), nil, fs.ModePerm))
+	name := writeFakePlugin(t, pluginDir, "confluent-foo")
 
 	pluginPaths, ok := SearchPath(&config.Config{})["confluent-foo"]
 
 	require.True(t, ok, "a plugin under the channel state directory must be discovered")
 	require.Equal(t, name, filepath.Base(pluginPaths[0]))
+}
+
+// When the home directory is unresolvable, config.StateDir fails and SearchPath degrades to $PATH
+// alone. The failure mode this guards against is the old behavior that joined a relative
+// ".confluent/plugins" (empty home + Join), which resolved against the working directory and would
+// run whatever confluent-* executables happened to sit there.
+func TestSearchPath_StateDirError(t *testing.T) {
+	// os.UserHomeDir reads HOME on Unix and USERPROFILE on Windows; clearing both makes it error,
+	// which is what drives config.StateDir to fail.
+	t.Setenv("HOME", "")
+	t.Setenv("USERPROFILE", "")
+
+	// Plant a plugin in a working-directory-relative ".confluent/plugins": a regressed degrade path
+	// would scan it, the correct one must not.
+	t.Chdir(t.TempDir())
+	relativePluginDir := filepath.Join(".confluent", "plugins")
+	require.NoError(t, os.MkdirAll(relativePluginDir, 0700))
+	writeFakePlugin(t, relativePluginDir, "confluent-cwd")
+
+	// A plugin on $PATH must still be discovered with no reachable state directory.
+	pathDir := t.TempDir()
+	name := writeFakePlugin(t, pathDir, "confluent-foo")
+	t.Setenv("PATH", pathDir)
+
+	plugins := SearchPath(&config.Config{})
+
+	pluginPaths, ok := plugins["confluent-foo"]
+	require.True(t, ok, "plugins on $PATH must still be discovered when the state directory is unavailable")
+	require.Equal(t, name, filepath.Base(pluginPaths[0]))
+	require.NotContains(t, plugins, "confluent-cwd", "a working-directory-relative plugins directory must not be scanned")
+}
+
+// writeFakePlugin creates an empty executable for a plugin named base (with the Windows .exe suffix
+// where applicable) in dir, and returns the file name written.
+func writeFakePlugin(t *testing.T, dir, base string) string {
+	if runtime.GOOS == "windows" {
+		base += ".exe"
+	}
+	require.NoError(t, os.WriteFile(filepath.Join(dir, base), nil, fs.ModePerm))
+	return base
 }
 
 func TestVersionRegex(t *testing.T) {

--- a/pkg/version/channel.go
+++ b/pkg/version/channel.go
@@ -24,8 +24,14 @@ const (
 )
 
 func (c Channel) String() string {
-	channels := [...]string{"stable", "prerelease", "dev"}
-	return channels[c]
+	switch c {
+	case Stable:
+		return "stable"
+	case Prerelease:
+		return "prerelease"
+	default:
+		return "dev"
+	}
 }
 
 // StateDirSuffix is appended to ".confluent" to name the channel's state directory. Only Stable

--- a/pkg/version/channel.go
+++ b/pkg/version/channel.go
@@ -28,16 +28,18 @@ func (c Channel) String() string {
 	return channels[c]
 }
 
-// StateDirSuffix is appended to ".confluent" to name the channel's state directory. Stable returns
-// an empty string, which is what keeps existing installs on the path they already use.
+// StateDirSuffix is appended to ".confluent" to name the channel's state directory. Only Stable
+// returns an empty string, which is what keeps existing installs on the path they already use; any
+// unrecognized channel falls through to the dev suffix so an unfamiliar build isolates itself rather
+// than sharing production state.
 func (c Channel) StateDirSuffix() string {
 	switch c {
+	case Stable:
+		return ""
 	case Prerelease:
 		return "-prerelease"
-	case Dev:
-		return "-dev"
 	default:
-		return ""
+		return "-dev"
 	}
 }
 
@@ -65,11 +67,24 @@ func ChannelOf(s string) Channel {
 	switch {
 	case prerelease == "":
 		return Stable
-	case strings.Contains(strings.ToUpper(prerelease), snapshotMarker):
+	case hasSnapshotToken(prerelease):
 		return Dev
 	default:
 		return Prerelease
 	}
+}
+
+// hasSnapshotToken reports whether the snapshot marker appears as a whole segment of the prerelease,
+// not merely as a substring, so a published label like 5.0.0-presnapshot stays a prerelease. The
+// segment is the goreleaser template's own `-SNAPSHOT-<sha>`, joined with hyphens onto any existing
+// prerelease dot-identifiers, so both delimiters bound a token.
+func hasSnapshotToken(prerelease string) bool {
+	for _, token := range strings.FieldsFunc(prerelease, func(r rune) bool { return r == '-' || r == '.' }) {
+		if strings.EqualFold(token, snapshotMarker) {
+			return true
+		}
+	}
+	return false
 }
 
 // processChannel is the channel of the running binary. The version is fixed at link time, so there

--- a/pkg/version/channel.go
+++ b/pkg/version/channel.go
@@ -1,0 +1,91 @@
+package version
+
+import (
+	"strings"
+
+	"github.com/hashicorp/go-version"
+)
+
+// Channel is the release stream a binary was built from. It selects the directory the CLI keeps its
+// state in, so a production install, a prerelease under evaluation, and a local build never share
+// contexts or credentials.
+type Channel int
+
+const (
+	// Stable is a published GA release, and the only channel that uses the historical path.
+	Stable Channel = iota
+
+	// Prerelease is a published release candidate or preview, tagged with a semver prerelease
+	// segment such as v5.0.0-rc1.
+	Prerelease
+
+	// Dev is anything built outside the release pipeline.
+	Dev
+)
+
+func (c Channel) String() string {
+	channels := [...]string{"stable", "prerelease", "dev"}
+	return channels[c]
+}
+
+// StateDirSuffix is appended to ".confluent" to name the channel's state directory. Stable returns
+// an empty string, which is what keeps existing installs on the path they already use.
+func (c Channel) StateDirSuffix() string {
+	switch c {
+	case Prerelease:
+		return "-prerelease"
+	case Dev:
+		return "-dev"
+	default:
+		return ""
+	}
+}
+
+// snapshotMarker is what goreleaser puts in a local build's version. Its default template is
+// "{{ .Version }}-SNAPSHOT-{{ .ShortCommit }}" and it does not strip an existing prerelease segment,
+// so during a release-candidate cycle `make build` stamps 5.0.0-rc1-SNAPSHOT-<sha>.
+const snapshotMarker = "SNAPSHOT"
+
+// ChannelOf classifies the version string the linker stamps into main.version.
+//
+// A prerelease segment alone cannot mean "published prerelease", since `make build` puts one on
+// every developer's binary; the snapshot marker is what separates them. Anything else carrying one
+// is treated as published, which errs toward isolating an unfamiliar build. That includes a
+// Confluent Platform suffix like 4.72.0-cp1, which no tag in this repo's history uses.
+//
+// Not folded into Version.IsReleased on purpose: it answers a different question, and treats 0.0.1
+// as released.
+func ChannelOf(s string) Channel {
+	semver, err := version.NewSemver(s)
+	if err != nil || semver.Segments()[0] == 0 {
+		return Dev
+	}
+
+	prerelease := semver.Prerelease()
+	switch {
+	case prerelease == "":
+		return Stable
+	case strings.Contains(strings.ToUpper(prerelease), snapshotMarker):
+		return Dev
+	default:
+		return Prerelease
+	}
+}
+
+// processChannel is the channel of the running binary. The version is fixed at link time, so there
+// is one answer per process, and command construction needs it before any Config exists.
+//
+// Dev is the default because an unstamped binary did not come from the release pipeline, which also
+// keeps a `go test` process aligned with the test binaries it drives.
+var processChannel = Dev
+
+// SetProcessChannel records the running binary's channel. Call it once from main, before loading
+// configuration or constructing commands.
+func SetProcessChannel(channel Channel) {
+	processChannel = channel
+}
+
+// ProcessChannel reports the running binary's channel.
+func ProcessChannel() Channel {
+	return processChannel
+}

--- a/pkg/version/channel_test.go
+++ b/pkg/version/channel_test.go
@@ -56,6 +56,14 @@ func TestChannel_StateDirSuffix(t *testing.T) {
 	req.Equal("-dev", Channel(99).StateDirSuffix(), "an unrecognized channel must isolate itself, not share production state")
 }
 
+func TestChannel_String(t *testing.T) {
+	req := require.New(t)
+
+	req.Equal("stable", Stable.String())
+	req.Equal("prerelease", Prerelease.String())
+	req.Equal("dev", Dev.String())
+}
+
 func TestProcessChannel_DefaultsToDev(t *testing.T) {
 	require.Equal(t, Dev, ProcessChannel(), "a binary with no version stamped in must not touch production state")
 }

--- a/pkg/version/channel_test.go
+++ b/pkg/version/channel_test.go
@@ -62,6 +62,7 @@ func TestChannel_String(t *testing.T) {
 	req.Equal("stable", Stable.String())
 	req.Equal("prerelease", Prerelease.String())
 	req.Equal("dev", Dev.String())
+	req.Equal("dev", Channel(99).String(), "an unrecognized channel must not panic")
 }
 
 func TestProcessChannel_DefaultsToDev(t *testing.T) {

--- a/pkg/version/channel_test.go
+++ b/pkg/version/channel_test.go
@@ -1,0 +1,64 @@
+package version
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestChannelOf(t *testing.T) {
+	tests := []struct {
+		name    string
+		version string
+		want    Channel
+	}{
+		{"GA release", "4.72.0", Stable},
+		{"GA release with a v prefix", "v4.72.0", Stable},
+		{"release candidate", "5.0.0-rc1", Prerelease},
+		{"release candidate with a v prefix", "v5.0.0-rc1", Prerelease},
+		{"preview", "5.0.0-preview.2", Prerelease},
+		{"beta", "5.0.0-beta3", Prerelease},
+		{"unrecognized prerelease marker", "5.0.0-nightly.4", Prerelease},
+		{"build metadata on a GA tag", "4.72.0+dirty", Stable},
+		// What `make build` actually stamps. It carries a prerelease segment but is a local build,
+		// so misreading it as Prerelease would drop developers into the testers' state directory.
+		{"goreleaser snapshot", "4.72.0-SNAPSHOT-d962911bb", Dev},
+		{"goreleaser snapshot, lowercased", "4.72.0-snapshot-d962911bb", Dev},
+		// goreleaser does not strip the tag's prerelease segment, so during an RC cycle a local
+		// build carries both. The snapshot marker has to win, or every developer lands in the
+		// prerelease directory precisely when real testers are using it.
+		{"snapshot built during an RC cycle", "5.0.0-rc1-SNAPSHOT-d962911bb", Dev},
+		{"snapshot built during a beta cycle", "5.0.0-beta.1-SNAPSHOT-d962911bb", Dev},
+		{"bare go build, nothing stamped", "0.0.0", Dev},
+		{"explicit dev stamp", "0.0.0-dev-a1b2c3d", Dev},
+		{"any 0.x is a local build", "0.9.1", Dev},
+		{"unparsable", "not-a-version", Dev},
+		{"empty", "", Dev},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.want, ChannelOf(test.version))
+		})
+	}
+}
+
+func TestChannel_StateDirSuffix(t *testing.T) {
+	req := require.New(t)
+
+	req.Empty(Stable.StateDirSuffix(), "stable must keep using the existing ~/.confluent path")
+	req.Equal("-prerelease", Prerelease.StateDirSuffix())
+	req.Equal("-dev", Dev.StateDirSuffix())
+}
+
+func TestProcessChannel_DefaultsToDev(t *testing.T) {
+	require.Equal(t, Dev, ProcessChannel(), "a binary with no version stamped in must not touch production state")
+}
+
+func TestSetProcessChannel(t *testing.T) {
+	t.Cleanup(func() { SetProcessChannel(Dev) })
+
+	SetProcessChannel(Stable)
+
+	require.Equal(t, Stable, ProcessChannel())
+}

--- a/pkg/version/channel_test.go
+++ b/pkg/version/channel_test.go
@@ -24,6 +24,10 @@ func TestChannelOf(t *testing.T) {
 		// so misreading it as Prerelease would drop developers into the testers' state directory.
 		{"goreleaser snapshot", "4.72.0-SNAPSHOT-d962911bb", Dev},
 		{"goreleaser snapshot, lowercased", "4.72.0-snapshot-d962911bb", Dev},
+		// The marker is matched as a whole segment, not a substring, so a published label that merely
+		// contains the letters stays a prerelease.
+		{"snapshot only as a substring", "5.0.0-snapshotx", Prerelease},
+		{"snapshot only as a substring, prefixed", "5.0.0-presnapshot.1", Prerelease},
 		// goreleaser does not strip the tag's prerelease segment, so during an RC cycle a local
 		// build carries both. The snapshot marker has to win, or every developer lands in the
 		// prerelease directory precisely when real testers are using it.
@@ -49,6 +53,7 @@ func TestChannel_StateDirSuffix(t *testing.T) {
 	req.Empty(Stable.StateDirSuffix(), "stable must keep using the existing ~/.confluent path")
 	req.Equal("-prerelease", Prerelease.StateDirSuffix())
 	req.Equal("-dev", Dev.StateDirSuffix())
+	req.Equal("-dev", Channel(99).StateDirSuffix(), "an unrecognized channel must isolate itself, not share production state")
 }
 
 func TestProcessChannel_DefaultsToDev(t *testing.T) {

--- a/test/channel_state_test.go
+++ b/test/channel_state_test.go
@@ -1,0 +1,99 @@
+package test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// The channel a build resolves its state directory from is decided in cmd/confluent/main.go, before
+// any command runs. Unit tests cover the classifier and the path it produces, but neither can see
+// whether main actually calls it: the integration binary carries no version stamp, so "wired
+// correctly" and "not wired at all" both come out as the dev channel.
+//
+// These build stamped binaries and run them, which is the only level at which that wiring is
+// observable. A regression here means every existing customer's login moves on upgrade.
+
+func TestChannelState_StampedBuildsUseSeparateDirectories(t *testing.T) {
+	tests := []struct {
+		name    string
+		version string
+		want    string
+		absent  string
+	}{
+		{"GA release keeps the historical path", "9.9.9", ".confluent", ".confluent-dev"},
+		{"release candidate is isolated", "9.9.9-rc1", ".confluent-prerelease", ".confluent"},
+		{"unstamped build is a local build", "", ".confluent-dev", ".confluent"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			home := t.TempDir()
+
+			runStampedCli(t, buildStampedCli(t, test.version), home)
+
+			require.DirExists(t, filepath.Join(home, test.want))
+			require.NoDirExists(t, filepath.Join(home, test.absent))
+		})
+	}
+}
+
+// The isolation the feature promises, rather than the paths it happens to pick: state written by
+// one channel must be invisible to another sharing the same home directory.
+func TestChannelState_ReleaseConfigIsInvisibleToLocalBuild(t *testing.T) {
+	home := t.TempDir()
+	release := buildStampedCli(t, "9.9.9")
+	local := buildStampedCli(t, "")
+
+	runStampedCli(t, release, home, "configuration", "update", "disable_update_check", "true")
+	before := readFile(t, filepath.Join(home, ".confluent", "config.json"))
+	runStampedCli(t, local, home, "configuration", "update", "disable_update_check", "true")
+
+	require.Equal(t, before, readFile(t, filepath.Join(home, ".confluent", "config.json")),
+		"a local build must not modify the release build's configuration")
+	require.FileExists(t, filepath.Join(home, ".confluent-dev", "config.json"))
+}
+
+// buildStampedCli compiles the CLI with the given main.version, or with none when version is empty.
+func buildStampedCli(t *testing.T, version string) string {
+	t.Helper()
+
+	binary := filepath.Join(t.TempDir(), "confluent")
+	args := []string{"build", "-o", binary}
+	if version != "" {
+		args = append(args, "-ldflags=-X main.version="+version)
+	}
+	args = append(args, "../cmd/confluent")
+
+	output, err := exec.Command("go", args...).CombinedOutput()
+	require.NoError(t, err, "go build failed: %s", output)
+
+	return binary
+}
+
+func runStampedCli(t *testing.T, binary, home string, args ...string) {
+	t.Helper()
+
+	if len(args) == 0 {
+		args = []string{"version"}
+	}
+
+	cmd := exec.Command(binary, args...)
+	// USERPROFILE covers Windows, where os.UserHomeDir ignores HOME.
+	cmd.Env = append(os.Environ(), "HOME="+home, "USERPROFILE="+home)
+
+	output, err := cmd.CombinedOutput()
+	require.NoError(t, err, "%s %v failed: %s", binary, args, output)
+}
+
+func readFile(t *testing.T, path string) []byte {
+	t.Helper()
+
+	contents, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	return contents
+}

--- a/test/channel_state_test.go
+++ b/test/channel_state_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -62,16 +63,30 @@ func buildStampedCli(t *testing.T, version string) string {
 	t.Helper()
 
 	binary := filepath.Join(t.TempDir(), "confluent")
-	args := []string{"build", "-o", binary}
-	if version != "" {
-		args = append(args, "-ldflags=-X main.version="+version)
+	if runtime.GOOS == "windows" {
+		binary += ".exe"
 	}
-	args = append(args, "../cmd/confluent")
+
+	// isTest keeps the stamped binary off the real update service, which `version` and
+	// `configuration update` below would otherwise hit; the normal integration build stamps it too.
+	ldflags := "-X main.isTest=true"
+	if version != "" {
+		ldflags += " -X main.version=" + version
+	}
+
+	args := []string{"build", "-ldflags=" + ldflags, "-o", binary, mainPackagePath()}
 
 	output, err := exec.Command("go", args...).CombinedOutput()
 	require.NoError(t, err, "go build failed: %s", output)
 
 	return binary
+}
+
+// mainPackagePath resolves cmd/confluent from this file's own location rather than the working
+// directory, which a sibling suite (TestCLI) changes to the repo root without restoring.
+func mainPackagePath() string {
+	_, thisFile, _, _ := runtime.Caller(0)
+	return filepath.Join(filepath.Dir(thisFile), "..", "cmd", "confluent")
 }
 
 func runStampedCli(t *testing.T, binary, home string, args ...string) {

--- a/test/fixtures/output/configuration/help-onprem.golden
+++ b/test/fixtures/output/configuration/help-onprem.golden
@@ -8,7 +8,7 @@ Aliases:
 
 Available Commands:
   describe    Describe a user-configurable field.
-  list        List user-configurable fields in ~/.confluent/config.json.
+  list        List user-configurable fields in the CLI configuration file.
   update      Update a user-configurable field's value.
 
 Global Flags:

--- a/test/fixtures/output/configuration/help.golden
+++ b/test/fixtures/output/configuration/help.golden
@@ -8,7 +8,7 @@ Aliases:
 
 Available Commands:
   describe    Describe a user-configurable field.
-  list        List user-configurable fields in ~/.confluent/config.json.
+  list        List user-configurable fields in the CLI configuration file.
   update      Update a user-configurable field's value.
 
 Global Flags:

--- a/test/fixtures/output/configuration/list-help-onprem.golden
+++ b/test/fixtures/output/configuration/list-help-onprem.golden
@@ -1,4 +1,4 @@
-List user-configurable fields in ~/.confluent/config.json.
+List user-configurable fields in the CLI configuration file.
 
 Usage:
   confluent configuration list [flags]

--- a/test/fixtures/output/configuration/list-help.golden
+++ b/test/fixtures/output/configuration/list-help.golden
@@ -1,4 +1,4 @@
-List user-configurable fields in ~/.confluent/config.json.
+List user-configurable fields in the CLI configuration file.
 
 Usage:
   confluent configuration list [flags]

--- a/test/live/live_test.go
+++ b/test/live/live_test.go
@@ -19,6 +19,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+
+	"github.com/confluentinc/cli/v4/pkg/config"
 )
 
 var liveBin = "test/live/bin/confluent"
@@ -142,12 +144,17 @@ func (s *CLILiveTestSuite) setupTestContext(t *testing.T) *LiveTestState {
 	state.homeDir = homeDir
 
 	if configDir := os.Getenv("CLI_LIVE_TEST_CONFIG_DIR"); configDir != "" {
-		// Pre-authenticated mode: copy existing CLI config into isolated HOME
+		// Pre-authenticated mode: copy an existing CLI config into an isolated HOME. The source is
+		// usually a stable install's ~/.confluent; the destination must be where the binary under
+		// test will look.
+		//
+		// StateDirName() answers for this process, not that binary. They agree only because neither
+		// is version-stamped, so stamping build-for-live-test would break this.
 		srcDir := configDir
 		if filepath.Base(srcDir) != ".confluent" {
 			srcDir = filepath.Join(srcDir, ".confluent")
 		}
-		dstDir := filepath.Join(homeDir, ".confluent")
+		dstDir := filepath.Join(homeDir, config.StateDirName())
 		require.NoError(t, copyDir(srcDir, dstDir), "failed to copy config from %s", srcDir)
 
 		// Validate the copied config is authenticated


### PR DESCRIPTION
Release Notes
-------------

No user-facing changes. This adds a contributor build target and documents it; nothing ships in the CLI binary.

Checklist
---------

- [x] I have successfully built and used a custom CLI binary, without linter issues from this PR.
- [x] I have clearly specified in the `What` section below whether this PR applies to Confluent Cloud, Confluent Platform, or both.
- [ ] I have verified this PR in Confluent Cloud pre-prod or production environment, if applicable.
- [ ] I have verified this PR in Confluent Platform on-premises environment, if applicable.
- [x] I have attached manual CLI verification results or screenshots in the `Test & Review` section below.
- [ ] I have added appropriate CLI integration or unit tests for any new or updated commands and functionality.
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [x] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [ ] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [ ] Confluent Cloud prod
  - [ ] Confluent Cloud stag
  - [ ] Confluent Platform
  - [ ] Check this box if the feature is enabled for certain organizations only

_Cloud/Platform verification, tests, and feature-flag items are N/A: this adds a `make` target and docs, with no shipped-binary or command behavior to test._

What
----

Builds on the channel-state isolation below it to give contributors a one-command dev binary. `make build-dev` compiles `confluent-dev` onto your `PATH` (default `~/.local/bin/confluent-dev`); because a local build reports the **dev** channel, it keeps its state in `~/.confluent-dev`, isolated from the `~/.confluent` of any installed release - so you can hack on the CLI without logging out of your real one. Unlike the coverage-instrumented test builds, it keeps debug symbols so [`delve`](https://github.com/go-delve/delve) can attach.

`CONTRIBUTING.md` gains a "Running a Dev Build" section (including the caveat that `login --save` still shares the macOS keychain across channels), and `AGENTS.md` lists the new target.

Note: this edits the `Makefile`, which is a "⚠️ ask first" file in `AGENTS.md`'s edit-zone table - it adds a new target and touches no existing recipe. Editing the `Makefile` carries one non-obvious obligation: the Debian packaging build derives `debian/patches/standard_build_layout.patch` from `diff Makefile debian/Makefile`, so any `Makefile` change makes that checked-in patch stale. It's been regenerated here (`make generate-packaging-patch`) to keep CI green - that regeneration, not the new target, accounts for most of this diff's line count.

Applies to: neither Cloud nor Platform. Contributor tooling only.

Blast Radius
----

No customer impact - nothing here ships in the CLI binary. Contributor-facing only: a broken target would fail at `make build-dev` on a developer's machine, visibly and immediately, with no effect on released builds or CI.

References
----------

- Stacked on `channel-state-dir`, which provides the `~/.confluent-dev` isolation this target relies on.

Test & Review
-------------

- `make build-dev` produces `~/.local/bin/confluent-dev`; `confluent-dev version` reports the `0.0.0-dev-<sha>` version, and the binary reads/writes `~/.confluent-dev`, leaving `~/.confluent` untouched.
- `delve` can attach to the resulting binary (debug symbols retained).
- Reviewer check: confirm the `Makefile` change is additive (new `build-dev` target only), the `debian/patches/standard_build_layout.patch` diff is a clean regeneration rather than a hand-edit (`make generate-packaging-patch` reproduces it), and the `CONTRIBUTING.md` dev-build section is accurate.
