### PR TITLE
[INC-12958] Fix flink compute-pool-config live test: valid max-cfu

### DIFF
--- a/test/live/flink_compute_pool_config_live_test.go
+++ b/test/live/flink_compute_pool_config_live_test.go
@@ -14,7 +14,7 @@ func (s *CLILiveTestSuite) TestFlinkComputePoolConfigCRUDLive() {
 
 	// Variables
 	updatedDefaultPoolEnabled := "true"
-	updatedDefaultPoolMaxCfu := "25"
+	updatedDefaultPoolMaxCfu := "30"
 
 	// Cleanup (LIFO — execution is reverse-registration order)
 


### PR DESCRIPTION
Release Notes
-------------
_Test-only change — no user-facing behavior changes, no release note._

Checklist
---------
- [x] I have added appropriate CLI integration or unit tests for any new or updated commands and functionality. _(This PR fixes an existing live test; no new command.)_
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [ ] _Custom-binary build / Cloud pre-prod verification: not applicable — the change is a constant in a live-test file; correctness is established by the spec's `x-extensible-enum`._

What
----
Applies to **Confluent Cloud**.

`TestFlinkComputePoolConfigCRUDLive` was failing:

```
command 'confluent flink compute-pool-config update --max-cfu 25' failed:
Error: default_pool_max_cfu must be one of [5, 10, 20, 30, 40, 50]
```

`default_pool_max_cfu` is an `x-extensible-enum` of `[5, 10, 20, 30, 40, 50]`. The generated
update value `25` is **not** a member, so the live API rejects the update and the follow-up
"Verify" step then reads back the unchanged value (`10`) instead of `25`.

This file is a generated artifact (`Code generated by cli-terraform-generator … DO NOT EDIT`)
produced by a one-off merge-mode run, so it is corrected in place: `updatedDefaultPoolMaxCfu`
`25 → 30`, a valid enum member. This is exactly the value the fixed generator now emits
(it picks the next declared enum member after the example `20`).

Blast Radius
----
None for customers — the change is a single constant in a `//go:build live_test` file. It is
never compiled into a shipped binary and runs only in the internal live-test suite.

References
----------
- INC-12958
- Root-cause fix in the generator: confluentinc/cli-terraform-generator#403 (makes CLI
  live-test update values enum-aware so this class of bug can't be regenerated).

Test & Review
-------------
- `default_pool_max_cfu`'s allowed set is `[5, 10, 20, 30, 40, 50]` (spec `x-extensible-enum`);
  `30` is a member and differs from the account's current value, so the update is a real,
  accepted change and the Verify step asserts `30 == 30`.
- The generator PR above adds unit tests (`TestUpdatedValueStaysInDeclaredEnum`) proving the
  same `20 → 30` selection, so this constant stays consistent with regeneration.
