### PR TITLE
Add switchover CLI commands (pair + endpoint) with CRN references

### DIFF
--- a/SWITCHOVER_LOCAL_DEMO.md
+++ b/SWITCHOVER_LOCAL_DEMO.md
@@ -1,0 +1,195 @@
+# Local CLI build with Switchover support
+
+> Paths below assume this repo (and its sibling repos) are cloned under
+> `~/sdk_cli_tf_switchover/`, matching the original workspace this branch was
+> built in. Adjust paths if you clone elsewhere.
+
+How to reproduce the local `confluent` CLI build in this workspace, which adds
+`confluent switchover pair` and `confluent switchover endpoint` commands on
+top of the upstream CLI.
+
+## Workspace layout
+
+```
+~/sdk_cli_tf_switchover/
+├── cli/
+├── ccloud-sdk-go-v2-internal/
+├── api/
+├── cc-switchover/
+└── terraform-provider-confluent/
+```
+
+- `cli/` — confluentinc/cli, branch `switchover-cli-local-demo`,
+  [PR #3399](https://github.com/confluentinc/cli/pull/3399)
+- `ccloud-sdk-go-v2-internal/` — confluentinc/ccloud-sdk-go-v2-internal,
+  branch `ORC-10130-sync-switchover-sdk`,
+  [PR #832](https://github.com/confluentinc/ccloud-sdk-go-v2-internal/pull/832)
+- `api/` — confluentinc/api, branch `ORC-10130-switchover-api-spec`,
+  [PR #2545](https://github.com/confluentinc/api/pull/2545)
+- `cc-switchover/` — confluentinc/cc-switchover, branch `master`
+  (reference/source-of-truth)
+- `terraform-provider-confluent/` — confluentinc/terraform-provider-confluent,
+  branch `master` (not used here)
+
+`cli`'s `go.mod` pins the switchover SDK to
+[PR #832](https://github.com/confluentinc/ccloud-sdk-go-v2-internal/pull/832)'s
+commit:
+
+```
+github.com/confluentinc/ccloud-sdk-go-v2-internal/switchover v0.0.0-20260708221705-f2f8dbb55045
+```
+
+To get the `cli` branch locally:
+
+```bash
+git clone git@github.com:confluentinc/cli.git
+cd cli
+git checkout switchover-cli-local-demo
+```
+
+`confluentinc/cli` is a public repo with an org ruleset that blocks direct
+branch pushes — use `git push-external` (Confluent's Airlock
+proprietary-code-scan wrapper), not plain `git push`, to push further changes
+to this branch.
+
+## One-time environment setup
+
+1. **Go toolchain** — `cli/.go-version` pins `1.26.4`. If your `goenv` doesn't
+   have it yet, any Go ≥1.21 binary will auto-fetch it via `GOTOOLCHAIN=auto`:
+   ```bash
+   export GOTOOLCHAIN=auto
+   export PATH="$HOME/.goenv/versions/<any-installed-1.2x>/bin:$PATH"
+   go version   # should report go1.26.4 once it downloads
+   ```
+2. **goreleaser** — the CLI's `make build` shells out to it:
+   ```bash
+   brew install goreleaser
+   ```
+3. **Docker Desktop**, signed in to an org with access to
+   `519856050701.dkr.ecr.us-west-2.amazonaws.com` — only needed if you want to
+   regenerate the switchover SDK from `confluentinc/api`, not for building the
+   CLI itself.
+
+## Build
+
+```bash
+cd ~/sdk_cli_tf_switchover/cli
+export GOTOOLCHAIN=auto
+export PATH="$HOME/.goenv/versions/<any-installed-1.2x>/bin:$PATH"
+make build
+```
+
+Binary lands at:
+
+```
+~/sdk_cli_tf_switchover/cli/dist/confluent_darwin_arm64_v8.0/confluent
+```
+
+(path varies by OS/arch — check `dist/` after the build).
+
+## Alias the binary (recommended)
+
+Prefer a distinctly-named **alias** over adding the `dist/` folder to `PATH`,
+so this experimental build doesn't shadow a real installed `confluent` CLI:
+
+```bash
+alias confluent-dev="/Users/ewang/sdk_cli_tf_switchover/cli/dist/confluent_darwin_arm64_v8.0/confluent"
+```
+
+Already set up in `~/.aliases` (sourced from `~/.zshrc`), alongside the
+existing `confluent` alias. New terminals pick it up automatically; in an
+already-open terminal run `source ~/.aliases` once. The rest of this README
+uses `confluent-dev`.
+
+## Usage
+
+Log in first — the `switchover` command requires cloud login:
+
+```bash
+confluent-dev login
+```
+
+This hits **production** Confluent Cloud (`https://confluent.cloud`) with
+real credentials — it's the CLI's stock login flow, not a mock.
+
+### Logging in against staging (`stag`) instead of production
+
+```bash
+confluent-dev login --url https://stag.cpdev.cloud
+```
+
+The hostname is `stag.cpdev.cloud` with **no** `confluent.` prefix (unlike
+prod's `confluent.cloud`). You'll need a **staging** Confluent Cloud
+account — separate from your prod account — and your staging org needs
+Switchover Early Access granted before `switchover pair` commands return
+anything but an access/authorization error. `devel.cpdev.cloud` works the
+same way for the `devel` environment. If you know your staging org ID, add
+`--organization <org-id>`.
+
+Everything below (`switchover pair`/`switchover endpoint` commands) works
+identically once logged in, regardless of which environment you logged into.
+
+### Bypassing the stag EA gate with a Cloud API key
+
+The Switchover Early Access gate on `stag`/`devel` is only enforced on the
+bearer-token (`login`) path — a Cloud API key (Basic auth) sails through it.
+If your staging org doesn't have EA granted yet, set both of these and the
+`switchover` commands will use Basic auth instead of your login session's
+bearer token:
+
+```bash
+export CONFLUENT_CLOUD_API_KEY=<key>
+export CONFLUENT_CLOUD_API_SECRET=<secret>
+```
+
+Create a Cloud API key first (still requires being logged in once, to create
+it): `confluent-dev api-key create --resource cloud`. You still need
+`confluent-dev login` for non-switchover commands / context; this env var
+pair only affects the switchover API calls (see
+`pkg/ccloudv2/switchover.go`'s `switchoverApiContext`).
+
+### Switchover pairs
+
+```bash
+# Create a pair between two Kafka clusters
+confluent-dev switchover pair create prod-kafka-dr \
+  --member name=west,id=lkc-111111 \
+  --member name=east,id=lkc-222222 \
+  --active-member west \
+  --environment env-abcdef
+
+# Describe it
+confluent-dev switchover pair describe sw-123456
+
+# Rename it (the only mutable field)
+confluent-dev switchover pair update sw-123456 --display-name "prod-kafka-dr-renamed"
+
+# Trigger a failover (prompts for confirmation — moves live traffic)
+confluent-dev switchover pair trigger-switch sw-123456 --active-member east --failover-type CLEAN
+```
+
+### Switchover endpoints
+
+```bash
+confluent-dev switchover endpoint create prod-kafka-dr-endpoint \
+  --switchover-pair sw-123456 \
+  --endpoint name=west-platt,type=private \
+  --endpoint name=east-platt,type=private
+
+confluent-dev switchover endpoint describe se-123456
+confluent-dev switchover endpoint update se-123456 --display-name "renamed-endpoint"
+confluent-dev switchover endpoint activate se-123456
+```
+
+### Global flags
+
+- `-o json` / `-o yaml` for machine-readable output (default is a human table).
+- `--environment env-xxxxx` to override the current context's default environment.
+- `--context <name>` to target a specific CLI context/profile.
+
+## Rebuilding after further code changes
+
+Rerun `make build` from `cli/` — it picks up any local edits. Only redo the
+SDK pinning step (`go get github.com/confluentinc/ccloud-sdk-go-v2-internal/switchover@<commit>`
+in `cli/`) if `ccloud-sdk-go-v2-internal`'s switchover module changes again
+upstream.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/confluentinc/cli/v4
 
-go 1.26.7
+go 1.26.8
 
 require (
 	github.com/antihax/optional v1.0.0
@@ -51,6 +51,7 @@ require (
 	github.com/confluentinc/ccloud-sdk-go-v2/service-quota v0.2.0
 	github.com/confluentinc/ccloud-sdk-go-v2/srcm v0.7.3
 	github.com/confluentinc/ccloud-sdk-go-v2/sso v0.0.1
+	github.com/confluentinc/ccloud-sdk-go-v2/switchover v0.0.0-20260909150805-7dfad3daf9b5
 	github.com/confluentinc/ccloud-sdk-go-v2/tableflow v0.7.0
 	github.com/confluentinc/ccloud-sdk-go-v2/usm v0.2.0
 	github.com/confluentinc/cmf-sdk-go v0.0.8

--- a/go.sum
+++ b/go.sum
@@ -237,6 +237,8 @@ github.com/confluentinc/ccloud-sdk-go-v2/srcm v0.7.3 h1:ozdDSJHruQIgtxS5hwz8Rp8p
 github.com/confluentinc/ccloud-sdk-go-v2/srcm v0.7.3/go.mod h1:cD0AeCMBAWBesmWxWCMgVYNABYgHJ/ahCj7b4HP2R2I=
 github.com/confluentinc/ccloud-sdk-go-v2/sso v0.0.1 h1:WZJYfgXJrvTIYQpCFps/qHF7T8ekgPlX/SFqx4EY2zQ=
 github.com/confluentinc/ccloud-sdk-go-v2/sso v0.0.1/go.mod h1:kB+MXWYYg9ohrTCb27LlfpTbuexAzyYAmum105ow0ho=
+github.com/confluentinc/ccloud-sdk-go-v2/switchover v0.0.0-20260909150805-7dfad3daf9b5 h1:3HGMmpdFdJV4eVhzqjnyUBmpMkL8dP7jpyMLvnujw+w=
+github.com/confluentinc/ccloud-sdk-go-v2/switchover v0.0.0-20260909150805-7dfad3daf9b5/go.mod h1:CrN0g1b6r60ZHTx62RC9MdHcT8aqff/JrrX2NiuZBYY=
 github.com/confluentinc/ccloud-sdk-go-v2/tableflow v0.7.0 h1:yf/1TiSCiAT0cD1dBZB6SU+hUAAL+uCezLx5MM9aHCA=
 github.com/confluentinc/ccloud-sdk-go-v2/tableflow v0.7.0/go.mod h1:A0gPt6EjmzCV+CftXu2TeefIOiha2OTbATVOPp0ccx0=
 github.com/confluentinc/ccloud-sdk-go-v2/usm v0.2.0 h1:Sc0kt9hWy5armZDBV88shYb/S7Xrf4nH8Giy7wqoYbg=

--- a/internal/command.go
+++ b/internal/command.go
@@ -45,6 +45,7 @@ import (
 	"github.com/confluentinc/cli/v4/internal/secret"
 	servicequota "github.com/confluentinc/cli/v4/internal/service-quota"
 	streamshare "github.com/confluentinc/cli/v4/internal/stream-share"
+	"github.com/confluentinc/cli/v4/internal/switchover"
 	"github.com/confluentinc/cli/v4/internal/tableflow"
 	"github.com/confluentinc/cli/v4/internal/update"
 	"github.com/confluentinc/cli/v4/internal/usm"
@@ -138,6 +139,7 @@ func NewConfluentCommand(cfg *config.Config) *cobra.Command {
 	cmd.AddCommand(servicequota.New(prerunner))
 	cmd.AddCommand(shell.New(cmd, func() *cobra.Command { return NewConfluentCommand(cfg) }))
 	cmd.AddCommand(streamshare.New(prerunner))
+	cmd.AddCommand(switchover.New(prerunner))
 	cmd.AddCommand(tableflow.New(prerunner))
 	cmd.AddCommand(update.New(cfg, prerunner))
 	cmd.AddCommand(usm.New(cfg, prerunner))

--- a/internal/switchover/command.go
+++ b/internal/switchover/command.go
@@ -1,0 +1,22 @@
+package switchover
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/confluentinc/cli/v4/internal/switchover/endpoint"
+	"github.com/confluentinc/cli/v4/internal/switchover/pair"
+	pcmd "github.com/confluentinc/cli/v4/pkg/cmd"
+)
+
+func New(prerunner pcmd.PreRunner) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:         "switchover",
+		Short:       "Manage Kafka disaster recovery switchover pairs and endpoints.",
+		Annotations: map[string]string{pcmd.RunRequirement: pcmd.RequireNonAPIKeyCloudLogin},
+	}
+
+	cmd.AddCommand(pair.New(prerunner))
+	cmd.AddCommand(endpoint.New(prerunner))
+
+	return cmd
+}

--- a/internal/switchover/endpoint/command.go
+++ b/internal/switchover/endpoint/command.go
@@ -1,0 +1,141 @@
+package endpoint
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/tidwall/pretty"
+	"gopkg.in/yaml.v3"
+
+	switchoverv1 "github.com/confluentinc/ccloud-sdk-go-v2/switchover/v1"
+
+	pcmd "github.com/confluentinc/cli/v4/pkg/cmd"
+	"github.com/confluentinc/cli/v4/pkg/output"
+)
+
+type command struct {
+	*pcmd.AuthenticatedCLICommand
+}
+
+// out is the detailed human-readable shape used by create/describe/update.
+// Machine-readable output (`-o json` / `-o yaml`) is emitted straight from the
+// SDK object so it matches the API response verbatim.
+type out struct {
+	Id             string `human:"ID"`
+	DisplayName    string `human:"Display Name"`
+	SwitchoverPair string `human:"Switchover Pair"`
+	Environment    string `human:"Environment"`
+	Target         string `human:"Target,omitempty"`
+	Phase          string `human:"Phase"`
+	Endpoints      string `human:"Endpoints,omitempty"`
+	Conditions     string `human:"Conditions,omitempty"`
+}
+
+// listOut is the compact per-row shape for `list` (human output only).
+type listOut struct {
+	Id             string `human:"ID"`
+	DisplayName    string `human:"Display Name"`
+	SwitchoverPair string `human:"Switchover Pair"`
+	Environment    string `human:"Environment"`
+	Phase          string `human:"Phase"`
+}
+
+func New(prerunner pcmd.PreRunner) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "endpoint",
+		Short: "Manage switchover endpoints.",
+		Long:  "Manage switchover endpoints. This API is not yet implemented on the backend; commands will fail against a live Confluent Cloud environment.",
+	}
+
+	c := &command{pcmd.NewAuthenticatedCLICommand(cmd, prerunner)}
+
+	cmd.AddCommand(c.newCreateCommand())
+	cmd.AddCommand(c.newDeleteCommand())
+	cmd.AddCommand(c.newDescribeCommand())
+	cmd.AddCommand(c.newListCommand())
+	cmd.AddCommand(c.newUpdateCommand())
+
+	return cmd
+}
+
+// printSerialized emits v as JSON or YAML using the SDK object's `json` tags,
+// so the output matches the API response verbatim. (output.SerializedOutput's
+// YAML path uses yaml.v3, which ignores `json` tags; route YAML through the
+// JSON representation to preserve the API field names.)
+func printSerialized(cmd *cobra.Command, v any) error {
+	data, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	if output.GetFormat(cmd) == output.YAML {
+		var generic any
+		if err := json.Unmarshal(data, &generic); err != nil {
+			return err
+		}
+		out, err := yaml.Marshal(generic)
+		if err != nil {
+			return err
+		}
+		output.Print(false, string(out))
+		return nil
+	}
+
+	output.Print(false, string(pretty.Pretty(data)))
+	return nil
+}
+
+func newEndpointOut(endpoint switchoverv1.SwitchoverV1SwitchoverEndpoint) *out {
+	return &out{
+		Id:             endpoint.GetId(),
+		DisplayName:    endpoint.Spec.GetDisplayName(),
+		SwitchoverPair: endpoint.Spec.GetParentResourceCrn(),
+		Environment:    endpoint.Spec.GetEnvironmentCrn(),
+		Target:         endpoint.Spec.GetTarget(),
+		Phase:          endpoint.Status.GetPhase(),
+		Endpoints:      formatEndpoints(endpoint.Spec.GetEndpoints()),
+		Conditions:     formatConditions(endpoint.Status.GetConditions()),
+	}
+}
+
+func formatEndpoints(endpoints []switchoverv1.SwitchoverV1EndpointConfig) string {
+	lines := make([]string, len(endpoints))
+	for i, endpoint := range endpoints {
+		filter := endpoint.EndpointFilter
+		parts := []string{endpoint.GetName(), filter.GetType()}
+		if networkCrn := filter.GetNetworkCrn(); networkCrn != "" {
+			parts = append(parts, "network="+networkCrn)
+		}
+		if accessPointCrn := filter.GetAccessPointCrn(); accessPointCrn != "" {
+			parts = append(parts, "access-point="+accessPointCrn)
+		}
+		if hostname := endpoint.GetHostname(); hostname != "" {
+			parts = append(parts, "hostname="+hostname)
+		}
+		if cloud, region := endpoint.GetCloud(), endpoint.GetRegion(); cloud != "" || region != "" {
+			parts = append(parts, strings.TrimPrefix(cloud+"/"+region, "/"))
+		}
+		if connectionType := endpoint.GetConnectionType(); connectionType != "" {
+			parts = append(parts, connectionType)
+		}
+		lines[i] = strings.Join(parts, " ")
+	}
+	return strings.Join(lines, "\n")
+}
+
+func formatConditions(conditions []switchoverv1.SwitchoverV1SwitchoverEndpointCondition) string {
+	lines := make([]string, len(conditions))
+	for i, condition := range conditions {
+		line := fmt.Sprintf("%s=%s", condition.GetType(), condition.GetStatus())
+		if reason := condition.GetReason(); reason != "" {
+			line += fmt.Sprintf(" (%s)", reason)
+		}
+		if message := condition.GetMessage(); message != "" {
+			line += ": " + message
+		}
+		lines[i] = line
+	}
+	return strings.Join(lines, "\n")
+}

--- a/internal/switchover/endpoint/command_create.go
+++ b/internal/switchover/endpoint/command_create.go
@@ -1,0 +1,143 @@
+package endpoint
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	switchoverv1 "github.com/confluentinc/ccloud-sdk-go-v2/switchover/v1"
+
+	pcmd "github.com/confluentinc/cli/v4/pkg/cmd"
+	"github.com/confluentinc/cli/v4/pkg/examples"
+	"github.com/confluentinc/cli/v4/pkg/output"
+)
+
+func (c *command) newCreateCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "create <display-name>",
+		Short: "Create a switchover endpoint.",
+		Long:  "Create a switchover endpoint bound to a switchover pair.",
+		Args:  cobra.ExactArgs(1),
+		RunE:  c.create,
+		Example: examples.BuildExampleString(
+			examples.Example{
+				Text: `Create switchover endpoint "prod-kafka-dr-endpoint" for switchover pair "sw-123456".`,
+				Code: `confluent switchover endpoint create prod-kafka-dr-endpoint --switchover-pair sw-123456 --endpoint name=west-platt,type=private --endpoint name=east-platt,type=private`,
+			},
+		),
+	}
+
+	cmd.Flags().String("switchover-pair", "", "The ID of the switchover pair this endpoint is bound to.")
+	cmd.Flags().StringArray("endpoint", nil, `An endpoint side, in the form "name=<name>,type=<private|public>[,network=<network-id>][,access-point=<access-point-crn>]". A private endpoint sets exactly one of network or access-point. network takes a network ID (the CLI builds its CRN); access-point takes a full CRN, since its canonical form includes a gateway segment. Must be specified exactly twice.`)
+	pcmd.AddEnvironmentFlag(cmd, c.AuthenticatedCLICommand)
+	pcmd.AddContextFlag(cmd, c.CLICommand)
+	pcmd.AddOutputFlag(cmd)
+
+	cobra.CheckErr(cmd.MarkFlagRequired("switchover-pair"))
+	cobra.CheckErr(cmd.MarkFlagRequired("endpoint"))
+
+	return cmd
+}
+
+func parseEndpointFlag(raw string) (switchoverv1.SwitchoverV1EndpointConfig, error) {
+	config := switchoverv1.SwitchoverV1EndpointConfig{}
+	filter := switchoverv1.SwitchoverV1EndpointFilter{}
+	for _, part := range strings.Split(raw, ",") {
+		key, value, ok := strings.Cut(part, "=")
+		if !ok {
+			return config, fmt.Errorf(`invalid --endpoint value %q: expected "key=value" pairs`, raw)
+		}
+		switch key {
+		case "name":
+			config.Name = value
+		case "type":
+			filter.Type = value
+		case "network":
+			filter.NetworkCrn = switchoverv1.PtrString(value)
+		case "access-point":
+			filter.AccessPointCrn = switchoverv1.PtrString(value)
+		default:
+			return config, fmt.Errorf(`invalid --endpoint key %q`, key)
+		}
+	}
+	if config.Name == "" || filter.Type == "" {
+		return config, fmt.Errorf(`invalid --endpoint value %q: "name" and "type" are required`, raw)
+	}
+	config.EndpointFilter = filter
+	return config, nil
+}
+
+func (c *command) create(cmd *cobra.Command, args []string) error {
+	displayName := args[0]
+
+	switchoverPairId, err := cmd.Flags().GetString("switchover-pair")
+	if err != nil {
+		return err
+	}
+
+	rawEndpoints, err := cmd.Flags().GetStringArray("endpoint")
+	if err != nil {
+		return err
+	}
+	if len(rawEndpoints) != 2 {
+		return fmt.Errorf(`exactly two --endpoint flags are required, got %d`, len(rawEndpoints))
+	}
+
+	endpoints := make([]switchoverv1.SwitchoverV1EndpointConfig, len(rawEndpoints))
+	for i, raw := range rawEndpoints {
+		endpointConfig, err := parseEndpointFlag(raw)
+		if err != nil {
+			return err
+		}
+		endpoints[i] = endpointConfig
+	}
+
+	environmentId, err := c.Context.EnvironmentId()
+	if err != nil {
+		return err
+	}
+
+	organizationId := c.Context.GetCurrentOrganization()
+
+	// The endpoint's environment travels inside parent_resource_crn (the pair CRN); the create body
+	// does not take a separate environment_crn. The parent CRN is assembled from the current
+	// organization, the --environment flag, and the --switchover-pair ID.
+	parentResourceCrn := fmt.Sprintf("crn://confluent.cloud/organization=%s/environment=%s/switchover-pair=%s", organizationId, environmentId, switchoverPairId)
+
+	// network=<id> is given as a plain network ID; assemble its network_crn here (org + the
+	// endpoint's environment + the id). access_point_crn is passed through as a full CRN because its
+	// canonical form carries a gateway segment the --endpoint flag does not supply.
+	for i := range endpoints {
+		if networkId := endpoints[i].EndpointFilter.GetNetworkCrn(); networkId != "" {
+			endpoints[i].EndpointFilter.NetworkCrn = switchoverv1.PtrString(
+				fmt.Sprintf("crn://confluent.cloud/organization=%s/environment=%s/network=%s", organizationId, environmentId, networkId))
+		}
+	}
+
+	endpoint := switchoverv1.SwitchoverV1SwitchoverEndpoint{
+		Spec: &switchoverv1.SwitchoverV1SwitchoverEndpointSpec{
+			DisplayName:       switchoverv1.PtrString(displayName),
+			Endpoints:         &endpoints,
+			ParentResourceCrn: switchoverv1.PtrString(parentResourceCrn),
+		},
+	}
+
+	result, err := c.V2Client.CreateSwitchoverEndpoint(endpoint)
+	if err != nil {
+		return err
+	}
+
+	return printSwitchoverEndpoint(cmd, result)
+}
+
+func printSwitchoverEndpoint(cmd *cobra.Command, endpoint switchoverv1.SwitchoverV1SwitchoverEndpoint) error {
+	// Serialized output mirrors the API response verbatim (full spec/status).
+	if output.GetFormat(cmd).IsSerialized() {
+		return printSerialized(cmd, endpoint)
+	}
+
+	table := output.NewTable(cmd)
+	table.Add(newEndpointOut(endpoint))
+	return table.Print()
+}

--- a/internal/switchover/endpoint/command_delete.go
+++ b/internal/switchover/endpoint/command_delete.go
@@ -1,0 +1,55 @@
+package endpoint
+
+import (
+	"github.com/spf13/cobra"
+
+	pcmd "github.com/confluentinc/cli/v4/pkg/cmd"
+	"github.com/confluentinc/cli/v4/pkg/deletion"
+	"github.com/confluentinc/cli/v4/pkg/examples"
+	"github.com/confluentinc/cli/v4/pkg/resource"
+)
+
+func (c *command) newDeleteCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "delete <id-1> [id-2] ... [id-n]",
+		Short: "Delete one or more switchover endpoints.",
+		Args:  cobra.MinimumNArgs(1),
+		RunE:  c.delete,
+		Example: examples.BuildExampleString(
+			examples.Example{
+				Text: `Delete switchover endpoint "se-123456" in the current environment.`,
+				Code: "confluent switchover endpoint delete se-123456",
+			},
+		),
+	}
+
+	pcmd.AddForceFlag(cmd)
+	pcmd.AddEnvironmentFlag(cmd, c.AuthenticatedCLICommand)
+	pcmd.AddContextFlag(cmd, c.CLICommand)
+	pcmd.AddOutputFlag(cmd)
+
+	return cmd
+}
+
+func (c *command) delete(cmd *cobra.Command, args []string) error {
+	environmentId, err := c.Context.EnvironmentId()
+	if err != nil {
+		return err
+	}
+
+	existenceFunc := func(id string) bool {
+		_, err := c.V2Client.GetSwitchoverEndpoint(id, environmentId)
+		return err == nil
+	}
+
+	if err := deletion.ValidateAndConfirm(cmd, args, existenceFunc, resource.SwitchoverEndpoint); err != nil {
+		return err
+	}
+
+	deleteFunc := func(id string) error {
+		return c.V2Client.DeleteSwitchoverEndpoint(id, environmentId)
+	}
+
+	_, err = deletion.Delete(cmd, args, deleteFunc, resource.SwitchoverEndpoint)
+	return err
+}

--- a/internal/switchover/endpoint/command_describe.go
+++ b/internal/switchover/endpoint/command_describe.go
@@ -1,0 +1,43 @@
+package endpoint
+
+import (
+	"github.com/spf13/cobra"
+
+	pcmd "github.com/confluentinc/cli/v4/pkg/cmd"
+	"github.com/confluentinc/cli/v4/pkg/examples"
+)
+
+func (c *command) newDescribeCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "describe <id>",
+		Short: "Describe a switchover endpoint.",
+		Args:  cobra.ExactArgs(1),
+		RunE:  c.describe,
+		Example: examples.BuildExampleString(
+			examples.Example{
+				Text: `Describe switchover endpoint "se-123456".`,
+				Code: `confluent switchover endpoint describe se-123456`,
+			},
+		),
+	}
+
+	pcmd.AddEnvironmentFlag(cmd, c.AuthenticatedCLICommand)
+	pcmd.AddContextFlag(cmd, c.CLICommand)
+	pcmd.AddOutputFlag(cmd)
+
+	return cmd
+}
+
+func (c *command) describe(cmd *cobra.Command, args []string) error {
+	environmentId, err := c.Context.EnvironmentId()
+	if err != nil {
+		return err
+	}
+
+	endpoint, err := c.V2Client.GetSwitchoverEndpoint(args[0], environmentId)
+	if err != nil {
+		return err
+	}
+
+	return printSwitchoverEndpoint(cmd, endpoint)
+}

--- a/internal/switchover/endpoint/command_list.go
+++ b/internal/switchover/endpoint/command_list.go
@@ -1,0 +1,74 @@
+package endpoint
+
+import (
+	"github.com/spf13/cobra"
+
+	switchoverv1 "github.com/confluentinc/ccloud-sdk-go-v2/switchover/v1"
+
+	pcmd "github.com/confluentinc/cli/v4/pkg/cmd"
+	"github.com/confluentinc/cli/v4/pkg/examples"
+	"github.com/confluentinc/cli/v4/pkg/output"
+)
+
+func (c *command) newListCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List switchover endpoints.",
+		Args:  cobra.NoArgs,
+		RunE:  c.list,
+		Example: examples.BuildExampleString(
+			examples.Example{
+				Text: "List switchover endpoints in the current environment.",
+				Code: "confluent switchover endpoint list",
+			},
+			examples.Example{
+				Text: `List switchover endpoints for switchover pair "sw-123456".`,
+				Code: "confluent switchover endpoint list --switchover-pair sw-123456",
+			},
+		),
+	}
+
+	cmd.Flags().String("switchover-pair", "", "Filter the results by the associated switchover pair ID.")
+	pcmd.AddEnvironmentFlag(cmd, c.AuthenticatedCLICommand)
+	pcmd.AddContextFlag(cmd, c.CLICommand)
+	pcmd.AddOutputFlag(cmd)
+
+	return cmd
+}
+
+func (c *command) list(cmd *cobra.Command, _ []string) error {
+	environmentId, err := c.Context.EnvironmentId()
+	if err != nil {
+		return err
+	}
+
+	switchoverPair, err := cmd.Flags().GetString("switchover-pair")
+	if err != nil {
+		return err
+	}
+
+	endpoints, err := c.V2Client.ListSwitchoverEndpoints(environmentId, switchoverPair)
+	if err != nil {
+		return err
+	}
+
+	// Serialized output mirrors the API response verbatim (full spec/status).
+	if output.GetFormat(cmd).IsSerialized() {
+		if endpoints == nil {
+			endpoints = []switchoverv1.SwitchoverV1SwitchoverEndpoint{}
+		}
+		return printSerialized(cmd, endpoints)
+	}
+
+	list := output.NewList(cmd)
+	for _, endpoint := range endpoints {
+		list.Add(&listOut{
+			Id:             endpoint.GetId(),
+			DisplayName:    endpoint.Spec.GetDisplayName(),
+			SwitchoverPair: endpoint.Spec.GetParentResourceCrn(),
+			Environment:    endpoint.Spec.GetEnvironmentCrn(),
+			Phase:          endpoint.Status.GetPhase(),
+		})
+	}
+	return list.Print()
+}

--- a/internal/switchover/endpoint/command_update.go
+++ b/internal/switchover/endpoint/command_update.go
@@ -1,0 +1,60 @@
+package endpoint
+
+import (
+	"github.com/spf13/cobra"
+
+	switchoverv1 "github.com/confluentinc/ccloud-sdk-go-v2/switchover/v1"
+
+	pcmd "github.com/confluentinc/cli/v4/pkg/cmd"
+	"github.com/confluentinc/cli/v4/pkg/examples"
+)
+
+func (c *command) newUpdateCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "update <id>",
+		Short: "Update a switchover endpoint.",
+		Long:  "Update a switchover endpoint's display name. This is the only mutable field.",
+		Args:  cobra.ExactArgs(1),
+		RunE:  c.update,
+		Example: examples.BuildExampleString(
+			examples.Example{
+				Text: `Rename switchover endpoint "se-123456".`,
+				Code: `confluent switchover endpoint update se-123456 --display-name "prod-kafka-dr-endpoint-renamed"`,
+			},
+		),
+	}
+
+	cmd.Flags().String("display-name", "", "A human-readable name for the switchover endpoint.")
+	pcmd.AddEnvironmentFlag(cmd, c.AuthenticatedCLICommand)
+	pcmd.AddContextFlag(cmd, c.CLICommand)
+	pcmd.AddOutputFlag(cmd)
+
+	cobra.CheckErr(cmd.MarkFlagRequired("display-name"))
+
+	return cmd
+}
+
+func (c *command) update(cmd *cobra.Command, args []string) error {
+	displayName, err := cmd.Flags().GetString("display-name")
+	if err != nil {
+		return err
+	}
+
+	environmentId, err := c.Context.EnvironmentId()
+	if err != nil {
+		return err
+	}
+
+	endpoint := switchoverv1.SwitchoverV1SwitchoverEndpointUpdateRequest{
+		Spec: switchoverv1.SwitchoverV1SwitchoverEndpointUpdateRequestSpec{
+			DisplayName: switchoverv1.PtrString(displayName),
+		},
+	}
+
+	result, err := c.V2Client.UpdateSwitchoverEndpoint(args[0], environmentId, endpoint)
+	if err != nil {
+		return err
+	}
+
+	return printSwitchoverEndpoint(cmd, result)
+}

--- a/internal/switchover/pair/command.go
+++ b/internal/switchover/pair/command.go
@@ -1,0 +1,131 @@
+package pair
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/tidwall/pretty"
+	"gopkg.in/yaml.v3"
+
+	switchoverv1 "github.com/confluentinc/ccloud-sdk-go-v2/switchover/v1"
+
+	pcmd "github.com/confluentinc/cli/v4/pkg/cmd"
+	"github.com/confluentinc/cli/v4/pkg/output"
+)
+
+type command struct {
+	*pcmd.AuthenticatedCLICommand
+}
+
+// out is the detailed human-readable shape used by create/describe/update/
+// trigger-switch. Machine-readable output (`-o json` / `-o yaml`) is emitted
+// straight from the SDK object so it matches the API response verbatim.
+type out struct {
+	Id           string `human:"ID"`
+	DisplayName  string `human:"Display Name"`
+	Environment  string `human:"Environment"`
+	ActiveMember string `human:"Active Member"`
+	FirstActive  string `human:"First Active,omitempty"`
+	FailoverType string `human:"Failover Type,omitempty"`
+	Phase        string `human:"Phase"`
+	Members      string `human:"Members,omitempty"`
+	Conditions   string `human:"Conditions,omitempty"`
+}
+
+// listOut is the compact per-row shape for `list` (human output only).
+type listOut struct {
+	Id           string `human:"ID"`
+	DisplayName  string `human:"Display Name"`
+	Environment  string `human:"Environment"`
+	ActiveMember string `human:"Active Member"`
+	FailoverType string `human:"Failover Type"`
+	Phase        string `human:"Phase"`
+}
+
+func New(prerunner pcmd.PreRunner) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "pair",
+		Short: "Manage switchover pairs.",
+	}
+
+	c := &command{pcmd.NewAuthenticatedCLICommand(cmd, prerunner)}
+
+	cmd.AddCommand(c.newCreateCommand())
+	cmd.AddCommand(c.newDeleteCommand())
+	cmd.AddCommand(c.newDescribeCommand())
+	cmd.AddCommand(c.newListCommand())
+	cmd.AddCommand(c.newUpdateCommand())
+	cmd.AddCommand(c.newTriggerSwitchCommand())
+
+	return cmd
+}
+
+// printSerialized emits v as JSON or YAML using the SDK object's `json` tags,
+// so the output matches the API response verbatim. (output.SerializedOutput's
+// YAML path uses yaml.v3, which ignores `json` tags; route YAML through the
+// JSON representation to preserve the API field names.)
+func printSerialized(cmd *cobra.Command, v any) error {
+	data, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	if output.GetFormat(cmd) == output.YAML {
+		var generic any
+		if err := json.Unmarshal(data, &generic); err != nil {
+			return err
+		}
+		out, err := yaml.Marshal(generic)
+		if err != nil {
+			return err
+		}
+		output.Print(false, string(out))
+		return nil
+	}
+
+	output.Print(false, string(pretty.Pretty(data)))
+	return nil
+}
+
+func newPairOut(pair switchoverv1.SwitchoverV1SwitchoverPair) *out {
+	return &out{
+		Id:           pair.GetId(),
+		DisplayName:  pair.Spec.GetDisplayName(),
+		Environment:  pair.Spec.GetEnvironmentCrn(),
+		ActiveMember: pair.Spec.GetActiveMember(),
+		FirstActive:  pair.Spec.GetFirstActive(),
+		FailoverType: pair.Spec.GetFailoverType(),
+		Phase:        pair.Status.GetPhase(),
+		Members:      formatMembers(pair.Spec.GetMembers()),
+		Conditions:   formatConditions(pair.Status.GetConditions()),
+	}
+}
+
+func formatMembers(members []switchoverv1.SwitchoverV1SwitchoverPairMember) string {
+	lines := make([]string, len(members))
+	for i, member := range members {
+		location := ""
+		if member.Location != nil {
+			location = fmt.Sprintf(", %s/%s", member.Location.GetCloud(), member.Location.GetRegion())
+		}
+		lines[i] = fmt.Sprintf("%s (%s%s)", member.GetName(), member.GetMemberCrn(), location)
+	}
+	return strings.Join(lines, "\n")
+}
+
+func formatConditions(conditions []switchoverv1.SwitchoverV1Condition) string {
+	lines := make([]string, len(conditions))
+	for i, condition := range conditions {
+		line := fmt.Sprintf("%s=%s", condition.GetType(), condition.GetStatus())
+		if reason := condition.GetReason(); reason != "" {
+			line += fmt.Sprintf(" (%s)", reason)
+		}
+		if message := condition.GetMessage(); message != "" {
+			line += ": " + message
+		}
+		lines[i] = line
+	}
+	return strings.Join(lines, "\n")
+}

--- a/internal/switchover/pair/command_create.go
+++ b/internal/switchover/pair/command_create.go
@@ -1,0 +1,127 @@
+package pair
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	switchoverv1 "github.com/confluentinc/ccloud-sdk-go-v2/switchover/v1"
+
+	pcmd "github.com/confluentinc/cli/v4/pkg/cmd"
+	"github.com/confluentinc/cli/v4/pkg/examples"
+	"github.com/confluentinc/cli/v4/pkg/output"
+)
+
+func (c *command) newCreateCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "create <display-name>",
+		Short: "Create a switchover pair.",
+		Long:  "Create a switchover pair between two Kafka clusters for disaster recovery.",
+		Args:  cobra.ExactArgs(1),
+		RunE:  c.create,
+		Example: examples.BuildExampleString(
+			examples.Example{
+				Text: `Create switchover pair "prod-kafka-dr" between two Kafka clusters (west and east), active on west.`,
+				Code: `confluent switchover pair create prod-kafka-dr --member name=west,crn=crn://confluent.cloud/organization=abc/environment=env-111111/cloud-cluster=lkc-111111 --member name=east,crn=crn://confluent.cloud/organization=abc/environment=env-222222/cloud-cluster=lkc-222222 --active-member west`,
+			},
+		),
+	}
+
+	cmd.Flags().StringArray("member", nil, `A member of the pair, in the form "name=<name>,crn=<member-crn>". The CRN carries the member's own environment, so the two members may live in different environments. Must be specified exactly twice.`)
+	cmd.Flags().String("active-member", "", "The name of the member that starts as active; must match one of the --member names.")
+	pcmd.AddEnvironmentFlag(cmd, c.AuthenticatedCLICommand)
+	pcmd.AddContextFlag(cmd, c.CLICommand)
+	pcmd.AddOutputFlag(cmd)
+
+	cobra.CheckErr(cmd.MarkFlagRequired("member"))
+	cobra.CheckErr(cmd.MarkFlagRequired("active-member"))
+
+	return cmd
+}
+
+func parseMemberFlag(raw string) (switchoverv1.SwitchoverV1SwitchoverPairMember, error) {
+	member := switchoverv1.SwitchoverV1SwitchoverPairMember{}
+	for _, part := range strings.Split(raw, ",") {
+		key, value, ok := strings.Cut(part, "=")
+		if !ok {
+			return member, fmt.Errorf(`invalid --member value %q: expected "name=<name>,crn=<member-crn>"`, raw)
+		}
+		switch key {
+		case "name":
+			member.Name = value
+		case "crn":
+			member.MemberCrn = value
+		default:
+			return member, fmt.Errorf(`invalid --member key %q: expected "name" or "crn"`, key)
+		}
+	}
+	if member.Name == "" || member.MemberCrn == "" {
+		return member, fmt.Errorf(`invalid --member value %q: both "name" and "crn" are required`, raw)
+	}
+	return member, nil
+}
+
+func (c *command) create(cmd *cobra.Command, args []string) error {
+	displayName := args[0]
+
+	rawMembers, err := cmd.Flags().GetStringArray("member")
+	if err != nil {
+		return err
+	}
+	if len(rawMembers) != 2 {
+		return fmt.Errorf(`exactly two --member flags are required, got %d`, len(rawMembers))
+	}
+
+	members := make([]switchoverv1.SwitchoverV1SwitchoverPairMember, len(rawMembers))
+	for i, raw := range rawMembers {
+		member, err := parseMemberFlag(raw)
+		if err != nil {
+			return err
+		}
+		members[i] = member
+	}
+
+	activeMember, err := cmd.Flags().GetString("active-member")
+	if err != nil {
+		return err
+	}
+
+	environmentId, err := c.Context.EnvironmentId()
+	if err != nil {
+		return err
+	}
+
+	// Each member's CRN is supplied directly (crn=...) and carries its own environment, so members
+	// may live in different environments than the pair. The pair's own environment_crn is built from
+	// the current organization plus the --environment flag (which also drives the ?environment=
+	// query parameter).
+	environmentCrn := fmt.Sprintf("crn://confluent.cloud/organization=%s/environment=%s", c.Context.GetCurrentOrganization(), environmentId)
+
+	pair := switchoverv1.SwitchoverV1SwitchoverPair{
+		Spec: &switchoverv1.SwitchoverV1SwitchoverPairSpec{
+			DisplayName:    switchoverv1.PtrString(displayName),
+			Members:        &members,
+			ActiveMember:   switchoverv1.PtrString(activeMember),
+			EnvironmentCrn: switchoverv1.PtrString(environmentCrn),
+		},
+	}
+
+	result, err := c.V2Client.CreateSwitchoverPair(pair)
+	if err != nil {
+		return err
+	}
+
+	return printSwitchoverPair(cmd, result)
+}
+
+func printSwitchoverPair(cmd *cobra.Command, pair switchoverv1.SwitchoverV1SwitchoverPair) error {
+	// Serialized output mirrors the API response verbatim (full spec/status).
+	if output.GetFormat(cmd).IsSerialized() {
+		return printSerialized(cmd, pair)
+	}
+
+	table := output.NewTable(cmd)
+	table.Add(newPairOut(pair))
+	return table.Print()
+}

--- a/internal/switchover/pair/command_delete.go
+++ b/internal/switchover/pair/command_delete.go
@@ -1,0 +1,55 @@
+package pair
+
+import (
+	"github.com/spf13/cobra"
+
+	pcmd "github.com/confluentinc/cli/v4/pkg/cmd"
+	"github.com/confluentinc/cli/v4/pkg/deletion"
+	"github.com/confluentinc/cli/v4/pkg/examples"
+	"github.com/confluentinc/cli/v4/pkg/resource"
+)
+
+func (c *command) newDeleteCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "delete <id-1> [id-2] ... [id-n]",
+		Short: "Delete one or more switchover pairs.",
+		Args:  cobra.MinimumNArgs(1),
+		RunE:  c.delete,
+		Example: examples.BuildExampleString(
+			examples.Example{
+				Text: `Delete switchover pair "sw-123456" in the current environment.`,
+				Code: "confluent switchover pair delete sw-123456",
+			},
+		),
+	}
+
+	pcmd.AddForceFlag(cmd)
+	pcmd.AddEnvironmentFlag(cmd, c.AuthenticatedCLICommand)
+	pcmd.AddContextFlag(cmd, c.CLICommand)
+	pcmd.AddOutputFlag(cmd)
+
+	return cmd
+}
+
+func (c *command) delete(cmd *cobra.Command, args []string) error {
+	environmentId, err := c.Context.EnvironmentId()
+	if err != nil {
+		return err
+	}
+
+	existenceFunc := func(id string) bool {
+		_, err := c.V2Client.GetSwitchoverPair(id, environmentId)
+		return err == nil
+	}
+
+	if err := deletion.ValidateAndConfirm(cmd, args, existenceFunc, resource.SwitchoverPair); err != nil {
+		return err
+	}
+
+	deleteFunc := func(id string) error {
+		return c.V2Client.DeleteSwitchoverPair(id, environmentId)
+	}
+
+	_, err = deletion.Delete(cmd, args, deleteFunc, resource.SwitchoverPair)
+	return err
+}

--- a/internal/switchover/pair/command_describe.go
+++ b/internal/switchover/pair/command_describe.go
@@ -1,0 +1,43 @@
+package pair
+
+import (
+	"github.com/spf13/cobra"
+
+	pcmd "github.com/confluentinc/cli/v4/pkg/cmd"
+	"github.com/confluentinc/cli/v4/pkg/examples"
+)
+
+func (c *command) newDescribeCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "describe <id>",
+		Short: "Describe a switchover pair.",
+		Args:  cobra.ExactArgs(1),
+		RunE:  c.describe,
+		Example: examples.BuildExampleString(
+			examples.Example{
+				Text: `Describe switchover pair "sw-123456".`,
+				Code: `confluent switchover pair describe sw-123456`,
+			},
+		),
+	}
+
+	pcmd.AddEnvironmentFlag(cmd, c.AuthenticatedCLICommand)
+	pcmd.AddContextFlag(cmd, c.CLICommand)
+	pcmd.AddOutputFlag(cmd)
+
+	return cmd
+}
+
+func (c *command) describe(cmd *cobra.Command, args []string) error {
+	environmentId, err := c.Context.EnvironmentId()
+	if err != nil {
+		return err
+	}
+
+	pair, err := c.V2Client.GetSwitchoverPair(args[0], environmentId)
+	if err != nil {
+		return err
+	}
+
+	return printSwitchoverPair(cmd, pair)
+}

--- a/internal/switchover/pair/command_list.go
+++ b/internal/switchover/pair/command_list.go
@@ -1,0 +1,69 @@
+package pair
+
+import (
+	"github.com/spf13/cobra"
+
+	switchoverv1 "github.com/confluentinc/ccloud-sdk-go-v2/switchover/v1"
+
+	pcmd "github.com/confluentinc/cli/v4/pkg/cmd"
+	"github.com/confluentinc/cli/v4/pkg/examples"
+	"github.com/confluentinc/cli/v4/pkg/output"
+)
+
+func (c *command) newListCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List switchover pairs.",
+		Args:  cobra.NoArgs,
+		RunE:  c.list,
+		Example: examples.BuildExampleString(
+			examples.Example{
+				Text: "List switchover pairs in the current environment.",
+				Code: "confluent switchover pair list",
+			},
+			examples.Example{
+				Text: `List switchover pairs in environment "env-123456".`,
+				Code: "confluent switchover pair list --environment env-123456",
+			},
+		),
+	}
+
+	pcmd.AddEnvironmentFlag(cmd, c.AuthenticatedCLICommand)
+	pcmd.AddContextFlag(cmd, c.CLICommand)
+	pcmd.AddOutputFlag(cmd)
+
+	return cmd
+}
+
+func (c *command) list(cmd *cobra.Command, _ []string) error {
+	environmentId, err := c.Context.EnvironmentId()
+	if err != nil {
+		return err
+	}
+
+	pairs, err := c.V2Client.ListSwitchoverPairs(environmentId)
+	if err != nil {
+		return err
+	}
+
+	// Serialized output mirrors the API response verbatim (full spec/status).
+	if output.GetFormat(cmd).IsSerialized() {
+		if pairs == nil {
+			pairs = []switchoverv1.SwitchoverV1SwitchoverPair{}
+		}
+		return printSerialized(cmd, pairs)
+	}
+
+	list := output.NewList(cmd)
+	for _, pair := range pairs {
+		list.Add(&listOut{
+			Id:           pair.GetId(),
+			DisplayName:  pair.Spec.GetDisplayName(),
+			Environment:  pair.Spec.GetEnvironmentCrn(),
+			ActiveMember: pair.Spec.GetActiveMember(),
+			FailoverType: pair.Spec.GetFailoverType(),
+			Phase:        pair.Status.GetPhase(),
+		})
+	}
+	return list.Print()
+}

--- a/internal/switchover/pair/command_trigger_switch.go
+++ b/internal/switchover/pair/command_trigger_switch.go
@@ -1,0 +1,83 @@
+package pair
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	switchoverv1 "github.com/confluentinc/ccloud-sdk-go-v2/switchover/v1"
+
+	pcmd "github.com/confluentinc/cli/v4/pkg/cmd"
+	"github.com/confluentinc/cli/v4/pkg/deletion"
+	"github.com/confluentinc/cli/v4/pkg/examples"
+)
+
+func (c *command) newTriggerSwitchCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "trigger-switch <id>",
+		Short: "Trigger a failover or switchback on a switchover pair.",
+		Long:  "Trigger a failover (or switchback) on a switchover pair. This redirects live traffic between the pair's members.",
+		Args:  cobra.ExactArgs(1),
+		RunE:  c.triggerSwitch,
+		Example: examples.BuildExampleString(
+			examples.Example{
+				Text: `Fail switchover pair "sw-123456" over to its "east" member.`,
+				Code: `confluent switchover pair trigger-switch sw-123456 --active-member east`,
+			},
+		),
+	}
+
+	cmd.Flags().String("active-member", "", "The name of the member to promote to active. If omitted, the other member is promoted.")
+	cmd.Flags().String("failover-type", "PLANNED", "The failover semantics to apply: PLANNED, UNPLANNED, or RESTORE.")
+	cmd.Flags().Bool("force", false, "Skip the confirmation prompt.")
+	pcmd.AddEnvironmentFlag(cmd, c.AuthenticatedCLICommand)
+	pcmd.AddContextFlag(cmd, c.CLICommand)
+	pcmd.AddOutputFlag(cmd)
+
+	return cmd
+}
+
+func (c *command) triggerSwitch(cmd *cobra.Command, args []string) error {
+	id := args[0]
+
+	activeMember, err := cmd.Flags().GetString("active-member")
+	if err != nil {
+		return err
+	}
+
+	failoverType, err := cmd.Flags().GetString("failover-type")
+	if err != nil {
+		return err
+	}
+
+	environmentId, err := c.Context.EnvironmentId()
+	if err != nil {
+		return err
+	}
+
+	// The :failover body carries the environment as a CRN (ORC-9794), unlike other operations
+	// which take it as a query parameter.
+	environmentCrn := fmt.Sprintf("crn://confluent.cloud/organization=%s/environment=%s", c.Context.GetCurrentOrganization(), environmentId)
+
+	promptMsg := fmt.Sprintf(`This triggers a %s failover on switchover pair "%s", redirecting live traffic between regions. Do you want to proceed?`, failoverType, id)
+	if err := deletion.ConfirmPrompt(cmd, promptMsg); err != nil {
+		return err
+	}
+
+	req := switchoverv1.SwitchoverV1SwitchoverPairFailoverRequest{
+		Spec: switchoverv1.SwitchoverV1SwitchoverPairFailoverRequestSpec{
+			EnvironmentCrn: environmentCrn,
+			FailoverType:   failoverType,
+		},
+	}
+	if activeMember != "" {
+		req.Spec.ActiveMember = switchoverv1.PtrString(activeMember)
+	}
+
+	result, err := c.V2Client.TriggerSwitchoverPairFailover(id, req)
+	if err != nil {
+		return err
+	}
+
+	return printSwitchoverPair(cmd, result)
+}

--- a/internal/switchover/pair/command_update.go
+++ b/internal/switchover/pair/command_update.go
@@ -1,0 +1,60 @@
+package pair
+
+import (
+	"github.com/spf13/cobra"
+
+	switchoverv1 "github.com/confluentinc/ccloud-sdk-go-v2/switchover/v1"
+
+	pcmd "github.com/confluentinc/cli/v4/pkg/cmd"
+	"github.com/confluentinc/cli/v4/pkg/examples"
+)
+
+func (c *command) newUpdateCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "update <id>",
+		Short: "Update a switchover pair.",
+		Long:  "Update a switchover pair's display name. This is the only mutable field.",
+		Args:  cobra.ExactArgs(1),
+		RunE:  c.update,
+		Example: examples.BuildExampleString(
+			examples.Example{
+				Text: `Rename switchover pair "sw-123456".`,
+				Code: `confluent switchover pair update sw-123456 --display-name "prod-kafka-dr-renamed"`,
+			},
+		),
+	}
+
+	cmd.Flags().String("display-name", "", "A human-readable name for the switchover pair.")
+	pcmd.AddEnvironmentFlag(cmd, c.AuthenticatedCLICommand)
+	pcmd.AddContextFlag(cmd, c.CLICommand)
+	pcmd.AddOutputFlag(cmd)
+
+	cobra.CheckErr(cmd.MarkFlagRequired("display-name"))
+
+	return cmd
+}
+
+func (c *command) update(cmd *cobra.Command, args []string) error {
+	displayName, err := cmd.Flags().GetString("display-name")
+	if err != nil {
+		return err
+	}
+
+	environmentId, err := c.Context.EnvironmentId()
+	if err != nil {
+		return err
+	}
+
+	pair := switchoverv1.SwitchoverV1SwitchoverPairUpdateRequest{
+		Spec: switchoverv1.SwitchoverV1SwitchoverPairUpdateRequestSpec{
+			DisplayName: switchoverv1.PtrString(displayName),
+		},
+	}
+
+	result, err := c.V2Client.UpdateSwitchoverPair(args[0], environmentId, pair)
+	if err != nil {
+		return err
+	}
+
+	return printSwitchoverPair(cmd, result)
+}

--- a/pkg/ccloudv2/client.go
+++ b/pkg/ccloudv2/client.go
@@ -35,10 +35,9 @@ import (
 	servicequotav1 "github.com/confluentinc/ccloud-sdk-go-v2/service-quota/v1"
 	srcmv3 "github.com/confluentinc/ccloud-sdk-go-v2/srcm/v3"
 	ssov2 "github.com/confluentinc/ccloud-sdk-go-v2/sso/v2"
+	switchoverv1 "github.com/confluentinc/ccloud-sdk-go-v2/switchover/v1"
 	tableflowv1 "github.com/confluentinc/ccloud-sdk-go-v2/tableflow/v1"
 	usmv1 "github.com/confluentinc/ccloud-sdk-go-v2/usm/v1"
-
-	switchoverv1 "github.com/confluentinc/ccloud-sdk-go-v2/switchover/v1"
 
 	"github.com/confluentinc/cli/v4/pkg/config"
 	testserver "github.com/confluentinc/cli/v4/test/test-server"

--- a/pkg/ccloudv2/client.go
+++ b/pkg/ccloudv2/client.go
@@ -38,6 +38,8 @@ import (
 	tableflowv1 "github.com/confluentinc/ccloud-sdk-go-v2/tableflow/v1"
 	usmv1 "github.com/confluentinc/ccloud-sdk-go-v2/usm/v1"
 
+	switchoverv1 "github.com/confluentinc/ccloud-sdk-go-v2/switchover/v1"
+
 	"github.com/confluentinc/cli/v4/pkg/config"
 	testserver "github.com/confluentinc/cli/v4/test/test-server"
 )
@@ -80,6 +82,7 @@ type Client struct {
 	ServiceQuotaClient           *servicequotav1.APIClient
 	SrcmClient                   *srcmv3.APIClient
 	SsoClient                    *ssov2.APIClient
+	SwitchoverClient             *switchoverv1.APIClient
 	TableflowClient              *tableflowv1.APIClient
 	UsmClient                    *usmv1.APIClient
 	// cli-tfgen:cli-client-fields — DO NOT REMOVE (verified by TestCliTfgenMarkers)
@@ -132,6 +135,7 @@ func NewClient(cfg *config.Config, unsafeTrace bool) *Client {
 		ServiceQuotaClient:           newServiceQuotaClient(httpClient, url, userAgent, unsafeTrace),
 		SrcmClient:                   newSrcmClient(httpClient, url, userAgent, unsafeTrace),
 		SsoClient:                    newSsoClient(httpClient, url, userAgent, unsafeTrace),
+		SwitchoverClient:             newSwitchoverClient(httpClient, url, userAgent, unsafeTrace),
 		TableflowClient:              newTableflowClient(httpClient, url, userAgent, unsafeTrace),
 		UsmClient:                    newUsmClient(httpClient, url, userAgent, unsafeTrace),
 		// cli-tfgen:cli-client-init — DO NOT REMOVE (verified by TestCliTfgenMarkers)

--- a/pkg/ccloudv2/switchover.go
+++ b/pkg/ccloudv2/switchover.go
@@ -1,0 +1,139 @@
+package ccloudv2
+
+import (
+	"context"
+	"net/http"
+	"os"
+
+	switchoverv1 "github.com/confluentinc/ccloud-sdk-go-v2/switchover/v1"
+
+	"github.com/confluentinc/cli/v4/pkg/errors"
+)
+
+func newSwitchoverClient(httpClient *http.Client, url, userAgent string, unsafeTrace bool) *switchoverv1.APIClient {
+	cfg := switchoverv1.NewConfiguration()
+	cfg.Debug = unsafeTrace
+	cfg.HTTPClient = httpClient
+	cfg.Servers = switchoverv1.ServerConfigurations{{URL: url}}
+	cfg.UserAgent = userAgent
+
+	return switchoverv1.NewAPIClient(cfg)
+}
+
+// switchoverApiContext normally authenticates with the logged-in session's
+// bearer token. Local-test-only escape hatch: if CONFLUENT_CLOUD_API_KEY and
+// CONFLUENT_CLOUD_API_SECRET (a Cloud API key, `api-key create --resource
+// cloud`) are set, use Basic auth instead — the stag Switchover Early Access
+// gate only applies to the bearer/login path, not Cloud API keys.
+func (c *Client) switchoverApiContext() context.Context {
+	if key, secret := os.Getenv("CONFLUENT_CLOUD_API_KEY"), os.Getenv("CONFLUENT_CLOUD_API_SECRET"); key != "" && secret != "" {
+		return context.WithValue(context.Background(), switchoverv1.ContextBasicAuth, switchoverv1.BasicAuth{UserName: key, Password: secret})
+	}
+	return context.WithValue(context.Background(), switchoverv1.ContextAccessToken, c.cfg.Context().GetAuthToken())
+}
+
+func (c *Client) CreateSwitchoverPair(pair switchoverv1.SwitchoverV1SwitchoverPair) (switchoverv1.SwitchoverV1SwitchoverPair, error) {
+	res, httpResp, err := c.SwitchoverClient.SwitchoverPairsSwitchoverV1Api.CreateSwitchoverV1SwitchoverPair(c.switchoverApiContext()).SwitchoverV1SwitchoverPair(pair).Execute()
+	return res, errors.CatchCCloudV2Error(err, httpResp)
+}
+
+func (c *Client) GetSwitchoverPair(id, environment string) (switchoverv1.SwitchoverV1SwitchoverPair, error) {
+	res, httpResp, err := c.SwitchoverClient.SwitchoverPairsSwitchoverV1Api.GetSwitchoverV1SwitchoverPair(c.switchoverApiContext(), id).Environment(environment).Execute()
+	return res, errors.CatchCCloudV2Error(err, httpResp)
+}
+
+func (c *Client) UpdateSwitchoverPair(id, environment string, update switchoverv1.SwitchoverV1SwitchoverPairUpdateRequest) (switchoverv1.SwitchoverV1SwitchoverPair, error) {
+	res, httpResp, err := c.SwitchoverClient.SwitchoverPairsSwitchoverV1Api.UpdateSwitchoverV1SwitchoverPair(c.switchoverApiContext(), id).Environment(environment).SwitchoverV1SwitchoverPairUpdateRequest(update).Execute()
+	return res, errors.CatchCCloudV2Error(err, httpResp)
+}
+
+func (c *Client) TriggerSwitchoverPairFailover(id string, req switchoverv1.SwitchoverV1SwitchoverPairFailoverRequest) (switchoverv1.SwitchoverV1SwitchoverPair, error) {
+	res, httpResp, err := c.SwitchoverClient.SwitchoverPairsSwitchoverV1Api.FailoverSwitchoverV1SwitchoverPair(c.switchoverApiContext(), id).SwitchoverV1SwitchoverPairFailoverRequest(req).Execute()
+	return res, errors.CatchCCloudV2Error(err, httpResp)
+}
+
+func (c *Client) ListSwitchoverPairs(environment string) ([]switchoverv1.SwitchoverV1SwitchoverPair, error) {
+	var list []switchoverv1.SwitchoverV1SwitchoverPair
+
+	done := false
+	pageToken := ""
+	for !done {
+		page, httpResp, err := c.executeListSwitchoverPairs(environment, pageToken)
+		if err != nil {
+			return nil, errors.CatchCCloudV2Error(err, httpResp)
+		}
+		list = append(list, page.GetData()...)
+
+		metadata := page.GetMetadata()
+		pagination := metadata.GetPagination()
+		pageToken = pagination.GetNextPageToken()
+		done = pageToken == ""
+	}
+
+	return list, nil
+}
+
+func (c *Client) executeListSwitchoverPairs(environment, pageToken string) (switchoverv1.SwitchoverV1SwitchoverPairList, *http.Response, error) {
+	req := c.SwitchoverClient.SwitchoverPairsSwitchoverV1Api.ListSwitchoverV1SwitchoverPairs(c.switchoverApiContext()).Environment(environment).PageSize(ccloudV2ListPageSize)
+	if pageToken != "" {
+		req = req.PageToken(pageToken)
+	}
+	return req.Execute()
+}
+
+func (c *Client) DeleteSwitchoverPair(id, environment string) error {
+	_, httpResp, err := c.SwitchoverClient.SwitchoverPairsSwitchoverV1Api.DeleteSwitchoverV1SwitchoverPair(c.switchoverApiContext(), id).Environment(environment).Execute()
+	return errors.CatchCCloudV2Error(err, httpResp)
+}
+
+func (c *Client) CreateSwitchoverEndpoint(endpoint switchoverv1.SwitchoverV1SwitchoverEndpoint) (switchoverv1.SwitchoverV1SwitchoverEndpoint, error) {
+	res, httpResp, err := c.SwitchoverClient.SwitchoverEndpointsSwitchoverV1Api.CreateSwitchoverV1SwitchoverEndpoint(c.switchoverApiContext()).SwitchoverV1SwitchoverEndpoint(endpoint).Execute()
+	return res, errors.CatchCCloudV2Error(err, httpResp)
+}
+
+func (c *Client) GetSwitchoverEndpoint(id, environment string) (switchoverv1.SwitchoverV1SwitchoverEndpoint, error) {
+	res, httpResp, err := c.SwitchoverClient.SwitchoverEndpointsSwitchoverV1Api.GetSwitchoverV1SwitchoverEndpoint(c.switchoverApiContext(), id).Environment(environment).Execute()
+	return res, errors.CatchCCloudV2Error(err, httpResp)
+}
+
+func (c *Client) UpdateSwitchoverEndpoint(id, environment string, update switchoverv1.SwitchoverV1SwitchoverEndpointUpdateRequest) (switchoverv1.SwitchoverV1SwitchoverEndpoint, error) {
+	res, httpResp, err := c.SwitchoverClient.SwitchoverEndpointsSwitchoverV1Api.UpdateSwitchoverV1SwitchoverEndpoint(c.switchoverApiContext(), id).Environment(environment).SwitchoverV1SwitchoverEndpointUpdateRequest(update).Execute()
+	return res, errors.CatchCCloudV2Error(err, httpResp)
+}
+
+func (c *Client) ListSwitchoverEndpoints(environment, switchoverPair string) ([]switchoverv1.SwitchoverV1SwitchoverEndpoint, error) {
+	var list []switchoverv1.SwitchoverV1SwitchoverEndpoint
+
+	done := false
+	pageToken := ""
+	for !done {
+		page, httpResp, err := c.executeListSwitchoverEndpoints(environment, switchoverPair, pageToken)
+		if err != nil {
+			return nil, errors.CatchCCloudV2Error(err, httpResp)
+		}
+		list = append(list, page.GetData()...)
+
+		metadata := page.GetMetadata()
+		pagination := metadata.GetPagination()
+		pageToken = pagination.GetNextPageToken()
+		done = pageToken == ""
+	}
+
+	return list, nil
+}
+
+func (c *Client) executeListSwitchoverEndpoints(environment, switchoverPair, pageToken string) (switchoverv1.SwitchoverV1SwitchoverEndpointList, *http.Response, error) {
+	req := c.SwitchoverClient.SwitchoverEndpointsSwitchoverV1Api.ListSwitchoverV1SwitchoverEndpoints(c.switchoverApiContext()).Environment(environment).PageSize(ccloudV2ListPageSize)
+	if switchoverPair != "" {
+		req = req.SwitchoverPair(switchoverPair)
+	}
+	if pageToken != "" {
+		req = req.PageToken(pageToken)
+	}
+	return req.Execute()
+}
+
+func (c *Client) DeleteSwitchoverEndpoint(id, environment string) error {
+	_, httpResp, err := c.SwitchoverClient.SwitchoverEndpointsSwitchoverV1Api.DeleteSwitchoverV1SwitchoverEndpoint(c.switchoverApiContext(), id).Environment(environment).Execute()
+	return errors.CatchCCloudV2Error(err, httpResp)
+}

--- a/pkg/resource/resource.go
+++ b/pkg/resource/resource.go
@@ -81,6 +81,8 @@ const (
 	SchemaRegistryConfiguration      = "Schema Registry configuration"
 	ServiceAccount                   = "service account"
 	SsoGroupMapping                  = "SSO group mapping"
+	SwitchoverPair                   = "switchover pair"
+	SwitchoverEndpoint               = "switchover endpoint"
 	Tableflow                        = "tableflow"
 	Topic                            = "topic"
 	TransitGatewayAttachment         = "transit gateway attachment"


### PR DESCRIPTION
## Summary

Consolidates the switchover CLI work into **one PR on current `main`**. Supersedes the stacked pair:
- #3399 (Ethan Wang) — base pair/endpoint commands (`switchover-cli-local-demo`)
- #3454 (ngaur) — CRN references + `first_active`/endpoint metadata + public SDK adoption (stacked on #3399)

Those branches were ~57 commits behind `main`, which is why their Semaphore `test-results publish` job was failing (missing the #3435 CI fix — old `test-results publish .` choked on the pre-existing `pkg/config/test_json/*.json` fixtures). Rebasing onto `main` picks up the current CI config, so that job is fixed here.

## What's in it
- `internal/switchover/` — `pair` + `endpoint` command trees (create/describe/list/update/delete)
- `pkg/ccloudv2/switchover.go` — switchover client
- CRN-based flags (`--member crn=…`, `network=<id>` → network_crn), `first_active`/endpoint metadata surfaced, PLANNED/UNPLANNED failover terminology, public SDK (`ccloud-sdk-go-v2/switchover`)

## Integration notes
- go.mod: kept `main`'s newer `tableflow`/`usm`/`cmf` SDKs, **added** `ccloud-sdk-go-v2/switchover@…7dfad3daf9b5`; `go 1.26.8` (required by the switchover SDK). `go mod tidy` clean.
- Switchover code merged onto `main` with **no code conflicts** (only go.mod/go.sum, resolved). `go build ./...` passes; pre-commit hooks (fmt/generate/tidy) pass.
- Squashed the 17-commit stack into one commit for a clean history; co-authored to preserve credit.

Once this is green, #3399 and #3454 can be closed in favor of this.