### PR TITLE
[IDENTITY-6268] Re-add scim-enabled flag to org CLI commands

### DIFF
--- a/cmd/lint/main.go
+++ b/cmd/lint/main.go
@@ -353,6 +353,7 @@ var vocabWords = []string{
 	"savepoints",
 	"scala",
 	"schemas",
+	"scim",
 	"server",
 	"signup",
 	"siv",

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/confluentinc/cli/v4
 
-go 1.26.5
+go 1.26.7
 
 require (
 	github.com/antihax/optional v1.0.0
@@ -45,7 +45,7 @@ require (
 	github.com/confluentinc/ccloud-sdk-go-v2/networking-gateway v0.7.0
 	github.com/confluentinc/ccloud-sdk-go-v2/networking-ip v0.2.0
 	github.com/confluentinc/ccloud-sdk-go-v2/networking-privatelink v0.3.0
-	github.com/confluentinc/ccloud-sdk-go-v2/org v0.13.0
+	github.com/confluentinc/ccloud-sdk-go-v2/org v0.15.0
 	github.com/confluentinc/ccloud-sdk-go-v2/provider-integration v0.2.0
 	github.com/confluentinc/ccloud-sdk-go-v2/rtce v0.1.0
 	github.com/confluentinc/ccloud-sdk-go-v2/service-quota v0.2.0

--- a/go.mod
+++ b/go.mod
@@ -45,7 +45,7 @@ require (
 	github.com/confluentinc/ccloud-sdk-go-v2/networking-gateway v0.7.0
 	github.com/confluentinc/ccloud-sdk-go-v2/networking-ip v0.2.0
 	github.com/confluentinc/ccloud-sdk-go-v2/networking-privatelink v0.3.0
-	github.com/confluentinc/ccloud-sdk-go-v2/org v0.14.0
+	github.com/confluentinc/ccloud-sdk-go-v2/org v0.13.0
 	github.com/confluentinc/ccloud-sdk-go-v2/provider-integration v0.2.0
 	github.com/confluentinc/ccloud-sdk-go-v2/rtce v0.1.0
 	github.com/confluentinc/ccloud-sdk-go-v2/service-quota v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -225,8 +225,8 @@ github.com/confluentinc/ccloud-sdk-go-v2/networking-ip v0.2.0 h1:ZHNF2DeqVlNPuKG
 github.com/confluentinc/ccloud-sdk-go-v2/networking-ip v0.2.0/go.mod h1:KTShFBZA7WG8LcxlWjJpoZFdWkJ+uOw3dDuwAHs5eKU=
 github.com/confluentinc/ccloud-sdk-go-v2/networking-privatelink v0.3.0 h1:mC0E1nKUt57AxMM4Lpdfd+KA/YZwJVwro9ER+dCUFi8=
 github.com/confluentinc/ccloud-sdk-go-v2/networking-privatelink v0.3.0/go.mod h1:GIHF2cYOUKx+6ycYokr4i8E4cuNBC22xqvO/IhqZ31U=
-github.com/confluentinc/ccloud-sdk-go-v2/org v0.13.0 h1:/H/6SmonnvOzhjLA/6xSTSvq6N/uMuoPc66VEp/qxV8=
-github.com/confluentinc/ccloud-sdk-go-v2/org v0.13.0/go.mod h1:BNnhFTvGhJSbyaklv0YkoTDWUdiWppLyu2hzfdxOWYM=
+github.com/confluentinc/ccloud-sdk-go-v2/org v0.15.0 h1:rbtGf2SFWjfXzgi+boRjYbARditK0GIfFPLS1baIy+c=
+github.com/confluentinc/ccloud-sdk-go-v2/org v0.15.0/go.mod h1:VhKDWY80oJi+YPMsE0Wq5e5VBt6kRvl//Ez790tuKO0=
 github.com/confluentinc/ccloud-sdk-go-v2/provider-integration v0.2.0 h1:UN2a+aqYhk95ro+wVLkeB/8W7n+UV2KsE3jNFbbDCSw=
 github.com/confluentinc/ccloud-sdk-go-v2/provider-integration v0.2.0/go.mod h1:TzompS9F0G6awN5xMC+nguNG8ULElN5UqX2XOBOIPuM=
 github.com/confluentinc/ccloud-sdk-go-v2/rtce v0.1.0 h1:OBa2vm09bOG1oojOP1vNj8V7+M2AfUkYP1sRQ+xlRm4=

--- a/go.sum
+++ b/go.sum
@@ -225,8 +225,8 @@ github.com/confluentinc/ccloud-sdk-go-v2/networking-ip v0.2.0 h1:ZHNF2DeqVlNPuKG
 github.com/confluentinc/ccloud-sdk-go-v2/networking-ip v0.2.0/go.mod h1:KTShFBZA7WG8LcxlWjJpoZFdWkJ+uOw3dDuwAHs5eKU=
 github.com/confluentinc/ccloud-sdk-go-v2/networking-privatelink v0.3.0 h1:mC0E1nKUt57AxMM4Lpdfd+KA/YZwJVwro9ER+dCUFi8=
 github.com/confluentinc/ccloud-sdk-go-v2/networking-privatelink v0.3.0/go.mod h1:GIHF2cYOUKx+6ycYokr4i8E4cuNBC22xqvO/IhqZ31U=
-github.com/confluentinc/ccloud-sdk-go-v2/org v0.14.0 h1:n+4lb+CFCExljsp4Goyb4JTDL/UibGUhT0k++5JNhw8=
-github.com/confluentinc/ccloud-sdk-go-v2/org v0.14.0/go.mod h1:z+7wtFzDczbMGda7AG7w14BGE3pQSjaFYhNbvkZAlOs=
+github.com/confluentinc/ccloud-sdk-go-v2/org v0.13.0 h1:/H/6SmonnvOzhjLA/6xSTSvq6N/uMuoPc66VEp/qxV8=
+github.com/confluentinc/ccloud-sdk-go-v2/org v0.13.0/go.mod h1:BNnhFTvGhJSbyaklv0YkoTDWUdiWppLyu2hzfdxOWYM=
 github.com/confluentinc/ccloud-sdk-go-v2/provider-integration v0.2.0 h1:UN2a+aqYhk95ro+wVLkeB/8W7n+UV2KsE3jNFbbDCSw=
 github.com/confluentinc/ccloud-sdk-go-v2/provider-integration v0.2.0/go.mod h1:TzompS9F0G6awN5xMC+nguNG8ULElN5UqX2XOBOIPuM=
 github.com/confluentinc/ccloud-sdk-go-v2/rtce v0.1.0 h1:OBa2vm09bOG1oojOP1vNj8V7+M2AfUkYP1sRQ+xlRm4=

--- a/internal/organization/command.go
+++ b/internal/organization/command.go
@@ -17,10 +17,11 @@ type organizationCommand struct {
 }
 
 type organizationOut struct {
-	IsCurrent  bool   `human:"Current" serialized:"is_current"`
-	ID         string `human:"ID" serialized:"id"`
-	Name       string `human:"Name" serialized:"name"`
-	JitEnabled bool   `human:"JIT Enabled" serialized:"jit_enabled"`
+	IsCurrent   bool   `human:"Current" serialized:"is_current"`
+	ID          string `human:"ID" serialized:"id"`
+	Name        string `human:"Name" serialized:"name"`
+	JitEnabled  bool   `human:"JIT Enabled" serialized:"jit_enabled"`
+	ScimEnabled bool   `human:"SCIM Enabled" serialized:"scim_enabled"`
 }
 
 func New(cfg *config.Config, prerunner pcmd.PreRunner) *cobra.Command { //nolint:unparam
@@ -48,10 +49,11 @@ func New(cfg *config.Config, prerunner pcmd.PreRunner) *cobra.Command { //nolint
 func (c *organizationCommand) printOrganization(cmd *cobra.Command, organization orgv2.OrgV2Organization) error {
 	table := output.NewTable(cmd)
 	out := &organizationOut{
-		IsCurrent:  organization.GetId() == c.Context.GetCurrentOrganization(),
-		ID:         organization.GetId(),
-		Name:       organization.GetDisplayName(),
-		JitEnabled: organization.GetJitEnabled(),
+		IsCurrent:   organization.GetId() == c.Context.GetCurrentOrganization(),
+		ID:          organization.GetId(),
+		Name:        organization.GetDisplayName(),
+		JitEnabled:  organization.GetJitEnabled(),
+		ScimEnabled: organization.GetScimEnabled(),
 	}
 	table.Add(out)
 	return table.Print()

--- a/internal/organization/command_list.go
+++ b/internal/organization/command_list.go
@@ -36,10 +36,11 @@ func (c *organizationCommand) list(cmd *cobra.Command, _ []string) error {
 	list := output.NewList(cmd)
 	for _, organization := range organizations {
 		out := &organizationOut{
-			IsCurrent:  organization.GetId() == c.Context.GetCurrentOrganization(),
-			ID:         organization.GetId(),
-			Name:       organization.GetDisplayName(),
-			JitEnabled: organization.GetJitEnabled(),
+			IsCurrent:   organization.GetId() == c.Context.GetCurrentOrganization(),
+			ID:          organization.GetId(),
+			Name:        organization.GetDisplayName(),
+			JitEnabled:  organization.GetJitEnabled(),
+			ScimEnabled: organization.GetScimEnabled(),
 		}
 		list.Add(out)
 	}

--- a/internal/organization/command_update.go
+++ b/internal/organization/command_update.go
@@ -25,6 +25,7 @@ func (c *organizationCommand) newUpdateCommand() *cobra.Command {
 	// Optional flags
 	cmd.Flags().String("name", "", "Name of the Confluent Cloud organization.")
 	cmd.Flags().Bool("jit-enabled", false, "Toggle Just-In-Time (JIT) user provisioning for SSO-enabled organizations.")
+	cmd.Flags().Bool("scim-enabled", false, "Toggle System for Cross-domain Identity Management (SCIM) user provisioning for SSO-enabled organizations.")
 
 	pcmd.AddContextFlag(cmd, c.CLICommand)
 	pcmd.AddOutputFlag(cmd)
@@ -51,6 +52,14 @@ func (c *organizationCommand) update(cmd *cobra.Command, _ []string) error {
 			return err
 		}
 		updateReq.JitEnabled = orgv2.PtrBool(jitEnabled)
+	}
+
+	if cmd.Flags().Changed("scim-enabled") {
+		scimEnabled, err := cmd.Flags().GetBool("scim-enabled")
+		if err != nil {
+			return err
+		}
+		updateReq.ScimEnabled = orgv2.PtrBool(scimEnabled)
 	}
 
 	organization, httpResp, err := c.V2Client.UpdateOrgOrganization(id, updateReq)

--- a/test/fixtures/output/organization/describe-json.golden
+++ b/test/fixtures/output/organization/describe-json.golden
@@ -2,5 +2,6 @@
   "is_current": true,
   "id": "abc-123",
   "name": "default",
-  "jit_enabled": true
+  "jit_enabled": true,
+  "scim_enabled": true
 }

--- a/test/fixtures/output/organization/describe.golden
+++ b/test/fixtures/output/organization/describe.golden
@@ -1,6 +1,7 @@
-+-------------+---------+
-| Current     | true    |
-| ID          | abc-123 |
-| Name        | default |
-| JIT Enabled | true    |
-+-------------+---------+
++--------------+---------+
+| Current      | true    |
+| ID           | abc-123 |
+| Name         | default |
+| JIT Enabled  | true    |
+| SCIM Enabled | true    |
++--------------+---------+

--- a/test/fixtures/output/organization/list-json.golden
+++ b/test/fixtures/output/organization/list-json.golden
@@ -3,18 +3,21 @@
     "is_current": true,
     "id": "abc-123",
     "name": "org1",
-    "jit_enabled": true
+    "jit_enabled": true,
+    "scim_enabled": true
   },
   {
     "is_current": false,
     "id": "abc-456",
     "name": "org2",
-    "jit_enabled": true
+    "jit_enabled": true,
+    "scim_enabled": false
   },
   {
     "is_current": false,
     "id": "abc-789",
     "name": "org3",
-    "jit_enabled": true
+    "jit_enabled": true,
+    "scim_enabled": true
   }
 ]

--- a/test/fixtures/output/organization/list.golden
+++ b/test/fixtures/output/organization/list.golden
@@ -1,5 +1,5 @@
-  Current |   ID    | Name | JIT Enabled  
-----------+---------+------+--------------
-  *       | abc-123 | org1 | true         
-          | abc-456 | org2 | true         
-          | abc-789 | org3 | true         
+  Current |   ID    | Name | JIT Enabled | SCIM Enabled  
+----------+---------+------+-------------+---------------
+  *       | abc-123 | org1 | true        | true          
+          | abc-456 | org2 | true        | false         
+          | abc-789 | org3 | true        | true          

--- a/test/fixtures/output/organization/update-help.golden
+++ b/test/fixtures/output/organization/update-help.golden
@@ -6,6 +6,7 @@ Usage:
 Flags:
       --name string      Name of the Confluent Cloud organization.
       --jit-enabled      Toggle Just-In-Time (JIT) user provisioning for SSO-enabled organizations.
+      --scim-enabled     Toggle System for Cross-domain Identity Management (SCIM) user provisioning for SSO-enabled organizations.
       --context string   CLI context name.
   -o, --output string    Specify the output format as "human", "json", or "yaml". (default "human")
 

--- a/test/fixtures/output/organization/update-json.golden
+++ b/test/fixtures/output/organization/update-json.golden
@@ -2,5 +2,6 @@
   "is_current": true,
   "id": "abc-123",
   "name": "default-updated",
-  "jit_enabled": true
+  "jit_enabled": true,
+  "scim_enabled": true
 }

--- a/test/fixtures/output/organization/update.golden
+++ b/test/fixtures/output/organization/update.golden
@@ -1,7 +1,8 @@
 Updated organization "abc-123".
-+-------------+-----------------+
-| Current     | true            |
-| ID          | abc-123         |
-| Name        | default-updated |
-| JIT Enabled | true            |
-+-------------+-----------------+
++--------------+-----------------+
+| Current      | true            |
+| ID           | abc-123         |
+| Name         | default-updated |
+| JIT Enabled  | true            |
+| SCIM Enabled | true            |
++--------------+-----------------+

--- a/test/test-server/org_handlers.go
+++ b/test/test-server/org_handlers.go
@@ -143,6 +143,7 @@ func handleOrgOrganization(t *testing.T) http.HandlerFunc {
 			Id:          orgv2.PtrString(id),
 			DisplayName: orgv2.PtrString(displayName),
 			JitEnabled:  orgv2.PtrBool(true),
+			ScimEnabled: orgv2.PtrBool(true),
 		}
 		err := json.NewEncoder(w).Encode(organization)
 		require.NoError(t, err)
@@ -155,9 +156,9 @@ func handleOrgOrganizations(t *testing.T) http.HandlerFunc {
 		switch r.Method {
 		case http.MethodGet:
 			organizationList := &orgv2.OrgV2OrganizationList{Data: []orgv2.OrgV2Organization{
-				{Id: orgv2.PtrString("abc-123"), DisplayName: orgv2.PtrString("org1"), JitEnabled: orgv2.PtrBool(true)},
-				{Id: orgv2.PtrString("abc-456"), DisplayName: orgv2.PtrString("org2"), JitEnabled: orgv2.PtrBool(true)},
-				{Id: orgv2.PtrString("abc-789"), DisplayName: orgv2.PtrString("org3"), JitEnabled: orgv2.PtrBool(true)},
+				{Id: orgv2.PtrString("abc-123"), DisplayName: orgv2.PtrString("org1"), JitEnabled: orgv2.PtrBool(true), ScimEnabled: orgv2.PtrBool(true)},
+				{Id: orgv2.PtrString("abc-456"), DisplayName: orgv2.PtrString("org2"), JitEnabled: orgv2.PtrBool(true), ScimEnabled: orgv2.PtrBool(false)},
+				{Id: orgv2.PtrString("abc-789"), DisplayName: orgv2.PtrString("org3"), JitEnabled: orgv2.PtrBool(true), ScimEnabled: orgv2.PtrBool(true)},
 			}}
 			setPageToken(organizationList, &organizationList.Metadata, r.URL)
 			err := json.NewEncoder(w).Encode(organizationList)


### PR DESCRIPTION
Release Notes
-------------

New Features
- Re-added the `scim-enabled` flag to `confluent organization update` (`confluent organization describe`/`list` now also surface `SCIM Enabled`).

What
----
**Applies to:** Confluent Cloud only

#3236 originally added this and was merged, then reverted in #3372. 

This PR:
- Pins `ccloud-sdk-go-v2/org` back to v0.13.0 (the last version with SCIM support) via `go.mod`/`go.sum`.
- Re-applies the `scim-enabled` flag against the current generated `organization` command structure (post #3431 migration), mirroring the existing `jit-enabled` pattern.
- Updates goldens and the mock server accordingly.

A PR reverting ccloud-sdk-go-v2#368 is filed separately to restore SCIM support upstream; once merged and released, this can go back to tracking the latest org SDK version.

Blast Radius
----
Low impact — this only affects customers using `confluent organization update --scim-enabled` and the new `SCIM Enabled` column, and reintroduces already-reviewed behavior from #3236.

Test & Review
-------------
- [x] `go build ./...`
- [x] `go test ./internal/organization/...`
- [x] `go test ./test/... -run 'TestCLI/TestOrganization$'`
- [x] `go test ./test/... -run 'TestCLI/TestHelp$'` (full command-tree help goldens, including `organization update --help`)

References
----------
- Jira: https://confluentinc.atlassian.net/browse/IDENTITY-6268
- Reverts revert: #3372
- Original: #3236
- Upstream SDK fix: confluentinc/ccloud-sdk-go-v2#368 (revert PR pending)