### PR TITLE
[APIE-1481] (Follow-Up) Auto-complete hints carry the description for generated commands

### DIFF
--- a/internal/ccpm/command_plugin.go
+++ b/internal/ccpm/command_plugin.go
@@ -94,7 +94,7 @@ func (c *customConnectPluginCommand) autocompleteCustomConnectPlugins() []string
 	suggestions := make([]string, len(customConnectPlugins))
 	for i, customConnectPlugin := range customConnectPlugins {
 		spec := customConnectPlugin.GetSpec()
-		suggestions[i] = fmt.Sprintf("%s\t%s", customConnectPlugin.GetId(), spec.GetDisplayName())
+		suggestions[i] = fmt.Sprintf("%s\t%s: %s", customConnectPlugin.GetId(), spec.GetDisplayName(), spec.GetDescription())
 	}
 	return suggestions
 }

--- a/internal/ccpm/command_plugin.go
+++ b/internal/ccpm/command_plugin.go
@@ -94,7 +94,10 @@ func (c *customConnectPluginCommand) autocompleteCustomConnectPlugins() []string
 	suggestions := make([]string, len(customConnectPlugins))
 	for i, customConnectPlugin := range customConnectPlugins {
 		spec := customConnectPlugin.GetSpec()
-		suggestions[i] = fmt.Sprintf("%s\t%s: %s", customConnectPlugin.GetId(), spec.GetDisplayName(), spec.GetDescription())
+		suggestions[i] = fmt.Sprintf("%s\t%s", customConnectPlugin.GetId(), spec.GetDisplayName())
+		if description := spec.GetDescription(); description != "" {
+			suggestions[i] += ": " + description
+		}
 	}
 	return suggestions
 }

--- a/internal/iam/command_identity_provider.go
+++ b/internal/iam/command_identity_provider.go
@@ -89,7 +89,7 @@ func (c *identityProviderCommand) autocompleteIdentityProviders() []string {
 
 	suggestions := make([]string, len(identityProviders))
 	for i, identityProvider := range identityProviders {
-		suggestions[i] = fmt.Sprintf("%s\t%s", identityProvider.GetId(), identityProvider.GetDisplayName())
+		suggestions[i] = fmt.Sprintf("%s\t%s: %s", identityProvider.GetId(), identityProvider.GetDisplayName(), identityProvider.GetDescription())
 	}
 	return suggestions
 }

--- a/internal/iam/command_identity_provider.go
+++ b/internal/iam/command_identity_provider.go
@@ -89,7 +89,10 @@ func (c *identityProviderCommand) autocompleteIdentityProviders() []string {
 
 	suggestions := make([]string, len(identityProviders))
 	for i, identityProvider := range identityProviders {
-		suggestions[i] = fmt.Sprintf("%s\t%s: %s", identityProvider.GetId(), identityProvider.GetDisplayName(), identityProvider.GetDescription())
+		suggestions[i] = fmt.Sprintf("%s\t%s", identityProvider.GetId(), identityProvider.GetDisplayName())
+		if description := identityProvider.GetDescription(); description != "" {
+			suggestions[i] += ": " + description
+		}
 	}
 	return suggestions
 }

--- a/internal/iam/command_service_account.go
+++ b/internal/iam/command_service_account.go
@@ -87,7 +87,10 @@ func (c *serviceAccountCommand) autocompleteServiceAccounts() []string {
 
 	suggestions := make([]string, len(serviceAccounts))
 	for i, serviceAccount := range serviceAccounts {
-		suggestions[i] = fmt.Sprintf("%s\t%s: %s", serviceAccount.GetId(), serviceAccount.GetDisplayName(), serviceAccount.GetDescription())
+		suggestions[i] = fmt.Sprintf("%s\t%s", serviceAccount.GetId(), serviceAccount.GetDisplayName())
+		if description := serviceAccount.GetDescription(); description != "" {
+			suggestions[i] += ": " + description
+		}
 	}
 	return suggestions
 }

--- a/internal/iam/command_service_account.go
+++ b/internal/iam/command_service_account.go
@@ -87,7 +87,7 @@ func (c *serviceAccountCommand) autocompleteServiceAccounts() []string {
 
 	suggestions := make([]string, len(serviceAccounts))
 	for i, serviceAccount := range serviceAccounts {
-		suggestions[i] = fmt.Sprintf("%s\t%s", serviceAccount.GetId(), serviceAccount.GetDisplayName())
+		suggestions[i] = fmt.Sprintf("%s\t%s: %s", serviceAccount.GetId(), serviceAccount.GetDisplayName(), serviceAccount.GetDescription())
 	}
 	return suggestions
 }

--- a/test/ccpm_test.go
+++ b/test/ccpm_test.go
@@ -42,6 +42,9 @@ func (s *CLITestSuite) TestCCPMPlugin() {
 		{args: "ccpm plugin delete ccp-123456 --environment env-123456", input: "y\n", fixture: "ccpm/plugin-delete-prompt.golden"},
 		{args: "ccpm plugin delete ccp-123456 --environment env-123456", input: "n\n", fixture: "ccpm/plugin-delete-cancelled.golden"},
 		{args: "ccpm plugin delete invalid-id --environment env-123456 --force", fixture: "ccpm/plugin-delete-not-found.golden", exitCode: 1},
+
+		// Positional autocomplete: the hint pairs the id with "<name>: <description>".
+		{args: `__complete ccpm plugin describe ""`, fixture: "ccpm/plugin-describe-autocomplete.golden"},
 	}
 
 	for _, test := range tests {

--- a/test/fixtures/output/ccpm/plugin-describe-autocomplete.golden
+++ b/test/fixtures/output/ccpm/plugin-describe-autocomplete.golden
@@ -1,0 +1,4 @@
+ccp-123456	CliPluginTest1: Test plugin
+ccp-789012	CliPluginTest2: Test plugin
+:4
+Completion ended with directive: ShellCompDirectiveNoFileComp

--- a/test/fixtures/output/iam/identity-provider/describe-autocomplete.golden
+++ b/test/fixtures/output/iam/identity-provider/describe-autocomplete.golden
@@ -1,5 +1,5 @@
-op-12345	identity-provider
-op-abc	another-provider
-op-67890	okta-with-identity-claim
+op-12345	identity-provider: providing identities.
+op-abc	another-provider: providing identities.
+op-67890	okta-with-identity-claim: new description.
 :4
 Completion ended with directive: ShellCompDirectiveNoFileComp

--- a/test/fixtures/output/iam/service-account/describe-autocomplete.golden
+++ b/test/fixtures/output/iam/service-account/describe-autocomplete.golden
@@ -1,4 +1,4 @@
-sa-12345	service-account
-sa-67890	other-service-account
+sa-12345	service-account: at your service.
+sa-67890	other-service-account: another one.
 :4
 Completion ended with directive: ShellCompDirectiveNoFileComp


### PR DESCRIPTION
Release Notes
-------------
<!--
If this PR introduces any user-facing changes, please document them below. Please delete any unused section titles and placeholders.
Please match the style of previous release notes: https://docs.confluent.io/confluent-cli/current/release-notes.html
-->

Breaking Changes
- PLACEHOLDER

New Features
- The auto-complete hints function now displays the `description` in additional to resource ID and name for `confluent iam [service-account | identity-provider]` and `confluent ccpm plugin` commands

Bug Fixes
- PLACEHOLDER

Checklist
---------
<!-- 
Check each item below to ensure high-quality CLI development practices are followed. PR approval will not be granted until the checklist is fully reviewed.
For detailed instructions, please refer to this Confluence page: https://confluentinc.atlassian.net/wiki/spaces/AEGI/pages/3949592874/
-->
- [x] I have successfully built and used a custom CLI binary, without linter issues from this PR.
- [x] I have clearly specified in the `What` section below whether this PR applies to Confluent Cloud, Confluent Platform, or both. 
- [x] I have verified this PR in Confluent Cloud pre-prod or production environment, if applicable.
- [ ] I have verified this PR in Confluent Platform on-premises environment, if applicable.
- [x] I have attached manual CLI verification results or screenshots in the `Test & Review` section below.
- [x] I have added appropriate CLI integration or unit tests for any new or updated commands and functionality.
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [x] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [x] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [x] Confluent Cloud prod
  - [ ] Confluent Cloud stag
  - [ ] Confluent Platform
  - [ ] Check this box if the feature is enabled for certain organizations only

What
----
<!--
Briefly describe **what** you have changed and **why** these changes are necessary.
Optionally include: 
- The problem being solved or the feature being added. 
- The implementation strategy or approach taken. 
- Key technical details, design decisions, or any additional context reviewers should be aware of.
-->
For auto-complete functions, earlier CLI source code has the `description` field included if it exists.

This PR adds the functionality back for the migrated commands having the `description` field.

Blast Radius
----
<!--
The Blast Radius section should include information on what will be the customer(s) impact if something goes wrong or unexpectedly, 
adding this section will trigger the PR author to think about the impact from product perspective, examples can be:
- Confluent Cloud customers who are using confluent kafka topic any subcommand will be blocked.
- Confluent Cloud customers who are using confluent kafka topic list commands will be blocked.
- Confluent Platform customers who are using --schema flag will be impacted.
- All customers who are using SSO to login will be impacted.
-->
Minimal, only `confluent iam [service-account | identity-provider]` and `confluent ccpm plugin` commands users may see broken auto-complete prompts. 

References
----------
<!-- Include links to relevant resources for this PR, such as: 
- Related GitHub issues 
- Tickets (JIRA, etc.) 
- Internal documentation or design specs 
- Other related PRs 
Copy and paste the links below for easy reference.
-->
This is a follow-up PR for:
https://github.com/confluentinc/cli-terraform-generator/pull/467

Test & Review
-------------
<!-- Has this PR been tested? If so, explain **how** it was tested. Include: 
- Steps taken to verify the changes. 
- Links to manual verification documents, logs, or screenshots to save reviewers' time. 
- Any additional notes on testing (e.g., environments used, edge cases tested). 
- Screenshot showing successful resource creation, updates etc.
Example: - [Manual Verification Document](https://docs.google.com/document/d/1GwXz9hNOkub_Br-2nssoYWCf6elZBvwo7TMhCNYinwE/edit?tab=t.0#heading=h.dvbi09ntxjw6)
-->
See the screenshots of the auto-complete prompts with descriptions following the comma:
<img width="1151" height="275" alt="Screenshot 2026-09-03 at 6 13 56 PM" src="https://github.com/user-attachments/assets/a0149644-31e9-4707-863b-19b64891072d" />
<img width="1293" height="130" alt="Screenshot 2026-09-03 at 6 14 21 PM" src="https://github.com/user-attachments/assets/397fe11b-393c-42eb-8171-3f4e3eb9f12a" />

