### PR TITLE
[APIE-1621] feat(config): make concurrent config writes safe

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -65,7 +65,7 @@ blocks:
 
   - name: windows/amd64
     run:
-      when: "branch = 'main'"
+      when: "branch = 'main' or change_in(['/pkg/config', '/.semaphore/semaphore.yml'], {default_branch: 'main', pipeline_file: 'ignore'})"
     dependencies: []
     task:
       agent:

--- a/go.mod
+++ b/go.mod
@@ -119,6 +119,7 @@ require (
 	golang.org/x/crypto v0.56.0
 	golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f
 	golang.org/x/oauth2 v0.36.0
+	golang.org/x/sys v0.47.0
 	golang.org/x/term v0.45.0
 	golang.org/x/text v0.41.0
 	google.golang.org/grpc v1.83.2
@@ -283,7 +284,6 @@ require (
 	golang.org/x/mod v0.40.0 // indirect
 	golang.org/x/net v0.58.0 // indirect
 	golang.org/x/sync v0.22.0 // indirect
-	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/time v0.14.0 // indirect
 	golang.org/x/tools v0.49.0 // indirect
 	google.golang.org/api v0.264.0 // indirect

--- a/internal/login/command_test.go
+++ b/internal/login/command_test.go
@@ -13,6 +13,7 @@ import (
 	"math/big"
 	"net/http"
 	"os"
+	"path/filepath"
 	"reflect"
 	"slices"
 	"testing"
@@ -744,6 +745,11 @@ func TestValidateUrl(t *testing.T) {
 func newLoginCmd(ctrl *gomock.Controller, auth *ccloudv1mock.Auth, userInterface *ccloudv1mock.UserInterface, isCloud bool, req *require.Assertions, authTokenHandler pauth.AuthTokenHandler, loginCredentialsManager pauth.LoginCredentialsManager, loginOrganizationManager pauth.LoginOrganizationManager) (*cobra.Command, *config.Config) {
 	config.SetTempHomeDir()
 	cfg := config.New()
+	// give each test its own config file so Save()'s lock-and-merge re-reads only this
+	// test's state, not another login test's leftover at the shared default path.
+	tempDir, err := os.MkdirTemp("", "cli-login-test")
+	req.NoError(err)
+	cfg.Filename = filepath.Join(tempDir, "config.json")
 	var ccloudClientFactory *climock.MockCCloudClientFactory
 	var mdsClientManager *climock.MockMDSClientManager
 	var prerunner pcmd.PreRunner

--- a/pkg/ccloudv2/utils.go
+++ b/pkg/ccloudv2/utils.go
@@ -88,10 +88,10 @@ func NewRetryableHttpClient(cfg *config.Config, unsafeTrace bool) *http.Client {
 // rather than surfaced to the caller.
 func refreshAndSave(cfg *config.Config, v1Client *ccloudv1.Client) {
 	if err := cfg.Context().RefreshSession(v1Client); err != nil {
-		log.CliLogger.Warnf("failed to refresh session after 401: %v", err)
+		log.CliLogger.Warnf("Failed to refresh session after 401: %v", err)
 	}
 	if err := cfg.Save(); err != nil {
-		log.CliLogger.Warnf("failed to save config after session refresh: %v", err)
+		log.CliLogger.Warnf("Failed to save config after session refresh: %v", err)
 	}
 }
 

--- a/pkg/ccloudv2/utils.go
+++ b/pkg/ccloudv2/utils.go
@@ -72,8 +72,7 @@ func NewRetryableHttpClient(cfg *config.Config, unsafeTrace bool) *http.Client {
 			}
 			v1Client := ccloudv1.NewClient(params)
 
-			_ = cfg.Context().RefreshSession(v1Client)
-			_ = cfg.Save()
+			refreshAndSave(cfg, v1Client)
 
 			return true, err
 		}
@@ -82,6 +81,18 @@ func NewRetryableHttpClient(cfg *config.Config, unsafeTrace bool) *http.Client {
 	}
 
 	return client.StandardClient()
+}
+
+// refreshAndSave refreshes the session after a 401 and persists the result. Either step can
+// fail without aborting the retry that triggered it (whether it should is deferred to
+// APIE-1626), so both failures are logged here rather than surfaced to the caller.
+func refreshAndSave(cfg *config.Config, v1Client *ccloudv1.Client) {
+	if err := cfg.Context().RefreshSession(v1Client); err != nil {
+		log.CliLogger.Warnf("failed to refresh session after 401: %v", err)
+	}
+	if err := cfg.Save(); err != nil {
+		log.CliLogger.Warnf("failed to save config after session refresh: %v", err)
+	}
 }
 
 func NewRetryableHttpClientWithRedirect(unsafeTrace bool, checkRedirect func(*http.Request, []*http.Request) error) *http.Client {

--- a/pkg/ccloudv2/utils.go
+++ b/pkg/ccloudv2/utils.go
@@ -83,12 +83,15 @@ func NewRetryableHttpClient(cfg *config.Config, unsafeTrace bool) *http.Client {
 	return client.StandardClient()
 }
 
-// refreshAndSave refreshes the session after a 401 and persists the result. Either step can
-// fail without aborting the retry that triggered it, so both failures are logged here
-// rather than surfaced to the caller.
+// refreshAndSave refreshes the session after a 401 and persists the result. Either step
+// can fail without aborting the retry that triggered it, so both failures are logged
+// here rather than surfaced to the caller. A refresh failure means the retry will 401
+// again and the command ultimately fails, so it is logged at error level to reach the
+// user at the default verbosity. A save failure after a good refresh usually still lets
+// the command succeed (the refreshed token just is not persisted), so it stays a warning.
 func refreshAndSave(cfg *config.Config, v1Client *ccloudv1.Client) {
 	if err := cfg.Context().RefreshSession(v1Client); err != nil {
-		log.CliLogger.Warnf("Failed to refresh session after 401: %v", err)
+		log.CliLogger.Errorf("Failed to refresh session after 401: %v", err)
 	}
 	if err := cfg.Save(); err != nil {
 		log.CliLogger.Warnf("Failed to save config after session refresh: %v", err)

--- a/pkg/ccloudv2/utils.go
+++ b/pkg/ccloudv2/utils.go
@@ -84,8 +84,8 @@ func NewRetryableHttpClient(cfg *config.Config, unsafeTrace bool) *http.Client {
 }
 
 // refreshAndSave refreshes the session after a 401 and persists the result. Either step can
-// fail without aborting the retry that triggered it (whether it should is deferred to
-// APIE-1626), so both failures are logged here rather than surfaced to the caller.
+// fail without aborting the retry that triggered it, so both failures are logged here
+// rather than surfaced to the caller.
 func refreshAndSave(cfg *config.Config, v1Client *ccloudv1.Client) {
 	if err := cfg.Context().RefreshSession(v1Client); err != nil {
 		log.CliLogger.Warnf("failed to refresh session after 401: %v", err)

--- a/pkg/ccloudv2/utils_test.go
+++ b/pkg/ccloudv2/utils_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -116,8 +117,12 @@ func TestRefreshAndSave_LogsSaveFailure(t *testing.T) {
 	defer server.Close()
 
 	cfg := newTestConfig(t)
-	// point Save() at a parent directory that doesn't exist, so the lock file can't be created.
-	cfg.Filename = filepath.Join(cfg.Filename, "..", "missing-dir", "config.json")
+	// Put a regular file where Save() needs the config directory, so its MkdirAll
+	// fails with ENOTDIR. A merely-absent parent no longer forces a failure: Save()
+	// now creates the directory itself for fresh-machine first runs.
+	notADir := filepath.Join(t.TempDir(), "not-a-dir")
+	require.NoError(t, os.WriteFile(notADir, nil, 0600))
+	cfg.Filename = filepath.Join(notADir, "config.json")
 
 	logs := captureWarnings(t, func() {
 		refreshAndSave(cfg, newTestV1Client(server.URL))

--- a/pkg/ccloudv2/utils_test.go
+++ b/pkg/ccloudv2/utils_test.go
@@ -63,18 +63,25 @@ func TestToUpper(t *testing.T) {
 	require.Equal(t, "SASL_SSL", ToUpper("sasl-ssl"))
 }
 
-// captureWarnings swaps log.CliLogger for one that writes to a buffer at WARN
-// verbosity for the duration of fn, then returns everything logged.
-func captureWarnings(t *testing.T, fn func()) string {
+// captureLogs swaps log.CliLogger for one that writes to a buffer at the given
+// verbosity for the duration of fn, then returns everything emitted. Sub-level
+// messages are buffered and not flushed, matching real behavior at that verbosity.
+func captureLogs(t *testing.T, level log.Level, fn func()) string {
 	t.Helper()
 
 	var buf bytes.Buffer
 	original := log.CliLogger
-	log.CliLogger = log.New(log.WARN, &buf)
+	log.CliLogger = log.New(level, &buf)
 	defer func() { log.CliLogger = original }()
 
 	fn()
 	return buf.String()
+}
+
+// captureWarnings captures at WARN verbosity, where both warnings and errors emit.
+func captureWarnings(t *testing.T, fn func()) string {
+	t.Helper()
+	return captureLogs(t, log.WARN, fn)
 }
 
 func newTestV1Client(baseURL string) *ccloudv1.Client {
@@ -130,6 +137,25 @@ func TestRefreshAndSave_LogsSaveFailure(t *testing.T) {
 
 	require.Contains(t, logs, "Failed to save config")
 	require.NotContains(t, logs, "Failed to refresh session")
+}
+
+// A refresh failure means the retry will 401 again and the command fails, so it must
+// reach the user at the default ERROR verbosity, not only under -v. A save failure
+// stays a buffered warning (a good refresh whose persistence failed usually still lets
+// the command succeed), so it must not appear at default verbosity.
+func TestRefreshAndSave_RefreshFailureVisibleAtDefaultVerbosity(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	cfg := newTestConfig(t)
+
+	logs := captureLogs(t, log.ERROR, func() {
+		refreshAndSave(cfg, newTestV1Client(server.URL))
+	})
+
+	require.Contains(t, logs, "Failed to refresh session", "a refresh failure must be visible at default verbosity")
 }
 
 func TestRefreshAndSave_LogsNothingOnSuccess(t *testing.T) {

--- a/pkg/ccloudv2/utils_test.go
+++ b/pkg/ccloudv2/utils_test.go
@@ -1,10 +1,20 @@
 package ccloudv2
 
 import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	ccloudv1 "github.com/confluentinc/ccloud-sdk-go-v1-public"
+
+	"github.com/confluentinc/cli/v4/pkg/config"
+	"github.com/confluentinc/cli/v4/pkg/log"
 )
 
 func TestIsCCloudURL_True(t *testing.T) {
@@ -50,4 +60,84 @@ func TestToLower(t *testing.T) {
 
 func TestToUpper(t *testing.T) {
 	require.Equal(t, "SASL_SSL", ToUpper("sasl-ssl"))
+}
+
+// captureWarnings swaps log.CliLogger for one that writes to a buffer at WARN
+// verbosity for the duration of fn, then returns everything logged.
+func captureWarnings(t *testing.T, fn func()) string {
+	t.Helper()
+
+	var buf bytes.Buffer
+	original := log.CliLogger
+	log.CliLogger = log.New(log.WARN, &buf)
+	defer func() { log.CliLogger = original }()
+
+	fn()
+	return buf.String()
+}
+
+func newTestV1Client(baseURL string) *ccloudv1.Client {
+	return ccloudv1.NewClient(&ccloudv1.Params{
+		BaseURL:    baseURL,
+		HttpClient: ccloudv1.BaseClient,
+		Logger:     log.CliLogger,
+	})
+}
+
+// newTestConfig returns a mock cloud config whose Save() writes under a fresh
+// temp directory rather than the real user config path.
+func newTestConfig(t *testing.T) *config.Config {
+	t.Helper()
+
+	cfg := config.AuthenticatedCloudConfigMock()
+	cfg.Filename = filepath.Join(t.TempDir(), "config.json")
+	return cfg
+}
+
+func TestRefreshAndSave_LogsRefreshFailure(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	cfg := newTestConfig(t)
+
+	logs := captureWarnings(t, func() {
+		refreshAndSave(cfg, newTestV1Client(server.URL))
+	})
+
+	require.Contains(t, logs, "failed to refresh session")
+}
+
+func TestRefreshAndSave_LogsSaveFailure(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		require.NoError(t, json.NewEncoder(w).Encode(ccloudv1.AuthenticateReply{Token: "new-token"}))
+	}))
+	defer server.Close()
+
+	cfg := newTestConfig(t)
+	// point Save() at a parent directory that doesn't exist, so the lock file can't be created.
+	cfg.Filename = filepath.Join(cfg.Filename, "..", "missing-dir", "config.json")
+
+	logs := captureWarnings(t, func() {
+		refreshAndSave(cfg, newTestV1Client(server.URL))
+	})
+
+	require.Contains(t, logs, "failed to save config")
+	require.NotContains(t, logs, "failed to refresh session")
+}
+
+func TestRefreshAndSave_LogsNothingOnSuccess(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		require.NoError(t, json.NewEncoder(w).Encode(ccloudv1.AuthenticateReply{Token: "new-token"}))
+	}))
+	defer server.Close()
+
+	cfg := newTestConfig(t)
+
+	logs := captureWarnings(t, func() {
+		refreshAndSave(cfg, newTestV1Client(server.URL))
+	})
+
+	require.Empty(t, logs)
 }

--- a/pkg/ccloudv2/utils_test.go
+++ b/pkg/ccloudv2/utils_test.go
@@ -107,7 +107,7 @@ func TestRefreshAndSave_LogsRefreshFailure(t *testing.T) {
 		refreshAndSave(cfg, newTestV1Client(server.URL))
 	})
 
-	require.Contains(t, logs, "failed to refresh session")
+	require.Contains(t, logs, "Failed to refresh session")
 }
 
 func TestRefreshAndSave_LogsSaveFailure(t *testing.T) {
@@ -128,8 +128,8 @@ func TestRefreshAndSave_LogsSaveFailure(t *testing.T) {
 		refreshAndSave(cfg, newTestV1Client(server.URL))
 	})
 
-	require.Contains(t, logs, "failed to save config")
-	require.NotContains(t, logs, "failed to refresh session")
+	require.Contains(t, logs, "Failed to save config")
+	require.NotContains(t, logs, "Failed to refresh session")
 }
 
 func TestRefreshAndSave_LogsNothingOnSuccess(t *testing.T) {

--- a/pkg/config/api_key_pair.go
+++ b/pkg/config/api_key_pair.go
@@ -15,7 +15,9 @@ type APIKeyPair struct {
 }
 
 func (c *APIKeyPair) DecryptSecret() error {
-	if (strings.HasPrefix(c.Secret, secret.AesGcm) && c.Salt != nil) || strings.HasPrefix(c.Secret, secret.Dpapi) {
+	// Ciphertext is stored as "PREFIX:payload", so the ":" is part of the marker:
+	// a plaintext secret that merely begins with the marker word is not encrypted.
+	if (strings.HasPrefix(c.Secret, secret.AesGcm+":") && c.Salt != nil) || strings.HasPrefix(c.Secret, secret.Dpapi+":") {
 		decryptedSecret, err := secret.Decrypt(c.Key, c.Secret, c.Salt, c.Nonce)
 		if err != nil {
 			return err
@@ -35,7 +37,7 @@ func (c *APIKeyPair) EncryptSecret() error {
 		c.Nonce = nonce
 	}
 
-	if !strings.HasPrefix(c.Secret, secret.AesGcm) && !strings.HasPrefix(c.Secret, secret.Dpapi) {
+	if !isEncryptedSecret(c.Secret) {
 		encryptedSecret, err := secret.Encrypt(c.Key, c.Secret, c.Salt, c.Nonce)
 		if err != nil {
 			return err

--- a/pkg/config/api_key_pair.go
+++ b/pkg/config/api_key_pair.go
@@ -35,7 +35,7 @@ func (c *APIKeyPair) EncryptSecret() error {
 		c.Nonce = nonce
 	}
 
-	if !strings.HasPrefix(c.Secret, secret.AesGcm) {
+	if !strings.HasPrefix(c.Secret, secret.AesGcm) && !strings.HasPrefix(c.Secret, secret.Dpapi) {
 		encryptedSecret, err := secret.Encrypt(c.Key, c.Secret, c.Salt, c.Nonce)
 		if err != nil {
 			return err

--- a/pkg/config/api_key_pair_test.go
+++ b/pkg/config/api_key_pair_test.go
@@ -30,3 +30,17 @@ func TestAPIKeyPair_EncryptSecret_SkipsAlreadyEncryptedAesGcmSecret(t *testing.T
 	require.NoError(t, err)
 	require.Equal(t, aesGcmSecret, pair.Secret)
 }
+
+// The cipher markers are stored as a "PREFIX:payload" pair, so the prefix guard
+// must include the ":". A plaintext secret that merely begins with the marker
+// word (no delimiter) must still be encrypted, not mistaken for ciphertext.
+func TestAPIKeyPair_EncryptSecret_EncryptsPlaintextBeginningWithCipherWord(t *testing.T) {
+	plain := secret.Dpapi + "-this-is-actually-plaintext"
+	pair := &APIKeyPair{Key: "key", Secret: plain}
+
+	require.NoError(t, pair.EncryptSecret())
+
+	require.NotEqual(t, plain, pair.Secret, "a plaintext secret merely beginning with the cipher word must be encrypted")
+	require.NoError(t, pair.DecryptSecret())
+	require.Equal(t, plain, pair.Secret, "encryption of a marker-word plaintext must round-trip")
+}

--- a/pkg/config/api_key_pair_test.go
+++ b/pkg/config/api_key_pair_test.go
@@ -1,0 +1,32 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/confluentinc/cli/v4/pkg/secret"
+)
+
+// A concurrent session's merged-in secret already carries a platform prefix (AesGcm on Unix,
+// Dpapi on Windows). EncryptSecret must leave it untouched rather than double-wrapping it.
+
+func TestAPIKeyPair_EncryptSecret_SkipsAlreadyEncryptedDpapiSecret(t *testing.T) {
+	dpapiSecret := secret.Dpapi + ":already-encrypted-on-windows"
+	pair := &APIKeyPair{Key: "key", Secret: dpapiSecret}
+
+	err := pair.EncryptSecret()
+
+	require.NoError(t, err)
+	require.Equal(t, dpapiSecret, pair.Secret)
+}
+
+func TestAPIKeyPair_EncryptSecret_SkipsAlreadyEncryptedAesGcmSecret(t *testing.T) {
+	aesGcmSecret := secret.AesGcm + ":already-encrypted-on-unix"
+	pair := &APIKeyPair{Key: "key", Secret: aesGcmSecret}
+
+	err := pair.EncryptSecret()
+
+	require.NoError(t, err)
+	require.Equal(t, aesGcmSecret, pair.Secret)
+}

--- a/pkg/config/atomic_write.go
+++ b/pkg/config/atomic_write.go
@@ -1,0 +1,47 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// writeFileAtomic writes data to path via a temp file in the SAME directory,
+// then renames it into place. Same-directory is required: a temp on another
+// filesystem breaks rename with EXDEV. On POSIX the parent directory is fsynced
+// after the rename so a crash can't lose the rename even when the bytes are
+// durable; on Windows the rename itself is the durability boundary.
+func writeFileAtomic(path string, data []byte, perm os.FileMode) error {
+	dir := filepath.Dir(path)
+
+	tmp, err := os.CreateTemp(dir, filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return fmt.Errorf("unable to create temp config file: %w", err)
+	}
+	tmpName := tmp.Name()
+	// Best-effort cleanup if we bail before the rename; a successful rename
+	// consumes the temp so the remove becomes a no-op.
+	defer os.Remove(tmpName)
+
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return fmt.Errorf("unable to write temp config file: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		tmp.Close()
+		return fmt.Errorf("unable to fsync temp config file: %w", err)
+	}
+	if err := tmp.Chmod(perm); err != nil {
+		tmp.Close()
+		return fmt.Errorf("unable to set temp config file permissions: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("unable to close temp config file: %w", err)
+	}
+
+	if err := renameReplace(tmpName, path); err != nil {
+		return fmt.Errorf("unable to rename config file into place: %w", err)
+	}
+
+	return fsyncDir(dir)
+}

--- a/pkg/config/atomic_write.go
+++ b/pkg/config/atomic_write.go
@@ -6,12 +6,16 @@ import (
 	"path/filepath"
 )
 
+// configFilePerm is the mode config files are written with: owner read/write
+// only, since they hold credentials.
+const configFilePerm os.FileMode = 0600
+
 // writeFileAtomic writes data to path via a temp file in the SAME directory,
 // then renames it into place. Same-directory is required: a temp on another
 // filesystem breaks rename with EXDEV. On POSIX the parent directory is fsynced
 // after the rename so a crash can't lose the rename even when the bytes are
 // durable; on Windows the rename itself is the durability boundary.
-func writeFileAtomic(path string, data []byte, perm os.FileMode) error {
+func writeFileAtomic(path string, data []byte) error {
 	dir := filepath.Dir(path)
 
 	tmp, err := os.CreateTemp(dir, filepath.Base(path)+".tmp-*")
@@ -31,7 +35,7 @@ func writeFileAtomic(path string, data []byte, perm os.FileMode) error {
 		tmp.Close()
 		return fmt.Errorf("unable to fsync temp config file: %w", err)
 	}
-	if err := tmp.Chmod(perm); err != nil {
+	if err := tmp.Chmod(configFilePerm); err != nil {
 		tmp.Close()
 		return fmt.Errorf("unable to set temp config file permissions: %w", err)
 	}

--- a/pkg/config/atomic_write_other.go
+++ b/pkg/config/atomic_write_other.go
@@ -1,0 +1,26 @@
+//go:build !windows
+
+package config
+
+import (
+	"fmt"
+	"os"
+)
+
+// renameReplace atomically replaces newpath with oldpath via POSIX rename(2).
+func renameReplace(oldpath, newpath string) error {
+	return os.Rename(oldpath, newpath)
+}
+
+// fsyncDir flushes the directory entry so the rename survives a crash.
+func fsyncDir(dir string) error {
+	d, err := os.Open(dir)
+	if err != nil {
+		return fmt.Errorf("unable to open config directory for fsync: %w", err)
+	}
+	defer d.Close()
+	if err := d.Sync(); err != nil {
+		return fmt.Errorf("unable to fsync config directory: %w", err)
+	}
+	return nil
+}

--- a/pkg/config/atomic_write_other.go
+++ b/pkg/config/atomic_write_other.go
@@ -1,4 +1,4 @@
-//go:build !windows
+//go:build darwin || linux
 
 package config
 

--- a/pkg/config/atomic_write_test.go
+++ b/pkg/config/atomic_write_test.go
@@ -1,0 +1,37 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestWriteFileAtomic_ReplacesExistingAndSetsPerms(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	require.NoError(t, os.WriteFile(path, []byte("old"), 0600))
+
+	require.NoError(t, writeFileAtomic(path, []byte("new-contents"), 0600))
+
+	got, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.Equal(t, "new-contents", string(got))
+
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	require.Equal(t, os.FileMode(0600), info.Mode().Perm())
+}
+
+func TestWriteFileAtomic_LeavesNoTempOnSuccess(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+
+	require.NoError(t, writeFileAtomic(path, []byte("x"), 0600))
+
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	require.Len(t, entries, 1, "temp file was not cleaned up / renamed")
+	require.Equal(t, "config.json", entries[0].Name())
+}

--- a/pkg/config/atomic_write_test.go
+++ b/pkg/config/atomic_write_test.go
@@ -13,7 +13,7 @@ func TestWriteFileAtomic_ReplacesExistingAndSetsPerms(t *testing.T) {
 	path := filepath.Join(dir, "config.json")
 	require.NoError(t, os.WriteFile(path, []byte("old"), 0600))
 
-	require.NoError(t, writeFileAtomic(path, []byte("new-contents"), 0600))
+	require.NoError(t, writeFileAtomic(path, []byte("new-contents")))
 
 	got, err := os.ReadFile(path)
 	require.NoError(t, err)
@@ -28,7 +28,7 @@ func TestWriteFileAtomic_LeavesNoTempOnSuccess(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.json")
 
-	require.NoError(t, writeFileAtomic(path, []byte("x"), 0600))
+	require.NoError(t, writeFileAtomic(path, []byte("x")))
 
 	entries, err := os.ReadDir(dir)
 	require.NoError(t, err)

--- a/pkg/config/atomic_write_test.go
+++ b/pkg/config/atomic_write_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -21,7 +22,11 @@ func TestWriteFileAtomic_ReplacesExistingAndSetsPerms(t *testing.T) {
 
 	info, err := os.Stat(path)
 	require.NoError(t, err)
-	require.Equal(t, os.FileMode(0600), info.Mode().Perm())
+	// Windows does not expose POSIX permission bits through Mode().Perm(), so the
+	// 0600 assertion only holds off Windows (matching config_test.go's own guard).
+	if runtime.GOOS != "windows" {
+		require.Equal(t, os.FileMode(0600), info.Mode().Perm())
+	}
 }
 
 func TestWriteFileAtomic_LeavesNoTempOnSuccess(t *testing.T) {

--- a/pkg/config/atomic_write_windows.go
+++ b/pkg/config/atomic_write_windows.go
@@ -1,0 +1,29 @@
+//go:build windows
+
+package config
+
+import (
+	"os"
+	"time"
+)
+
+// renameReplace retries the rename briefly: on Windows a third-party handle
+// holder (antivirus, indexer, backup agent) transiently holding the destination
+// open makes MoveFileEx(REPLACE_EXISTING) fail. This is unrelated to our lock,
+// which is on the sidecar, not the data file.
+func renameReplace(oldpath, newpath string) error {
+	var err error
+	for _, backoff := range []time.Duration{0, 20 * time.Millisecond, 50 * time.Millisecond, 100 * time.Millisecond, 200 * time.Millisecond} {
+		if backoff > 0 {
+			time.Sleep(backoff)
+		}
+		if err = os.Rename(oldpath, newpath); err == nil {
+			return nil
+		}
+	}
+	return err
+}
+
+// fsyncDir is a no-op on Windows: there is no directory fsync, and the NTFS
+// rename is itself the durability boundary.
+func fsyncDir(_ string) error { return nil }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -100,6 +100,12 @@ type Config struct {
 	overwrittenCurrentEnvironment  string
 	overwrittenCurrentKafkaCluster string
 
+	// baseline is this process's view of the persisted config as of its last
+	// load or successful save. Save() diffs baseline against the live config to
+	// learn what THIS process changed, so a concurrent writer's fields can be
+	// preserved. Never serialized.
+	baseline *Config
+
 	// Deprecated
 	DisablePluginsOnce bool `json:"disable_plugins_once,omitempty"`
 }
@@ -190,27 +196,12 @@ func (c *Config) Load() error {
 		return fmt.Errorf(errors.UnableToReadConfigurationFileErrorMsg, filename, err)
 	}
 
+	if err := wireContexts(c); err != nil {
+		return err
+	}
+
 	var save bool
 	for _, context := range c.Contexts {
-		// Some "pre-validation"
-		if context.Name == "" {
-			return errors.NewCorruptedConfigError(errors.NoNameContextErrorMsg, "", c.Filename)
-		}
-		if context.CredentialName == "" {
-			return errors.NewCorruptedConfigError(errors.UnspecifiedCredentialErrorMsg, context.Name, c.Filename)
-		}
-		if context.PlatformName == "" {
-			return errors.NewCorruptedConfigError(errors.UnspecifiedPlatformErrorMsg, context.Name, c.Filename)
-		}
-		context.Credential = c.Credentials[context.CredentialName]
-		context.Platform = c.Platforms[context.PlatformName]
-		context.Config = c
-		if context.KafkaClusterContext == nil {
-			return errors.NewCorruptedConfigError(`context "%s" missing KafkaClusterContext`, context.Name, c.Filename)
-		}
-		context.KafkaClusterContext.Context = context
-		context.State = c.ContextStates[context.Name]
-
 		// Migrate deprecated NetrcMachineName to MachineName
 		if context.NetrcMachineName != "" && context.MachineName == "" {
 			context.MachineName = context.NetrcMachineName
@@ -237,6 +228,75 @@ func (c *Config) Load() error {
 	}
 
 	return c.Validate()
+}
+
+// wireContexts rebuilds the cross-references Load() relies on: each context's
+// Credential/Platform/Config back-pointer, its KafkaClusterContext parent, and
+// its State pointer aliased to c.ContextStates[name]. Validate()'s DeepEqual on
+// context state only holds because State and ContextStates[name] are the same
+// object, so a bare json.Unmarshal is never enough.
+func wireContexts(c *Config) error {
+	for _, context := range c.Contexts {
+		if context.Name == "" {
+			return errors.NewCorruptedConfigError(errors.NoNameContextErrorMsg, "", c.Filename)
+		}
+		if context.CredentialName == "" {
+			return errors.NewCorruptedConfigError(errors.UnspecifiedCredentialErrorMsg, context.Name, c.Filename)
+		}
+		if context.PlatformName == "" {
+			return errors.NewCorruptedConfigError(errors.UnspecifiedPlatformErrorMsg, context.Name, c.Filename)
+		}
+		context.Credential = c.Credentials[context.CredentialName]
+		context.Platform = c.Platforms[context.PlatformName]
+		context.Config = c
+		if context.KafkaClusterContext == nil {
+			return errors.NewCorruptedConfigError(`context "%s" missing KafkaClusterContext`, context.Name, c.Filename)
+		}
+		context.KafkaClusterContext.Context = context
+		context.State = c.ContextStates[context.Name]
+	}
+	return nil
+}
+
+// readConfigFromDisk re-reads the persisted config and rebuilds its pointer
+// graph. It does NOT run migrations and never writes — it is the "theirs" side
+// of Save()'s merge, so it must not recurse into Save(). json:"-" fields
+// (Filename, IsTest, Version, DisableUpdates) are copied from template because a
+// fresh unmarshal cannot recover them.
+func readConfigFromDisk(path string, template *Config) (*Config, error) {
+	input, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	disk := New()
+	if err := json.Unmarshal(input, disk); err != nil {
+		return nil, fmt.Errorf(errors.UnableToReadConfigurationFileErrorMsg, path, err)
+	}
+
+	disk.Filename = template.Filename
+	disk.IsTest = template.IsTest
+	disk.Version = template.Version
+	disk.DisableUpdates = template.DisableUpdates
+
+	if err := wireContexts(disk); err != nil {
+		return nil, err
+	}
+	return disk, nil
+}
+
+// snapshotBaseline deep-copies the persisted fields into c.baseline via a JSON
+// round-trip (json:"-" and unexported fields are intentionally excluded — the
+// merge only diffs persisted state).
+func (c *Config) snapshotBaseline() {
+	data, err := json.Marshal(c)
+	if err != nil {
+		c.baseline = New()
+		return
+	}
+	b := New()
+	_ = json.Unmarshal(data, b)
+	c.baseline = b
 }
 
 // Save writes the CLI config to disk.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -429,9 +429,16 @@ func (c *Config) saveLocked() error {
 		return err
 	}
 
-	// merged is exactly what is now on disk (encrypted), so it becomes the ancestor
-	// the next Save diffs against.
-	c.baseline = merged.deepCopyPersisted()
+	// The next Save's three-way merge diffs baseline against the live config, so the
+	// baseline must match the live config for every field this process did not edit,
+	// not the merged disk state. merged holds concurrent changes this process pulled in
+	// from disk but never wrote back into c; using merged as the ancestor would make a
+	// later Save read those untouched fields as local edits and revert the concurrent
+	// change. Snapshotting c keeps the ancestor aligned with what this process knows.
+	// c itself is left as-is, so its in-memory view of a field it did not touch stays
+	// at the loaded value until the process exits; that matches how a load-once CLI
+	// already behaves, and only the ancestor advances here.
+	c.baseline = c.deepCopyPersisted()
 	return nil
 }
 
@@ -477,10 +484,13 @@ func (c *Config) encryptSecrets() error {
 // can be diffed field for field. PreRun leaves the live config (ref) with every
 // credential secret and the current context's tokens in plaintext while other
 // contexts' tokens stay encrypted; this decrypts exactly the fields ref holds in
-// plaintext. Save() calls it on the encrypted baseline. It decrypts rather than
-// re-encrypting ref because that is deterministic on every platform (Windows DPAPI
-// ciphertext is not), and it never runs Validate (which would re-enter Save under
-// the held lock).
+// plaintext. Save() calls it on the baseline, which is encrypted straight from load
+// or writeWholeConfig but already in ref's representation after a merged save (whose
+// baseline is a live-config snapshot); the guard below only decrypts a field where
+// the baseline holds ciphertext ref does not, so an already-aligned field is a no-op.
+// It decrypts rather than re-encrypting ref because that is deterministic on every
+// platform (Windows DPAPI ciphertext is not), and it never runs Validate (which would
+// re-enter Save under the held lock).
 func (c *Config) decryptToMatch(ref *Config) error {
 	// Decrypt a field only where c holds ciphertext and ref holds plaintext: that is
 	// the one case where the two representations differ and c must be brought down to

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -106,6 +106,14 @@ type Config struct {
 	// preserved. Never serialized.
 	baseline *Config
 
+	// writing is set on the exact config whose Validate() runs under the write
+	// lock. Validate()'s in-memory normalization (nil-map init, invalid-active-
+	// cluster reset) reaches back through Context.Save() to persist itself; that
+	// nested Save() would deadlock on the already-held sidecar lock. The flag
+	// short-circuits it — the enclosing locked write persists the normalized
+	// struct as soon as Validate() returns. Never serialized.
+	writing bool
+
 	// Deprecated
 	DisablePluginsOnce bool `json:"disable_plugins_once,omitempty"`
 }
@@ -314,7 +322,21 @@ func (c *Config) deepCopyPersisted() *Config {
 // merges this process's own changes onto it (so a concurrent session's fields
 // are not lost), and writes the result atomically.
 func (c *Config) Save() error {
-	lock := newFileLock(c.GetFilename())
+	// A Save() re-entered from Validate()'s normalization while this process
+	// already holds the lock is a no-op: the enclosing locked write persists the
+	// fully-normalized struct as soon as Validate() returns.
+	if c.writing {
+		return nil
+	}
+
+	// Create the config directory before opening the sidecar lock file inside it:
+	// on a fresh machine (~/.confluent absent) opening the lock would ENOENT.
+	filename := c.GetFilename()
+	if err := os.MkdirAll(filepath.Dir(filename), 0700); err != nil {
+		return fmt.Errorf("unable to create config directory %s: %w", filename, err)
+	}
+
+	lock := newFileLock(filename)
 	if err := lock.lock(lockTimeout); err != nil {
 		return err
 	}
@@ -375,7 +397,13 @@ func (c *Config) saveLocked() error {
 		return err
 	}
 
-	if err := merged.Validate(); err != nil {
+	// Validate() normalizes merged in memory and, via Context.Save(), tries to
+	// re-persist under the lock we already hold. writing neutralizes that nested
+	// Save(); the normalized merged is written just below.
+	merged.writing = true
+	err = merged.Validate()
+	merged.writing = false
+	if err != nil {
 		return err
 	}
 
@@ -431,7 +459,12 @@ func (c *Config) save() error {
 		defer c.restoreOverwrittenCredentials(tempCredentials)
 	}
 
-	if err := c.Validate(); err != nil {
+	// See saveLocked: writing neutralizes the nested Save() that Validate()'s
+	// normalization triggers, so it does not re-acquire the held lock.
+	c.writing = true
+	err := c.Validate()
+	c.writing = false
+	if err != nil {
 		return err
 	}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -110,7 +110,7 @@ type Config struct {
 	// lock. Validate()'s in-memory normalization (nil-map init, invalid-active-
 	// cluster reset) reaches back through Context.Save() to persist itself; that
 	// nested Save() would deadlock on the already-held sidecar lock. The flag
-	// short-circuits it — the enclosing locked write persists the normalized
+	// short-circuits it, so the enclosing locked write persists the normalized
 	// struct as soon as Validate() returns. Never serialized.
 	writing bool
 
@@ -270,7 +270,7 @@ func wireContexts(c *Config) error {
 }
 
 // readConfigFromDisk re-reads the persisted config and rebuilds its pointer
-// graph. It does NOT run migrations and never writes — it is the "theirs" side
+// graph. It does NOT run migrations and never writes; it is the "theirs" side
 // of Save()'s merge, so it must not recurse into Save(). json:"-" fields
 // (Filename, IsTest, Version, DisableUpdates) are copied from template because a
 // fresh unmarshal cannot recover them.
@@ -297,7 +297,7 @@ func readConfigFromDisk(path string, template *Config) (*Config, error) {
 }
 
 // snapshotBaseline deep-copies the persisted fields into c.baseline via a JSON
-// round-trip (json:"-" and unexported fields are intentionally excluded — the
+// round-trip (json:"-" and unexported fields are intentionally excluded, since the
 // merge only diffs persisted state).
 func (c *Config) snapshotBaseline() {
 	c.baseline = c.deepCopyPersisted()
@@ -305,7 +305,7 @@ func (c *Config) snapshotBaseline() {
 
 // deepCopyPersisted returns an independent copy of c's persisted fields via a
 // JSON round-trip. json:"-" and unexported fields (Filename, baseline, ...) are
-// intentionally dropped — only persisted state participates in the merge. The
+// intentionally dropped, so only persisted state participates in the merge. The
 // copy shares no pointers with c, so wiring or encrypting it never mutates c.
 func (c *Config) deepCopyPersisted() *Config {
 	data, err := json.Marshal(c)
@@ -485,7 +485,7 @@ func (c *Config) save() error {
 }
 
 // isEmptyFile reports whether path exists but holds no bytes. A missing file or
-// any stat error is not "empty" — the caller handles absence via os.IsNotExist.
+// any stat error is not "empty"; the caller handles absence via os.IsNotExist.
 func isEmptyFile(path string) bool {
 	info, err := os.Stat(path)
 	return err == nil && info.Size() == 0

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -199,6 +199,7 @@ func (c *Config) Load() error {
 	if err := wireContexts(c); err != nil {
 		return err
 	}
+	c.snapshotBaseline() // baseline = pristine on-disk state, before migrations
 
 	var save bool
 	for _, context := range c.Contexts {
@@ -224,7 +225,9 @@ func (c *Config) Load() error {
 	}
 
 	if save {
-		_ = c.Save()
+		if err := c.Save(); err != nil {
+			return err
+		}
 	}
 
 	return c.Validate()
@@ -289,33 +292,133 @@ func readConfigFromDisk(path string, template *Config) (*Config, error) {
 // round-trip (json:"-" and unexported fields are intentionally excluded — the
 // merge only diffs persisted state).
 func (c *Config) snapshotBaseline() {
+	c.baseline = c.deepCopyPersisted()
+}
+
+// deepCopyPersisted returns an independent copy of c's persisted fields via a
+// JSON round-trip. json:"-" and unexported fields (Filename, baseline, ...) are
+// intentionally dropped — only persisted state participates in the merge. The
+// copy shares no pointers with c, so wiring or encrypting it never mutates c.
+func (c *Config) deepCopyPersisted() *Config {
 	data, err := json.Marshal(c)
 	if err != nil {
-		c.baseline = New()
-		return
+		return New()
 	}
 	b := New()
 	_ = json.Unmarshal(data, b)
-	c.baseline = b
+	return b
 }
 
-// Save writes the CLI config to disk.
+// Save atomically and safely persists the config. It serializes writers on a
+// sidecar lock, re-reads the current on-disk state under the lock, three-way-
+// merges this process's own changes onto it (so a concurrent session's fields
+// are not lost), and writes the result atomically.
 func (c *Config) Save() error {
-	tempKafkaCluster := c.resolveOverwrittenKafkaCluster()
-	tempEnvironment := c.resolveOverwrittenCurrentEnvironment()
-	tempContext := c.resolveOverwrittenContext()
-	var tempAuthToken string
-	var tempAuthRefreshToken string
-	tempCredentials := map[string]string{}
+	lock := newFileLock(c.GetFilename())
+	if err := lock.lock(lockTimeout); err != nil {
+		return err
+	}
+	defer func() { _ = lock.unlock() }()
+	return c.saveLocked()
+}
 
+// saveLocked runs the read-merge-write under an already-held lock.
+func (c *Config) saveLocked() error {
+	// Resolve flag overrides on the live config so the merge sees the user's
+	// real selection, not an ephemeral --context/--environment/--cluster value.
+	tempKafkaCluster := c.resolveOverwrittenKafkaCluster()
+	defer c.restoreOverwrittenKafkaCluster(tempKafkaCluster)
+	tempEnvironment := c.resolveOverwrittenCurrentEnvironment()
+	defer c.restoreOverwrittenEnvironment(tempEnvironment)
+	tempContext := c.resolveOverwrittenContext()
+	defer c.restoreOverwrittenContext(tempContext)
+
+	// If we have no baseline (e.g. Save called on a config that was constructed,
+	// not loaded), treat our current state as the baseline: nothing to merge.
+	if c.baseline == nil {
+		c.snapshotBaseline()
+	}
+
+	disk, err := readConfigFromDisk(c.GetFilename(), c)
+	if err != nil {
+		// A missing or empty (e.g. crash-truncated, or a freshly-created temp)
+		// file has nothing to preserve: write our state directly, no merge.
+		if os.IsNotExist(err) || isEmptyFile(c.GetFilename()) {
+			if err := c.save(); err != nil {
+				return err
+			}
+			c.snapshotBaseline()
+			return nil
+		}
+		return err
+	}
+
+	// Merge against a deep copy of c, not c itself: threeWayMerge inserts the
+	// "ours" side's map values (our *Context pointers) into the result, and the
+	// wireContexts/encrypt steps below mutate them. Using a copy keeps live c
+	// pristine and plaintext for continued execution after the save.
+	merged := threeWayMerge(c.baseline, c.deepCopyPersisted(), disk)
+	if err := wireContexts(merged); err != nil {
+		return err
+	}
+
+	// Encrypt on the merged struct, never on c: c stays plaintext for continued
+	// execution, and the encrypt helpers are guarded against double-encrypting
+	// the already-encrypted tokens that came from disk for untouched contexts.
+	if merged.Context() != nil {
+		st := merged.Context().GetState()
+		if err := merged.encryptContextStateTokens(st.AuthToken, st.AuthRefreshToken); err != nil {
+			return err
+		}
+	}
+	if err := merged.encryptCredentialsAPISecret(); err != nil {
+		return err
+	}
+
+	if err := merged.Validate(); err != nil {
+		return err
+	}
+
+	data, err := json.MarshalIndent(merged, "", "  ")
+	if err != nil {
+		return fmt.Errorf("unable to marshal config: %w", err)
+	}
+
+	filename := c.GetFilename()
+	if err := os.MkdirAll(filepath.Dir(filename), 0700); err != nil {
+		return fmt.Errorf("unable to create config directory %s: %w", filename, err)
+	}
+	if err := writeFileAtomic(filename, data); err != nil {
+		return err
+	}
+
+	// Our persisted view is now current; the next Save diffs from here.
+	c.snapshotBaseline()
+	return nil
+}
+
+// save marshals and atomically writes the live config WITHOUT locking or
+// merging. Callers must hold the lock (or knowingly not need it, e.g. writing a
+// brand-new default file). Save() is the normal, locked, merging entry point.
+func (c *Config) save() error {
+	tempKafkaCluster := c.resolveOverwrittenKafkaCluster()
+	defer c.restoreOverwrittenKafkaCluster(tempKafkaCluster)
+	tempEnvironment := c.resolveOverwrittenCurrentEnvironment()
+	defer c.restoreOverwrittenEnvironment(tempEnvironment)
+	tempContext := c.resolveOverwrittenContext()
+	defer c.restoreOverwrittenContext(tempContext)
+
+	var tempAuthToken, tempAuthRefreshToken string
+	tempCredentials := map[string]string{}
 	if c.Context() != nil {
 		tempAuthToken = c.Context().GetState().AuthToken
 		tempAuthRefreshToken = c.Context().GetState().AuthRefreshToken
 		if err := c.encryptContextStateTokens(tempAuthToken, tempAuthRefreshToken); err != nil {
 			return err
 		}
+		defer c.restoreOverwrittenAuthToken(tempAuthToken)
+		defer c.restoreOverwrittenAuthRefreshToken(tempAuthRefreshToken)
 	}
-
 	if c.Credentials != nil {
 		for name, credential := range c.Credentials {
 			if credential.APIKeyPair != nil {
@@ -325,35 +428,34 @@ func (c *Config) Save() error {
 		if err := c.encryptCredentialsAPISecret(); err != nil {
 			return err
 		}
+		defer c.restoreOverwrittenCredentials(tempCredentials)
 	}
 
 	if err := c.Validate(); err != nil {
 		return err
 	}
 
-	cfg, err := json.MarshalIndent(c, "", "  ")
+	data, err := json.MarshalIndent(c, "", "  ")
 	if err != nil {
 		return fmt.Errorf("unable to marshal config: %w", err)
 	}
 
 	filename := c.GetFilename()
-
 	if err := os.MkdirAll(filepath.Dir(filename), 0700); err != nil {
 		return fmt.Errorf("unable to create config directory %s: %w", filename, err)
 	}
-
-	if err := os.WriteFile(filename, cfg, 0600); err != nil {
-		return fmt.Errorf("unable to write config to file %s: %w", filename, err)
+	if err := writeFileAtomic(filename, data); err != nil {
+		return err
 	}
 
-	c.restoreOverwrittenContext(tempContext)
-	c.restoreOverwrittenEnvironment(tempEnvironment)
-	c.restoreOverwrittenKafkaCluster(tempKafkaCluster)
-	c.restoreOverwrittenAuthToken(tempAuthToken)
-	c.restoreOverwrittenAuthRefreshToken(tempAuthRefreshToken)
-	c.restoreOverwrittenCredentials(tempCredentials)
-
 	return nil
+}
+
+// isEmptyFile reports whether path exists but holds no bytes. A missing file or
+// any stat error is not "empty" — the caller handles absence via os.IsNotExist.
+func isEmptyFile(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && info.Size() == 0
 }
 
 func (c *Config) encryptCredentialsAPISecret() error {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -196,7 +196,12 @@ func (c *Config) Load() error {
 	input, err := os.ReadFile(filename)
 	if err != nil {
 		if os.IsNotExist(err) {
-			// Save a default version if none exists yet.
+			// Save a default version if none exists yet. Snapshot a baseline first so this
+			// save merges under the lock instead of overwriting: another session can create
+			// the config between this missing-file read and the locked save, and that file
+			// must survive. A config constructed without Load keeps a nil baseline and still
+			// writes whole.
+			c.snapshotBaseline()
 			if err := c.Save(); err != nil {
 				return fmt.Errorf("unable to save configuration file: %w", err)
 			}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -365,10 +365,11 @@ func (c *Config) saveLocked() error {
 	tempContext := c.resolveOverwrittenContext()
 	defer c.restoreOverwrittenContext(tempContext)
 
-	// If we have no baseline (e.g. Save called on a config that was constructed,
-	// not loaded), treat our current state as the baseline: nothing to merge.
+	// No baseline means this config was constructed, not loaded, so there is no
+	// common ancestor to merge against and the caller is declaring its state whole
+	// (e.g. test config reset). Overwrite directly, matching pre-merge semantics.
 	if c.baseline == nil {
-		c.snapshotBaseline()
+		return c.writeWholeConfig()
 	}
 
 	disk, err := readConfigFromDisk(c.GetFilename(), c)
@@ -376,34 +377,37 @@ func (c *Config) saveLocked() error {
 		// A missing or empty (e.g. a freshly-created temp) file has nothing to
 		// preserve: write our state directly, no merge.
 		if os.IsNotExist(err) || isEmptyFile(c.GetFilename()) {
-			if err := c.save(); err != nil {
-				return err
-			}
-			c.snapshotBaseline()
-			return nil
+			return c.writeWholeConfig()
 		}
 		return err
 	}
 
-	// Merge against a deep copy of c, not c itself: threeWayMerge inserts the
-	// "ours" side's map values (our *Context pointers) into the result, and the
-	// wireContexts/encrypt steps below mutate them. Using a copy keeps live c
-	// pristine and plaintext for continued execution after the save.
-	merged := threeWayMerge(c.baseline, c.deepCopyPersisted(), disk)
+	// ours is the live config's persisted state. PreRun left it partially decrypted:
+	// every credential secret and the current context's tokens are plaintext, while
+	// other contexts' tokens stay encrypted.
+	ours := c.deepCopyPersisted()
+
+	// Decrypt the encrypted baseline to ours' representation before diffing, so a
+	// secret we did not touch is not mistaken for a local change. We decrypt (a
+	// deterministic operation on every platform) rather than re-encrypt ours: Windows
+	// DPAPI ciphertext is not reproducible, so an encrypt-based match would flag every
+	// secret as changed and reintroduce the very lost-write bug this guards against.
+	base := c.baseline.deepCopyPersisted()
+	if err := base.decryptToMatch(ours); err != nil {
+		return err
+	}
+
+	merged, err := threeWayMerge(base, ours, disk)
+	if err != nil {
+		return err
+	}
 	if err := merged.wireContexts(); err != nil {
 		return err
 	}
 
-	// Encrypt on the merged struct, never on c: c stays plaintext for continued
-	// execution, and the encrypt helpers are guarded against double-encrypting
-	// the already-encrypted tokens that came from disk for untouched contexts.
-	if merged.Context() != nil {
-		st := merged.Context().GetState()
-		if err := merged.encryptContextStateTokens(st.AuthToken, st.AuthRefreshToken); err != nil {
-			return err
-		}
-	}
-	if err := merged.encryptCredentialsAPISecret(); err != nil {
+	// Re-encrypt the secrets that ended up plaintext (the ones we changed, taken from
+	// ours). Untouched secrets came from disk still encrypted; the guards skip them.
+	if err := merged.encryptSecrets(); err != nil {
 		return err
 	}
 
@@ -425,9 +429,99 @@ func (c *Config) saveLocked() error {
 		return err
 	}
 
-	// Our persisted view is now current; the next Save diffs from here.
-	c.snapshotBaseline()
+	// merged is exactly what is now on disk (encrypted), so it becomes the ancestor
+	// the next Save diffs against.
+	c.baseline = merged.deepCopyPersisted()
 	return nil
+}
+
+// writeWholeConfig persists c directly (no merge) and refreshes the baseline from
+// the resulting on-disk state, so the next Save has an encrypted ancestor to diff
+// against. Used when there is nothing to merge: a missing or empty file, or a
+// config that was constructed rather than loaded.
+func (c *Config) writeWholeConfig() error {
+	if err := c.save(); err != nil {
+		return err
+	}
+	// Refresh the baseline from disk (encrypted) rather than from the live config,
+	// which save() has restored to its decrypted form. A read failure here does not
+	// undo the successful write, so fall back to the live snapshot.
+	if disk, err := readConfigFromDisk(c.GetFilename(), c); err == nil {
+		c.baseline = disk
+	} else {
+		c.snapshotBaseline()
+	}
+	return nil
+}
+
+// encryptSecrets encrypts c's plaintext secrets into their on-disk form: every
+// context's auth tokens and all credential API secrets. Save() calls it on the merged
+// result to re-encrypt the secrets it took from the (plaintext) live config; secrets
+// carried over from disk are already encrypted and the guards skip them. Every context
+// is covered (not just the current one) because a merge can leave a plaintext token in
+// a context that is not current at write time, and none may reach disk.
+func (c *Config) encryptSecrets() error {
+	for _, ctx := range c.Contexts {
+		if ctx.GetState() == nil {
+			continue
+		}
+		st := ctx.GetState()
+		if err := c.encryptStateTokensForContext(ctx, st.AuthToken, st.AuthRefreshToken); err != nil {
+			return err
+		}
+	}
+	return c.encryptCredentialsAPISecret()
+}
+
+// decryptToMatch decrypts c's secrets to the same representation as ref so the two
+// can be diffed field for field. PreRun leaves the live config (ref) with every
+// credential secret and the current context's tokens in plaintext while other
+// contexts' tokens stay encrypted; this decrypts exactly the fields ref holds in
+// plaintext. Save() calls it on the encrypted baseline. It decrypts rather than
+// re-encrypting ref because that is deterministic on every platform (Windows DPAPI
+// ciphertext is not), and it never runs Validate (which would re-enter Save under
+// the held lock).
+func (c *Config) decryptToMatch(ref *Config) error {
+	// Decrypt a field only where c holds ciphertext and ref holds plaintext: that is
+	// the one case where the two representations differ and c must be brought down to
+	// match. Gating on c's own cipher marker matters because a plaintext token that is
+	// not cipher-prefixed (e.g. a cloud refresh token, which is never encrypted) would
+	// otherwise be fed to Decrypt and fail authentication.
+	for name, credential := range c.Credentials {
+		refCredential := ref.Credentials[name]
+		if credential.APIKeyPair == nil || refCredential == nil || refCredential.APIKeyPair == nil {
+			continue
+		}
+		if isEncryptedSecret(credential.APIKeyPair.Secret) && !isEncryptedSecret(refCredential.APIKeyPair.Secret) {
+			if err := credential.APIKeyPair.DecryptSecret(); err != nil {
+				return err
+			}
+		}
+	}
+
+	for name, state := range c.ContextStates {
+		refState := ref.ContextStates[name]
+		if state == nil || refState == nil {
+			continue
+		}
+		if isEncryptedSecret(state.AuthToken) && !isEncryptedSecret(refState.AuthToken) {
+			if err := state.DecryptAuthToken(name); err != nil {
+				return err
+			}
+		}
+		if isEncryptedSecret(state.AuthRefreshToken) && !isEncryptedSecret(refState.AuthRefreshToken) {
+			if err := state.DecryptAuthRefreshToken(name); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// isEncryptedSecret reports whether s carries a cipher marker (so it is ciphertext,
+// not a plaintext value a command left in place). The ":" is part of the marker.
+func isEncryptedSecret(s string) bool {
+	return strings.HasPrefix(s, secret.AesGcm+":") || strings.HasPrefix(s, secret.Dpapi+":")
 }
 
 // save marshals and atomically writes the live config WITHOUT locking or
@@ -507,39 +601,49 @@ func (c *Config) encryptCredentialsAPISecret() error {
 }
 
 func (c *Config) encryptContextStateTokens(tempAuthToken, tempAuthRefreshToken string) error {
-	if c.Context().GetState().Salt == nil || c.Context().GetState().Nonce == nil {
+	return c.encryptStateTokensForContext(c.Context(), tempAuthToken, tempAuthRefreshToken)
+}
+
+// encryptStateTokensForContext encrypts ctx's auth tokens in place. It is idempotent:
+// an already-encrypted token carries a cipher prefix and matches none of the plaintext
+// token shapes below, so it is left untouched. The ctx parameter lets Save() encrypt
+// every context's state, not only the current one, so a plaintext token can never
+// reach disk under a context that is not current at write time.
+func (c *Config) encryptStateTokensForContext(ctx *Context, tempAuthToken, tempAuthRefreshToken string) error {
+	state := ctx.GetState()
+	if state.Salt == nil || state.Nonce == nil {
 		salt, nonce, err := secret.GenerateSaltAndNonce()
 		if err != nil {
 			return err
 		}
-		c.Context().GetState().Salt = salt
-		c.Context().GetState().Nonce = nonce
+		state.Salt = salt
+		state.Nonce = nonce
 	}
 
 	if regexp.MustCompile(authTokenRegex).MatchString(tempAuthToken) {
-		encryptedAuthToken, err := secret.Encrypt(c.Context().Name, tempAuthToken, c.Context().GetState().Salt, c.Context().GetState().Nonce)
+		encryptedAuthToken, err := secret.Encrypt(ctx.Name, tempAuthToken, state.Salt, state.Nonce)
 		if err != nil {
 			return err
 		}
-		c.Context().GetState().AuthToken = encryptedAuthToken
+		state.AuthToken = encryptedAuthToken
 	}
 
 	// The Confluent Gov environment and the Confluent Platform MDS return a refresh token that does not match `authRefreshTokenRegex` and cannot be distinguished from an already encrypted refresh token.
-	// We prefix encrypted tokens with "AES/GCM/NoPadding" on Unix systems and "DPAPI" on Windows to ensure that they are only encrypted once.
-	prefix := secret.AesGcm
+	// We prefix encrypted tokens with "AES/GCM/NoPadding:" on Unix systems and "DPAPI:" on Windows to ensure that they are only encrypted once. The ":" is part of the marker, so a plaintext token merely beginning with the marker word is still encrypted.
+	prefix := secret.AesGcm + ":"
 	if runtime.GOOS == "windows" {
-		prefix = secret.Dpapi
+		prefix = secret.Dpapi + ":"
 	}
-	isUnencryptedConfluentGov := !strings.HasPrefix(tempAuthRefreshToken, prefix) && (strings.Contains(c.Context().PlatformName, "confluentgov.com") || strings.Contains(c.Context().PlatformName, "confluentgov-internal.com"))
+	isUnencryptedConfluentGov := !strings.HasPrefix(tempAuthRefreshToken, prefix) && (strings.Contains(ctx.PlatformName, "confluentgov.com") || strings.Contains(ctx.PlatformName, "confluentgov-internal.com"))
 
-	isUnencryptedConfluentPlatform := tempAuthRefreshToken != "" && !strings.HasPrefix(tempAuthRefreshToken, prefix) && !c.Context().IsCloud(c.IsTest)
+	isUnencryptedConfluentPlatform := tempAuthRefreshToken != "" && !strings.HasPrefix(tempAuthRefreshToken, prefix) && !ctx.IsCloud(c.IsTest)
 
 	if regexp.MustCompile(authRefreshTokenRegex).MatchString(tempAuthRefreshToken) || isUnencryptedConfluentGov || isUnencryptedConfluentPlatform {
-		encryptedAuthRefreshToken, err := secret.Encrypt(c.Context().Name, tempAuthRefreshToken, c.Context().GetState().Salt, c.Context().GetState().Nonce)
+		encryptedAuthRefreshToken, err := secret.Encrypt(ctx.Name, tempAuthRefreshToken, state.Salt, state.Nonce)
 		if err != nil {
 			return err
 		}
-		c.Context().State.AuthRefreshToken = encryptedAuthRefreshToken
+		state.AuthRefreshToken = encryptedAuthRefreshToken
 	}
 
 	return nil

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -112,6 +112,11 @@ type Config struct {
 	// nested Save() would deadlock on the already-held sidecar lock. The flag
 	// short-circuits it, so the enclosing locked write persists the normalized
 	// struct as soon as Validate() returns. Never serialized.
+	//
+	// Known limitation: KafkaClusterContext.Validate() couples normalization to
+	// persistence via Save(), so a lock timeout hit during that normalization
+	// surfaces as a panic rather than a returned error. Splitting normalization
+	// from persistence is a deferred follow-up.
 	writing bool
 
 	// Deprecated
@@ -204,7 +209,7 @@ func (c *Config) Load() error {
 		return fmt.Errorf(errors.UnableToReadConfigurationFileErrorMsg, filename, err)
 	}
 
-	if err := wireContexts(c); err != nil {
+	if err := c.wireContexts(); err != nil {
 		return err
 	}
 	c.snapshotBaseline() // baseline = pristine on-disk state, before migrations
@@ -246,7 +251,7 @@ func (c *Config) Load() error {
 // its State pointer aliased to c.ContextStates[name]. Validate()'s DeepEqual on
 // context state only holds because State and ContextStates[name] are the same
 // object, so a bare json.Unmarshal is never enough.
-func wireContexts(c *Config) error {
+func (c *Config) wireContexts() error {
 	for _, context := range c.Contexts {
 		if context.Name == "" {
 			return errors.NewCorruptedConfigError(errors.NoNameContextErrorMsg, "", c.Filename)
@@ -277,7 +282,12 @@ func wireContexts(c *Config) error {
 func readConfigFromDisk(path string, template *Config) (*Config, error) {
 	input, err := os.ReadFile(path)
 	if err != nil {
-		return nil, err
+		// Keep the raw error for a missing file so saveLocked's os.IsNotExist
+		// check still fires; wrap any other read error as Load() does.
+		if os.IsNotExist(err) {
+			return nil, err
+		}
+		return nil, fmt.Errorf(errors.UnableToReadConfigurationFileErrorMsg, path, err)
 	}
 
 	disk := New()
@@ -290,7 +300,7 @@ func readConfigFromDisk(path string, template *Config) (*Config, error) {
 	disk.Version = template.Version
 	disk.DisableUpdates = template.DisableUpdates
 
-	if err := wireContexts(disk); err != nil {
+	if err := disk.wireContexts(); err != nil {
 		return nil, err
 	}
 	return disk, nil
@@ -363,8 +373,8 @@ func (c *Config) saveLocked() error {
 
 	disk, err := readConfigFromDisk(c.GetFilename(), c)
 	if err != nil {
-		// A missing or empty (e.g. crash-truncated, or a freshly-created temp)
-		// file has nothing to preserve: write our state directly, no merge.
+		// A missing or empty (e.g. a freshly-created temp) file has nothing to
+		// preserve: write our state directly, no merge.
 		if os.IsNotExist(err) || isEmptyFile(c.GetFilename()) {
 			if err := c.save(); err != nil {
 				return err
@@ -380,7 +390,7 @@ func (c *Config) saveLocked() error {
 	// wireContexts/encrypt steps below mutate them. Using a copy keeps live c
 	// pristine and plaintext for continued execution after the save.
 	merged := threeWayMerge(c.baseline, c.deepCopyPersisted(), disk)
-	if err := wireContexts(merged); err != nil {
+	if err := merged.wireContexts(); err != nil {
 		return err
 	}
 
@@ -401,9 +411,8 @@ func (c *Config) saveLocked() error {
 	// re-persist under the lock we already hold. writing neutralizes that nested
 	// Save(); the normalized merged is written just below.
 	merged.writing = true
-	err = merged.Validate()
-	merged.writing = false
-	if err != nil {
+	defer func() { merged.writing = false }()
+	if err := merged.Validate(); err != nil {
 		return err
 	}
 
@@ -412,11 +421,7 @@ func (c *Config) saveLocked() error {
 		return fmt.Errorf("unable to marshal config: %w", err)
 	}
 
-	filename := c.GetFilename()
-	if err := os.MkdirAll(filepath.Dir(filename), 0700); err != nil {
-		return fmt.Errorf("unable to create config directory %s: %w", filename, err)
-	}
-	if err := writeFileAtomic(filename, data); err != nil {
+	if err := writeFileAtomic(c.GetFilename(), data); err != nil {
 		return err
 	}
 
@@ -462,9 +467,8 @@ func (c *Config) save() error {
 	// See saveLocked: writing neutralizes the nested Save() that Validate()'s
 	// normalization triggers, so it does not re-acquire the held lock.
 	c.writing = true
-	err := c.Validate()
-	c.writing = false
-	if err != nil {
+	defer func() { c.writing = false }()
+	if err := c.Validate(); err != nil {
 		return err
 	}
 
@@ -473,19 +477,18 @@ func (c *Config) save() error {
 		return fmt.Errorf("unable to marshal config: %w", err)
 	}
 
-	filename := c.GetFilename()
-	if err := os.MkdirAll(filepath.Dir(filename), 0700); err != nil {
-		return fmt.Errorf("unable to create config directory %s: %w", filename, err)
-	}
-	if err := writeFileAtomic(filename, data); err != nil {
+	if err := writeFileAtomic(c.GetFilename(), data); err != nil {
 		return err
 	}
 
 	return nil
 }
 
-// isEmptyFile reports whether path exists but holds no bytes. A missing file or
-// any stat error is not "empty"; the caller handles absence via os.IsNotExist.
+// isEmptyFile reports whether path exists but holds no bytes. This tolerates a
+// legacy zero-byte config file (nothing to preserve, so the caller skips the
+// merge); a non-empty but corrupt file is not "empty" and is correctly surfaced
+// as a hard error by the unmarshal instead. A missing file or any stat error is
+// not "empty"; the caller handles absence via os.IsNotExist.
 func isEmptyFile(path string) bool {
 	info, err := os.Stat(path)
 	return err == nil && info.Size() == 0

--- a/pkg/config/config_concurrent_test.go
+++ b/pkg/config/config_concurrent_test.go
@@ -45,7 +45,7 @@ func TestSave_ConcurrentDifferentFields_NoLostWrite(t *testing.T) {
 
 // helper: a saved single-context config with an API-key credential and two known
 // Kafka clusters (so switching the active cluster passes Validate).
-func newSavedConfig(t *testing.T, path, apiSecret string) {
+func newSavedConfig(t *testing.T, path string) {
 	t.Helper()
 
 	c := New()
@@ -54,7 +54,7 @@ func newSavedConfig(t *testing.T, path, apiSecret string) {
 	c.Credentials["cred"] = &Credential{
 		Name:           "cred",
 		CredentialType: APIKey,
-		APIKeyPair:     &APIKeyPair{Key: "api-key", Secret: apiSecret},
+		APIKeyPair:     &APIKeyPair{Key: "api-key", Secret: "secret-original"},
 	}
 	state := new(ContextState)
 	ctx := &Context{
@@ -160,7 +160,7 @@ func TestEncryptSecrets_EncryptsNonCurrentContextTokens(t *testing.T) {
 func TestSave_ConcurrentSameContextDifferentFields_NoLostWrite(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.json")
-	newSavedConfig(t, path, "secret-original")
+	newSavedConfig(t, path)
 
 	a := loadDecrypted(t, path)
 	b := loadDecrypted(t, path)
@@ -185,7 +185,7 @@ func TestSave_ConcurrentSameContextDifferentFields_NoLostWrite(t *testing.T) {
 func TestSave_ConcurrentSharedCredential_NotClobbered(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.json")
-	newSavedConfig(t, path, "secret-original")
+	newSavedConfig(t, path)
 
 	b := loadDecrypted(t, path) // holds decrypted "secret-original"
 	a := loadDecrypted(t, path)
@@ -211,7 +211,7 @@ func TestSave_ConcurrentSharedCredential_NotClobbered(t *testing.T) {
 func TestSave_SecondSaveInSameProcess_PreservesConcurrentDiskChange(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.json")
-	newSavedConfig(t, path, "secret-original")
+	newSavedConfig(t, path)
 
 	p := loadDecrypted(t, path)     // this process, baseline captured at load
 	other := loadDecrypted(t, path) // a concurrent session
@@ -241,7 +241,7 @@ func TestSave_SecondSaveInSameProcess_PreservesConcurrentDiskChange(t *testing.T
 func TestSave_SecondSaveInSameProcess_PreservesConcurrentSecretRotation(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.json")
-	newSavedConfig(t, path, "secret-original")
+	newSavedConfig(t, path)
 
 	p := loadDecrypted(t, path)     // this process, holds decrypted "secret-original"
 	other := loadDecrypted(t, path) // a concurrent session

--- a/pkg/config/config_concurrent_test.go
+++ b/pkg/config/config_concurrent_test.go
@@ -1,10 +1,13 @@
 package config
 
 import (
+	"encoding/json"
 	"fmt"
+	"os"
 	"path/filepath"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -263,4 +266,41 @@ func TestSave_SecondSaveInSameProcess_PreservesConcurrentSecretRotation(t *testi
 	require.Equal(t, "secret-rotated", final.Credentials["cred"].APIKeyPair.Secret,
 		"the second save must not revert the concurrent rotation")
 	require.Equal(t, "env-c", final.Contexts["ctx"].CurrentEnvironment)
+}
+
+// On a fresh machine two sessions can both read the config as missing before either
+// writes it. If one then creates it, the other's initial in-Load save must merge that
+// file rather than overwrite it with a default. The sidecar lock is held here to force
+// the exact window: the loading session reads the file missing, then blocks on the lock
+// inside its save while another session's config lands on disk.
+func TestLoad_FreshMachineDoesNotClobberConcurrentlyCreatedConfig(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+
+	holder := newFileLock(path)
+	require.NoError(t, holder.lock(lockTimeout))
+
+	b := New()
+	b.Filename = path
+	loadErr := make(chan error, 1)
+	go func() { loadErr <- b.Load() }() // reads the missing file, then blocks on the held lock
+
+	// b has passed the missing-file read and is waiting on the lock; now another session's
+	// config appears on disk before we release it.
+	time.Sleep(300 * time.Millisecond)
+	other := New()
+	other.Filename = path
+	other.Platforms["from-other"] = &Platform{Name: "from-other", Server: "https://other.example.com"}
+	data, err := json.MarshalIndent(other, "", "  ")
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(path, data, 0600))
+	require.NoError(t, holder.unlock())
+
+	require.NoError(t, <-loadErr)
+
+	final := New()
+	final.Filename = path
+	require.NoError(t, final.Load())
+	require.Contains(t, final.Platforms, "from-other",
+		"a config another session created after this session read the file missing must survive the fresh-machine load")
 }

--- a/pkg/config/config_concurrent_test.go
+++ b/pkg/config/config_concurrent_test.go
@@ -202,3 +202,65 @@ func TestSave_ConcurrentSharedCredential_NotClobbered(t *testing.T) {
 		"a's concurrent credential rotation must not be clobbered by b's unrelated save")
 	require.Equal(t, "env-from-b", final.Contexts["ctx"].CurrentEnvironment)
 }
+
+// A process that merges a concurrent disk change into its first save must not revert
+// that change on a later save in the same process. The merge writes the concurrent
+// field to disk but leaves the live config's copy stale, so if the post-save baseline
+// tracks the merged (disk) value while ours stays stale, the next diff misreads the
+// untouched field as a local edit and overwrites the concurrent change.
+func TestSave_SecondSaveInSameProcess_PreservesConcurrentDiskChange(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	newSavedConfig(t, path, "secret-original")
+
+	p := loadDecrypted(t, path)     // this process, baseline captured at load
+	other := loadDecrypted(t, path) // a concurrent session
+	require.True(t, p.EnableColor, "precondition: color starts enabled (New()'s default)")
+
+	other.EnableColor = false // a field p never touches
+	require.NoError(t, other.Save())
+
+	p.Contexts["ctx"].CurrentEnvironment = "env-b" // p's first, unrelated edit
+	require.NoError(t, p.Save())
+
+	mid := loadDecrypted(t, path)
+	require.False(t, mid.EnableColor, "the first save must merge in the concurrent color change")
+
+	p.Contexts["ctx"].CurrentEnvironment = "env-c" // p's second edit, still not touching color
+	require.NoError(t, p.Save())
+
+	final := loadDecrypted(t, path)
+	require.False(t, final.EnableColor, "the second save must not revert the concurrently-disabled color")
+	require.Equal(t, "env-c", final.Contexts["ctx"].CurrentEnvironment)
+}
+
+// The same second-save hazard on a secret rather than a scalar. The post-save baseline
+// is a snapshot of the live config, whose credential secret is plaintext, while disk
+// holds ciphertext; this pins that decryptToMatch still aligns the two so a concurrent
+// rotation this process never touched survives a later save in the same process.
+func TestSave_SecondSaveInSameProcess_PreservesConcurrentSecretRotation(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	newSavedConfig(t, path, "secret-original")
+
+	p := loadDecrypted(t, path)     // this process, holds decrypted "secret-original"
+	other := loadDecrypted(t, path) // a concurrent session
+
+	other.Credentials["cred"].APIKeyPair.Secret = "secret-rotated" // a field p never touches
+	require.NoError(t, other.Save())
+
+	p.Contexts["ctx"].CurrentEnvironment = "env-b" // p's first, unrelated edit
+	require.NoError(t, p.Save())
+
+	mid := loadDecrypted(t, path)
+	require.Equal(t, "secret-rotated", mid.Credentials["cred"].APIKeyPair.Secret,
+		"the first save must merge in the concurrent rotation")
+
+	p.Contexts["ctx"].CurrentEnvironment = "env-c" // p's second edit, still not touching the secret
+	require.NoError(t, p.Save())
+
+	final := loadDecrypted(t, path)
+	require.Equal(t, "secret-rotated", final.Credentials["cred"].APIKeyPair.Secret,
+		"the second save must not revert the concurrent rotation")
+	require.Equal(t, "env-c", final.Contexts["ctx"].CurrentEnvironment)
+}

--- a/pkg/config/config_concurrent_test.go
+++ b/pkg/config/config_concurrent_test.go
@@ -1,0 +1,44 @@
+package config
+
+import (
+	"fmt"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Two sessions each add a DIFFERENT platform concurrently. Before the lock+merge
+// work, the last writer's whole-file overwrite dropped the other's platform.
+func TestSave_ConcurrentDifferentFields_NoLostWrite(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+
+	seed := New()
+	seed.Filename = path
+	require.NoError(t, seed.Save())
+
+	const n = 8
+	var wg sync.WaitGroup
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			c, err := readConfigFromDisk(path, seed)
+			require.NoError(t, err)
+			c.snapshotBaseline()
+			name := fmt.Sprintf("platform-%d", i)
+			c.Platforms[name] = &Platform{Name: name}
+			require.NoError(t, c.Save())
+		}(i)
+	}
+	wg.Wait()
+
+	final, err := readConfigFromDisk(path, seed)
+	require.NoError(t, err)
+	for i := 0; i < n; i++ {
+		require.Contains(t, final.Platforms, fmt.Sprintf("platform-%d", i),
+			"every concurrent session's platform must survive")
+	}
+}

--- a/pkg/config/config_concurrent_test.go
+++ b/pkg/config/config_concurrent_test.go
@@ -42,3 +42,163 @@ func TestSave_ConcurrentDifferentFields_NoLostWrite(t *testing.T) {
 			"every concurrent session's platform must survive")
 	}
 }
+
+// helper: a saved single-context config with an API-key credential and two known
+// Kafka clusters (so switching the active cluster passes Validate).
+func newSavedConfig(t *testing.T, path, apiSecret string) {
+	t.Helper()
+
+	c := New()
+	c.Filename = path
+	c.Platforms["platform"] = &Platform{Name: "platform", Server: "https://example.com"}
+	c.Credentials["cred"] = &Credential{
+		Name:           "cred",
+		CredentialType: APIKey,
+		APIKeyPair:     &APIKeyPair{Key: "api-key", Secret: apiSecret},
+	}
+	state := new(ContextState)
+	ctx := &Context{
+		Name:               "ctx",
+		PlatformName:       "platform",
+		CredentialName:     "cred",
+		CurrentEnvironment: "env-a",
+		Platform:           c.Platforms["platform"],
+		Credential:         c.Credentials["cred"],
+		State:              state,
+		Config:             c,
+	}
+	ctx.KafkaClusterContext = &KafkaClusterContext{
+		ActiveKafkaCluster: "lkc-1",
+		KafkaClusterConfigs: map[string]*KafkaClusterConfig{
+			"lkc-1": {ID: "lkc-1", Name: "one"},
+			"lkc-2": {ID: "lkc-2", Name: "two"},
+		},
+		Context: ctx,
+	}
+	c.Contexts["ctx"] = ctx
+	c.ContextStates["ctx"] = state
+	c.CurrentContext = "ctx"
+
+	require.NoError(t, c.Save())
+}
+
+// helper: load and decrypt as PreRun does, leaving the live config plaintext while
+// the merge baseline stays encrypted (the split the three-way merge must tolerate).
+func loadDecrypted(t *testing.T, path string) *Config {
+	t.Helper()
+
+	c := New()
+	c.Filename = path
+	require.NoError(t, c.Load())
+	require.NoError(t, c.DecryptCredentials())
+	require.NoError(t, c.DecryptContextStates())
+	return c
+}
+
+// decryptToMatch must align the encrypted baseline to the live plaintext so an
+// untouched secret is not seen as changed. This holds by decryption, independent of
+// whether re-encryption would reproduce the ciphertext (it does not on Windows/DPAPI).
+func TestDecryptToMatch_AlignsBaselineToLivePlaintext(t *testing.T) {
+	plaintext := "top-secret"
+	stored := &APIKeyPair{Key: "k", Secret: plaintext}
+	require.NoError(t, stored.EncryptSecret())
+	require.True(t, isEncryptedSecret(stored.Secret))
+
+	base := New()
+	base.Credentials["cred"] = &Credential{Name: "cred", APIKeyPair: &APIKeyPair{
+		Key: "k", Secret: stored.Secret, Salt: stored.Salt, Nonce: stored.Nonce,
+	}}
+	ref := New()
+	ref.Credentials["cred"] = &Credential{Name: "cred", APIKeyPair: &APIKeyPair{Key: "k", Secret: plaintext}}
+
+	require.NoError(t, base.decryptToMatch(ref))
+
+	require.Equal(t, plaintext, base.Credentials["cred"].APIKeyPair.Secret,
+		"baseline secret must be decrypted to the live plaintext, so an untouched secret is not seen as changed")
+}
+
+// A stored plaintext token (e.g. a cloud refresh token, which is never encrypted)
+// carries no cipher prefix but may sit beside a salt. decryptToMatch must not feed
+// it to Decrypt, which would fail authentication on a value that was never encrypted.
+func TestDecryptToMatch_SkipsPlaintextBaselineTokens(t *testing.T) {
+	base := New()
+	base.ContextStates["ctx"] = &ContextState{
+		AuthRefreshToken: "refreshToken", // plaintext, no cipher prefix
+		Salt:             []byte("0123456789012345678901234"),
+		Nonce:            []byte("012345678901"),
+	}
+	ref := New()
+	ref.ContextStates["ctx"] = &ContextState{AuthRefreshToken: "refreshToken"}
+
+	require.NoError(t, base.decryptToMatch(ref), "a plaintext baseline token must be left as-is, not decrypted")
+	require.Equal(t, "refreshToken", base.ContextStates["ctx"].AuthRefreshToken)
+}
+
+// A merge can leave a plaintext token in a context that is not current at write time
+// (e.g. after a concurrent `context use` switch). encryptSecrets must encrypt every
+// context's token, not only the current one, so none reaches disk plaintext.
+func TestEncryptSecrets_EncryptsNonCurrentContextTokens(t *testing.T) {
+	c := New()
+	for _, name := range []string{"A", "B"} {
+		state := &ContextState{AuthToken: "org-1-y0ur.jwt.T0kEn"} // plaintext JWT-shaped token
+		ctx := &Context{Name: name, PlatformName: "https://confluent.cloud", State: state, Config: c}
+		ctx.KafkaClusterContext = &KafkaClusterContext{Context: ctx}
+		c.Contexts[name] = ctx
+		c.ContextStates[name] = state
+	}
+	c.CurrentContext = "B" // A is not current
+
+	require.NoError(t, c.encryptSecrets())
+
+	require.True(t, isEncryptedSecret(c.ContextStates["A"].AuthToken), "a non-current context's plaintext token must be encrypted")
+	require.True(t, isEncryptedSecret(c.ContextStates["B"].AuthToken), "the current context's token must be encrypted")
+}
+
+// Two sessions change different fields of the SAME context (environment vs. active
+// Kafka cluster). Both live inside one Contexts map value, so an atomic per-key
+// overlay drops the earlier writer's field; the merge must combine them.
+func TestSave_ConcurrentSameContextDifferentFields_NoLostWrite(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	newSavedConfig(t, path, "secret-original")
+
+	a := loadDecrypted(t, path)
+	b := loadDecrypted(t, path)
+
+	a.Contexts["ctx"].CurrentEnvironment = "env-b" // like `confluent environment use`
+	require.NoError(t, a.Save())
+
+	b.Contexts["ctx"].KafkaClusterContext.SetActiveKafkaCluster("lkc-2") // like `confluent kafka cluster use`
+	require.NoError(t, b.Save())
+
+	final := loadDecrypted(t, path)
+	require.Equal(t, "env-b", final.Contexts["ctx"].CurrentEnvironment,
+		"the environment change must survive the concurrent Kafka-cluster save")
+	require.Equal(t, "lkc-2", final.Contexts["ctx"].KafkaClusterContext.GetActiveKafkaClusterId(),
+		"the concurrent Kafka-cluster change must survive")
+}
+
+// A session that never touched a shared credential must not clobber another
+// session's concurrent update to it. The live copy is decrypted while the baseline
+// is encrypted, so a representation-blind diff wrongly reads the credential as
+// locally changed and overwrites the concurrent rotation.
+func TestSave_ConcurrentSharedCredential_NotClobbered(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	newSavedConfig(t, path, "secret-original")
+
+	b := loadDecrypted(t, path) // holds decrypted "secret-original"
+	a := loadDecrypted(t, path)
+
+	a.Credentials["cred"].APIKeyPair.Secret = "secret-rotated"
+	require.NoError(t, a.Save())
+
+	// b never touched the credential; it changes an unrelated field and saves after a.
+	b.Contexts["ctx"].CurrentEnvironment = "env-from-b"
+	require.NoError(t, b.Save())
+
+	final := loadDecrypted(t, path)
+	require.Equal(t, "secret-rotated", final.Credentials["cred"].APIKeyPair.Secret,
+		"a's concurrent credential rotation must not be clobbered by b's unrelated save")
+	require.Equal(t, "env-from-b", final.Contexts["ctx"].CurrentEnvironment)
+}

--- a/pkg/config/config_concurrent_test.go
+++ b/pkg/config/config_concurrent_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// Two sessions each add a DIFFERENT platform concurrently. Before the lock+merge
-// work, the last writer's whole-file overwrite dropped the other's platform.
+// each goroutine adds a different platform concurrently; before the lock and merge
+// work, the last writer's whole-file overwrite dropped the others.
 func TestSave_ConcurrentDifferentFields_NoLostWrite(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.json")

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -10,6 +10,7 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
@@ -1293,6 +1294,81 @@ func TestSave_MergesConcurrentDiskChange(t *testing.T) {
 	require.NotContains(t, final.Platforms, "a", "our delete must persist")
 	require.Contains(t, final.Platforms, "b")
 	require.Contains(t, final.Platforms, "c", "the other session's concurrent add must not be lost")
+}
+
+// A fresh machine has no ~/.confluent directory. Save() must create the parent
+// directory before opening the sidecar lock file inside it, or the lock open
+// ENOENTs and the CLI cannot start.
+func TestSave_CreatesMissingParentDirectory(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "does", "not", "exist", "config.json")
+
+	c := New()
+	c.Filename = path
+
+	require.NoError(t, c.Load(), "Load on a missing file Saves a default and must create the parent directory")
+	require.FileExists(t, path)
+
+	c.Platforms["p"] = &Platform{Name: "p"}
+	require.NoError(t, c.Save(), "a subsequent Save into the now-existing directory must also succeed")
+}
+
+// Validate() normalizes the config in memory (resetting an invalid active Kafka
+// cluster, initializing a nil KafkaClusterConfigs map) and re-persists via a
+// nested Context.Save(). That nested Save() runs while the enclosing Save()
+// holds the sidecar lock; it must not try to re-acquire it (which would block
+// for lockTimeout and then panic), and the normalization must reach disk.
+func TestSave_NormalizesInvalidActiveKafkaWithoutDeadlock(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+
+	// Seed a valid empty file so Save() takes the read-merge-write path that
+	// validates the throwaway "merged" config (the path the deadlock lived on).
+	seed := New()
+	seed.Filename = path
+	require.NoError(t, seed.Save())
+
+	// baseline = empty on-disk state, so the context below is a net addition and
+	// survives the three-way merge into "merged".
+	c := New()
+	c.Filename = path
+	c.snapshotBaseline()
+
+	c.Platforms["platform"] = &Platform{Name: "platform", Server: "https://example.com"}
+	c.Credentials["cred"] = &Credential{Name: "cred", CredentialType: Username}
+	state := new(ContextState)
+	ctx := &Context{
+		Name:           "ctx",
+		PlatformName:   "platform",
+		CredentialName: "cred",
+		Platform:       c.Platforms["platform"],
+		Credential:     c.Credentials["cred"],
+		State:          state,
+		Config:         c,
+	}
+	// Active cluster with no stored config and a nil configs map: Validate()
+	// resets the active cluster and initializes the map, each a nested Save().
+	ctx.KafkaClusterContext = &KafkaClusterContext{
+		ActiveKafkaCluster:  "lkc-ghost",
+		KafkaClusterConfigs: nil,
+		Context:             ctx,
+	}
+	c.Contexts["ctx"] = ctx
+	c.ContextStates["ctx"] = state
+	c.CurrentContext = "ctx"
+
+	done := make(chan error, 1)
+	go func() { done <- c.Save() }()
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("Save() deadlocked re-acquiring the sidecar lock during Validate() normalization")
+	}
+
+	final, err := readConfigFromDisk(path, seed)
+	require.NoError(t, err)
+	require.Empty(t, final.Contexts["ctx"].KafkaClusterContext.GetActiveKafkaClusterId(),
+		"the invalid active Kafka cluster reset must be persisted, not just held in memory")
 }
 
 func TestSnapshotBaseline_IsIndependentCopy(t *testing.T) {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -19,6 +19,7 @@ import (
 	ccloudv1 "github.com/confluentinc/ccloud-sdk-go-v1-public"
 
 	"github.com/confluentinc/cli/v4/pkg/errors"
+	"github.com/confluentinc/cli/v4/pkg/secret"
 	"github.com/confluentinc/cli/v4/pkg/utils"
 	pversion "github.com/confluentinc/cli/v4/pkg/version"
 	testserver "github.com/confluentinc/cli/v4/test/test-server"
@@ -1294,6 +1295,61 @@ func TestSave_MergesConcurrentDiskChange(t *testing.T) {
 	require.NotContains(t, final.Platforms, "a", "our delete must persist")
 	require.Contains(t, final.Platforms, "b")
 	require.Contains(t, final.Platforms, "c", "the other session's concurrent add must not be lost")
+}
+
+// A Confluent Platform (non-cloud) refresh token that happens to begin with the
+// bare cipher marker word (no ":") is still plaintext and must be encrypted, not
+// mistaken for ciphertext and skipped. Mirrors the APIKeyPair delimiter fix.
+func TestEncryptContextStateTokens_EncryptsPlatformRefreshTokenBeginningWithCipherWord(t *testing.T) {
+	c := New()
+	c.Platforms["p"] = &Platform{Name: "p", Server: "https://mds.example.com"}
+	c.Credentials["cred"] = &Credential{Name: "cred", CredentialType: Username}
+	state := &ContextState{}
+	ctx := &Context{
+		Name:           "ctx",
+		PlatformName:   "https://mds.example.com",
+		CredentialName: "cred",
+		Platform:       c.Platforms["p"],
+		Credential:     c.Credentials["cred"],
+		State:          state,
+		Config:         c,
+	}
+	ctx.KafkaClusterContext = &KafkaClusterContext{Context: ctx}
+	c.Contexts["ctx"] = ctx
+	c.ContextStates["ctx"] = state
+	c.CurrentContext = "ctx"
+
+	refresh := secret.AesGcm + "-not-actually-encrypted" // begins with the marker word, no ":"
+	state.AuthRefreshToken = refresh
+
+	require.NoError(t, c.encryptContextStateTokens("", refresh))
+
+	require.NotEqual(t, refresh, state.AuthRefreshToken,
+		"a non-cloud refresh token merely beginning with the cipher word must be encrypted")
+}
+
+// A config that was constructed rather than loaded has no baseline, so there is
+// nothing to merge against and it declares its state whole (e.g. test config
+// reset). Save() must overwrite the existing file, not treat the live object as
+// unchanged and silently keep disk's values.
+func TestSave_NoBaselineOverwritesExistingFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+
+	seed := New()
+	seed.Filename = path
+	seed.DisablePlugins = false
+	require.NoError(t, seed.Save())
+
+	fresh := New()
+	fresh.Filename = path
+	fresh.DisablePlugins = true
+	require.NoError(t, fresh.Save())
+
+	final, err := readConfigFromDisk(path, seed)
+	require.NoError(t, err)
+	require.True(t, final.DisablePlugins,
+		"a constructed (never-loaded) config's Save must overwrite the existing file, not merge it away")
 }
 
 // A fresh machine has no ~/.confluent directory. Save() must create the parent

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -269,6 +269,8 @@ func TestConfig_Load(t *testing.T) {
 				ctx.KafkaClusterContext.KafkaClusterConfigs = cfg.Contexts[contextName].KafkaClusterContext.KafkaClusterConfigs
 			}
 
+			// baseline is a load-time impl detail, not under test here.
+			cfg.baseline = nil
 			if !t.Failed() && !reflect.DeepEqual(cfg, test.want) {
 				t.Errorf("Config.Load() =\n%+v, want \n%+v", cfg, test.want)
 			}
@@ -709,6 +711,8 @@ func TestConfig_AddContext(t *testing.T) {
 			if (err != nil) != test.wantErr {
 				t.Errorf("AddContext() error = %v, wantErr %v", err, test.wantErr)
 			}
+			// baseline is a save-time impl detail, not under test here.
+			test.config.baseline = nil
 			if !test.wantErr && !reflect.DeepEqual(test.want, test.config) {
 				t.Errorf("AddContext() got = %v, want %v", test.config, test.want)
 			}
@@ -726,6 +730,9 @@ func TestConfig_CreateContext(t *testing.T) {
 	}
 
 	SetTempHomeDir()
+	// Isolate from the shared default config path so Save's read-merge can't pick
+	// up another test's leftover config.
+	cfg.Filename = filepath.Join(t.TempDir(), "config.json")
 	err := cfg.CreateContext("context", "https://example.com", "api-key", "api-secret")
 	require.NoError(t, err)
 
@@ -738,6 +745,9 @@ func TestConfig_CreateContext(t *testing.T) {
 
 func TestConfig_UseContext(t *testing.T) {
 	cfg := AuthenticatedCloudConfigMock()
+	// Isolate from the shared default config path so Save's read-merge can't pick
+	// up (or leave behind) another test's leftover config.
+	cfg.Filename = filepath.Join(t.TempDir(), "config.json")
 	contextName := cfg.Context().Name
 	cfg.CurrentContext = ""
 	type fields struct {
@@ -1250,6 +1260,39 @@ func TestReadConfigFromDisk_WiresGraphAndPassesValidate(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, path, got.Filename, "json:\"-\" Filename must be carried from the template")
 	require.NoError(t, got.Validate())
+}
+
+func TestSave_MergesConcurrentDiskChange(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+
+	// Seed: two platforms.
+	seed := New()
+	seed.Filename = path
+	seed.Platforms["a"] = &Platform{Name: "a"}
+	seed.Platforms["b"] = &Platform{Name: "b"}
+	require.NoError(t, seed.Save())
+
+	// This process loads, then another session adds platform "c" on disk.
+	ours, err := readConfigFromDisk(path, seed)
+	require.NoError(t, err)
+	ours.snapshotBaseline()
+
+	other, err := readConfigFromDisk(path, seed)
+	require.NoError(t, err)
+	other.snapshotBaseline()
+	other.Platforms["c"] = &Platform{Name: "c"}
+	require.NoError(t, other.Save())
+
+	// Now this process deletes "a" and saves.
+	delete(ours.Platforms, "a")
+	require.NoError(t, ours.Save())
+
+	final, err := readConfigFromDisk(path, seed)
+	require.NoError(t, err)
+	require.NotContains(t, final.Platforms, "a", "our delete must persist")
+	require.Contains(t, final.Platforms, "b")
+	require.Contains(t, final.Platforms, "c", "the other session's concurrent add must not be lost")
 }
 
 func TestSnapshotBaseline_IsIndependentCopy(t *testing.T) {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1237,3 +1237,27 @@ func TestParseFlagsIntoConfig(t *testing.T) {
 		}
 	}
 }
+
+func TestReadConfigFromDisk_WiresGraphAndPassesValidate(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+
+	seed := New()
+	seed.Filename = path
+	require.NoError(t, seed.Save())
+
+	got, err := readConfigFromDisk(path, seed)
+	require.NoError(t, err)
+	require.Equal(t, path, got.Filename, "json:\"-\" Filename must be carried from the template")
+	require.NoError(t, got.Validate())
+}
+
+func TestSnapshotBaseline_IsIndependentCopy(t *testing.T) {
+	c := New()
+	c.CurrentContext = "a"
+	c.snapshotBaseline()
+
+	c.CurrentContext = "b"
+
+	require.Equal(t, "a", c.baseline.CurrentContext, "baseline must not alias live config")
+}

--- a/pkg/config/lock.go
+++ b/pkg/config/lock.go
@@ -6,12 +6,20 @@ import (
 	"time"
 
 	"github.com/confluentinc/cli/v4/pkg/errors"
+	"github.com/confluentinc/cli/v4/pkg/output"
 )
 
-// lockTimeout bounds how long a writer waits for the sidecar lock. It must
-// dwarf the sub-millisecond read-modify-write it guards, so only genuine
-// contention, never the operation itself, can time out.
-const lockTimeout = 10 * time.Second
+// lockTimeout bounds how long a writer waits for the sidecar lock. It still
+// dwarfs the sub-millisecond read-modify-write it guards, so only genuine
+// contention can time out, but is short enough to fail fast rather than hang a
+// user behind a stuck or long-running peer.
+const lockTimeout = 3 * time.Second
+
+// contentionWarnDelay is how long lock() polls unsuccessfully before printing a
+// one-time note that another process holds the lock. It sits well under
+// lockTimeout, so a genuinely contended wait is explained while the
+// sub-millisecond common case stays silent.
+const contentionWarnDelay = 1 * time.Second
 
 // fileLock guards config writes with a sidecar `<config>.lock` file. We lock a
 // dedicated sidecar, never the data file: the atomic rename in writeFileAtomic
@@ -39,12 +47,41 @@ func (l *fileLock) lock(timeout time.Duration) error {
 	}
 	l.f = f
 
-	if err := lockHandle(f, timeout); err != nil {
+	if err := acquireWithTimeout(f, timeout); err != nil {
 		f.Close()
 		l.f = nil
 		return err
 	}
 	return nil
+}
+
+// acquireWithTimeout polls tryLockHandle (the per-OS non-blocking single
+// attempt) until it acquires the lock or timeout elapses. A blocking OS lock
+// would ignore the timeout, so we spin at a fixed interval. After
+// contentionWarnDelay of failed attempts it prints a one-time stderr note, so a
+// user genuinely waiting on another confluent process is not left staring at a
+// silent hang; the fast common case acquires on the first try and stays quiet.
+func acquireWithTimeout(f *os.File, timeout time.Duration) error {
+	start := time.Now()
+	deadline := start.Add(timeout)
+	warned := false
+	for {
+		acquired, err := tryLockHandle(f)
+		if err != nil {
+			return fmt.Errorf("unable to lock config file: %w", err)
+		}
+		if acquired {
+			return nil
+		}
+		if !warned && time.Since(start) >= contentionWarnDelay {
+			output.ErrPrintln(false, "Waiting for another confluent process to finish updating the configuration file...")
+			warned = true
+		}
+		if time.Now().After(deadline) {
+			return errConfigLockContended
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
 }
 
 // unlock releases the lock and closes the underlying file handle. It is a no-op if the lock

--- a/pkg/config/lock.go
+++ b/pkg/config/lock.go
@@ -10,7 +10,7 @@ import (
 
 // lockTimeout bounds how long a writer waits for the sidecar lock. It must
 // dwarf the sub-millisecond read-modify-write it guards, so only genuine
-// contention — never the operation itself — can time out.
+// contention, never the operation itself, can time out.
 const lockTimeout = 10 * time.Second
 
 // fileLock guards config writes with a sidecar `<config>.lock` file. We lock a

--- a/pkg/config/lock.go
+++ b/pkg/config/lock.go
@@ -24,10 +24,14 @@ type fileLock struct {
 	f    *os.File
 }
 
+// newFileLock builds a lock for the sidecar file next to configPath. It does not open or
+// acquire anything yet; call lock to do that.
 func newFileLock(configPath string) *fileLock {
 	return &fileLock{path: configPath + ".lock"}
 }
 
+// lock opens (creating if needed) the sidecar file and blocks until it acquires an exclusive
+// lock on it or timeout elapses, whichever comes first.
 func (l *fileLock) lock(timeout time.Duration) error {
 	f, err := os.OpenFile(l.path, os.O_CREATE|os.O_RDWR, 0600)
 	if err != nil {
@@ -43,6 +47,8 @@ func (l *fileLock) lock(timeout time.Duration) error {
 	return nil
 }
 
+// unlock releases the lock and closes the underlying file handle. It is a no-op if the lock
+// was never acquired.
 func (l *fileLock) unlock() error {
 	if l.f == nil {
 		return nil

--- a/pkg/config/lock.go
+++ b/pkg/config/lock.go
@@ -1,0 +1,62 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/confluentinc/cli/v4/pkg/errors"
+)
+
+// lockTimeout bounds how long a writer waits for the sidecar lock. It must
+// dwarf the sub-millisecond read-modify-write it guards, so only genuine
+// contention — never the operation itself — can time out.
+const lockTimeout = 10 * time.Second
+
+// fileLock guards config writes with a sidecar `<config>.lock` file. We lock a
+// dedicated sidecar, never the data file: the atomic rename in writeFileAtomic
+// swaps a new inode into the data path, so a flock held on the data file would
+// stop excluding anyone. The sidecar is created once and never renamed or
+// unlinked. flock (POSIX) and LockFileEx (Windows) both release on handle close
+// or process death, so there is deliberately no stale-lock recovery.
+type fileLock struct {
+	path string
+	f    *os.File
+}
+
+func newFileLock(configPath string) *fileLock {
+	return &fileLock{path: configPath + ".lock"}
+}
+
+func (l *fileLock) lock(timeout time.Duration) error {
+	f, err := os.OpenFile(l.path, os.O_CREATE|os.O_RDWR, 0600)
+	if err != nil {
+		return fmt.Errorf("unable to open config lock file %s: %w", l.path, err)
+	}
+	l.f = f
+
+	if err := lockHandle(f, timeout); err != nil {
+		f.Close()
+		l.f = nil
+		return err
+	}
+	return nil
+}
+
+func (l *fileLock) unlock() error {
+	if l.f == nil {
+		return nil
+	}
+	err := unlockHandle(l.f)
+	closeErr := l.f.Close()
+	l.f = nil
+	if err != nil {
+		return err
+	}
+	return closeErr
+}
+
+var errConfigLockContended = errors.NewErrorWithSuggestions(
+	"another `confluent` process is updating the configuration file",
+	"Wait for the other command to finish, then retry.",
+)

--- a/pkg/config/lock_other.go
+++ b/pkg/config/lock_other.go
@@ -24,7 +24,7 @@ func tryLockHandle(f *os.File) (bool, error) {
 	return false, err
 }
 
-// unlockHandle releases the flock taken by lockHandle.
+// unlockHandle releases the flock taken by tryLockHandle.
 func unlockHandle(f *os.File) error {
 	return unix.Flock(int(f.Fd()), unix.LOCK_UN)
 }

--- a/pkg/config/lock_other.go
+++ b/pkg/config/lock_other.go
@@ -1,34 +1,27 @@
-//go:build !windows
+//go:build darwin || linux
 
 package config
 
 import (
-	"fmt"
 	"os"
-	"time"
 
 	"golang.org/x/sys/unix"
 )
 
-// lockHandle takes an exclusive flock, polling in non-blocking mode so we can honor the
-// timeout (a bare LOCK_EX would block uninterruptibly). Only EWOULDBLOCK means contention
-// from another holder; any other error is a real failure and is returned immediately
-// instead of being retried until timeout.
-func lockHandle(f *os.File, timeout time.Duration) error {
-	deadline := time.Now().Add(timeout)
-	for {
-		err := unix.Flock(int(f.Fd()), unix.LOCK_EX|unix.LOCK_NB)
-		if err == nil {
-			return nil
-		}
-		if err != unix.EWOULDBLOCK {
-			return fmt.Errorf("unable to lock config file: %w", err)
-		}
-		if time.Now().After(deadline) {
-			return errConfigLockContended
-		}
-		time.Sleep(10 * time.Millisecond)
+// tryLockHandle makes one non-blocking attempt at an exclusive flock. It reports
+// whether the lock was acquired; EWOULDBLOCK means another holder has it (not
+// acquired, no error), while any other error is a real failure. The shared
+// acquireWithTimeout loop owns the polling and timeout (a bare LOCK_EX would
+// block uninterruptibly and ignore the timeout).
+func tryLockHandle(f *os.File) (bool, error) {
+	err := unix.Flock(int(f.Fd()), unix.LOCK_EX|unix.LOCK_NB)
+	if err == nil {
+		return true, nil
 	}
+	if err == unix.EWOULDBLOCK {
+		return false, nil
+	}
+	return false, err
 }
 
 // unlockHandle releases the flock taken by lockHandle.

--- a/pkg/config/lock_other.go
+++ b/pkg/config/lock_other.go
@@ -10,8 +10,10 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-// lockHandle takes an exclusive flock, polling in non-blocking mode so we can
-// honor the timeout (a bare LOCK_EX would block uninterruptibly).
+// lockHandle takes an exclusive flock, polling in non-blocking mode so we can honor the
+// timeout (a bare LOCK_EX would block uninterruptibly). Only EWOULDBLOCK means contention
+// from another holder; any other error is a real failure and is returned immediately
+// instead of being retried until timeout.
 func lockHandle(f *os.File, timeout time.Duration) error {
 	deadline := time.Now().Add(timeout)
 	for {
@@ -29,6 +31,7 @@ func lockHandle(f *os.File, timeout time.Duration) error {
 	}
 }
 
+// unlockHandle releases the flock taken by lockHandle.
 func unlockHandle(f *os.File) error {
 	return unix.Flock(int(f.Fd()), unix.LOCK_UN)
 }

--- a/pkg/config/lock_other.go
+++ b/pkg/config/lock_other.go
@@ -1,0 +1,34 @@
+//go:build !windows
+
+package config
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+// lockHandle takes an exclusive flock, polling in non-blocking mode so we can
+// honor the timeout (a bare LOCK_EX would block uninterruptibly).
+func lockHandle(f *os.File, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for {
+		err := unix.Flock(int(f.Fd()), unix.LOCK_EX|unix.LOCK_NB)
+		if err == nil {
+			return nil
+		}
+		if err != unix.EWOULDBLOCK {
+			return fmt.Errorf("unable to lock config file: %w", err)
+		}
+		if time.Now().After(deadline) {
+			return errConfigLockContended
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func unlockHandle(f *os.File) error {
+	return unix.Flock(int(f.Fd()), unix.LOCK_UN)
+}

--- a/pkg/config/lock_test.go
+++ b/pkg/config/lock_test.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -22,20 +21,23 @@ func TestFileLock_SerializesTwoHolders(t *testing.T) {
 	_, err := os.Stat(cfgPath + ".lock")
 	require.NoError(t, err)
 
-	var held atomic.Bool
-	held.Store(true)
+	// The second holder signals the instant it acquires. That signal must not
+	// arrive while l1 still holds the lock, and must arrive once l1 releases.
 	acquired := make(chan struct{})
-
 	go func() {
 		l2 := newFileLock(cfgPath)
 		require.NoError(t, l2.lock(lockTimeout))
-		require.False(t, held.Load(), "second holder acquired while first still held the lock")
-		require.NoError(t, l2.unlock())
 		close(acquired)
+		require.NoError(t, l2.unlock())
 	}()
 
-	time.Sleep(100 * time.Millisecond) // give the goroutine time to block on lock()
-	held.Store(false)
+	select {
+	case <-acquired:
+		t.Fatal("second holder acquired the lock while the first still held it")
+	case <-time.After(200 * time.Millisecond):
+		// Expected: still blocked on the held lock.
+	}
+
 	require.NoError(t, l1.unlock())
 
 	select {

--- a/pkg/config/lock_test.go
+++ b/pkg/config/lock_test.go
@@ -1,0 +1,57 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFileLock_SerializesTwoHolders(t *testing.T) {
+	cfgPath := filepath.Join(t.TempDir(), "config.json")
+
+	l1 := newFileLock(cfgPath)
+	require.NoError(t, l1.lock(lockTimeout))
+
+	// The sidecar sits next to the data file and is created, not the data file.
+	_, err := os.Stat(cfgPath + ".lock")
+	require.NoError(t, err)
+
+	var held atomic.Bool
+	held.Store(true)
+	acquired := make(chan struct{})
+
+	go func() {
+		l2 := newFileLock(cfgPath)
+		require.NoError(t, l2.lock(lockTimeout))
+		require.False(t, held.Load(), "second holder acquired while first still held the lock")
+		require.NoError(t, l2.unlock())
+		close(acquired)
+	}()
+
+	time.Sleep(100 * time.Millisecond) // give the goroutine time to block on lock()
+	held.Store(false)
+	require.NoError(t, l1.unlock())
+
+	select {
+	case <-acquired:
+	case <-time.After(lockTimeout):
+		t.Fatal("second holder never acquired the lock after release")
+	}
+}
+
+func TestFileLock_TimesOut(t *testing.T) {
+	cfgPath := filepath.Join(t.TempDir(), "config.json")
+
+	l1 := newFileLock(cfgPath)
+	require.NoError(t, l1.lock(lockTimeout))
+	defer func() { _ = l1.unlock() }()
+
+	l2 := newFileLock(cfgPath)
+	err := l2.lock(50 * time.Millisecond)
+
+	require.Error(t, err)
+}

--- a/pkg/config/lock_test.go
+++ b/pkg/config/lock_test.go
@@ -1,8 +1,10 @@
 package config
 
 import (
+	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -54,4 +56,53 @@ func TestFileLock_TimesOut(t *testing.T) {
 	err := l2.lock(50 * time.Millisecond)
 
 	require.Error(t, err)
+}
+
+// A writer that waits past contentionWarnDelay for a held lock prints a one-time
+// note, so a user is not left staring at a silent hang. The uncontended fast path
+// (which every other test exercises) must stay quiet.
+func TestFileLock_WarnsOnlyAfterSustainedContention(t *testing.T) {
+	cfgPath := filepath.Join(t.TempDir(), "config.json")
+	const waitingNote = "Waiting for another confluent process"
+
+	// Contended: the first holder keeps the lock while the second waits past the
+	// warn delay before timing out, so the note must appear exactly once.
+	l1 := newFileLock(cfgPath)
+	require.NoError(t, l1.lock(lockTimeout))
+
+	contendedStderr := captureStderr(t, func() {
+		l2 := newFileLock(cfgPath)
+		require.Error(t, l2.lock(contentionWarnDelay+500*time.Millisecond))
+	})
+	require.NoError(t, l1.unlock())
+
+	require.Equal(t, 1, strings.Count(contendedStderr, waitingNote), "the waiting note must print exactly once under sustained contention")
+
+	// Uncontended: the lock is free, so acquisition is immediate and silent.
+	uncontendedStderr := captureStderr(t, func() {
+		l3 := newFileLock(cfgPath)
+		require.NoError(t, l3.lock(lockTimeout))
+		require.NoError(t, l3.unlock())
+	})
+
+	require.NotContains(t, uncontendedStderr, waitingNote, "the fast uncontended path must not print the waiting note")
+}
+
+// captureStderr redirects os.Stderr for the duration of fn and returns what was
+// written, so a test can assert on output.ErrPrintln notices.
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	orig := os.Stderr
+	os.Stderr = w
+	defer func() { os.Stderr = orig }()
+
+	fn()
+
+	require.NoError(t, w.Close())
+	out, err := io.ReadAll(r)
+	require.NoError(t, err)
+	return string(out)
 }

--- a/pkg/config/lock_windows.go
+++ b/pkg/config/lock_windows.go
@@ -3,35 +3,27 @@
 package config
 
 import (
-	"fmt"
 	"os"
-	"time"
 
 	"golang.org/x/sys/windows"
 )
 
-// lockHandle takes an exclusive lock, polling in non-blocking mode so we can honor the
-// timeout (a blocking LockFileEx would block uninterruptibly). Only ERROR_LOCK_VIOLATION
-// means contention from another holder; any other error is a real failure and is returned
-// immediately instead of being retried until timeout.
-func lockHandle(f *os.File, timeout time.Duration) error {
-	handle := windows.Handle(f.Fd())
-	deadline := time.Now().Add(timeout)
+// tryLockHandle makes one non-blocking attempt at an exclusive lock. It reports
+// whether the lock was acquired; ERROR_LOCK_VIOLATION means another holder has
+// it (not acquired, no error), while any other error is a real failure. The
+// shared acquireWithTimeout loop owns the polling and timeout (a blocking
+// LockFileEx would block uninterruptibly and ignore the timeout).
+func tryLockHandle(f *os.File) (bool, error) {
 	var overlapped windows.Overlapped
-	for {
-		// LOCKFILE_FAIL_IMMEDIATELY makes the call non-blocking so we can poll to a deadline.
-		err := windows.LockFileEx(handle, windows.LOCKFILE_EXCLUSIVE_LOCK|windows.LOCKFILE_FAIL_IMMEDIATELY, 0, 1, 0, &overlapped)
-		if err == nil {
-			return nil
-		}
-		if err != windows.ERROR_LOCK_VIOLATION {
-			return fmt.Errorf("unable to lock config file: %w", err)
-		}
-		if time.Now().After(deadline) {
-			return errConfigLockContended
-		}
-		time.Sleep(10 * time.Millisecond)
+	// LOCKFILE_FAIL_IMMEDIATELY makes the call non-blocking so the shared loop can poll.
+	err := windows.LockFileEx(windows.Handle(f.Fd()), windows.LOCKFILE_EXCLUSIVE_LOCK|windows.LOCKFILE_FAIL_IMMEDIATELY, 0, 1, 0, &overlapped)
+	if err == nil {
+		return true, nil
 	}
+	if err == windows.ERROR_LOCK_VIOLATION {
+		return false, nil
+	}
+	return false, err
 }
 
 // unlockHandle releases the lock taken by lockHandle.

--- a/pkg/config/lock_windows.go
+++ b/pkg/config/lock_windows.go
@@ -1,0 +1,32 @@
+//go:build windows
+
+package config
+
+import (
+	"os"
+	"time"
+
+	"golang.org/x/sys/windows"
+)
+
+func lockHandle(f *os.File, timeout time.Duration) error {
+	handle := windows.Handle(f.Fd())
+	deadline := time.Now().Add(timeout)
+	var overlapped windows.Overlapped
+	for {
+		// LOCKFILE_FAIL_IMMEDIATELY makes the call non-blocking so we can poll to a deadline.
+		err := windows.LockFileEx(handle, windows.LOCKFILE_EXCLUSIVE_LOCK|windows.LOCKFILE_FAIL_IMMEDIATELY, 0, 1, 0, &overlapped)
+		if err == nil {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return errConfigLockContended
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func unlockHandle(f *os.File) error {
+	var overlapped windows.Overlapped
+	return windows.UnlockFileEx(windows.Handle(f.Fd()), 0, 1, 0, &overlapped)
+}

--- a/pkg/config/lock_windows.go
+++ b/pkg/config/lock_windows.go
@@ -26,7 +26,7 @@ func tryLockHandle(f *os.File) (bool, error) {
 	return false, err
 }
 
-// unlockHandle releases the lock taken by lockHandle.
+// unlockHandle releases the lock taken by tryLockHandle.
 func unlockHandle(f *os.File) error {
 	var overlapped windows.Overlapped
 	return windows.UnlockFileEx(windows.Handle(f.Fd()), 0, 1, 0, &overlapped)

--- a/pkg/config/lock_windows.go
+++ b/pkg/config/lock_windows.go
@@ -3,12 +3,17 @@
 package config
 
 import (
+	"fmt"
 	"os"
 	"time"
 
 	"golang.org/x/sys/windows"
 )
 
+// lockHandle takes an exclusive lock, polling in non-blocking mode so we can honor the
+// timeout (a blocking LockFileEx would block uninterruptibly). Only ERROR_LOCK_VIOLATION
+// means contention from another holder; any other error is a real failure and is returned
+// immediately instead of being retried until timeout.
 func lockHandle(f *os.File, timeout time.Duration) error {
 	handle := windows.Handle(f.Fd())
 	deadline := time.Now().Add(timeout)
@@ -19,6 +24,9 @@ func lockHandle(f *os.File, timeout time.Duration) error {
 		if err == nil {
 			return nil
 		}
+		if err != windows.ERROR_LOCK_VIOLATION {
+			return fmt.Errorf("unable to lock config file: %w", err)
+		}
 		if time.Now().After(deadline) {
 			return errConfigLockContended
 		}
@@ -26,6 +34,7 @@ func lockHandle(f *os.File, timeout time.Duration) error {
 	}
 }
 
+// unlockHandle releases the lock taken by lockHandle.
 func unlockHandle(f *os.File) error {
 	var overlapped windows.Overlapped
 	return windows.UnlockFileEx(windows.Handle(f.Fd()), 0, 1, 0, &overlapped)

--- a/pkg/config/merge.go
+++ b/pkg/config/merge.go
@@ -1,0 +1,78 @@
+package config
+
+import "reflect"
+
+// threeWayMerge produces the config to persist. Disk ("theirs") is the base:
+// fields another session changed and this process did not touch are preserved.
+// This process's own changes — computed as base ("common ancestor") vs ours —
+// are then overlaid. For scalars, a value we changed from base wins; a value we
+// left alone keeps disk's. For maps, our adds/updates win and our deletes (in
+// base, absent from ours) are removed from disk, while keys only present on disk
+// survive.
+//
+// Field-class table (every persisted field of Config must appear here):
+//
+//	scalars:  DisableFeatureFlags, DisablePlugins, DisablePluginsOnceWindows,
+//	          DisableUpdateCheck, EnableColor, CurrentContext, DisablePluginsOnce
+//	*time:    LastUpdateCheckAt
+//	*struct:  LocalPorts
+//	maps:     Platforms, Credentials, Contexts, ContextStates, SavedCredentials
+func threeWayMerge(base, ours, disk *Config) *Config {
+	out := disk
+
+	out.DisableFeatureFlags = mergeScalar(base.DisableFeatureFlags, ours.DisableFeatureFlags, disk.DisableFeatureFlags)
+	out.DisablePlugins = mergeScalar(base.DisablePlugins, ours.DisablePlugins, disk.DisablePlugins)
+	out.DisablePluginsOnceWindows = mergeScalar(base.DisablePluginsOnceWindows, ours.DisablePluginsOnceWindows, disk.DisablePluginsOnceWindows)
+	out.DisableUpdateCheck = mergeScalar(base.DisableUpdateCheck, ours.DisableUpdateCheck, disk.DisableUpdateCheck)
+	out.EnableColor = mergeScalar(base.EnableColor, ours.EnableColor, disk.EnableColor)
+	out.CurrentContext = mergeScalar(base.CurrentContext, ours.CurrentContext, disk.CurrentContext)
+	out.DisablePluginsOnce = mergeScalar(base.DisablePluginsOnce, ours.DisablePluginsOnce, disk.DisablePluginsOnce)
+
+	out.LastUpdateCheckAt = mergePtr(base.LastUpdateCheckAt, ours.LastUpdateCheckAt, disk.LastUpdateCheckAt)
+	out.LocalPorts = mergePtr(base.LocalPorts, ours.LocalPorts, disk.LocalPorts)
+
+	out.Platforms = mergeMap(out.Platforms, base.Platforms, ours.Platforms)
+	out.Credentials = mergeMap(out.Credentials, base.Credentials, ours.Credentials)
+	out.Contexts = mergeMap(out.Contexts, base.Contexts, ours.Contexts)
+	out.ContextStates = mergeMap(out.ContextStates, base.ContextStates, ours.ContextStates)
+	out.SavedCredentials = mergeMap(out.SavedCredentials, base.SavedCredentials, ours.SavedCredentials)
+
+	return out
+}
+
+// mergeScalar returns ours if this process changed it from base, else disk's.
+func mergeScalar[T comparable](base, ours, disk T) T {
+	if ours != base {
+		return ours
+	}
+	return disk
+}
+
+// mergePtr treats a pointer field like a scalar, comparing pointed-to values.
+func mergePtr[T any](base, ours, disk *T) *T {
+	if !reflect.DeepEqual(base, ours) {
+		return ours
+	}
+	return disk
+}
+
+// mergeMap overlays this process's adds/updates/deletes onto the disk map.
+// Keys only on disk (a concurrent add) survive; keys we deleted (in base, not in
+// ours) are removed; keys we added or changed take our value.
+func mergeMap[V any](out, base, ours map[string]V) map[string]V {
+	if out == nil {
+		out = map[string]V{}
+	}
+	for k := range base {
+		if _, keptByUs := ours[k]; !keptByUs {
+			delete(out, k)
+		}
+	}
+	for k, v := range ours {
+		bv, inBase := base[k]
+		if !inBase || !reflect.DeepEqual(bv, v) {
+			out[k] = v
+		}
+	}
+	return out
+}

--- a/pkg/config/merge.go
+++ b/pkg/config/merge.go
@@ -4,7 +4,7 @@ import "reflect"
 
 // threeWayMerge produces the config to persist. Disk ("theirs") is the base:
 // fields another session changed and this process did not touch are preserved.
-// This process's own changes — computed as base ("common ancestor") vs ours —
+// This process's own changes, computed as base ("common ancestor") vs ours,
 // are then overlaid. For scalars, a value we changed from base wins; a value we
 // left alone keeps disk's. For maps, our adds/updates win and our deletes (in
 // base, absent from ours) are removed from disk, while keys only present on disk

--- a/pkg/config/merge.go
+++ b/pkg/config/merge.go
@@ -1,23 +1,27 @@
 package config
 
-import "reflect"
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"reflect"
+)
 
-// threeWayMerge produces the config to persist. Disk ("theirs") is the base:
-// fields another session changed and this process did not touch are preserved.
-// This process's own changes, computed as base ("common ancestor") vs ours,
-// are then overlaid. For scalars, a value we changed from base wins; a value we
-// left alone keeps disk's. For maps, our adds/updates win and our deletes (in
-// base, absent from ours) are removed from disk, while keys only present on disk
-// survive.
+// threeWayMerge produces the config to persist. Disk ("theirs") is the base onto
+// which this process's own changes are overlaid: a field another session changed
+// and this process did not touch is preserved. base is the common ancestor (our
+// view of the persisted state as of our last load or successful save); ours is
+// our current state. Scalars and pointer fields take ours when we changed them
+// from base, else disk's. Map fields merge per key AND per nested field, so two
+// sessions that changed different fields of the same value (for example a
+// context's environment vs. its active Kafka cluster) both survive; a key present
+// only on disk (a concurrent add) survives, and a key we deleted (in base, absent
+// from ours) is removed.
 //
-// Field-class table (every persisted field of Config must appear here):
-//
-//	scalars:  DisableFeatureFlags, DisablePlugins, DisablePluginsOnceWindows,
-//	          DisableUpdateCheck, EnableColor, CurrentContext, DisablePluginsOnce
-//	*time:    LastUpdateCheckAt
-//	*struct:  LocalPorts
-//	maps:     Platforms, Credentials, Contexts, ContextStates, SavedCredentials
-func threeWayMerge(base, ours, disk *Config) *Config {
+// Secrets must be in the same (encrypted) representation across all three inputs
+// before this runs, or a secret we never touched reads as a local change and
+// overwrites a concurrent update. saveLocked guarantees that via encryptSecrets.
+func threeWayMerge(base, ours, disk *Config) (*Config, error) {
 	out := disk
 
 	out.DisableFeatureFlags = mergeScalar(base.DisableFeatureFlags, ours.DisableFeatureFlags, disk.DisableFeatureFlags)
@@ -31,13 +35,24 @@ func threeWayMerge(base, ours, disk *Config) *Config {
 	out.LastUpdateCheckAt = mergePtr(base.LastUpdateCheckAt, ours.LastUpdateCheckAt, disk.LastUpdateCheckAt)
 	out.LocalPorts = mergePtr(base.LocalPorts, ours.LocalPorts, disk.LocalPorts)
 
-	out.Platforms = mergeMap(out.Platforms, base.Platforms, ours.Platforms)
-	out.Credentials = mergeMap(out.Credentials, base.Credentials, ours.Credentials)
-	out.Contexts = mergeMap(out.Contexts, base.Contexts, ours.Contexts)
-	out.ContextStates = mergeMap(out.ContextStates, base.ContextStates, ours.ContextStates)
-	out.SavedCredentials = mergeMap(out.SavedCredentials, base.SavedCredentials, ours.SavedCredentials)
+	var err error
+	if out.Platforms, err = mergeMapDeep(base.Platforms, ours.Platforms, disk.Platforms); err != nil {
+		return nil, err
+	}
+	if out.Credentials, err = mergeMapDeep(base.Credentials, ours.Credentials, disk.Credentials); err != nil {
+		return nil, err
+	}
+	if out.Contexts, err = mergeMapDeep(base.Contexts, ours.Contexts, disk.Contexts); err != nil {
+		return nil, err
+	}
+	if out.ContextStates, err = mergeMapDeep(base.ContextStates, ours.ContextStates, disk.ContextStates); err != nil {
+		return nil, err
+	}
+	if out.SavedCredentials, err = mergeMapDeep(base.SavedCredentials, ours.SavedCredentials, disk.SavedCredentials); err != nil {
+		return nil, err
+	}
 
-	return out
+	return out, nil
 }
 
 // mergeScalar returns ours if this process changed it from base, else disk's.
@@ -56,23 +71,115 @@ func mergePtr[T any](base, ours, disk *T) *T {
 	return disk
 }
 
-// mergeMap overlays this process's adds/updates/deletes onto the disk map.
-// Keys only on disk (a concurrent add) survive; keys we deleted (in base, not in
-// ours) are removed; keys we added or changed take our value.
-func mergeMap[V any](out, base, ours map[string]V) map[string]V {
+// mergeMapDeep three-way-merges one map field, recursing into each value's nested
+// structure so concurrent edits to different fields of the same value both
+// survive. It works in generic JSON form (map -> tree -> map) so it needs no
+// per-type knowledge; base is the common ancestor, ours our current map, disk the
+// on-disk map that changes are overlaid onto.
+func mergeMapDeep[V any](base, ours, disk map[string]V) (map[string]V, error) {
+	baseTree, err := toTree(base)
+	if err != nil {
+		return nil, err
+	}
+	oursTree, err := toTree(ours)
+	if err != nil {
+		return nil, err
+	}
+	diskTree, err := toTree(disk)
+	if err != nil {
+		return nil, err
+	}
+
+	merged := mergeValue(baseTree, oursTree, diskTree)
+
+	var out map[string]V
+	if err := fromTree(merged, &out); err != nil {
+		return nil, err
+	}
 	if out == nil {
 		out = map[string]V{}
 	}
-	for k := range base {
-		if _, keptByUs := ours[k]; !keptByUs {
-			delete(out, k)
+	return out, nil
+}
+
+// mergeValue three-way-merges one JSON value. base is the common ancestor, ours
+// our value, disk the on-disk value. Objects recurse key by key so nested
+// concurrent edits both survive; any other value (scalar, array, null) is atomic
+// and takes ours when we changed it from base, else disk's.
+func mergeValue(base, ours, disk any) any {
+	oursObj, oursIsObj := ours.(map[string]any)
+	diskObj, diskIsObj := disk.(map[string]any)
+	if !oursIsObj || !diskIsObj {
+		if !reflect.DeepEqual(base, ours) {
+			return ours
 		}
+		return disk
 	}
-	for k, v := range ours {
-		bv, inBase := base[k]
-		if !inBase || !reflect.DeepEqual(bv, v) {
-			out[k] = v
+	baseObj, _ := base.(map[string]any) // nil when base is absent or not an object
+
+	keys := make(map[string]struct{}, len(baseObj)+len(oursObj)+len(diskObj))
+	for k := range baseObj {
+		keys[k] = struct{}{}
+	}
+	for k := range oursObj {
+		keys[k] = struct{}{}
+	}
+	for k := range diskObj {
+		keys[k] = struct{}{}
+	}
+
+	out := make(map[string]any, len(keys))
+	for k := range keys {
+		bv, inBase := baseObj[k]
+		ov, inOurs := oursObj[k]
+		dv, inDisk := diskObj[k]
+
+		switch {
+		case !inOurs:
+			// We do not have the key. If it was in our ancestor we deleted it, and
+			// our delete wins; otherwise it is a concurrent add on disk, so keep it.
+			if !inBase {
+				out[k] = dv
+			}
+		case inDisk:
+			// Present on both sides: recurse so nested concurrent edits both survive.
+			out[k] = mergeValue(bv, ov, dv)
+		default:
+			// Disk lacks it. Keep ours if we added it (not in base) or changed it;
+			// if it is unchanged from base, disk deleted it, so respect that.
+			if !inBase || !reflect.DeepEqual(bv, ov) {
+				out[k] = ov
+			}
 		}
 	}
 	return out
+}
+
+// toTree renders v as a generic JSON value. UseNumber keeps numbers as exact
+// decimal strings so a large integer id is not corrupted by a float64 round-trip
+// and so equal numbers compare equal.
+func toTree(v any) (any, error) {
+	data, err := json.Marshal(v)
+	if err != nil {
+		return nil, fmt.Errorf("unable to convert config to merge tree: %w", err)
+	}
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.UseNumber()
+	var tree any
+	if err := decoder.Decode(&tree); err != nil {
+		return nil, fmt.Errorf("unable to convert config to merge tree: %w", err)
+	}
+	return tree, nil
+}
+
+// fromTree unmarshals a generic JSON value produced by mergeValue back into out.
+func fromTree(tree, out any) error {
+	data, err := json.Marshal(tree)
+	if err != nil {
+		return fmt.Errorf("unable to convert merge tree to config: %w", err)
+	}
+	if err := json.Unmarshal(data, out); err != nil {
+		return fmt.Errorf("unable to convert merge tree to config: %w", err)
+	}
+	return nil
 }

--- a/pkg/config/merge.go
+++ b/pkg/config/merge.go
@@ -18,9 +18,10 @@ import (
 // only on disk (a concurrent add) survives, and a key we deleted (in base, absent
 // from ours) is removed.
 //
-// Secrets must be in the same (encrypted) representation across all three inputs
-// before this runs, or a secret we never touched reads as a local change and
-// overwrites a concurrent update. saveLocked guarantees that via encryptSecrets.
+// base and ours must be in the same representation before this runs, or a secret this
+// process never touched reads as base != ours (a local change) and overwrites a
+// concurrent update. saveLocked aligns them via decryptToMatch. disk's own
+// representation does not matter: an untouched field is taken from disk wholesale.
 func threeWayMerge(base, ours, disk *Config) (*Config, error) {
 	out := disk
 

--- a/pkg/config/merge_test.go
+++ b/pkg/config/merge_test.go
@@ -62,3 +62,25 @@ func TestThreeWayMerge_UntouchedScalarTakesDisk(t *testing.T) {
 
 	require.True(t, got.EnableColor, "a field we didn't change must keep the disk value")
 }
+
+func TestThreeWayMerge_OurMapValueChangeWins(t *testing.T) {
+	base := cfgWithPlatforms("a")
+	ours := cfgWithPlatforms("a")
+	ours.Platforms["a"] = &Platform{Name: "a", Server: "https://new"} // we edited "a"
+	disk := cfgWithPlatforms("a")                                     // disk unchanged
+
+	got := threeWayMerge(base, ours, disk)
+
+	require.Equal(t, "https://new", got.Platforms["a"].Server, "our value change to an existing key must win")
+}
+
+func TestThreeWayMerge_UntouchedMapValueTakesDisk(t *testing.T) {
+	base := cfgWithPlatforms("a")
+	ours := cfgWithPlatforms("a") // we didn't touch "a"
+	disk := cfgWithPlatforms("a")
+	disk.Platforms["a"] = &Platform{Name: "a", Server: "https://disk-changed"} // another session edited "a"
+
+	got := threeWayMerge(base, ours, disk)
+
+	require.Equal(t, "https://disk-changed", got.Platforms["a"].Server, "a key we didn't touch must keep disk's in-place change")
+}

--- a/pkg/config/merge_test.go
+++ b/pkg/config/merge_test.go
@@ -20,7 +20,8 @@ func TestThreeWayMerge_PreservesConcurrentAdd(t *testing.T) {
 	ours := cfgWithPlatforms("a")      // we changed nothing about platforms
 	disk := cfgWithPlatforms("a", "b") // another session added "b"
 
-	got := threeWayMerge(base, ours, disk)
+	got, err := threeWayMerge(base, ours, disk)
+	require.NoError(t, err)
 
 	require.Contains(t, got.Platforms, "a")
 	require.Contains(t, got.Platforms, "b", "a concurrent add on disk must survive the merge")
@@ -31,7 +32,8 @@ func TestThreeWayMerge_AppliesOurDelete(t *testing.T) {
 	ours := cfgWithPlatforms("a")      // we deleted "b"
 	disk := cfgWithPlatforms("a", "b") // disk still has "b"
 
-	got := threeWayMerge(base, ours, disk)
+	got, err := threeWayMerge(base, ours, disk)
+	require.NoError(t, err)
 
 	require.Contains(t, got.Platforms, "a")
 	require.NotContains(t, got.Platforms, "b", "our delete must be applied to disk state")
@@ -45,7 +47,8 @@ func TestThreeWayMerge_OurScalarChangeWins(t *testing.T) {
 	disk := New()
 	disk.CurrentContext = "a" // disk unchanged
 
-	got := threeWayMerge(base, ours, disk)
+	got, err := threeWayMerge(base, ours, disk)
+	require.NoError(t, err)
 
 	require.Equal(t, "b", got.CurrentContext)
 }
@@ -58,7 +61,8 @@ func TestThreeWayMerge_UntouchedScalarTakesDisk(t *testing.T) {
 	disk := New()
 	disk.EnableColor = true // another session enabled color
 
-	got := threeWayMerge(base, ours, disk)
+	got, err := threeWayMerge(base, ours, disk)
+	require.NoError(t, err)
 
 	require.True(t, got.EnableColor, "a field we didn't change must keep the disk value")
 }
@@ -69,7 +73,8 @@ func TestThreeWayMerge_OurMapValueChangeWins(t *testing.T) {
 	ours.Platforms["a"] = &Platform{Name: "a", Server: "https://new"} // we edited "a"
 	disk := cfgWithPlatforms("a")                                     // disk unchanged
 
-	got := threeWayMerge(base, ours, disk)
+	got, err := threeWayMerge(base, ours, disk)
+	require.NoError(t, err)
 
 	require.Equal(t, "https://new", got.Platforms["a"].Server, "our value change to an existing key must win")
 }
@@ -80,7 +85,65 @@ func TestThreeWayMerge_UntouchedMapValueTakesDisk(t *testing.T) {
 	disk := cfgWithPlatforms("a")
 	disk.Platforms["a"] = &Platform{Name: "a", Server: "https://disk-changed"} // another session edited "a"
 
-	got := threeWayMerge(base, ours, disk)
+	got, err := threeWayMerge(base, ours, disk)
+	require.NoError(t, err)
 
 	require.Equal(t, "https://disk-changed", got.Platforms["a"].Server, "a key we didn't touch must keep disk's in-place change")
+}
+
+// helper: a config with one context carrying an environment and an active cluster
+func cfgWithContext(name, env, activeKafka string) *Config {
+	c := New()
+	c.Contexts[name] = &Context{
+		Name:                name,
+		CurrentEnvironment:  env,
+		KafkaClusterContext: &KafkaClusterContext{ActiveKafkaCluster: activeKafka},
+	}
+	return c
+}
+
+func TestThreeWayMerge_MergesConcurrentFieldsOfSameContext(t *testing.T) {
+	base := cfgWithContext("ctx", "env-a", "lkc-1")
+	ours := cfgWithContext("ctx", "env-b", "lkc-1") // we ran `environment use env-b`
+	disk := cfgWithContext("ctx", "env-a", "lkc-2") // another session ran `kafka cluster use lkc-2`
+
+	got, err := threeWayMerge(base, ours, disk)
+	require.NoError(t, err)
+
+	require.Equal(t, "env-b", got.Contexts["ctx"].CurrentEnvironment, "our field change must survive")
+	require.Equal(t, "lkc-2", got.Contexts["ctx"].KafkaClusterContext.ActiveKafkaCluster, "the concurrent field change on disk must survive")
+}
+
+// Arrays are leaves: a changed array takes ours wholesale, an untouched one keeps
+// disk's. No element-wise merging, matching the pre-existing atomic map-value merge.
+func TestMergeValue_TreatsArraysAtomically(t *testing.T) {
+	base := map[string]any{"list": []any{"a", "b"}}
+	ours := map[string]any{"list": []any{"a", "b", "c"}} // we appended "c"
+	disk := map[string]any{"list": []any{"a", "b"}}      // disk unchanged
+
+	got := mergeValue(base, ours, disk).(map[string]any)
+
+	require.Equal(t, []any{"a", "b", "c"}, got["list"], "a changed array takes ours wholesale")
+}
+
+func TestMergeValue_UntouchedArrayTakesDisk(t *testing.T) {
+	base := map[string]any{"list": []any{"a"}}
+	ours := map[string]any{"list": []any{"a"}}      // unchanged by us
+	disk := map[string]any{"list": []any{"a", "b"}} // another writer extended it
+
+	got := mergeValue(base, ours, disk).(map[string]any)
+
+	require.Equal(t, []any{"a", "b"}, got["list"], "an untouched array keeps disk's version")
+}
+
+func TestMergeValue_RecursesDeletesAndConcurrentAdds(t *testing.T) {
+	base := map[string]any{"keep": "v", "drop": "v"}
+	ours := map[string]any{"keep": "v", "mine": "v"}           // we deleted "drop" and added "mine"
+	disk := map[string]any{"keep": "v", "drop": "v", "x": "v"} // another writer added "x"
+
+	got := mergeValue(base, ours, disk).(map[string]any)
+
+	require.NotContains(t, got, "drop", "our delete must be applied")
+	require.Contains(t, got, "mine", "our add must survive")
+	require.Contains(t, got, "x", "a concurrent add must survive")
 }

--- a/pkg/config/merge_test.go
+++ b/pkg/config/merge_test.go
@@ -1,0 +1,64 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// helper: a config with one platform keyed by name
+func cfgWithPlatforms(names ...string) *Config {
+	c := New()
+	for _, n := range names {
+		c.Platforms[n] = &Platform{Name: n}
+	}
+	return c
+}
+
+func TestThreeWayMerge_PreservesConcurrentAdd(t *testing.T) {
+	base := cfgWithPlatforms("a")
+	ours := cfgWithPlatforms("a")      // we changed nothing about platforms
+	disk := cfgWithPlatforms("a", "b") // another session added "b"
+
+	got := threeWayMerge(base, ours, disk)
+
+	require.Contains(t, got.Platforms, "a")
+	require.Contains(t, got.Platforms, "b", "a concurrent add on disk must survive the merge")
+}
+
+func TestThreeWayMerge_AppliesOurDelete(t *testing.T) {
+	base := cfgWithPlatforms("a", "b")
+	ours := cfgWithPlatforms("a")      // we deleted "b"
+	disk := cfgWithPlatforms("a", "b") // disk still has "b"
+
+	got := threeWayMerge(base, ours, disk)
+
+	require.Contains(t, got.Platforms, "a")
+	require.NotContains(t, got.Platforms, "b", "our delete must be applied to disk state")
+}
+
+func TestThreeWayMerge_OurScalarChangeWins(t *testing.T) {
+	base := New()
+	base.CurrentContext = "a"
+	ours := New()
+	ours.CurrentContext = "b" // we ran `use b`
+	disk := New()
+	disk.CurrentContext = "a" // disk unchanged
+
+	got := threeWayMerge(base, ours, disk)
+
+	require.Equal(t, "b", got.CurrentContext)
+}
+
+func TestThreeWayMerge_UntouchedScalarTakesDisk(t *testing.T) {
+	base := New()
+	base.EnableColor = false
+	ours := New()
+	ours.EnableColor = false // we didn't touch it
+	disk := New()
+	disk.EnableColor = true // another session enabled color
+
+	got := threeWayMerge(base, ours, disk)
+
+	require.True(t, got.EnableColor, "a field we didn't change must keep the disk value")
+}


### PR DESCRIPTION
Release Notes
-------------

Bug Fixes
- Fixed concurrent `confluent` sessions overwriting each other's saved configuration (for example, the selected environment or Kafka cluster) and, on an interrupted write, truncating the config file. Config writes are now atomic and serialized across sessions.

Checklist
---------
- [ ] I have successfully built and used a custom CLI binary, without linter issues from this PR.
- [x] I have clearly specified in the `What` section below whether this PR applies to Confluent Cloud, Confluent Platform, or both.
- [ ] I have verified this PR in Confluent Cloud pre-prod or production environment, if applicable.
- [ ] I have verified this PR in Confluent Platform on-premises environment, if applicable.
- [ ] I have attached manual CLI verification results or screenshots in the `Test & Review` section below.
- [x] I have added appropriate CLI integration or unit tests for any new or updated commands and functionality.
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [x] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [ ] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [ ] Confluent Cloud prod
  - [ ] Confluent Cloud stag
  - [ ] Confluent Platform
  - [ ] Check this box if the feature is enabled for certain organizations only

What
----

Several `confluent` sessions now commonly run at once (parallel shells, or AI agents driving multiple sessions). Each session loads `~/.confluent/config.json` at startup and overwrites the whole file on save with no coordination, so the last writer wins and silently drops fields another session set (for example, the selected environment or Kafka cluster). An interrupted write could also truncate the file.

`Save()` now handles both problems, with no changes to any call site:

- **Atomic writes.** Each save writes a temp file, flushes it, and renames it into place, so a crash never leaves a truncated config file.
- **Locked, merged writes.** Saves serialize on a sidecar `config.json.lock` file (`flock` on POSIX, `LockFileEx` on Windows). `Save()` re-reads the on-disk config and three-way-merges in this process's own changes, using the state it loaded at startup as the common ancestor, so a concurrent session's fields survive instead of being clobbered.
- **Surfaced errors.** Session-refresh and config-save errors on the 401 token-refresh path were previously discarded; they're now logged.

No serialized field names or output formats change, and no golden files move. Applies to **both Confluent Cloud and Confluent Platform**, which share the config store.

Also folds in a small CI change (`APIE-1628`, see References) to run the `windows/amd64` test block on PRs touching `pkg/config`, since the lock is the one place this code diverges by OS.

Blast Radius
----

Config saves happen on common commands (`confluent login`, the various `... use` commands, token refresh), so the affected surface is broad, though the change is designed to fail safe:

- If the merge ever dropped a field, a session could lose its selected environment, cluster, or API key. That is the exact failure this PR fixes, so the risk is a regression reintroducing it, which the concurrent-writer regression test guards against.
- If a save cannot acquire the lock, the command waits up to a 3-second timeout, prints `another confluent process is updating the configuration file` with a retry suggestion, and returns that error rather than saving. Commands that previously always succeeded at saving can now surface this error under genuine contention.
- Mitigations: the write is atomic (a failed save never corrupts the existing file), the lock auto-releases on process exit (no stale-lock state to recover), and cross-platform lock and merge tests plus the concurrent-writer regression test cover the paths.

References
----------

- `APIE-1621` - safe, atomic, locked config writes (this PR).
- `APIE-1628` - run the Windows test block on PRs touching the config lock (folded into this PR).
- **Stacked on #3467** (`channel-state-dir`): this PR targets that branch, so the diff shown is incremental and it should be reviewed and merged after #3467. Basing on it also lets a local dev build self-isolate into a channel-scoped state dir, so concurrent-session behavior can be exercised by hand without touching your real `~/.confluent`. #3467 is likewise the precedent for the `pkg/config` restricted-zone review.

Test & Review
-------------

Automated (all green locally):

- `make lint` and the full `make unit-test` pass. New `pkg/config` tests cover a deterministic concurrent-writer lost-update regression (race-clean under `-race`), the atomic write, cross-platform locking, and the three-way merge; `pkg/ccloudv2` tests cover the error surfacing. No golden files change.
- Cross-compiles for `GOOS=windows` (the `LockFileEx` path).

For reviewers:

1. **Confirm the new Windows gate fired on this PR.** The `windows/amd64` Semaphore block should run because this PR touches `pkg/config`; this is the first live exercise of the `change_in()` condition. If it did not run, the `change_in()` scoping needs adjustment before it can be relied on.
2. Concurrency is covered by the automated regression test rather than a manual screenshot, since reproducing it by hand needs two racing sessions. `TestSave_ConcurrentDifferentFields_NoLostWrite` is the reproduction.
3. **Restricted zones.** This touches `pkg/config` and `.semaphore/semaphore.yml`; requesting the platform/restricted-zone owners' sign-off.

Known limitation (not a blocker): a concurrent refresh of the **same** context's auth token is last-writer-wins. A separate auth-state-lock follow-up covers that case; concurrent writes to different contexts or different fields are fully preserved.

Follow-up: a deferred refactor to separate normalization from persistence in the config `Validate()` path (removing an internal re-entrancy guard and a panic-on-lock-timeout edge case) is tracked as a follow-up sub-task.
