### PR TITLE
chore: add R2 code-review rules and manual promotion

### DIFF
--- a/.claude/rules/cobra-wiring.md
+++ b/.claude/rules/cobra-wiring.md
@@ -1,0 +1,20 @@
+---
+paths:
+  - "internal/**/command*.go"
+---
+
+# Cobra command wiring and Cloud/On-Prem gating
+
+- A subcommand must be registered on its parent (new top-level commands in `internal/command.go`);
+  an unregistered command file silently does not exist.
+- `Args` matches arity: `cobra.ExactArgs(N)` for fixed arity, `cobra.MinimumNArgs(1)` for
+  variadic/`delete`. Set `ValidArgsFunction: pcmd.NewValidArgsFunction(c.validArgs)` where completion
+  applies.
+- Mode-specific commands gate via the `annotations.RunRequirement` annotation
+  (`RequireCloudLogin` / `RequireOnPremLogin` / etc.) with the correct requirement. Meaningfully
+  divergent Cloud vs. on-prem behavior belongs in a `command_<sub>_onprem.go` sibling, not an
+  `if cfg.IsCloudLogin() { ... } else { ... }` branch inside one handler.
+- Multi-resource delete routes confirmation and deletion through `deletion.ValidateAndConfirm` and
+  `deletion.Delete`, not a hand-rolled prompt/loop; delete accepts variadic args.
+- Handlers access clients lazily via `c.V2Client` / `c.MDSClient` / `c.GetKafkaREST()`. Flag any
+  handler that authenticates or constructs a client itself; that belongs in the shared `PreRunner`.

--- a/.claude/rules/generator-and-internal-refs.md
+++ b/.claude/rules/generator-and-internal-refs.md
@@ -1,0 +1,23 @@
+---
+paths:
+  - "internal/**/*.go"
+---
+
+# Generator alignment and internal-reference hygiene
+
+Much of the CMF/CP command surface is emitted by `cli-terraform-generator`, and the standing goal is
+to hand-write as little as possible.
+
+- Flag hand-written Go that only re-derives a value already present in the OpenAPI spec, e.g. a
+  hardcoded pending/terminal phase set that duplicates the status enum, or a default hardcoded in the
+  command that the spec already defines.
+- Flag a one-off helper (map-field extraction, output conversion) that duplicates a sibling instead
+  of being generalized into `pkg/flink` (or similar). (Deeper "should this whole thing be generated?"
+  judgment is for human reviewers, not a per-diff check.)
+
+Internal-reference hygiene:
+
+- No internal identifiers (JIRA/APIE tickets, RFC links, internal service names like `cc-api`) should
+  leak into user-facing strings: `Short`/`Long`/`Example`, errors, suggestions. They may stay in
+  engineer-facing doc comments if useful there.
+- Flag PR-introduced comments that carry a stale ticket reference or sit above the wrong function.

--- a/.claude/rules/generator-and-internal-refs.md
+++ b/.claude/rules/generator-and-internal-refs.md
@@ -17,7 +17,7 @@ to hand-write as little as possible.
 
 Internal-reference hygiene:
 
-- No internal identifiers (JIRA/APIE tickets, RFC links, internal service names like `cc-api`) should
-  leak into user-facing strings: `Short`/`Long`/`Example`, errors, suggestions. They may stay in
-  engineer-facing doc comments if useful there.
+- No internal identifiers (ticket keys, RFC links, internal service or system names) should leak into
+  user-facing strings: `Short`/`Long`/`Example`, errors, suggestions. They may stay in engineer-facing
+  doc comments if useful there.
 - Flag PR-introduced comments that carry a stale ticket reference or sit above the wrong function.

--- a/.claude/rules/output-and-compatibility.md
+++ b/.claude/rules/output-and-compatibility.md
@@ -1,0 +1,38 @@
+---
+paths:
+  - "internal/**/*.go"
+  - "test/fixtures/output/**"
+---
+
+# Output structs and backward compatibility
+
+An `*Out` struct and its `human:` / `serialized:` (or `json:`/`yaml:`) tags are a command's
+user-facing contract, and the highest-traffic review surface in this repo. Scrutinize their design.
+
+Output and serialization design:
+
+- Serialized field names mirror the API/spec, not an invented CLI name. Matching the spec is what
+  lets these commands be generated later; flag a divergent name.
+- `omitempty` belongs on optional response fields only. A field the API always returns should not
+  carry it; an optional one should, so it drops out cleanly when absent.
+- Use `human:"-"` to hide a field from the human table while keeping it in `-o json`/`-o yaml`,
+  rather than dropping the field from the struct. Long or unbounded values usually warrant `human:"-"`.
+- The field set should be consistent across human/json/yaml, or an intentional divergence should be
+  explained. "A different set of fields per format" is a legitimate thing to question.
+- Choose new table columns deliberately: start narrow, since widening later is easy but removing a
+  column is a breaking change.
+
+Backward compatibility (this binary ships to enterprise customers; breaking changes need a major release):
+
+- Do not rename or remove a command, subcommand, or flag outside a major release.
+- Do not change or remove a `serialized:` field name or the `-o json`/`-o yaml` output format, and do
+  not add `omitempty` to a field that previously always emitted.
+- Renaming a `human:` column header is NOT breaking; renaming a `serialized:` key IS. Keep that
+  distinction straight before flagging.
+- Printing a status line (e.g. `Updated "x".`) to stdout on a command that also emits
+  `-o json`/`-o yaml` breaks `| jq`. Status messages belong on stderr, or are omitted for resources
+  that print a payload.
+- A changed json/yaml golden under `test/fixtures/output/**` signals a serialized-surface change;
+  confirm it is intended and non-breaking (or gated on a major).
+- Features marked EA (Early Access) or OP (Open Preview) may break across minor versions; that
+  instability should be disclosed in the command's `Short`/`Long`.

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -1,0 +1,19 @@
+---
+paths:
+  - "test/**"
+  - "**/*_test.go"
+---
+
+# Test coverage: failure paths, not just a golden
+
+- Every new command and flag needs an integration test in `test/` with matching golden files (global
+  flags like `-v` / `--unsafe-trace` are exempt).
+- Each new command needs a failure-path case, not only the happy path (e.g. not-found and
+  missing-required-flag). A green happy-path golden hides an untested error branch.
+- Mock handlers should assert the request they received (forwarded query params, method, body), not
+  just return a canned response. Otherwise a wrong-value-sent-to-server bug (including data-loss
+  paths like `delete --version`) still passes its golden.
+- Golden files are regenerated with `-update` only when the diff is the intended user-visible change;
+  golden churn unrelated to the PR's purpose is a red flag.
+- Unit tests are co-located with source in `internal/` and `pkg/` (testify, suite-based); a new
+  frequently-reused helper deserves one.

--- a/.claude/rules/validation-and-errors.md
+++ b/.claude/rules/validation-and-errors.md
@@ -1,0 +1,30 @@
+---
+paths:
+  - "internal/**/*.go"
+---
+
+# Backend-first validation and error-handling semantics
+
+Prefer backend validation:
+
+- Let the backend validate spec-recorded constraints (allowed enum values, required-ness, formats)
+  and surface its error. Flag new hand-rolled client-side validation that duplicates a spec constraint.
+- Use Cobra built-ins for flag relationships: `cmd.MarkFlagsMutuallyExclusive(...)` for `oneOf`
+  groups, `cmd.MarkFlagsRequiredTogether(...)` for co-required flags, not a bespoke
+  `if flagA != "" && flagB != "" { ... }` ladder.
+- Case normalization (`strings.ToUpper` on an enum before sending) should be a conscious choice; for
+  `x-extensible-enum` fields a client-side allow-list breaks forward compatibility.
+- Do not branch on backend error wording. String-matching a server message is brittle the moment the
+  backend rewords, and usually means the validation should have stayed server-side.
+
+Error-handling semantics (casing and `NewErrorWithSuggestions` are owned by convention and
+`lint-cli`; spend review attention here instead):
+
+- An existence or precheck helper must not collapse every failure (401, 500, timeout, connection
+  refused) into "not found". Only a true 404 maps to "not found"; other errors preserve their cause.
+- Status-code gating needs the right boundary: `< 400` treats a 3xx redirect as success and
+  unmarshals into a zero-value struct (printing a blank "success"). Prefer an explicit 2xx check,
+  noting `201` on create.
+- Errors must not be silently swallowed. The underlying cause should reach the user rather than a
+  generic substitute message.
+- Auth and configuration errors should name the missing or invalid setting.

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -24,6 +24,11 @@ The authoritative conventions live in `AGENTS.md` (symlinked as `CLAUDE.md`) and
 `pkg/deletion/README.md`, `pkg/cmd/ANNOTATIONS.md`). This skill applies them to a diff; when a
 convention is ambiguous, read the source of truth rather than re-deriving it from the diff.
 
+The same review conventions are mirrored, in review-framed form, as path-scoped rules in
+`.claude/rules/` (e.g. `output-and-compatibility.md`, `validation-and-errors.md`). Those are what the
+automated R2 code review consumes, since it runs headless and read-only in CI and cannot invoke this
+skill (which relies on `gh` and subagents). Keep the two in sync when a convention changes.
+
 ## Two Review Modes
 
 The mode is selected by the invocation context, not by the user. If the user supplies a PR

--- a/.semaphore/r2-code-review.yml
+++ b/.semaphore/r2-code-review.yml
@@ -1,0 +1,31 @@
+version: v1.0
+name: R2 Code Review for Confluent CLI
+
+# Hand-rolled MANUAL promotion for R2 (Claude Code) automated code review.
+# Manual (no auto_promote) is deliberate: R2 reviews on every push by design, so gating it behind a
+# manual trigger avoids a full Opus review on every commit. It runs only when someone clicks "promote".
+# It is hand-maintained rather than servicebot's `code_review: enable: true` because service.yml sets
+# `semaphore.pipeline_enable: false`, which disqualifies the servicebot-managed path. If Confluent
+# later ships an official servicebot code_review path, adopting it means flipping pipeline_enable and
+# retiring this file.
+
+agent:
+  machine:
+    type: s1-prod-ubuntu24-04-amd64-1
+
+execution_time_limit:
+  minutes: 20
+
+blocks:
+  - name: "R2 Code Review"
+    dependencies: []
+    task:
+      jobs:
+        - name: "R2 Code Review"
+          commands:
+            - checkout
+            # `r2` is provided by the Semaphore agent image and posts its results to the PR
+            # out-of-band (this pipeline reports nothing itself). `|| true` keeps a broken review from
+            # blocking CI (report tool issues to #r2); note it also masks a silent no-op, so a run that
+            # posts no PR comments may mean R2 failed to start, not that it found nothing.
+            - r2 code-review --verbose --timeout=15m || true

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -116,3 +116,5 @@ promotions:
     pipeline_file: ".semaphore/macos.yml"
   - name: "Run live integration tests"
     pipeline_file: ".semaphore/live-tests.yml"
+  - name: "R2 Code Review (manual)"
+    pipeline_file: ".semaphore/r2-code-review.yml"

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -117,4 +117,4 @@ promotions:
   - name: "Run live integration tests"
     pipeline_file: ".semaphore/live-tests.yml"
   - name: "R2 Code Review (manual)"
-    pipeline_file: ".semaphore/r2-code-review.yml"
+    pipeline_file: "r2-code-review.yml"


### PR DESCRIPTION
Release Notes
-------------
N/A - repo tooling only (`.claude/` and `.semaphore/`); no user-facing CLI change.

Breaking Changes
- None.

Checklist
---------
N/A - adds only `.claude/rules/` and a manual Semaphore promotion. The CLI-binary build, Cloud/Platform verification, and integration-test items do not apply, and there are no breaking changes.

What
----
Onboards this repo to R2 code review (Confluent's automated Claude Code reviewer) and gives it cli-specific guidance. Stacked on #3475 - review that first.

- **Five path-scoped `.claude/rules/*.md`** encode cli's review conventions: output/serialization design, backward compatibility, backend-first validation, error-handling semantics, Cobra wiring, testing, and generator alignment. R2 runs headless and read-only in CI and auto-loads a rule whenever it reads a file matching that rule's `paths:` glob, so this is how R2 gets repo-specific guidance. (The `pr-review` skill from #3475 is human-facing and cannot run in R2's sandbox, which has no `gh` or subagents; the rules mirror its substance and the skill now points at them.)
- **A manual Semaphore promotion** (`.semaphore/r2-code-review.yml` plus a `promotions:` entry). It is intentionally manual, not a default-pipeline block: R2 reviews on every push by design, so a manual trigger avoids a full review on every commit. `service.yml`'s `pipeline_enable: false` also rules out the servicebot `code_review:` path, forcing the hand-maintained route.

**Open question for reviewers:** the rules deliberately overlap `AGENTS.md` and the `pr-review` skill (same conventions, different consumers), and are self-contained so R2 loads complete per-file guidance rather than relying on `AGENTS.md` pickup (which R2's docs call unreliable across multi-package diffs). If the team prefers less duplication, the alternative is trimming them to only the substance `AGENTS.md` doesn't already cover.

Blast Radius
----
None. Adds review tooling and an opt-in CI promotion; no runtime, build, or customer impact. The promotion runs only when manually triggered from the Semaphore UI.

References
----------
- R2 code-review onboarding docs are internal to Confluent (`go/r2-code-review`).
- Stacked on #3475

Test & Review
-------------
- Rules checked for frontmatter/`paths:` glob correctness and for duplication against the skill.
- The Semaphore promotion checked for manual wiring, `checkout` placement, and `|| true` visibility; R2's documented onboarding pattern confirms `r2` is provided by the agent image and needs no vault or install step. YAML validated.
- **Pre-merge note:** manual onboarding may still require the repo to be enabled on the #r2 side - confirming before this is marked ready for review.
