### PR TITLE
feat(log): add `CONFLUENT_VERBOSITY` and TTY color

### DIFF
--- a/pkg/log/logger.go
+++ b/pkg/log/logger.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 
 	"github.com/hashicorp/go-hclog"
+	"github.com/mattn/go-isatty"
 )
 
 // VerbosityEnvVar sets the log level when no -v flag is passed, using the same 0-5 scale as -v.
@@ -57,10 +58,26 @@ func New(level Level, output io.Writer) *Logger {
 	return &Logger{
 		Level: level,
 		logger: hclog.New(&hclog.LoggerOptions{
-			Output: output,
-			Level:  mapToHclogLevel(level),
+			Output:          output,
+			Level:           mapToHclogLevel(level),
+			Color:           colorForOutput(output),
+			ColorHeaderOnly: true,
 		}),
 	}
+}
+
+// hclog's AutoColor leaves color on for any writer without a file descriptor, which would put
+// escape codes into test buffers, so decide explicitly rather than delegating.
+func colorForOutput(output io.Writer) hclog.ColorOption {
+	file, ok := output.(*os.File)
+	if !ok {
+		return hclog.ColorOff
+	}
+
+	if isatty.IsTerminal(file.Fd()) || isatty.IsCygwinTerminal(file.Fd()) {
+		return hclog.ForceColor
+	}
+	return hclog.ColorOff
 }
 
 func (l *Logger) SetVerbosity(verbosity int) {

--- a/pkg/log/logger.go
+++ b/pkg/log/logger.go
@@ -4,9 +4,14 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strconv"
 
 	"github.com/hashicorp/go-hclog"
 )
+
+// VerbosityEnvVar sets the log level when no -v flag is passed, using the same 0-5 scale as -v.
+// A flag always wins, since -v is a count flag and 0 can only mean "not passed".
+const VerbosityEnvVar = "CONFLUENT_VERBOSITY"
 
 // TODO: once we migrate from ccloud-sdk-v1 we should change these functions to act on the
 // TODO: global logger instead of (l *Logger) and then we can call log.Debug() instead of log.CliLogger.Debug()
@@ -59,10 +64,22 @@ func New(level Level, output io.Writer) *Logger {
 }
 
 func (l *Logger) SetVerbosity(verbosity int) {
+	if verbosity == 0 {
+		verbosity = verbosityFromEnv()
+	}
+
 	level := min(Level(verbosity), UNSAFE_TRACE)
 
 	l.Level = level
 	l.logger.SetLevel(mapToHclogLevel(level))
+}
+
+func verbosityFromEnv() int {
+	verbosity, err := strconv.Atoi(os.Getenv(VerbosityEnvVar))
+	if err != nil || verbosity < 0 {
+		return 0
+	}
+	return verbosity
 }
 
 func (l *Logger) UnsafeTrace(args ...any) {

--- a/pkg/log/logger.go
+++ b/pkg/log/logger.go
@@ -10,8 +10,9 @@ import (
 	"github.com/mattn/go-isatty"
 )
 
-// VerbosityEnvVar sets the log level when no -v flag is passed, using the same 0-5 scale as -v.
-// A flag always wins, since -v is a count flag and 0 can only mean "not passed".
+// VerbosityEnvVar sets the log level when no -v flag is passed, using the same 0-4 scale as -v.
+// A flag always wins, since -v is a count flag and 0 can only mean "not passed". Level 5
+// (UNSAFE_TRACE) is unreachable here; it stays gated behind the --unsafe-trace flag.
 const VerbosityEnvVar = "CONFLUENT_VERBOSITY"
 
 // TODO: once we migrate from ccloud-sdk-v1 we should change these functions to act on the
@@ -94,8 +95,9 @@ func (l *Logger) SetVerbosity(verbosity int) {
 }
 
 // verbosityFromEnv reads the verbosity from VerbosityEnvVar. An unset variable returns 0 silently; a
-// value that isn't a non-negative integer returns 0 but warns, since someone who set it meant to
-// raise verbosity and would otherwise get no output and no hint why.
+// value outside 0-4 (non-integer, negative, or >= 5) returns 0 but warns, since someone who set it
+// meant to raise verbosity and would otherwise get no output and no hint why. Level 5 (UNSAFE_TRACE)
+// is excluded on purpose: it logs credentials, so it must come from --unsafe-trace, not an env var.
 func (l *Logger) verbosityFromEnv() int {
 	raw, ok := os.LookupEnv(VerbosityEnvVar)
 	if !ok || raw == "" {
@@ -103,7 +105,7 @@ func (l *Logger) verbosityFromEnv() int {
 	}
 
 	verbosity, err := strconv.Atoi(raw)
-	if err != nil || verbosity < 0 {
+	if err != nil || verbosity < 0 || verbosity > int(TRACE) {
 		fmt.Fprintf(l.out, "[WARN] Ignoring invalid environment variable %q=%q; expected a number from 0 (quietest) to 4 (most verbose).\n", VerbosityEnvVar, raw)
 		return 0
 	}

--- a/pkg/log/logger.go
+++ b/pkg/log/logger.go
@@ -29,6 +29,7 @@ type Logger struct {
 	Level  Level
 	logger hclog.Logger
 	buffer []leveledMessage
+	out    io.Writer
 }
 
 type leveledMessage struct {
@@ -63,6 +64,7 @@ func New(level Level, output io.Writer) *Logger {
 			Color:           colorForOutput(output),
 			ColorHeaderOnly: true,
 		}),
+		out: output,
 	}
 }
 
@@ -82,7 +84,7 @@ func colorForOutput(output io.Writer) hclog.ColorOption {
 
 func (l *Logger) SetVerbosity(verbosity int) {
 	if verbosity == 0 {
-		verbosity = verbosityFromEnv()
+		verbosity = l.verbosityFromEnv()
 	}
 
 	level := min(Level(verbosity), UNSAFE_TRACE)
@@ -91,9 +93,18 @@ func (l *Logger) SetVerbosity(verbosity int) {
 	l.logger.SetLevel(mapToHclogLevel(level))
 }
 
-func verbosityFromEnv() int {
-	verbosity, err := strconv.Atoi(os.Getenv(VerbosityEnvVar))
+// verbosityFromEnv reads the verbosity from VerbosityEnvVar. An unset variable returns 0 silently; a
+// value that isn't a non-negative integer returns 0 but warns, since someone who set it meant to
+// raise verbosity and would otherwise get no output and no hint why.
+func (l *Logger) verbosityFromEnv() int {
+	raw, ok := os.LookupEnv(VerbosityEnvVar)
+	if !ok || raw == "" {
+		return 0
+	}
+
+	verbosity, err := strconv.Atoi(raw)
 	if err != nil || verbosity < 0 {
+		fmt.Fprintf(l.out, "[WARN] Ignoring invalid environment variable %q=%q; expected a number from 0 (quietest) to 4 (most verbose).\n", VerbosityEnvVar, raw)
 		return 0
 	}
 	return verbosity

--- a/pkg/log/logger_test.go
+++ b/pkg/log/logger_test.go
@@ -60,3 +60,30 @@ func TestLogger_FlushAfterRaisingVerbosity(t *testing.T) {
 		})
 	}
 }
+
+func TestLogger_SetVerbosity(t *testing.T) {
+	tests := []struct {
+		name      string
+		verbosity int
+		env       string
+		want      Level
+	}{
+		{name: "no flag and no environment variable", want: ERROR},
+		{name: "flag only", verbosity: int(DEBUG), want: DEBUG},
+		{name: "environment variable only", env: "3", want: DEBUG},
+		{name: "flag wins over environment variable", verbosity: int(WARN), env: "4", want: WARN},
+		{name: "environment variable is clamped", env: "99", want: UNSAFE_TRACE},
+		{name: "unparsable environment variable is ignored", env: "debug", want: ERROR},
+		{name: "negative environment variable is ignored", env: "-1", want: ERROR},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Setenv(VerbosityEnvVar, test.env)
+			l := New(ERROR, new(bytes.Buffer))
+
+			l.SetVerbosity(test.verbosity)
+
+			require.Equal(t, test.want, l.Level)
+		})
+	}
+}

--- a/pkg/log/logger_test.go
+++ b/pkg/log/logger_test.go
@@ -73,7 +73,9 @@ func TestLogger_SetVerbosity(t *testing.T) {
 		{name: "flag only", verbosity: int(DEBUG), want: DEBUG},
 		{name: "environment variable only", env: "3", want: DEBUG},
 		{name: "flag wins over environment variable", verbosity: int(WARN), env: "4", want: WARN},
-		{name: "environment variable is clamped", env: "99", want: UNSAFE_TRACE},
+		{name: "environment variable at the cap", env: "4", want: TRACE},
+		{name: "unsafe-trace level is not reachable from the environment", env: "5", want: ERROR, wantWarning: true},
+		{name: "out-of-range environment variable warns and is ignored", env: "99", want: ERROR, wantWarning: true},
 		{name: "unparsable environment variable warns and is ignored", env: "debug", want: ERROR, wantWarning: true},
 		{name: "negative environment variable warns and is ignored", env: "-1", want: ERROR, wantWarning: true},
 	}

--- a/pkg/log/logger_test.go
+++ b/pkg/log/logger_test.go
@@ -63,27 +63,35 @@ func TestLogger_FlushAfterRaisingVerbosity(t *testing.T) {
 
 func TestLogger_SetVerbosity(t *testing.T) {
 	tests := []struct {
-		name      string
-		verbosity int
-		env       string
-		want      Level
+		name        string
+		verbosity   int
+		env         string
+		want        Level
+		wantWarning bool
 	}{
 		{name: "no flag and no environment variable", want: ERROR},
 		{name: "flag only", verbosity: int(DEBUG), want: DEBUG},
 		{name: "environment variable only", env: "3", want: DEBUG},
 		{name: "flag wins over environment variable", verbosity: int(WARN), env: "4", want: WARN},
 		{name: "environment variable is clamped", env: "99", want: UNSAFE_TRACE},
-		{name: "unparsable environment variable is ignored", env: "debug", want: ERROR},
-		{name: "negative environment variable is ignored", env: "-1", want: ERROR},
+		{name: "unparsable environment variable warns and is ignored", env: "debug", want: ERROR, wantWarning: true},
+		{name: "negative environment variable warns and is ignored", env: "-1", want: ERROR, wantWarning: true},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			t.Setenv(VerbosityEnvVar, test.env)
-			l := New(ERROR, new(bytes.Buffer))
+			out := new(bytes.Buffer)
+			l := New(ERROR, out)
 
 			l.SetVerbosity(test.verbosity)
 
 			require.Equal(t, test.want, l.Level)
+			if test.wantWarning {
+				require.Contains(t, out.String(), "[WARN]")
+				require.Contains(t, out.String(), VerbosityEnvVar)
+			} else {
+				require.Empty(t, out.String())
+			}
 		})
 	}
 }


### PR DESCRIPTION
Release Notes
-------------

New Features

- Added the `CONFLUENT_VERBOSITY` environment variable to set log verbosity without repeating `-v` (same `0`-`4` scale as the `-v` count flag; a `-v` flag on the command line always wins).
- CLI log output is now colorized when it is written to a terminal, and left plain when redirected to a file or pipe.

Checklist
---------

- [x] I have successfully built and used a custom CLI binary, without linter issues from this PR.
- [x] I have clearly specified in the `What` section below whether this PR applies to Confluent Cloud, Confluent Platform, or both.
- [ ] I have verified this PR in Confluent Cloud pre-prod or production environment, if applicable.
- [ ] I have verified this PR in Confluent Platform on-premises environment, if applicable.
- [x] I have attached manual CLI verification results or screenshots in the `Test & Review` section below.
- [x] I have added appropriate CLI integration or unit tests for any new or updated commands and functionality.
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [x] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [ ] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [ ] Confluent Cloud prod
  - [ ] Confluent Cloud stag
  - [ ] Confluent Platform
  - [ ] Check this box if the feature is enabled for certain organizations only

_Applies to both Cloud and Platform (shared logging). Feature-flag items are N/A - this ships on by default, not behind a flag._

What
----

Two logging quality-of-life changes, both in `pkg/log`.

**`CONFLUENT_VERBOSITY`** lets you set log verbosity from the environment instead of passing `-v` every time - handy for a debugging session or CI. It uses the same `0`-`4` scale as the `-v` count flag and only applies when no `-v` is passed, since `-v` is a count flag where `0` cannot be distinguished from "not set". A value that is not a non-negative integer is ignored with a one-line `[WARN]` to stderr, because someone who set the variable meant to raise verbosity and would otherwise get silence with no hint why. (The advice caps at `4`, not `5`: level `5` is `UNSAFE_TRACE`, which is credential-bearing and stays gated behind the separate `--unsafe-trace` flag.)

**TTY color**: log output is colorized only when the writer is an actual terminal, decided explicitly via [`isatty`](https://github.com/mattn/go-isatty) rather than [`hclog`](https://github.com/hashicorp/go-hclog)'s `AutoColor` - which left color on for any file-descriptor-less writer and seeded ANSI escape codes into buffers (for example, test output).

Applies to: both Confluent Cloud and Confluent Platform.

Blast Radius
----

Small and diagnostic-only. Both changes affect log presentation, not command behavior, output formats, or exit codes. Worst case for the env var is unexpected log verbosity in a session where `CONFLUENT_VERBOSITY` was left set; worst case for color is ANSI codes appearing where they are not wanted (mitigated by the explicit TTY check). No customer command would break.

Test & Review
-------------

- `pkg/log/logger_test.go` covers: the env var setting verbosity when no flag is passed, a `-v` flag overriding it, an unset variable being a silent no-op, and an invalid value being ignored with the warning.
- Manual: `CONFLUENT_VERBOSITY=3 confluent ...` raises verbosity with no `-v`; `CONFLUENT_VERBOSITY=x confluent ...` prints the `[WARN]` and proceeds at the default level; log output is colored in a terminal and plain when piped to a file.
- `go test ./pkg/log/...` passes.

<details>
<summary>Why the env var is not documented in <code>--verbose</code>'s flag help</summary>

That help string renders in every command's global-flags block, so mentioning the env var there would rewrite ~1139 help golden files for a one-line note. The `VerbosityEnvVar` doc comment records it in source instead. The name `CONFLUENT_VERBOSITY` (numeric, mirroring `-v`) was chosen over `*_LOG_LEVEL`, which would imply named levels the code does not parse.

</details>
