### PR TITLE
[CLI-3798] deprecation of --max-partition-memory-bytes

### DIFF
--- a/internal/local/command_service_kafka.go
+++ b/internal/local/command_service_kafka.go
@@ -74,7 +74,7 @@ var (
 		"line-reader":                `The class name of the class to use for reading lines from stdin. By default each line is read as a separate message. (default "kafka.tools.ConsoleProducer$LineMessageReader")`,
 		"max-block-ms":               "The max time that the producer will block for during a send request. (default 60000)",
 		"max-memory-bytes":           "The total memory used by the producer to buffer records waiting to be sent to the server. (default 33554432)",
-		"max-partition-memory-bytes": "The buffer size allocated for a partition. When records are received which are small than this size, the producer will attempt to optimistically group them together until this size is reached. (default 16384)",
+		"max-partition-memory-bytes": "DEPRECATED: The buffer size allocated for a partition. When records are received which are smaller than this size, the producer will attempt to optimistically group them together until this size is reached. (default 16384)",
 		"message-send-max-retries":   "This property specifies the number of retries before the producer gives up and drops this message. Brokers can fail receiving a message for multiple reasons, and being unavailable transiently is just one of them. (default 3)",
 		"metadata-expiry-ms":         "The amount of time in milliseconds before a forced metadata refresh. This will occur independent of any leadership changes. (default 300000)",
 		"producer-property":          "A mechanism to pass user-defined properties in the form key=value to the producer.",

--- a/test/fixtures/output/local/services/kafka/produce-help-onprem.golden
+++ b/test/fixtures/output/local/services/kafka/produce-help-onprem.golden
@@ -23,7 +23,7 @@ Flags:
       --line-reader string               The class name of the class to use for reading lines from stdin. By default each line is read as a separate message. (default "kafka.tools.ConsoleProducer$LineMessageReader")
       --max-block-ms int                 The max time that the producer will block for during a send request. (default 60000)
       --max-memory-bytes int             The total memory used by the producer to buffer records waiting to be sent to the server. (default 33554432)
-      --max-partition-memory-bytes int   The buffer size allocated for a partition. When records are received which are small than this size, the producer will attempt to optimistically group them together until this size is reached. (default 16384)
+      --max-partition-memory-bytes int   DEPRECATED: The buffer size allocated for a partition. When records are received which are smaller than this size, the producer will attempt to optimistically group them together until this size is reached. (default 16384)
       --message-send-max-retries int     This property specifies the number of retries before the producer gives up and drops this message. Brokers can fail receiving a message for multiple reasons, and being unavailable transiently is just one of them. (default 3)
       --metadata-expiry-ms int           The amount of time in milliseconds before a forced metadata refresh. This will occur independent of any leadership changes. (default 300000)
       --producer\-property string         A mechanism to pass user-defined properties in the form key=value to the producer.

--- a/test/fixtures/output/local/services/kafka/produce-help.golden
+++ b/test/fixtures/output/local/services/kafka/produce-help.golden
@@ -23,7 +23,7 @@ Flags:
       --line-reader string               The class name of the class to use for reading lines from stdin. By default each line is read as a separate message. (default "kafka.tools.ConsoleProducer$LineMessageReader")
       --max-block-ms int                 The max time that the producer will block for during a send request. (default 60000)
       --max-memory-bytes int             The total memory used by the producer to buffer records waiting to be sent to the server. (default 33554432)
-      --max-partition-memory-bytes int   The buffer size allocated for a partition. When records are received which are small than this size, the producer will attempt to optimistically group them together until this size is reached. (default 16384)
+      --max-partition-memory-bytes int   DEPRECATED: The buffer size allocated for a partition. When records are received which are smaller than this size, the producer will attempt to optimistically group them together until this size is reached. (default 16384)
       --message-send-max-retries int     This property specifies the number of retries before the producer gives up and drops this message. Brokers can fail receiving a message for multiple reasons, and being unavailable transiently is just one of them. (default 3)
       --metadata-expiry-ms int           The amount of time in milliseconds before a forced metadata refresh. This will occur independent of any leadership changes. (default 300000)
       --producer\-property string         A mechanism to pass user-defined properties in the form key=value to the producer.


### PR DESCRIPTION
Release Notes
-------------

Bug Fixes
- Mark the `--max-partition-memory-bytes` flag as deprecated in the `confluent local services kafka produce` command

Checklist
---------
- [x] I have successfully built and used a custom CLI binary, without linter issues from this PR. <!-- make build, make lint-go, make lint-cli all pass -->
- [x] I have clearly specified in the `What` section below whether this PR applies to Confluent Cloud, Confluent Platform, or both.
- [ ] I have verified this PR in Confluent Cloud pre-prod or production environment, if applicable. <!-- N/A: no Confluent Cloud surface exposes this flag -->
- [ ] I have verified this PR in Confluent Platform on-premises environment, if applicable. <!-- N/A for a help-text-only change; verified via the on-prem help golden (produce-help-onprem.golden) in TestCLI/TestHelp -->
- [x] I have attached manual CLI verification results or screenshots in the `Test & Review` section below.
- [x] I have added appropriate CLI integration or unit tests for any new or updated commands and functionality. <!-- Existing TestCLI/TestHelp golden coverage updated for both cloud and on-prem help output -->
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [x] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [ ] I have put checkmarks below confirming that the feature associated with this PR is enabled in: <!-- N/A: not a feature-flagged feature; static help-text change -->
  - [ ] Confluent Cloud prod
  - [ ] Confluent Cloud stag
  - [ ] Confluent Platform
  - [ ] Check this box if the feature is enabled for certain organizations only

What
----
**Applies to: Confluent Platform** — specifically the on-prem `confluent local services kafka produce` command. No Confluent Cloud surface is affected: the cloud/native produce paths (`confluent kafka topic produce`, `confluent local kafka topic produce`) use native producers and never exposed this flag.

KIP-1231 deprecates the `--max-partition-memory-bytes` option in the Apache Kafka console producer. `confluent local services kafka produce` wraps that console producer and forwards this flag as a passthrough, so this PR reflects the deprecation in the CLI's help text.

Changes:
- Prepend the repo-standard `DEPRECATED: ` prefix (matching `pkg/featureflags/announcements_and_deprecation.go` and the `internal/tableflow` `--record-failure-strategy` precedent) to the flag's usage string in `internal/local/command_service_kafka.go`.
- Fix a pre-existing typo on the same line ("small" → "smaller").
- Update the two golden files that capture this help output (`produce-help.golden`, `produce-help-onprem.golden`).

The flag is retained and still works — removing it would be a breaking change. This is a help-text-only deprecation notice, matching the existing `--record-failure-strategy` precedent. It intentionally does not emit a runtime warning when the flag is used; that is the separate, server-driven LaunchDarkly deprecation mechanism and is out of scope here.

Blast Radius
----
Minimal. This is a help-text-only change to a single Confluent Platform local command flag; the flag's behavior is unchanged and it continues to work. Worst case if something is wrong: the `--help` output for `confluent local services kafka produce` renders incorrectly. No runtime, data-path, or Confluent Cloud impact.

References
----------
- Jira: [CLI-3798](https://confluentinc.atlassian.net/browse/CLI-3798)
- Blocked by: [INIT-15091](https://confluentinc.atlassian.net/browse/INIT-15091) — KIP-1231: Deprecate `--max-partition-memory-bytes` in ConsoleProducer
- KIP-1231 (Apache Kafka)

Test & Review
-------------
Verified locally:
- `make build` — pass
- `make lint-go` — pass
- `make lint-cli` — pass (confirms the `DEPRECATED:` text passes the user-facing-string spell check)
- `make integration-test INTEGRATION_TEST_ARGS="-run TestCLI/TestHelp"` — pass, including the two relevant subtests:
  - `TestCLI/TestHelp/local_services_kafka_produce_--help` (cloud config)
  - `TestCLI/TestHelp/local_services_kafka_produce_--help#01` (on-prem config)

Help output for this flag, before → after:
```
-      --max-partition-memory-bytes int   The buffer size allocated for a partition. When records are received which are small than this size, the producer will attempt to optimistically group them together until this size is reached. (default 16384)
+      --max-partition-memory-bytes int   DEPRECATED: The buffer size allocated for a partition. When records are received which are smaller than this size, the producer will attempt to optimistically group them together until this size is reached. (default 16384)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[CLI-3798]: https://confluentinc.atlassian.net/browse/CLI-3798?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ