### PR TITLE
fix(flink): reject application resources without metadata.name

### DIFF
--- a/internal/flink/command_application_test.go
+++ b/internal/flink/command_application_test.go
@@ -1,0 +1,24 @@
+package flink
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	pflink "github.com/confluentinc/cli/v4/pkg/flink"
+)
+
+func TestApplicationCreateRejectsMissingMetadataNameFromResourceFile(t *testing.T) {
+	resourceFilePath := filepath.Join(t.TempDir(), "application.yaml")
+	err := os.WriteFile(resourceFilePath, []byte("metadata: {}\n"), 0600)
+	require.NoError(t, err)
+
+	application, err := readApplicationResourceFile(resourceFilePath)
+	require.NoError(t, err)
+
+	_, err = (&pflink.CmfRestClient{}).CreateApplication(context.Background(), "environment", application)
+	require.EqualError(t, err, `application name is required: ensure the resource file contains a non-empty "metadata.name" field`)
+}

--- a/pkg/flink/cmf_rest_client.go
+++ b/pkg/flink/cmf_rest_client.go
@@ -158,11 +158,22 @@ func (cmfClient *CmfRestClient) CmfApiContext() context.Context {
 	return context.WithValue(context.Background(), cmfsdk.ContextAccessToken, cmfClient.AuthToken)
 }
 
+func getApplicationName(application cmfsdk.FlinkApplication) (string, error) {
+	applicationName, ok := application.Metadata["name"].(string)
+	if !ok || applicationName == "" {
+		return "", fmt.Errorf(`application name is required: ensure the resource file contains a non-empty "metadata.name" field`)
+	}
+	return applicationName, nil
+}
+
 // CreateApplication Create a Flink application in the specified environment.
 // Internally, since the call for Create and Update is the same, we check if the environment doesn't contain said application before creation.
 func (cmfClient *CmfRestClient) CreateApplication(ctx context.Context, environment string, application cmfsdk.FlinkApplication) (cmfsdk.FlinkApplication, error) {
 	// Get the name of the application
-	applicationName := application.Metadata["name"].(string)
+	applicationName, err := getApplicationName(application)
+	if err != nil {
+		return cmfsdk.FlinkApplication{}, err
+	}
 	_, httpResponse, _ := cmfClient.FlinkApplicationsApi.GetApplication(ctx, environment, applicationName).Execute()
 	// check if the application exists by checking the status code
 	if httpResponse != nil && httpResponse.StatusCode == http.StatusOK {
@@ -203,7 +214,10 @@ func (cmfClient *CmfRestClient) ListApplications(ctx context.Context, environmen
 // Internally, since the call for Create and Update is the same, we check if the environment contains said application before updation.
 func (cmfClient *CmfRestClient) UpdateApplication(ctx context.Context, environment string, application cmfsdk.FlinkApplication) (cmfsdk.FlinkApplication, error) {
 	// Get the name of the application
-	applicationName := application.Metadata["name"].(string)
+	applicationName, err := getApplicationName(application)
+	if err != nil {
+		return cmfsdk.FlinkApplication{}, err
+	}
 	_, httpResponse, err := cmfClient.FlinkApplicationsApi.GetApplication(ctx, environment, applicationName).Execute()
 	// check if the application exists by checking the status code
 	if httpResponse != nil && httpResponse.StatusCode == http.StatusNotFound {

--- a/pkg/flink/cmf_rest_client_test.go
+++ b/pkg/flink/cmf_rest_client_test.go
@@ -1,11 +1,88 @@
 package flink
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	cmfsdk "github.com/confluentinc/cmf-sdk-go/v1"
 )
+
+func TestGetApplicationName(t *testing.T) {
+	tests := []struct {
+		name        string
+		application cmfsdk.FlinkApplication
+		wantName    string
+		wantErr     string
+	}{
+		{
+			name:        "valid name",
+			application: cmfsdk.FlinkApplication{Metadata: map[string]interface{}{"name": "my-application"}},
+			wantName:    "my-application",
+		},
+		{
+			name:        "missing name",
+			application: cmfsdk.FlinkApplication{Metadata: map[string]interface{}{}},
+			wantErr:     `application name is required: ensure the resource file contains a non-empty "metadata.name" field`,
+		},
+		{
+			name:        "empty name",
+			application: cmfsdk.FlinkApplication{Metadata: map[string]interface{}{"name": ""}},
+			wantErr:     `application name is required: ensure the resource file contains a non-empty "metadata.name" field`,
+		},
+		{
+			name:        "non-string name",
+			application: cmfsdk.FlinkApplication{Metadata: map[string]interface{}{"name": 123}},
+			wantErr:     `application name is required: ensure the resource file contains a non-empty "metadata.name" field`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotName, err := getApplicationName(tt.application)
+			if tt.wantErr != "" {
+				require.EqualError(t, err, tt.wantErr)
+				require.Empty(t, gotName)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tt.wantName, gotName)
+		})
+	}
+}
+
+func TestApplicationMethodsRejectInvalidNames(t *testing.T) {
+	tests := []struct {
+		name   string
+		invoke func(*CmfRestClient) error
+	}{
+		{
+			name: "create",
+			invoke: func(client *CmfRestClient) error {
+				_, err := client.CreateApplication(context.Background(), "environment", cmfsdk.FlinkApplication{})
+				return err
+			},
+		},
+		{
+			name: "update",
+			invoke: func(client *CmfRestClient) error {
+				_, err := client.UpdateApplication(context.Background(), "environment", cmfsdk.FlinkApplication{})
+				return err
+			},
+		},
+	}
+
+	wantErr := `application name is required: ensure the resource file contains a non-empty "metadata.name" field`
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.invoke(&CmfRestClient{})
+			require.EqualError(t, err, wantErr)
+		})
+	}
+}
 
 func TestListAllPages(t *testing.T) {
 	// pagedFetcher emulates a CMF endpoint that pages by zero-based index (offset = page * size).


### PR DESCRIPTION
Release Notes
-------------
Breaking Changes
- NONE

New Features
- NONE

Bug Fixes
- `confluent flink application create` and `update` now return an error when `metadata.name` is missing, empty, or not a string instead of panicking.

Checklist
---------
- [x] I have successfully built and used a custom CLI binary, without linter issues from this PR.
- [x] I have clearly specified in the What section below whether this PR applies to Confluent Cloud, Confluent Platform, or both.
- [ ] I have verified this PR in Confluent Cloud pre-prod or production environment, if applicable.
- [ ] I have verified this PR in Confluent Platform on-premises environment, if applicable.
- [ ] I have attached manual CLI verification results or screenshots in the Test & Review section below.
- [x] I have added appropriate CLI integration or unit tests for any new or updated commands and functionality.
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [x] I have indicated the potential customer impact if something goes wrong in the Blast Radius section below.
- [ ] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [ ] Confluent Cloud prod
  - [ ] Confluent Cloud stag
  - [x] Confluent Platform
  - [ ] Check this box if the feature is enabled for certain organizations only

What
----
**Confluent Platform (CMF Flink).**

- Flink application resource files are decoded into a generic metadata map.
- The create and update paths used a direct type assertion for `metadata.name`.
- A valid YAML or JSON file without a usable name could panic the CLI.
- This change validates the name before making the CMF request.

Blast Radius
------------
- Valid resource files behave the same.
- Invalid `metadata.name` values now return a clear error.
- Only Flink application create and update are affected.

References
----------
- NONE

Test & Review
-------------
- `go test ./pkg/flink ./internal/flink -count=1`
- `go vet ./pkg/flink ./internal/flink`
- `go build -o /dev/null ./cmd/confluent`
- Built binary verification: `confluent --version`
- `golangci-lint run --timeout 10m`
- `make lint-cli`
- Unit tests cover valid, missing, empty, and non-string `metadata.name` values.
- A parser-boundary regression test covers a YAML resource with missing `metadata.name` before create.
