### PR TITLE
[DGS-25204] Do not send empty encrypted-key-material on dek create

### DIFF
--- a/internal/schema-registry/command_dek_create.go
+++ b/internal/schema-registry/command_dek_create.go
@@ -77,13 +77,16 @@ func (c *command) dekCreate(cmd *cobra.Command, _ []string) error {
 	}
 
 	createReq := srsdk.CreateDekRequest{
-		Subject:              srsdk.PtrString(subject),
-		Version:              srsdk.PtrInt32(version),
-		EncryptedKeyMaterial: srsdk.PtrString(encryptedKeyMaterial),
+		Subject: srsdk.PtrString(subject),
+		Version: srsdk.PtrInt32(version),
 	}
 
 	if cmd.Flags().Changed("algorithm") {
 		createReq.Algorithm = srsdk.PtrString(algorithm)
+	}
+
+	if cmd.Flags().Changed("encrypted-key-material") {
+		createReq.EncryptedKeyMaterial = srsdk.PtrString(encryptedKeyMaterial)
 	}
 
 	dek, err := client.CreateDek(kekName, createReq)

--- a/test/fixtures/output/schema-registry/dek/create-generated.golden
+++ b/test/fixtures/output/schema-registry/dek/create-generated.golden
@@ -1,0 +1,9 @@
++------------------------+---------------+
+| Name                   | kek-name      |
+| Subject                | payments      |
+| Version                | 1             |
+| Algorithm              | AES256_GCM    |
+| Key Material           | key-material  |
+| Encrypted Key Material |               |
+| Timestamp              | 1702346517344 |
++------------------------+---------------+

--- a/test/schema_registry_test.go
+++ b/test/schema_registry_test.go
@@ -171,6 +171,7 @@ func (s *CLITestSuite) TestSchemaRegistryKek() {
 func (s *CLITestSuite) TestSchemaRegistryDek() {
 	tests := []CLITest{
 		{args: "schema-registry dek create --kek-name kek-name --subject payments --algorithm AES256_GCM --version 1 --encrypted-key-material encrypted-key-material", fixture: "schema-registry/dek/create.golden"},
+		{args: "schema-registry dek create --kek-name kek-name --subject payments --algorithm AES256_GCM --version 1", fixture: "schema-registry/dek/create-generated.golden"},
 		{args: "schema-registry dek subject list --kek-name kek-name", fixture: "schema-registry/dek/list-subject.golden"},
 		{args: "schema-registry dek version list --kek-name kek-name --subject payments", fixture: "schema-registry/dek/list-version.golden"},
 		{args: "schema-registry dek describe --kek-name kek-name --subject payments", fixture: "schema-registry/dek/describe.golden"},

--- a/test/test-server/schema_registry_handlers.go
+++ b/test/test-server/schema_registry_handlers.go
@@ -647,6 +647,12 @@ func handleSRDeks(t *testing.T) http.HandlerFunc {
 			var req srsdk.CreateDekRequest
 			err := json.NewDecoder(r.Body).Decode(&req)
 			require.NoError(t, err)
+			// An unset --encrypted-key-material flag must be omitted from the request,
+			// not sent as an empty string. A present-but-empty value is treated by the
+			// backend as caller-supplied ciphertext and breaks DEK generation on shared KEKs.
+			if req.EncryptedKeyMaterial != nil {
+				require.NotEmpty(t, req.GetEncryptedKeyMaterial())
+			}
 			res := srsdk.Dek{
 				KekName:              srsdk.PtrString("kek-name"),
 				Algorithm:            req.Algorithm,


### PR DESCRIPTION
## Summary

https://confluentinc.atlassian.net/browse/DGS-25204

`confluent schema-registry dek create` returned HTTP 500 on shared KEKs when `--encrypted-key-material` was not provided.

`--encrypted-key-material` defaults to `""`, but the field was set unconditionally on `CreateDekRequest`, so an unset flag serialized as `"encryptedKeyMaterial": ""` — a present-but-empty JSON string. Schema Registry treats a present-but-empty value as caller-supplied ciphertext: it skips DEK generation, then fails the KMS round-trip (Base64-decoding `""` → empty bytes → KMS unwrap rejects), surfacing as `50070` / HTTP 500. Only shared KEKs hit this path; non-shared KEKs return a clean 4xx.

The sibling `--algorithm` field was already guarded with `cmd.Flags().Changed(...)` (#2811, "Do not pass \"\" to backend if --algorithm is unspecified") — the exact same bug, fixed for one field and missed for the other. This applies the identical guard.

## Changes

- `command_dek_create.go`: set `EncryptedKeyMaterial` only when the flag was explicitly changed.
- Integration test: added a `dek create` case with no `--encrypted-key-material` (the customer scenario).
- Mock server: assert the DEK POST request omits the field rather than sending an empty string — this is what distinguishes the bug from the fix, since the output table renders the field either way.

## Testing

- `TestSchemaRegistryDek` passes.
- Negative check: reverting only the one-line fix makes the new test fail with `Should NOT be empty, but was`, confirming it guards the regression.

## Scope

CLI half only. The two Schema Registry hardening items from triage (normalize empty→absent at the `createDek` boundary; classify KMS-rejected input as 4xx not 500) belong to the SR/DGov team and are tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)